### PR TITLE
Make answer citations map to a numbered source list, and open sources on click

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -24,7 +24,7 @@ from textual.css.query import NoMatches
 from textual.dom import DOMNode
 from textual.reactive import reactive
 from textual.screen import Screen
-from textual.widgets import Footer, Select, Static
+from textual.widgets import Footer, Markdown, Select, Static
 
 # Cancellation check for @work(thread=True) workers. Import at module level
 # since it's used in multiple methods.
@@ -42,6 +42,7 @@ from lilbee.cli.tui.screens.chat_helpers import (
     build_add_progress_callback,
     build_sync_progress_callback,
     close_stream,
+    open_local_file,
     remember_from_input,
     remove_copied_files,
 )
@@ -1708,6 +1709,16 @@ class ChatScreen(Screen[None]):
         """Main-thread failure: unblock the input and surface the error."""
         self.swapping_model = False
         self.app.notify(msg.MODEL_SWAP_FAILED.format(error=error), severity="error")
+
+    @on(Markdown.LinkClicked)
+    def _open_answer_link(self, event: Markdown.LinkClicked) -> None:
+        """Open a link clicked in an answer: ``file:`` citations open in the OS
+        default app for the file type; web links open in the browser."""
+        event.stop()
+        if event.href.startswith("file://"):
+            open_local_file(event.href)
+        else:
+            self.app.open_url(event.href)
 
     async def action_toggle_markdown(self) -> None:
         """Toggle between Markdown and plain-text rendering for chat responses."""

--- a/src/lilbee/cli/tui/screens/chat_helpers.py
+++ b/src/lilbee/cli/tui/screens/chat_helpers.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 import contextlib
 import logging
 import shutil
+import subprocess
+import sys
 import time
+import webbrowser
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
@@ -43,6 +48,31 @@ def close_stream(stream: Any) -> None:
     if isinstance(stream, ClosableIterator):
         with contextlib.suppress(Exception):
             stream.close()
+
+
+def _opener_argv(platform: str) -> list[str] | None:
+    """The platform's open-with-default-app command, or None to use the browser."""
+    if platform == "darwin":
+        return ["open"]
+    if platform.startswith("linux"):
+        return ["xdg-open"]
+    return None
+
+
+def open_local_file(href: str) -> None:
+    """Open a ``file:`` URL with the OS opener so it lands in the default app
+    for its type (an editor for markdown, a viewer for PDF), not a browser
+    rendering raw text. Platforms without a known opener fall back to the
+    webbrowser module."""
+    argv = _opener_argv(sys.platform)
+    if argv is None:
+        webbrowser.open(href)
+        return
+    path = url2pathname(urlparse(href).path)
+    try:
+        subprocess.run([*argv, path], check=False, timeout=10)  # noqa: S603 - fixed opener command; path comes from lilbee's own store
+    except (OSError, subprocess.TimeoutExpired):
+        log.warning("Could not open source file: %s", path)
 
 
 def detail_for_batch_progress(data: BatchProgressEvent, in_flight: list[str]) -> str:

--- a/src/lilbee/cli/tui/widgets/message.py
+++ b/src/lilbee/cli/tui/widgets/message.py
@@ -6,10 +6,12 @@ import time
 from pathlib import Path
 from typing import ClassVar
 
+from markdown_it import MarkdownIt
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.content import Content
 from textual.widgets import Collapsible, Markdown, Static
+from typing_extensions import override
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.pill import pill
@@ -21,6 +23,26 @@ _MD_UPDATE_INTERVAL = 0.1
 
 _SPEAKER_YOU = "[bold $primary]you[/]"
 _SPEAKER_LILBEE = "[bold $success]lilbee[/]"
+
+
+class _AnswerMarkdownIt(MarkdownIt):
+    """Markdown parser for answers, additionally allowing ``file:`` links.
+
+    markdown-it rejects ``file:`` destinations by default (a web-context XSS
+    guard), which left the Sources block's citation links rendering as raw
+    ``[label](file://...)`` text. Answers link to the reader's own documents on
+    disk, so re-admit the scheme; everything else keeps the default validation.
+    """
+
+    @override
+    def validateLink(self, url: str) -> bool:
+        return url.startswith("file://") or super().validateLink(url)
+
+
+def _answer_markdown_parser() -> MarkdownIt:
+    """Textual's default gfm-like parser with ``file:`` links admitted."""
+    return _AnswerMarkdownIt("gfm-like")
+
 
 _REASONING_BLOCK_CLASS = "reasoning-block"
 _REASONING_STREAMING_CLASS = "-streaming"
@@ -83,9 +105,19 @@ class AssistantMessage(Vertical):
         self.mount(header, before=self._content_widget)
 
     def _build_content_widget(self) -> Markdown | Static:
-        """Create the content widget based on the current rendering mode."""
+        """Create the content widget based on the current rendering mode.
+
+        ``open_links=False``: clicks route to the chat screen's link handler,
+        which opens ``file:`` citations with the OS opener instead of the
+        browser the default handling would use.
+        """
         if self._use_markdown:
-            return Markdown("", classes="response-md")
+            return Markdown(
+                "",
+                classes="response-md",
+                parser_factory=_answer_markdown_parser,
+                open_links=False,
+            )
         return Static("", classes="response-md")
 
     @property

--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -194,12 +194,22 @@ DEFAULT_CRAWL_EXCLUDE_PATTERNS: tuple[str, ...] = (
 
 
 DEFAULT_RAG_SYSTEM_PROMPT = (
-    "You are a precise, direct assistant grounded in the provided context. "
-    "Answer using only the context: if it doesn't contain enough information, "
-    "say so rather than guessing. Be specific: quote relevant passages and "
-    "reference context by number (e.g. [1], [2]) inline. Prefer exact values "
-    "over approximations. For code, prefer working examples over abstract "
-    "explanations. Keep responses concise unless asked to elaborate."
+    "You are a precise assistant answering from the user's own documents. "
+    "Ground every claim in the numbered context passages and nothing else; if "
+    "they don't cover the question, say so plainly instead of guessing or "
+    "answering from general knowledge. Synthesize across passages rather than "
+    "leaning on one, and if they disagree, note the conflict. Cite inline by "
+    "placing the passage number in brackets right after the claim it supports "
+    "(e.g. [1] or [2][5]), and cite only passages you actually used. Do not "
+    "write a Sources, References, or Bibliography list at the end; the app adds "
+    "the real source list for you. Prefer exact values, names, and short quotes "
+    "from the context over paraphrase. Handle any material: prose, notes, "
+    "tables, transcripts, or code; for code, prefer a working example. When "
+    "asked how to do something, lay the answer out as ordered steps; if the "
+    "context covers the procedure only partially, give the steps it contains "
+    "and name what's missing rather than glossing over the gap. Match the "
+    "answer's length to the question: exhaustive requests deserve every "
+    "relevant detail the context offers."
 )
 
 DEFAULT_GENERAL_SYSTEM_PROMPT = (

--- a/src/lilbee/retrieval/query/__init__.py
+++ b/src/lilbee/retrieval/query/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from lilbee.retrieval.query.dedup import (
-    deduplicate_sources,
     diversify_sources,
     filter_results,
     prepare_results,
@@ -13,6 +12,7 @@ from lilbee.retrieval.query.formatting import (
     build_context,
     display_source_path,
     format_source,
+    format_sources_block,
     strip_llm_citations,
 )
 from lilbee.retrieval.query.searcher import AskResult, ChatMessage, Searcher
@@ -22,11 +22,11 @@ __all__ = [
     "ChatMessage",
     "Searcher",
     "build_context",
-    "deduplicate_sources",
     "display_source_path",
     "diversify_sources",
     "filter_results",
     "format_source",
+    "format_sources_block",
     "prepare_results",
     "sort_by_relevance",
     "strip_llm_citations",

--- a/src/lilbee/retrieval/query/dedup.py
+++ b/src/lilbee/retrieval/query/dedup.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from lilbee.core.config import cfg
-from lilbee.data.store import CitationRecord, SearchChunk
-from lilbee.retrieval.query.formatting import format_source
+from lilbee.data.store import SearchChunk
 
 _DEFAULT_RELEVANCE_WEIGHT = 0.5
 
@@ -151,25 +150,6 @@ def filter_results(
             continue
         filtered.append(r)
     return filtered
-
-
-def deduplicate_sources(
-    results: list[SearchChunk],
-    max_citations: int = 5,
-    citations_map: dict[str, list[CitationRecord]] | None = None,
-) -> list[str]:
-    """Merge results from same source into deduplicated citation lines."""
-    seen: set[str] = set()
-    citation_lines: list[str] = []
-    for r in results:
-        cits = (citations_map or {}).get(r.source)
-        line = format_source(r, citations=cits)
-        if line not in seen:
-            seen.add(line)
-            citation_lines.append(line)
-            if len(citation_lines) >= max_citations:
-                break
-    return citation_lines
 
 
 def _sort_key(r: SearchChunk) -> float:

--- a/src/lilbee/retrieval/query/formatting.py
+++ b/src/lilbee/retrieval/query/formatting.py
@@ -16,11 +16,23 @@ Question: {question}"""
 
 _CITE_REF_RE = re.compile(r"\[(\d+)\]")
 
-# Matches trailing LLM-generated citation blocks like "Key sources:", "Sources:",
-# "References:", "Bibliography:", "Citations:" (with optional markdown heading).
+# An LLM-generated citation block: a "Sources:"/"References:"/... heading line
+# followed by a list (bullets, arrows, "[1]" or "1." numbering). Requiring the
+# list keeps an answer that legitimately discusses such a heading in prose
+# (e.g. "References:\n\nIt lists 40 works.") from being clipped.
 _LLM_CITATION_BLOCK_RE = re.compile(
-    r"\n{1,3}(?:#+\s*)?(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*\n.*",
+    r"\n{1,3}(?:#+\s*)?(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*\n"
+    r"\s*(?:[-*•→\[]|\d+[.)]).*",
     re.IGNORECASE | re.DOTALL,
+)
+
+# A citation-style heading at the very end of the text, nothing after it yet.
+# Mid-stream this is ambiguous (the next line decides list vs prose), so it is
+# held back rather than shown; at end of stream it is a dangling artifact of a
+# citation block the model never finished, and is dropped either way.
+_TRAILING_HEADING_RE = re.compile(
+    r"\n{1,3}(?:#+\s*)?(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*$",
+    re.IGNORECASE,
 )
 
 
@@ -170,31 +182,36 @@ def cited_subset(answer: str, sources: list[SearchChunk]) -> list[SearchChunk]:
     return [uniq[i - 1] for i in sorted(cited) if 1 <= i <= len(uniq)]
 
 
-def _drop_citation_block(text: str) -> str:
-    """Remove a trailing LLM-generated citation block without trimming whitespace.
+def _stream_safe_prefix(text: str) -> str:
+    """The prefix of *text* safe to show: a model-authored citation block
+    (heading plus list) is removed, and a bare trailing citation heading is
+    withheld until whatever follows disambiguates it.
 
     Kept rstrip-free so the streaming filter can track emitted length exactly;
     ``strip_llm_citations`` layers the final rstrip on top for one-shot answers.
     """
-    return _LLM_CITATION_BLOCK_RE.sub("", text)
+    cleaned = _LLM_CITATION_BLOCK_RE.sub("", text)
+    return _TRAILING_HEADING_RE.sub("", cleaned)
 
 
 def strip_llm_citations(text: str) -> str:
-    """Remove LLM-generated trailing citation blocks from answer text."""
-    return _drop_citation_block(text).rstrip()
+    """Remove an LLM-generated trailing citation block (or dangling citation
+    heading) from answer text. Prose that merely mentions such a heading stays."""
+    return _stream_safe_prefix(text).rstrip()
 
 
 class StreamingCitationFilter:
-    """Suppress a model-generated trailing ``Sources:``/``References:`` block as
+    """Suppress a model-generated ``Sources:``/``References:`` citation block as
     it streams, so only lilbee's authoritative source list reaches the reader.
 
     A one-shot answer can be stripped after the fact, but streamed tokens are
     already on screen by the time the block is recognizable. This feeds the
     answer in incrementally and only releases text once it is certain not to be
     the start of a citation block: everything up to the last newline is safe to
-    show, while the final (possibly partial) line is held back until more text
-    arrives or the stream ends. If a citation heading does appear, the block and
-    everything after it is dropped for good.
+    show, the final (possibly partial) line is held back until more text
+    arrives, and a bare citation heading is held until the next line shows
+    whether a list (a citation block, dropped) or prose (a legitimate mention,
+    shown) follows. A heading left dangling when the stream ends is dropped.
     """
 
     def __init__(self) -> None:
@@ -204,7 +221,7 @@ class StreamingCitationFilter:
     def feed(self, text: str) -> str:
         """Accept the next answer chunk; return the portion safe to show now."""
         self._buffer += text
-        stripped = _drop_citation_block(self._buffer)
+        stripped = _stream_safe_prefix(self._buffer)
         cut = stripped.rfind("\n")
         committed = stripped if cut == -1 else stripped[:cut]
         if len(committed) > self._emitted:
@@ -215,7 +232,7 @@ class StreamingCitationFilter:
 
     def flush(self) -> str:
         """Release any remaining safe text once the stream has ended."""
-        final = _drop_citation_block(self._buffer)
+        final = _stream_safe_prefix(self._buffer)
         if len(final) > self._emitted:
             out = final[self._emitted :]
             self._emitted = len(final)

--- a/src/lilbee/retrieval/query/formatting.py
+++ b/src/lilbee/retrieval/query/formatting.py
@@ -47,8 +47,46 @@ def display_source_path(source: str) -> str:
         return str(resolved)
 
 
+_WEB_PREFIX = "_web"
+_SOURCE_SEP = " · "
+
+
+def _source_label(source: str) -> str:
+    """Readable name for a source. Web-ingested docs collapse to ``host · slug``;
+    local files keep their documents-dir-relative path."""
+    prefix = f"{_WEB_PREFIX}/"
+    if not source.startswith(prefix):
+        return source
+    segments = [p for p in source.removeprefix(prefix).split("/") if p != "index.md"]
+    if not segments:
+        return source
+    host = segments[0].removeprefix("www.")
+    slug = segments[-1].removesuffix(".md")
+    return host if slug == host else f"{host}{_SOURCE_SEP}{slug}"
+
+
+def _source_file_url(source: str) -> str | None:
+    """A ``file://`` URL to the source on disk, so a reader can click it open, or
+    None when the path can't be resolved to an absolute location."""
+    try:
+        return (cfg.documents_dir / source).resolve(strict=False).as_uri()
+    except (OSError, ValueError):
+        return None
+
+
+def _source_locator(result: SearchChunk) -> str:
+    """The ``, page N`` / ``, lines A-B`` suffix for a source line, or ''."""
+    if result.content_type == "pdf" and (result.page_start or result.page_end):
+        ps, pe = result.page_start, result.page_end
+        return f", page {ps}" if ps == pe else f", pages {ps}-{pe}"
+    if result.content_type == "code" and (result.line_start or result.line_end):
+        ls, le = result.line_start, result.line_end
+        return f", line {ls}" if ls == le else f", lines {ls}-{le}"
+    return ""
+
+
 def _format_citation(citation: CitationRecord) -> str:
-    """Format a single citation record as an indented attribution line."""
+    """Format a single wiki transitive citation as an indented attribution line."""
     source_display = display_source_path(citation["source_filename"])
     if citation["page_start"] or citation["page_end"]:
         ps, pe = citation["page_start"], citation["page_end"]
@@ -62,32 +100,60 @@ def _format_citation(citation: CitationRecord) -> str:
 
 
 def format_source(result: SearchChunk, citations: list[CitationRecord] | None = None) -> str:
-    """Format a search result as a source citation line.
-    For wiki chunks, shows the wiki page path followed by indented transitive citations.
+    """Format a source as a clickable, readable citation: a ``[label](file-url)``
+    markdown link plus any page/line locator. Web docs render as ``host · slug``;
+    wiki chunks append their indented transitive citations.
     """
-    source_display = display_source_path(result.source)
+    label = _source_label(result.source)
+    url = _source_file_url(result.source)
+    head = f"[{label}]({url})" if url else label
     if result.chunk_type is ChunkType.WIKI and citations:
-        parts = [f"  → {source_display}"]
-        for cit in citations:
-            parts.append(_format_citation(cit))
-        return "\n".join(parts)
+        return "\n".join([head, *(_format_citation(c) for c in citations)])
+    return f"{head}{_source_locator(result)}"
 
-    if result.content_type == "pdf":
-        ps, pe = result.page_start, result.page_end
-        pages = f"page {ps}" if ps == pe else f"pages {ps}-{pe}"
-        return f"  → {source_display}, {pages}"
 
-    if result.content_type == "code":
-        ls, le = result.line_start, result.line_end
-        lines = f"line {ls}" if ls == le else f"lines {ls}-{le}"
-        return f"  → {source_display}, {lines}"
-
-    return f"  → {source_display}"
+def unique_sources(results: list[SearchChunk]) -> list[SearchChunk]:
+    """The first chunk of each distinct source, in retrieval order. A source's
+    1-based position here is the citation number the model emits (see
+    ``build_context``) and the number shown in the Sources block, so the answer's
+    ``[n]`` markers and the source list always agree."""
+    seen: set[str] = set()
+    out: list[SearchChunk] = []
+    for r in results:
+        if r.source not in seen:
+            seen.add(r.source)
+            out.append(r)
+    return out
 
 
 def build_context(results: list[SearchChunk]) -> str:
-    """Build context block from search results."""
-    return "\n\n".join(f"[{i}] {r.chunk}" for i, r in enumerate(results, 1))
+    """Number each passage by its source file, not its position, so citation
+    numbers are stable while streaming and map 1:1 to the Sources block. Passages
+    from the same file share a number."""
+    order: dict[str, int] = {}
+    for r in results:
+        order.setdefault(r.source, len(order) + 1)
+    return "\n\n".join(f"[{order[r.source]}] {r.chunk}" for r in results)
+
+
+def format_sources_block(
+    results: list[SearchChunk],
+    citations_map: dict[str, list[CitationRecord]] | None = None,
+) -> str:
+    """The authoritative numbered ``Sources:`` block appended to an answer. Each
+    unique source is numbered to match the ``[n]`` markers the model emitted, so
+    every inline citation resolves to a line here. '' when there are no sources."""
+    sources = unique_sources(results)
+    if not sources:
+        return ""
+    # A markdown ordered list, so a Markdown renderer puts each source on its own
+    # line (plain "  → path" lines collapse into one soft-wrapped paragraph) and
+    # the list number is the citation number the model cited inline.
+    lines = [
+        f"{i}. {format_source(r, citations=(citations_map or {}).get(r.source))}"
+        for i, r in enumerate(sources, 1)
+    ]
+    return "\n\nSources:\n\n" + "\n".join(lines)
 
 
 def _extract_cited_indices(text: str) -> set[int]:
@@ -96,11 +162,67 @@ def _extract_cited_indices(text: str) -> set[int]:
 
 
 def cited_subset(answer: str, sources: list[SearchChunk]) -> list[SearchChunk]:
-    """The sources the answer actually cited via [n] markers, in order (empty if none)."""
+    """The sources the answer actually cited via [n] markers, where n indexes the
+    unique sources (matching ``build_context``/``format_sources_block``). Empty if
+    none cited."""
+    uniq = unique_sources(sources)
     cited = _extract_cited_indices(answer)
-    return [sources[i - 1] for i in sorted(cited) if 1 <= i <= len(sources)]
+    return [uniq[i - 1] for i in sorted(cited) if 1 <= i <= len(uniq)]
+
+
+def _drop_citation_block(text: str) -> str:
+    """Remove a trailing LLM-generated citation block without trimming whitespace.
+
+    Kept rstrip-free so the streaming filter can track emitted length exactly;
+    ``strip_llm_citations`` layers the final rstrip on top for one-shot answers.
+    """
+    return _LLM_CITATION_BLOCK_RE.sub("", text)
 
 
 def strip_llm_citations(text: str) -> str:
     """Remove LLM-generated trailing citation blocks from answer text."""
-    return _LLM_CITATION_BLOCK_RE.sub("", text).rstrip()
+    return _drop_citation_block(text).rstrip()
+
+
+class StreamingCitationFilter:
+    """Suppress a model-generated trailing ``Sources:``/``References:`` block as
+    it streams, so only lilbee's authoritative source list reaches the reader.
+
+    A one-shot answer can be stripped after the fact, but streamed tokens are
+    already on screen by the time the block is recognizable. This feeds the
+    answer in incrementally and only releases text once it is certain not to be
+    the start of a citation block: everything up to the last newline is safe to
+    show, while the final (possibly partial) line is held back until more text
+    arrives or the stream ends. If a citation heading does appear, the block and
+    everything after it is dropped for good.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._emitted = 0
+
+    def feed(self, text: str) -> str:
+        """Accept the next answer chunk; return the portion safe to show now."""
+        self._buffer += text
+        stripped = _drop_citation_block(self._buffer)
+        cut = stripped.rfind("\n")
+        committed = stripped if cut == -1 else stripped[:cut]
+        if len(committed) > self._emitted:
+            out = committed[self._emitted :]
+            self._emitted = len(committed)
+            return out
+        return ""
+
+    def flush(self) -> str:
+        """Release any remaining safe text once the stream has ended."""
+        final = _drop_citation_block(self._buffer)
+        if len(final) > self._emitted:
+            out = final[self._emitted :]
+            self._emitted = len(final)
+            return out
+        return ""
+
+    @property
+    def answer(self) -> str:
+        """The full answer shown so far, with any citation block removed."""
+        return strip_llm_citations(self._buffer)

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -27,7 +27,6 @@ from lilbee.retrieval.embedder import Embedder
 from lilbee.retrieval.query.dedup import (
     _greedy_cover,
     _relevance_weight,
-    deduplicate_sources,
     filter_results,
     order_by_fusion,
     prepare_results,
@@ -35,8 +34,10 @@ from lilbee.retrieval.query.dedup import (
 from lilbee.retrieval.query.expansion import EXPANSION_MAX_TOKENS, EXPANSION_PROMPT
 from lilbee.retrieval.query.formatting import (
     CONTEXT_TEMPLATE,
+    StreamingCitationFilter,
     build_context,
     cited_subset,
+    format_sources_block,
     strip_llm_citations,
 )
 from lilbee.retrieval.query.history_window import estimate_text_tokens
@@ -674,9 +675,7 @@ class Searcher:
         if not result.sources:
             return result.answer
         answer = strip_llm_citations(result.answer)
-        source_list = result.cited_sources if result.cited_sources else result.sources
-        citations = deduplicate_sources(source_list)
-        return f"{answer}\n\nSources:\n" + "\n".join(citations)
+        return f"{answer}{format_sources_block(result.sources)}"
 
     def _stream_direct(
         self,
@@ -725,7 +724,7 @@ class Searcher:
         results, messages = rag
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
-        answer_parts: list[str] = []
+        cite_filter = StreamingCitationFilter()
         events = stream_chat_with_cap(
             self._provider,
             cast("list[dict[str, Any]]", provider_messages),
@@ -736,16 +735,20 @@ class Searcher:
         )
         try:
             for token in cap_events_as_stream_tokens(events):
-                if not token.is_reasoning:
-                    answer_parts.append(token.content)
-                yield token
+                if token.is_reasoning:
+                    yield token
+                    continue
+                shown = cite_filter.feed(token.content)
+                if shown:
+                    yield StreamToken(content=shown, is_reasoning=False)
         except (ConnectionError, OSError) as exc:
             yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
-        # LLM-generated citation blocks in streamed tokens cannot be
-        # retroactively stripped. The system prompt discourages them; this
-        # only filters the code-appended Sources block to cited chunks.
-        full_answer = "".join(answer_parts)
-        used = cited_subset(full_answer, results)
-        source_list = used if used else results
-        citations = deduplicate_sources(source_list)
-        yield StreamToken(content="\n\nSources:\n" + "\n".join(citations), is_reasoning=False)
+        tail = cite_filter.flush()
+        if tail:
+            yield StreamToken(content=tail, is_reasoning=False)
+        # A model that emits its own trailing Sources block has had it dropped by
+        # the filter above; this authoritative list is numbered to match the
+        # ``[n]`` markers the model used, so every citation resolves to a line.
+        block = format_sources_block(results)
+        if block:
+            yield StreamToken(content=block, is_reasoning=False)

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -18,7 +18,7 @@ from lilbee.core.results import DocumentResult, group
 from lilbee.data.store import ChunkType, EmbeddingModelMismatchError
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.roles import WorkerRole
-from lilbee.retrieval.query.formatting import cited_subset
+from lilbee.retrieval.query.formatting import StreamingCitationFilter, cited_subset
 from lilbee.retrieval.query.searcher import SEARCH_NEEDS_EMBEDDER
 from lilbee.retrieval.reasoning import (
     CAP_CONTINUATION_PROMPT,
@@ -150,6 +150,34 @@ def _chat_warming_events() -> list[str]:
     return [sse_event(SseEvent.WARMING, {"role": WorkerRole.CHAT.value})]
 
 
+def _put_answer_token(
+    content: str,
+    put: Callable[[str | None], None],
+    cite_filter: StreamingCitationFilter | None,
+    answer_parts: list[str],
+) -> None:
+    """Filter one streamed answer chunk (dropping a model Sources block on
+    grounded turns), record it, and push it to the SSE queue."""
+    token = cite_filter.feed(content) if cite_filter else content
+    if token:
+        answer_parts.append(token)
+        put(sse_event(SseEvent.TOKEN, {"token": token}))
+
+
+def _put_answer_tail(
+    put: Callable[[str | None], None],
+    cite_filter: StreamingCitationFilter | None,
+    answer_parts: list[str],
+) -> None:
+    """Release any answer text the filter held back once the stream ends."""
+    if cite_filter is None:
+        return
+    tail = cite_filter.flush()
+    if tail:
+        answer_parts.append(tail)
+        put(sse_event(SseEvent.TOKEN, {"token": tail}))
+
+
 def _run_llm_stream(
     messages: list[ChatMessage],
     opts: dict[str, Any] | None,
@@ -157,11 +185,15 @@ def _run_llm_stream(
     cancel: threading.Event,
     error_holder: list[BaseException],
     answer_parts: list[str],
+    cite_filter: StreamingCitationFilter | None,
 ) -> None:
     """Forward tokens from the cap-aware chat orchestrator into the SSE queue.
 
     Answer tokens (not reasoning) are also accumulated into *answer_parts* so the
-    caller can feed the finished answer to auto-extraction.
+    caller can feed the finished answer to auto-extraction. When *cite_filter* is
+    set (grounded turns), answer tokens pass through it so a model-generated
+    ``Sources:`` block never reaches the client alongside the authoritative
+    SOURCES event; ungrounded turns pass ``None`` and stream verbatim.
     """
     try:
         events = stream_chat_with_cap(
@@ -183,14 +215,15 @@ def _run_llm_stream(
                         {"token": CAP_NOTICE_TEMPLATE.format(chars=event.cap_chars)},
                     )
                 )
+            elif event.is_reasoning:
+                if event.content:
+                    put(sse_event(SseEvent.REASONING, {"token": event.content}))
             elif event.content:
-                kind = SseEvent.REASONING if event.is_reasoning else SseEvent.TOKEN
-                if kind is SseEvent.TOKEN:
-                    answer_parts.append(event.content)
-                put(sse_event(kind, {"token": event.content}))
+                _put_answer_token(event.content, put, cite_filter, answer_parts)
     except Exception as exc:
         error_holder.append(exc)
     finally:
+        _put_answer_tail(put, cite_filter, answer_parts)
         put(None)
 
 
@@ -219,6 +252,33 @@ async def _emit_extracted_memories(question: str, answer: str) -> AsyncGenerator
         items=[MemoryExtractedItem(id=m.id, kind=m.kind, text=m.text) for m in stored],
     )
     yield sse_event(SseEvent.MEMORY_EXTRACTED, event.model_dump(mode="json"))
+
+
+def _mismatch_detail(exc: EmbeddingModelMismatchError) -> str | None:
+    """The index's persisted embedder when dims match, so a client can offer to
+    adopt it; None when they don't match and adoption wouldn't help."""
+    return exc.persisted_model if exc.dims_match else None
+
+
+async def _emit_sources_and_memories(
+    question: str,
+    answer_parts: list[str],
+    sources: list[SearchChunk],
+) -> AsyncGenerator[str, None]:
+    """Emit the trailing SOURCES event, ``done``, and any memory-extracted event.
+
+    SOURCES carries the cited subset (what the answer referenced), falling back to
+    the full retrieved set when the answer cited nothing, mirroring
+    ``Searcher.ask_stream``. Auto-extraction trails ``done`` so clients that stop
+    at ``done`` are unaffected; the memories are stored regardless.
+    """
+    answer = "".join(answer_parts)
+    cited = cited_subset(answer, sources)
+    source_list = cited if cited else sources
+    yield sse_event(SseEvent.SOURCES, [clean_result(s) for s in source_list])
+    yield sse_done({})
+    async for event in _emit_extracted_memories(question, answer):
+        yield event
 
 
 async def _stream_rag_response(
@@ -259,7 +319,7 @@ async def _stream_rag_response(
             )
         except EmbeddingModelMismatchError as mismatch:
             # detail carries the index's embedder so the client can offer to adopt it.
-            detail = mismatch.persisted_model if mismatch.dims_match else None
+            detail = _mismatch_detail(mismatch)
             yield sse_error(str(mismatch), code=SseErrorCode.INDEX_EMBEDDER_MISMATCH, detail=detail)
             return
         if rag is None:
@@ -272,6 +332,9 @@ async def _stream_rag_response(
     sse = SseStream()
     error_holder: list[BaseException] = []
     answer_parts: list[str] = []
+    # Only grounded turns append an authoritative SOURCES event, so only they
+    # need a model-generated Sources block suppressed.
+    cite_filter = StreamingCitationFilter() if results else None
 
     executor_fut = sse.loop.run_in_executor(
         None,
@@ -282,6 +345,7 @@ async def _stream_rag_response(
         sse.cancel,
         error_holder,
         answer_parts,
+        cite_filter,
     )
     task = asyncio.ensure_future(executor_fut)
     async for event in sse.drain(task, "RAG stream"):
@@ -299,17 +363,7 @@ async def _stream_rag_response(
     # Ensure executor thread has finished before yielding final events
     await executor_fut
 
-    # SOURCES carries the cited subset (what the answer referenced), falling back
-    # to the full retrieved set when the answer carries no inline citations.
-    # Mirrors Searcher.ask_stream's ``used if used else results``.
-    cited = cited_subset("".join(answer_parts), results)
-    source_list = cited if cited else results
-    yield sse_event(SseEvent.SOURCES, [clean_result(s) for s in source_list])
-    yield sse_done({})
-
-    # Auto-extraction (and its notification) trails ``done`` so clients that stop
-    # at ``done`` are unaffected; the memories are stored regardless.
-    async for event in _emit_extracted_memories(question, "".join(answer_parts)):
+    async for event in _emit_sources_and_memories(question, answer_parts, results):
         yield event
 
 
@@ -370,6 +424,48 @@ def chat_stream(
     )
 
 
+def _resolve_chat_stream_context(
+    searcher: Searcher,
+    question: str,
+    history: list[ChatMessage],
+    top_k: int | None,
+    chunk_type: ChunkType | None,
+) -> tuple[list[str], tuple[list[SearchChunk], list[ChatMessage]] | None]:
+    """Resolve the leading SSE frames and the (sources, messages) for a chat
+    stream. When the second element is None the turn can't proceed: emit the
+    frames (a clean refusal or error) and stop. Otherwise emit the frames
+    (warming) and stream the answer grounded in the returned sources."""
+    frames = list(_chat_warming_events())
+    if searcher.search_unavailable():
+        # Search mode with no embedder can't ground; refuse cleanly with the same
+        # token the ask stream emits instead of silently answering off-corpus.
+        frames += [
+            sse_event(SseEvent.TOKEN, {"token": SEARCH_NEEDS_EMBEDDER}),
+            sse_event(SseEvent.SOURCES, []),
+            sse_done({}),
+        ]
+        return frames, None
+    if _retrieval_off(searcher, top_k):
+        # Chat-only mode, no embedder, or an explicit top_k:0 pure-LLM call:
+        # answer directly with no RAG context.
+        return frames, ([], searcher.direct_messages(question, history))
+    try:
+        rag = searcher.build_rag_context(
+            question, top_k=top_k or 0, history=history, chunk_type=chunk_type
+        )
+    except EmbeddingModelMismatchError as exc:
+        frames.append(
+            sse_error(
+                str(exc), code=SseErrorCode.INDEX_EMBEDDER_MISMATCH, detail=_mismatch_detail(exc)
+            )
+        )
+        return frames, None
+    if rag is None:
+        frames.append(sse_error("No relevant documents found."))
+        return frames, None
+    return frames, rag
+
+
 async def _stream_chat_response(
     question: str,
     history: list[ChatMessage],
@@ -378,51 +474,25 @@ async def _stream_chat_response(
     chunk_type: ChunkType | None,
 ) -> AsyncGenerator[str, None]:
     """Drive ``dispatch_chat_stream`` and emit reasoning/token/sources/done SSE events."""
-    for warming in _chat_warming_events():
-        yield warming
-
-    searcher = get_services().searcher
-    if searcher.search_unavailable():
-        # Search mode with no embedder can't ground; refuse cleanly with the same
-        # token the ask stream emits instead of silently answering off-corpus.
-        yield sse_event(SseEvent.TOKEN, {"token": SEARCH_NEEDS_EMBEDDER})
-        yield sse_event(SseEvent.SOURCES, [])
-        yield sse_done({})
+    frames, ctx = _resolve_chat_stream_context(
+        get_services().searcher, question, history, top_k, chunk_type
+    )
+    for frame in frames:
+        yield frame
+    if ctx is None:
         return
-    if _retrieval_off(searcher, top_k):
-        # Chat-only mode, no embedder, or an explicit top_k:0 pure-LLM call:
-        # answer directly with no RAG context.
-        sources: list[SearchChunk] = []
-        messages = searcher.direct_messages(question, history)
-    else:
-        try:
-            rag = searcher.build_rag_context(
-                question, top_k=top_k or 0, history=history, chunk_type=chunk_type
-            )
-        except EmbeddingModelMismatchError as exc:
-            # detail carries the index's embedder so the client can offer to adopt it.
-            detail = exc.persisted_model if exc.dims_match else None
-            yield sse_error(str(exc), code=SseErrorCode.INDEX_EMBEDDER_MISMATCH, detail=detail)
-            return
-        if rag is None:
-            yield sse_error("No relevant documents found.")
-            return
-        sources, messages = rag
+    sources, messages = ctx
 
     req = _build_canonical_request(messages, options)
     answer_parts: list[str] = []
+    # Only grounded turns append an authoritative SOURCES event, so only they
+    # need a model-generated Sources block suppressed.
+    cite_filter = StreamingCitationFilter() if sources else None
     try:
         async for event in _cap_aware_chat_events(req):
-            if (
-                isinstance(event, StreamToken)
-                and not event.is_reasoning
-                # The reasoning-exhausted notice is streamed to the client but is
-                # not a real answer: keep it out of answer_parts so it seeds no
-                # memory and isn't treated as a citation source (bb-cpu).
-                and event.content != REASONING_EXHAUSTED_NOTICE
-            ):
-                answer_parts.append(event.content)
-            yield _sse_for_chat_event(event)
+            frame = _chat_answer_frame(event, cite_filter, answer_parts)
+            if frame:
+                yield frame
     except Exception as exc:
         raw = str(exc)
         code, user_message = _classify_stream_error(exc)
@@ -430,15 +500,12 @@ async def _stream_chat_response(
         yield sse_error(user_message, code=code, detail=raw if code else None)
         return
 
-    # SOURCES carries the cited subset (what the answer referenced), falling back
-    # to the full retrieved set when the answer carries no inline citations.
-    # Mirrors Searcher.ask_stream's ``used if used else results``.
-    cited = cited_subset("".join(answer_parts), sources)
-    source_list = cited if cited else sources
-    yield sse_event(SseEvent.SOURCES, [clean_result(s) for s in source_list])
-    yield sse_done({})
-    async for mem_event in _emit_extracted_memories(question, "".join(answer_parts)):
-        yield mem_event
+    tail_frame = _chat_answer_tail_frame(cite_filter, answer_parts)
+    if tail_frame:
+        yield tail_frame
+
+    async for frame in _emit_sources_and_memories(question, answer_parts, sources):
+        yield frame
 
 
 async def _cap_aware_chat_events(
@@ -531,6 +598,50 @@ def _sse_for_chat_event(event: StreamToken | CapNotice) -> str:
         )
     kind = SseEvent.REASONING if event.is_reasoning else SseEvent.TOKEN
     return sse_event(kind, {"token": event.content})
+
+
+def _chat_answer_frame(
+    event: StreamToken | CapNotice,
+    cite_filter: StreamingCitationFilter | None,
+    answer_parts: list[str],
+) -> str:
+    """Render the SSE frame for one chat event and record answer text, dropping a
+    model Sources block on grounded turns. Returns '' when nothing should emit.
+
+    The reasoning-exhausted notice streams to the client but is not a real
+    answer, so it is left out of *answer_parts*: it seeds no memory and is not
+    treated as a citation source.
+    """
+    is_answer = (
+        isinstance(event, StreamToken)
+        and not event.is_reasoning
+        and event.content != REASONING_EXHAUSTED_NOTICE
+    )
+    if not is_answer:
+        return _sse_for_chat_event(event)
+    content = cast("StreamToken", event).content
+    if cite_filter is None:
+        answer_parts.append(content)
+        return _sse_for_chat_event(event)
+    shown = cite_filter.feed(content)
+    if not shown:
+        return ""
+    answer_parts.append(shown)
+    return sse_event(SseEvent.TOKEN, {"token": shown})
+
+
+def _chat_answer_tail_frame(
+    cite_filter: StreamingCitationFilter | None,
+    answer_parts: list[str],
+) -> str:
+    """SSE frame releasing any answer text the filter held back, or '' if none."""
+    if cite_filter is None:
+        return ""
+    tail = cite_filter.flush()
+    if not tail:
+        return ""
+    answer_parts.append(tail)
+    return sse_event(SseEvent.TOKEN, {"token": tail})
 
 
 def _text_from_event(event: Any) -> str:

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -10,6 +10,7 @@ from textual.app import ComposeResult
 from textual.events import Key
 from textual.widgets import Input, TabbedContent
 
+from lilbee.catalog.models import CatalogResult
 from lilbee.catalog.types import ModelTask
 from lilbee.cli.tui.screens.catalog import CatalogScreen
 from lilbee.cli.tui.screens.catalog_grouping import for_you_sort_key, row_cache_signature
@@ -20,6 +21,24 @@ from lilbee.cli.tui.screens.catalog_utils import (
 )
 from lilbee.runtime.hardware import FitChip, FitLevel
 from tests._lilbee_app_test_host import LilbeeAppHost
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No test in this module may reach the network.
+
+    CatalogScreen's mount kicks off fetch workers (HF catalog pages, remote
+    model classification, frontier discovery). A live HF result resolving
+    mid-test raced a test's patched screen and fed a MagicMock into the search
+    filter, a timing-dependent CI flake. Empty results keep every path local;
+    tests that need rows inject them directly.
+    """
+    monkeypatch.setattr(
+        "lilbee.cli.tui.screens.catalog.get_catalog",
+        lambda *a, **k: CatalogResult(total=0, limit=0, offset=0, models=[], has_more=False),
+    )
+    monkeypatch.setattr("lilbee.cli.tui.screens.catalog.classify_all_remote_models", lambda: [])
+    monkeypatch.setattr("lilbee.modelhub.model_manager.discover_api_models", lambda: {})
 
 
 def _row(

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -66,6 +66,23 @@ class _CatalogTestApp(LilbeeAppHost):
         yield CatalogScreen()
 
 
+def _fake_tabs_query_one(screen: CatalogScreen, fake_tabs: object):
+    """A ``query_one`` substitute faking only the ``#catalog-tabs`` strip.
+
+    Faking every query poisons unrelated lookups: a mount-time fetch worker
+    resolving mid-test re-renders rows and reads the search input through
+    ``query_one``, and a MagicMock search needle blows up row matching.
+    """
+    real_query_one = screen.query_one
+
+    def query_one(selector, *args, **kwargs):
+        if selector == "#catalog-tabs":
+            return fake_tabs
+        return real_query_one(selector, *args, **kwargs)
+
+    return query_one
+
+
 async def test_action_select_tab_switches_active_tab() -> None:
     from tests._async_wait import wait_until
 
@@ -576,7 +593,7 @@ async def test_activate_initial_tab_retries_while_tab_strip_mounts(monkeypatch) 
             ],
         )
         rescheduled: list[object] = []
-        monkeypatch.setattr(screen, "query_one", lambda *_a, **_k: fake_tabs)
+        monkeypatch.setattr(screen, "query_one", _fake_tabs_query_one(screen, fake_tabs))
         monkeypatch.setattr(screen, "call_after_refresh", lambda fn, *a: rescheduled.append(fn))
         budget = screen._activation_retries
         screen._activate_initial_tab()  # must not raise
@@ -601,7 +618,7 @@ async def test_activate_initial_tab_retry_budget_exhausts(monkeypatch) -> None:
             side_effect=["discover", ValueError("No Tab with id '--content-tab-chat'")],
         )
         rescheduled: list[object] = []
-        monkeypatch.setattr(screen, "query_one", lambda *_a, **_k: fake_tabs)
+        monkeypatch.setattr(screen, "query_one", _fake_tabs_query_one(screen, fake_tabs))
         monkeypatch.setattr(screen, "call_after_refresh", lambda fn, *a: rescheduled.append(fn))
         # The post-activation boot fetches are exercised elsewhere; the fake
         # TabbedContent would otherwise leak into their tab-id parsing.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -212,10 +212,21 @@ class TestFormatSource:
         r = _make_result(source="_web/index.md", content_type="text")
         assert format_source(r).startswith("[_web/index.md](file://")
 
-    def test_unresolvable_path_renders_plain_label_without_link(self):
-        # An embedded null byte can't resolve to a file URL; degrade to bare text.
-        r = _make_result(source="bad\x00name.md", content_type="text")
-        assert format_source(r) == "bad\x00name.md"
+    def test_unresolvable_path_renders_plain_label_without_link(self, monkeypatch):
+        # A source that can't resolve to a file URL degrades to bare text. The
+        # failure is injected directly: OS-level triggers like null bytes vary
+        # by platform and Python version (Windows 3.13 percent-encodes NUL
+        # instead of raising).
+        class _UnresolvableDir:
+            def __truediv__(self, other: str) -> "_UnresolvableDir":
+                raise OSError("cannot resolve")
+
+        monkeypatch.setattr(
+            "lilbee.retrieval.query.formatting.cfg",
+            mock.Mock(documents_dir=_UnresolvableDir()),
+        )
+        r = _make_result(source="doc.md", content_type="text")
+        assert format_source(r) == "doc.md"
 
 
 class TestUniqueSources:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -11,17 +11,19 @@ from lilbee.providers.base import ChatResult, FinishReason
 from lilbee.retrieval.query import (
     Searcher,
     build_context,
-    deduplicate_sources,
     filter_results,
     format_source,
+    format_sources_block,
     sort_by_relevance,
     strip_llm_citations,
 )
 from lilbee.retrieval.query.dedup import _relevance_weight
 from lilbee.retrieval.query.formatting import (
+    StreamingCitationFilter,
     _extract_cited_indices,
     _format_citation,
     cited_subset,
+    unique_sources,
 )
 from lilbee.retrieval.query.searcher import _GROUNDED_REFUSAL, SEARCH_NEEDS_EMBEDDER
 from tests.conftest import make_citation
@@ -190,33 +192,68 @@ class TestFormatSource:
         r = _make_result(source="readme.md", content_type="text")
         result = format_source(r)
         assert "readme.md" in result
-        # Text sources should not carry page/line annotations appended after
-        # the source path. The path itself may contain "page" or "line" as
-        # substrings (e.g. tmp dirs), so only check the tail.
-        tail = result.split("readme.md", 1)[1]
-        assert "page" not in tail
-        assert "line" not in tail
+        # Text sources carry no page/line locator suffix (", page N" / ", line N").
+        assert ", page" not in result
+        assert ", line" not in result
+
+    def test_renders_a_clickable_markdown_link(self):
+        r = _make_result(source="notes/readme.md", content_type="text")
+        result = format_source(r)
+        # [label](file-url): readable label, file:// target so the reader can open it.
+        assert result.startswith("[notes/readme.md](file://")
+        assert result.endswith(".md)")
+
+    def test_web_source_gets_a_readable_host_slug_label(self):
+        r = _make_result(source="_web/www.example.com/how-to-foo/index.md", content_type="text")
+        assert format_source(r).startswith("[example.com · how-to-foo](file://")
+
+    def test_degenerate_web_path_keeps_raw_source_label(self):
+        # Nothing left after dropping index.md: fall back to the stored path.
+        r = _make_result(source="_web/index.md", content_type="text")
+        assert format_source(r).startswith("[_web/index.md](file://")
+
+    def test_unresolvable_path_renders_plain_label_without_link(self):
+        # An embedded null byte can't resolve to a file URL; degrade to bare text.
+        r = _make_result(source="bad\x00name.md", content_type="text")
+        assert format_source(r) == "bad\x00name.md"
 
 
-class TestDeduplicateSources:
-    def test_removes_duplicates(self):
+class TestUniqueSources:
+    def test_first_chunk_per_distinct_source_in_order(self):
         results = [
-            _make_result(source="a.pdf", page_start=1, page_end=1),
-            _make_result(source="a.pdf", page_start=1, page_end=1),
-            _make_result(source="b.pdf", page_start=2, page_end=2),
+            _make_result(source="a.md", chunk="a1"),
+            _make_result(source="b.md", chunk="b1"),
+            _make_result(source="a.md", chunk="a2"),
         ]
-        citations = deduplicate_sources(results)
-        assert len(citations) == 2
+        uniq = unique_sources(results)
+        assert [r.source for r in uniq] == ["a.md", "b.md"]
+        assert uniq[0].chunk == "a1"
 
-    def test_caps_at_max_citations(self):
-        results = [_make_result(source=f"file{i}.pdf", page_start=i, page_end=i) for i in range(10)]
-        citations = deduplicate_sources(results, max_citations=5)
-        assert len(citations) == 5
 
-    def test_custom_max_citations(self):
-        results = [_make_result(source=f"file{i}.pdf", page_start=i, page_end=i) for i in range(10)]
-        citations = deduplicate_sources(results, max_citations=3)
-        assert len(citations) == 3
+class TestFormatSourcesBlock:
+    def test_numbers_each_unique_source_matching_inline_markers(self):
+        results = [
+            _make_result(source="a.md", content_type="text"),
+            _make_result(source="b.md", content_type="text"),
+        ]
+        block = format_sources_block(results)
+        assert block.startswith("\n\nSources:\n\n")
+        assert "1. [a.md](file://" in block
+        assert "2. [b.md](file://" in block
+
+    def test_collapses_repeated_source_to_one_number(self):
+        results = [
+            _make_result(source="a.md", content_type="text"),
+            _make_result(source="a.md", content_type="text"),
+            _make_result(source="b.md", content_type="text"),
+        ]
+        block = format_sources_block(results)
+        assert "1. [a.md](file://" in block
+        assert "2. [b.md](file://" in block
+        assert "3." not in block
+
+    def test_empty_when_no_sources(self):
+        assert format_sources_block([]) == ""
 
 
 class TestSortByRelevance:
@@ -317,12 +354,27 @@ class TestDiversifySources:
 
 
 class TestBuildContext:
-    def test_numbers_chunks(self):
-        results = [_make_result(chunk="chunk one"), _make_result(chunk="chunk two")]
+    def test_numbers_passages_by_source(self):
+        results = [
+            _make_result(source="a.md", chunk="chunk one"),
+            _make_result(source="b.md", chunk="chunk two"),
+        ]
         ctx = build_context(results)
-        assert "[1]" in ctx
-        assert "[2]" in ctx
-        assert "chunk one" in ctx
+        assert "[1] chunk one" in ctx
+        assert "[2] chunk two" in ctx
+
+    def test_passages_from_the_same_source_share_a_number(self):
+        # Stable, streamable numbers that map 1:1 to the Sources block: two
+        # passages from one file are both [1], the next distinct file is [2].
+        results = [
+            _make_result(source="a.md", chunk="one"),
+            _make_result(source="a.md", chunk="two"),
+            _make_result(source="b.md", chunk="three"),
+        ]
+        ctx = build_context(results)
+        assert "[1] one" in ctx
+        assert "[1] two" in ctx
+        assert "[2] three" in ctx
 
 
 @pytest.mark.usefixtures("wiki_enabled")
@@ -537,6 +589,46 @@ class TestFormattingHelpers:
         assert cited_subset("[5] does not exist", [_make_result()]) == []
 
 
+class TestStreamingCitationFilter:
+    """The streamed answer must never surface a model-generated Sources block,
+    since lilbee appends its own authoritative one right after."""
+
+    @staticmethod
+    def _run(chunks: list[str]) -> tuple[str, StreamingCitationFilter]:
+        f = StreamingCitationFilter()
+        shown = "".join(f.feed(c) for c in chunks) + f.flush()
+        return shown, f
+
+    def test_passes_answer_without_a_citation_block_through_verbatim(self):
+        shown, f = self._run(["The answer ", "is 42.\n\nMore ", "detail here."])
+        assert shown == "The answer is 42.\n\nMore detail here."
+        assert f.answer == "The answer is 42.\n\nMore detail here."
+
+    def test_drops_a_trailing_sources_block(self):
+        shown, f = self._run(["Grounded answer [1].", "\n\nSources:\n- made-up.pdf"])
+        assert "made-up.pdf" not in shown
+        assert "Sources:" not in shown
+        assert shown.startswith("Grounded answer [1].")
+        assert "made-up.pdf" not in f.answer
+
+    def test_never_leaks_a_heading_split_across_chunks(self):
+        # "References:" arrives one letter at a time, then its list.
+        chunks = ["Body text.", "\n\nRef", "erences", ":", "\n- x.pdf", "\n- y.pdf"]
+        shown, _ = self._run(chunks)
+        assert "References" not in shown
+        assert "x.pdf" not in shown
+        assert shown.startswith("Body text.")
+
+    def test_holds_only_the_trailing_partial_line(self):
+        # A completed line is released promptly (its newline waits with the next
+        # line so a citation heading right after it can never leak); only the
+        # final line is held until flush.
+        f = StreamingCitationFilter()
+        assert f.feed("first line\n") == "first line"
+        assert f.feed("second line") == ""
+        assert f.flush() == "\nsecond line"
+
+
 class TestCitedSources:
     """bb-ky3: ask_raw exposes the answer's cited subset so JSON consumers get
     the same citation truth the string method computes."""
@@ -558,15 +650,18 @@ class TestCitedSources:
         assert result.sources
         assert result.cited_sources == []
 
-    def test_ask_lists_only_the_cited_source(self, mock_svc):
+    def test_ask_numbers_sources_to_match_inline_markers(self, mock_svc):
+        # The text answer lists every retrieved source numbered, so an inline [1]
+        # resolves to source 1 in the block. (Which sources were actually cited
+        # is exposed separately via ask_raw().cited_sources, tested above.)
         mock_svc.store.search.return_value = [
             _make_result(source="a.pdf", chunk="alpha", distance=0.1),
             _make_result(source="b.pdf", chunk="beta", distance=0.2),
         ]
         mock_svc.provider.chat.return_value = _text_result("From [1] we learn the answer.")
         answer = get_services().searcher.ask("q")
-        assert "a.pdf" in answer
-        assert "b.pdf" not in answer
+        assert "1. [a.pdf](file://" in answer
+        assert "2. [b.pdf](file://" in answer
 
 
 class TestContextBudget:
@@ -701,6 +796,20 @@ class TestAskStream:
         combined = "".join(st.content for st in stream_tokens)
         assert "Hello world" in combined
         assert "Sources:" in combined
+
+    def test_model_sources_block_is_suppressed_leaving_one_authoritative_list(self, mock_svc):
+        """A model that appends its own Sources block must not double up with
+        lilbee's: the streamed output carries exactly one Sources block and none
+        of the model's invented source lines."""
+        mock_svc.store.search.return_value = [_make_result(source="real.pdf", chunk="alpha")]
+        mock_svc.provider.chat.return_value = iter(
+            ["Grounded answer [1].", "\n\nSources:\n- invented.pdf"]
+        )
+        combined = "".join(st.content for st in get_services().searcher.ask_stream("test"))
+        assert combined.count("Sources:") == 1
+        assert "invented.pdf" not in combined
+        assert "real.pdf" in combined
+        assert "Grounded answer [1]." in combined
 
     def test_empty_results_streams_grounded_refusal(self, mock_svc):
         """Zero RAG hits stream a single grounded-refusal token, no Sources block,
@@ -2108,15 +2217,17 @@ class TestExtractCitedIndices:
         assert _extract_cited_indices("[1] and [1] again.") == {1}
 
 
-class TestAskCitesOnlyUsedSources:
-    def test_ask_cites_only_referenced(self, mock_svc):
+class TestAskSourcesBlock:
+    def test_ask_numbers_all_sources_so_markers_resolve(self, mock_svc):
+        # Every retrieved source is listed and numbered so an inline [1] resolves
+        # to source 1; the answer no longer drops the passages it didn't cite.
         r1 = _make_result(source="used.pdf", chunk="oil info", chunk_index=0)
         r2 = _make_result(source="unused.pdf", chunk="unrelated", chunk_index=1)
         mock_svc.store.search.return_value = [r1, r2]
         mock_svc.provider.chat.return_value = _text_result("Oil is 5 quarts [1].")
         answer = get_services().searcher.ask("oil capacity?")
-        assert "used.pdf" in answer
-        assert "unused.pdf" not in answer
+        assert "1. [used.pdf](file://" in answer
+        assert "2. [unused.pdf](file://" in answer
 
     def test_ask_falls_back_to_all_sources_when_no_refs(self, mock_svc):
         r1 = _make_result(source="a.pdf", chunk="oil info", chunk_index=0)
@@ -2135,16 +2246,25 @@ class TestAskCitesOnlyUsedSources:
         assert answer.count("Sources:") == 1
 
 
-class TestAskStreamCitesOnlyUsedSources:
-    def test_stream_cites_only_referenced(self, mock_svc):
+class TestAskStreamSourcesBlock:
+    def test_stream_releases_held_back_final_line_before_sources(self, mock_svc):
+        # The filter holds the last (possibly partial) line until the stream
+        # ends; the flush tail must still reach the reader ahead of the block.
+        mock_svc.store.search.return_value = [_make_result(source="a.pdf", chunk="oil")]
+        mock_svc.provider.chat.return_value = iter(["First line [1].\n", "Held final line."])
+        combined = "".join(st.content for st in get_services().searcher.ask_stream("q"))
+        assert "First line [1].\nHeld final line." in combined
+        assert combined.index("Held final line.") < combined.index("Sources:")
+
+    def test_stream_numbers_all_sources_so_markers_resolve(self, mock_svc):
         r1 = _make_result(source="used.pdf", chunk="oil info", chunk_index=0)
         r2 = _make_result(source="unused.pdf", chunk="unrelated", chunk_index=1)
         mock_svc.store.search.return_value = [r1, r2]
         mock_svc.provider.chat.return_value = iter(["Oil is 5 quarts ", "[1]."])
         tokens = list(get_services().searcher.ask_stream("oil capacity?"))
         combined = "".join(st.content for st in tokens)
-        assert "used.pdf" in combined
-        assert "unused.pdf" not in combined
+        assert "1. [used.pdf](file://" in combined
+        assert "2. [unused.pdf](file://" in combined
 
     def test_stream_falls_back_when_no_refs(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result(source="a.pdf", chunk="oil")]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -619,6 +619,31 @@ class TestStreamingCitationFilter:
         assert "x.pdf" not in shown
         assert shown.startswith("Body text.")
 
+    def test_prose_after_a_heading_line_streams_through(self):
+        # A heading the answer legitimately discusses is not a citation block:
+        # no list follows, so the heading and its prose both reach the reader.
+        chunks = ["The paper is structured simply.", "\n\nReferences:", "\nIt lists 40 works."]
+        shown, f = self._run(chunks)
+        assert "References:" in shown
+        assert "It lists 40 works." in shown
+        assert f.answer.endswith("It lists 40 works.")
+
+    def test_dangling_heading_at_stream_end_is_dropped(self):
+        # The model emitted a citation heading and stopped; showing it would put
+        # a stray "Sources:" right above lilbee's authoritative block.
+        shown, f = self._run(["Grounded answer [1].", "\n\nSources:\n"])
+        assert "Sources" not in shown
+        assert shown == "Grounded answer [1]."
+        assert f.answer == "Grounded answer [1]."
+
+    def test_heading_is_held_not_shown_while_ambiguous(self):
+        # Mid-stream, a bare heading must not be emitted until the next line
+        # decides list (drop) versus prose (show).
+        f = StreamingCitationFilter()
+        assert f.feed("Answer.\n\nSources:\n") == "Answer."
+        assert f.feed("- fake.pdf\n- other.pdf") == ""
+        assert f.flush() == ""
+
     def test_holds_only_the_trailing_partial_line(self):
         # A completed line is released promptly (its newline waits with the next
         # line so a citation heading right after it can never leak); only the
@@ -2204,6 +2229,16 @@ class TestStripLlmCitations:
     def test_preserves_inline_source_mention(self):
         text = "The sources indicate that oil capacity is 5 quarts."
         assert strip_llm_citations(text) == text
+
+    def test_preserves_heading_followed_by_prose(self):
+        # An answer discussing a document's References section is not a
+        # citation block; only heading-plus-list gets stripped.
+        text = "The paper has three parts.\n\nReferences:\nIt lists 40 works."
+        assert strip_llm_citations(text) == text
+
+    def test_removes_dangling_heading(self):
+        text = "The answer is 42.\n\nSources:\n"
+        assert strip_llm_citations(text) == "The answer is 42."
 
 
 class TestExtractCitedIndices:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -459,6 +459,78 @@ class TestAskStream:
         payload = json.loads(sources_event.split("data: ")[1].strip())
         assert [s["source"] for s in payload] == ["cited.md"]
 
+    async def test_model_sources_block_suppressed_in_grounded_stream(self, mock_svc):
+        """A model that appends its own Sources block must not double up with the
+        authoritative SOURCES event: no token frame carries the model's list."""
+        cited = _SAMPLE_CHUNK.model_copy(update={"source": "real.md", "chunk_index": 0})
+        mock_svc.searcher.build_rag_context.return_value = ([cited], [])
+        mock_svc.provider.chat.return_value = iter(
+            ["Grounded answer [1].", "\n\nSources:\n- invented.md"]
+        )
+        events = [e async for e in handlers.ask_stream("question")]
+        token_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: token")
+        )
+        assert "invented.md" not in token_text
+        assert "Sources:" not in token_text
+        assert "Grounded answer [1]." in token_text
+        sources_event = next(e for e in events if e and e.startswith("event: sources"))
+        payload = json.loads(sources_event.split("data: ")[1].strip())
+        assert [s["source"] for s in payload] == ["real.md"]
+
+    async def test_grounded_stream_releases_held_back_final_line(self, mock_svc):
+        """The citation filter holds the last line until the stream ends; the
+        flushed tail must still be emitted as a token before SOURCES."""
+        cited = _SAMPLE_CHUNK.model_copy(update={"source": "real.md", "chunk_index": 0})
+        mock_svc.searcher.build_rag_context.return_value = ([cited], [])
+        mock_svc.provider.chat.return_value = iter(["First line [1].\n", "Held final line."])
+        events = [e async for e in handlers.ask_stream("question")]
+        token_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: token")
+        )
+        assert "First line [1].\nHeld final line." in token_text
+
+    async def test_grounded_stream_forwards_reasoning_tokens(self, mock_svc, monkeypatch):
+        """With show_reasoning on, reasoning content streams on the reasoning
+        channel and stays out of the answer (and the citation filter)."""
+        monkeypatch.setattr(cfg, "show_reasoning", True)
+        cited = _SAMPLE_CHUNK.model_copy(update={"source": "real.md", "chunk_index": 0})
+        mock_svc.searcher.build_rag_context.return_value = ([cited], [])
+        mock_svc.provider.chat.return_value = iter(["<think>pondering</think>", "answer [1]"])
+        events = [e async for e in handlers.ask_stream("question")]
+        reasoning_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: reasoning")
+        )
+        token_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: token")
+        )
+        assert "pondering" in reasoning_text
+        assert "answer [1]" in token_text
+        assert "pondering" not in token_text
+
+    async def test_ungrounded_stream_leaves_model_sources_intact(self, mock_svc):
+        """Chat mode has no authoritative list, so a model Sources block streams
+        verbatim (matching CLI direct streaming) rather than being stripped."""
+        mock_svc.searcher.skip_retrieval.return_value = True
+        mock_svc.searcher.direct_messages.return_value = [{"role": "user", "content": "q"}]
+        mock_svc.provider.chat.return_value = iter(["Answer.", "\n\nSources:\n- x.md"])
+        events = [e async for e in handlers.ask_stream("q")]
+        token_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: token")
+        )
+        assert "Sources:" in token_text
+        assert "x.md" in token_text
+
     async def test_unknown_error_yields_internal_error(self, mock_svc):
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
         mock_svc.provider.chat.side_effect = RuntimeError("model missing")
@@ -902,6 +974,46 @@ class TestChatStream:
         sources_event = next(e for e in events if e and e.startswith("event: sources"))
         payload = json.loads(sources_event.split("data: ")[1].strip())
         assert [s["source"] for s in payload] == ["a.md", "b.md"]
+
+    async def test_model_sources_block_suppressed_in_grounded_stream(self, mock_svc, monkeypatch):
+        """A model Sources block in chat streaming is dropped so it doesn't double
+        up with the authoritative SOURCES event."""
+        cited = _SAMPLE_CHUNK.model_copy(update={"source": "real.md", "chunk_index": 0})
+        mock_svc.searcher.build_rag_context.return_value = ([cited], [])
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat_stream",
+            lambda req: _canonical_text_stream(["Grounded [1].", "\n\nSources:\n- invented.md"]),
+        )
+        events = [e async for e in handlers.chat_stream("q", [])]
+        token_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: token")
+        )
+        assert "invented.md" not in token_text
+        assert "Sources:" not in token_text
+        assert "Grounded [1]." in token_text
+        sources_event = next(e for e in events if e and e.startswith("event: sources"))
+        payload = json.loads(sources_event.split("data: ")[1].strip())
+        assert [s["source"] for s in payload] == ["real.md"]
+
+    async def test_chat_stream_releases_held_back_final_line(self, mock_svc, monkeypatch):
+        """The chat SSE path also flushes the filter's held-back tail as a token."""
+        cited = _SAMPLE_CHUNK.model_copy(update={"source": "real.md", "chunk_index": 0})
+        mock_svc.searcher.build_rag_context.return_value = ([cited], [])
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat_stream",
+            lambda req: _canonical_text_stream(["First line [1].\n", "Held final line."]),
+        )
+        events = [e async for e in handlers.chat_stream("q", [])]
+        token_text = "".join(
+            json.loads(e.split("data: ")[1].strip())["token"]
+            for e in events
+            if e and e.startswith("event: token")
+        )
+        assert "First line [1].\nHeld final line." in token_text
 
     async def test_emits_warming_event_when_chat_cold(self, mock_svc, monkeypatch):
         mock_svc.provider.role_ready.return_value = False
@@ -3831,6 +3943,7 @@ class TestRunLlmStreamCancel:
                 cancel,
                 error_holder,
                 [],
+                None,
             )
         # Should have None sentinel
         items = []
@@ -3880,6 +3993,7 @@ class TestReasoningCapHandling:
                     cancel,
                     error_holder,
                     [],
+                    None,
                 )
 
             events = self._drain(queue)
@@ -3916,6 +4030,7 @@ class TestReasoningCapHandling:
                     cancel,
                     error_holder,
                     [],
+                    None,
                 )
 
             assert mock_provider.chat.call_count == 1
@@ -3957,6 +4072,7 @@ class TestReasoningCapHandling:
                     cancel,
                     error_holder,
                     [],
+                    None,
                 )
 
             assert mock_provider.chat.call_count == 1
@@ -3992,6 +4108,7 @@ class TestReasoningCapHandling:
                     cancel,
                     error_holder,
                     [],
+                    None,
                 )
 
             events = self._drain(queue)

--- a/tests/test_tui_open_link.py
+++ b/tests/test_tui_open_link.py
@@ -1,0 +1,86 @@
+"""Answer citation links: the markdown parser admits file: URLs and clicks open
+the source file with the OS opener instead of a browser."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from textual.widgets import Markdown
+
+from lilbee.cli.tui.screens import chat as chat_screen
+from lilbee.cli.tui.screens.chat_helpers import _opener_argv, open_local_file
+from lilbee.cli.tui.widgets.message import _answer_markdown_parser
+
+
+class TestAnswerMarkdownParser:
+    def test_admits_file_links(self):
+        assert _answer_markdown_parser().validateLink("file:///Users/t/doc.md")
+
+    def test_keeps_default_scheme_rejections(self):
+        # Only file: is re-admitted; the XSS-guard defaults stay in force.
+        assert not _answer_markdown_parser().validateLink("javascript:alert(1)")
+
+    def test_parses_a_sources_block_file_link(self):
+        tokens = _answer_markdown_parser().parse("1. [label](file:///Users/t/My%20Docs/doc.md)")
+        links = [t for tok in tokens if tok.children for t in tok.children if t.type == "link_open"]
+        assert [link.attrs["href"] for link in links] == ["file:///Users/t/My%20Docs/doc.md"]
+
+
+class TestOpenerArgv:
+    @pytest.mark.parametrize(
+        ("platform", "expected"),
+        [
+            ("darwin", ["open"]),
+            ("linux", ["xdg-open"]),
+            ("linux2", ["xdg-open"]),
+            ("win32", None),
+        ],
+    )
+    def test_platform_opener(self, platform, expected):
+        assert _opener_argv(platform) == expected
+
+
+class TestOpenLocalFile:
+    def test_opens_decoded_path_with_platform_opener(self, monkeypatch):
+        monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.sys.platform", "darwin")
+        run = mock.Mock()
+        monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.subprocess.run", run)
+        open_local_file("file:///Users/t/My%20Docs/doc.md")
+        assert run.call_args.args[0] == ["open", "/Users/t/My Docs/doc.md"]
+
+    def test_unknown_platform_falls_back_to_webbrowser(self, monkeypatch):
+        monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.sys.platform", "win32")
+        opened = mock.Mock()
+        monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.webbrowser.open", opened)
+        open_local_file("file:///C:/docs/doc.md")
+        opened.assert_called_once_with("file:///C:/docs/doc.md")
+
+    def test_opener_failure_is_logged_not_raised(self, monkeypatch):
+        monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.sys.platform", "linux")
+        monkeypatch.setattr(
+            "lilbee.cli.tui.screens.chat_helpers.subprocess.run",
+            mock.Mock(side_effect=OSError("no xdg-open")),
+        )
+        open_local_file("file:///home/t/doc.md")  # must not raise
+
+
+class TestOpenAnswerLink:
+    def _click(self, href: str) -> Markdown.LinkClicked:
+        return Markdown.LinkClicked(mock.Mock(spec=Markdown), href)
+
+    def test_file_link_opens_locally(self, monkeypatch):
+        opened = mock.Mock()
+        monkeypatch.setattr(chat_screen, "open_local_file", opened)
+        screen = mock.Mock()
+        chat_screen.ChatScreen._open_answer_link(screen, self._click("file:///tmp/doc.md"))
+        opened.assert_called_once_with("file:///tmp/doc.md")
+        screen.app.open_url.assert_not_called()
+
+    def test_web_link_opens_in_browser(self, monkeypatch):
+        opened = mock.Mock()
+        monkeypatch.setattr(chat_screen, "open_local_file", opened)
+        screen = mock.Mock()
+        chat_screen.ChatScreen._open_answer_link(screen, self._click("https://example.com/page"))
+        screen.app.open_url.assert_called_once_with("https://example.com/page")
+        opened.assert_not_called()

--- a/tests/test_tui_open_link.py
+++ b/tests/test_tui_open_link.py
@@ -43,11 +43,17 @@ class TestOpenerArgv:
 
 class TestOpenLocalFile:
     def test_opens_decoded_path_with_platform_opener(self, monkeypatch):
+        # url2pathname's separator style varies by host OS, so assert the two
+        # behaviors that matter (opener choice, %20 decoded) not the literal path.
         monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.sys.platform", "darwin")
         run = mock.Mock()
         monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.subprocess.run", run)
         open_local_file("file:///Users/t/My%20Docs/doc.md")
-        assert run.call_args.args[0] == ["open", "/Users/t/My Docs/doc.md"]
+        opener, path = run.call_args.args[0]
+        assert opener == "open"
+        assert "My Docs" in path
+        assert path.endswith("doc.md")
+        assert "%20" not in path
 
     def test_unknown_platform_falls_back_to_webbrowser(self, monkeypatch):
         monkeypatch.setattr("lilbee.cli.tui.screens.chat_helpers.sys.platform", "win32")


### PR DESCRIPTION
## Problem

Three citation bugs in chat answers:

1. Inline markers were numbered by retrieval position, but the Sources block was a deduplicated file list. An answer could cite [6] above a three-entry list with nothing to point at.
2. A model that wrote its own Sources list doubled up with lilbee's authoritative block in streaming, where already-emitted tokens can't be retracted.
3. Source lines rendered as raw home-directory paths. Turning them into markdown links didn't help: markdown-it rejects file: destinations by default, so the TUI showed raw `[label](file://...)` text.

**Before**

```
...redistributes energy evenly [3], minimizing wasted growth [1].
Easier from seed than from clones [7].

Sources: → ~/Library/Application Support/lilbee/documents/_web/example.com/training-guide/index.md → ~/Library/Application Support/lilbee/documents/_web/example.com/quick-guide/index.md → ~/Library/...
```

[7] resolves to nothing, the list has three unnumbered entries, and the paths wrap into an unreadable blob.

**After**

```
...redistributes energy evenly [1], minimizing wasted growth [2].
Easier from seed than from clones [3].

Sources:

 1. example.com · training-guide
 2. example.com · quick-guide
 3. example.com · glossary
```

Every inline number resolves to a line in the list. Each label renders as a clickable link that opens the source in the default app for its file type.

## Solution

- Passages are numbered by source file, not retrieval position. Numbers stay stable while streaming, dedupe naturally, and match the Sources list one to one; `cited_subset` reverses the same mapping so the structured SOURCES event and `cited_sources` agree with the text.
- A `StreamingCitationFilter` drops model-authored Sources/References blocks on all three streaming surfaces by holding back only the trailing incomplete line of the answer. The rewritten prompt also tells the model not to write one.
- Sources render as markdown links with readable labels; web-crawled docs collapse to `host · slug`. The TUI answer widget re-admits the file: scheme through a markdown-it subclass, and clicks route to the OS opener.
- The answer prompt is rewritten for mixed material: synthesize across passages, note conflicts, lay procedures out as ordered steps, and name what's missing when the context only partially covers a request.
