### PR TITLE
Centralize engine source pins and bump gguf-parser to v0.25.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Sourced by bash on every platform; a CRLF checkout would embed \r in the pins.
+engine-versions.env text eol=lf

--- a/.github/actions/bundle-llama-server/action.yml
+++ b/.github/actions/bundle-llama-server/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   llama-cpp-version:
     description: >-
-      llama.cpp source tag to build from (blank = the pin in build_llama_server.sh).
+      llama.cpp source tag to build from (blank = the pin in engine-versions.env).
       Set for a backend whose toolchain can't compile the default (e.g. CUDA 12.1).
     required: false
     default: ""
@@ -37,7 +37,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: packaging/engine-wheel/lilbee_engine/bin
-        key: engine-${{ inputs.cache-env }}-${{ inputs.backend }}-tk${{ inputs.toolkit-version }}-llcp${{ inputs.llama-cpp-version }}-${{ hashFiles('tools/wheel-build/build_llama_server.sh', 'tools/wheel-build/cmake_args.sh', 'tools/wheel-build/install_gpu_toolkit.sh') }}
+        key: engine-${{ inputs.cache-env }}-${{ inputs.backend }}-tk${{ inputs.toolkit-version }}-llcp${{ inputs.llama-cpp-version }}-${{ hashFiles('engine-versions.env', 'tools/wheel-build/build_llama_server.sh', 'tools/wheel-build/cmake_args.sh', 'tools/wheel-build/install_gpu_toolkit.sh') }}
     - name: Set up Go (for llama-swap + gguf-parser)
       if: steps.engine-cache.outputs.cache-hit != 'true'
       uses: actions/setup-go@v5

--- a/.github/workflows/build-multigpu.yml
+++ b/.github/workflows/build-multigpu.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       llama_cpp_version:
-        description: "Override the llama-cpp-python release tag whose vendored llama.cpp gets built (blank = the pin in tools/wheel-build/build_llama_server.sh)."
+        description: "Override the llama-cpp-python release tag whose vendored llama.cpp gets built (blank = the pin in engine-versions.env)."
         default: ""
         required: false
   workflow_call:
@@ -22,7 +22,7 @@ on:
         type: string
         default: ""
       llama_cpp_version:
-        description: "Override the llama-cpp-python release tag whose vendored llama.cpp gets built (blank = the pin in tools/wheel-build/build_llama_server.sh)."
+        description: "Override the llama-cpp-python release tag whose vendored llama.cpp gets built (blank = the pin in engine-versions.env)."
         type: string
         default: ""
 
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: echo "LLAMA_BUILD_DIR=/c/lb" >> "$GITHUB_ENV"
 
-      # Every engine source is tag-pinned in build_llama_server.sh, so the same
+      # Every engine source is tag-pinned in engine-versions.env, so the same
       # key means byte-identical output. Caches saved from tag runs are not
       # restorable by later runs, so warm-engine-cache.yml builds these on main;
       # release runs (and the executable bundle steps, which share this key
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packaging/engine-wheel/lilbee_engine/bin
-          key: engine-${{ matrix.os }}-${{ matrix.backend }}-tk${{ matrix.cuda }}-llcp${{ inputs.llama_cpp_version }}-${{ hashFiles('tools/wheel-build/build_llama_server.sh', 'tools/wheel-build/cmake_args.sh', 'tools/wheel-build/install_gpu_toolkit.sh') }}
+          key: engine-${{ matrix.os }}-${{ matrix.backend }}-tk${{ matrix.cuda }}-llcp${{ inputs.llama_cpp_version }}-${{ hashFiles('engine-versions.env', 'tools/wheel-build/build_llama_server.sh', 'tools/wheel-build/cmake_args.sh', 'tools/wheel-build/install_gpu_toolkit.sh') }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,22 +208,20 @@ jobs:
 
       - name: Install llama-swap + gguf-parser (engine helpers)
         shell: bash
-        env:
-          # Keep in sync with tools/wheel-build/build_llama_server.sh.
-          LLAMA_SWAP_VERSION: v223
-          GGUF_PARSER_REF: main
         run: |
           set -euxo pipefail
+          # Shared pins with tools/wheel-build/build_llama_server.sh.
+          source engine-versions.env
           helperdir="${HOME}/engine-helpers"
           mkdir -p "${helperdir}"
           exe=""
           if [ "${{ runner.os }}" = "Windows" ]; then exe=".exe"; fi
           work="$(mktemp -d)"
-          git clone -q --depth 1 --branch "${LLAMA_SWAP_VERSION}" \
+          git clone -q --depth 1 --branch "${ENGINE_LLAMA_SWAP_VERSION}" \
             https://github.com/mostlygeek/llama-swap.git "${work}/llama-swap"
           ( cd "${work}/llama-swap" && go build -trimpath -o "${helperdir}/llama-swap${exe}" . )
           # gguf-parser's CLI lives under a nested go.mod in cmd/gguf-parser.
-          git clone -q --depth 1 --branch "${GGUF_PARSER_REF}" \
+          git clone -q --depth 1 --branch "${ENGINE_GGUF_PARSER_REF}" \
             https://github.com/gpustack/gguf-parser-go.git "${work}/gguf-parser-go"
           ( cd "${work}/gguf-parser-go/cmd/gguf-parser" && go build -trimpath -o "${helperdir}/gguf-parser${exe}" . )
           if command -v cygpath >/dev/null 2>&1; then

--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -21,6 +21,7 @@ on:
     paths:
       - uv.lock
       - pyproject.toml
+      - engine-versions.env
       - tools/wheel-build/**
       - .github/workflows/flatpak-validate.yml
 

--- a/.github/workflows/warm-engine-cache.yml
+++ b/.github/workflows/warm-engine-cache.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: [main]
     paths:
+      - 'engine-versions.env'
       - 'tools/wheel-build/build_llama_server.sh'
       - 'tools/wheel-build/cmake_args.sh'
       - 'tools/wheel-build/install_gpu_toolkit.sh'

--- a/engine-versions.env
+++ b/engine-versions.env
@@ -1,0 +1,14 @@
+# Pinned sources for the bundled engine, shared by the wheel build
+# (tools/wheel-build/build_llama_server.sh) and CI's engine-helper install.
+# Bump deliberately; a change here invalidates the cached engine binaries.
+#
+# ENGINE_LLAMA_CPP_VERSION: the llama-cpp-python release tag whose vendored
+# llama.cpp commit llama-server is built from. Re-run the Metal/CPU/GPU
+# self-check matrix when bumping. llama-cpp-python is only a BUILD-TIME
+# source; lilbee no longer depends on it at runtime.
+ENGINE_LLAMA_CPP_VERSION=0.3.30
+
+# The two Go engine helpers bundled alongside llama-server, built from source
+# (deterministic, no release-asset-name guessing).
+ENGINE_LLAMA_SWAP_VERSION=v223
+ENGINE_GGUF_PARSER_REF=v0.25.0

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -8,30 +8,23 @@
 # Reads:
 #   BACKEND            cpu|vulkan|metal|cu121..cu125|rocm|sycl
 #   LLAMA_CPP_VERSION  llama.cpp source tag (via the llama-cpp-python release that
-#                      vendors it; defaults to the pin below)
+#                      vendors it; defaults to the pin in engine-versions.env)
 #   TARGET_ARCH        cross-compile target (optional; defaults to host)
 #   LLAMA_BUILD_DIR    work dir (default /tmp/llama-build)
 
 set -euxo pipefail
-
-# Pinned llama.cpp source: the llama-cpp-python release tag whose vendored
-# llama.cpp commit we build the server from. Bump deliberately (and re-run the
-# Metal/CPU/GPU self-check matrix) rather than tracking latest. llama-cpp-python
-# is only a BUILD-TIME source here -- lilbee no longer depends on it at runtime.
-_DEFAULT_LLAMA_CPP_VERSION="0.3.30"
-
-# Pinned source tags for the two Go engine helpers bundled alongside llama-server.
-# Built from source (deterministic, no release-asset-name guessing); the wheel-build
-# job provides the Go toolchain. Bump deliberately.
-_LLAMA_SWAP_VERSION="v223"
-_GGUF_PARSER_REF="v0.24.1"
 
 backend="${BACKEND:?BACKEND is required}"
 build_dir="${LLAMA_BUILD_DIR:-/tmp/llama-build}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 target_arch="${TARGET_ARCH:-}"
 pkg_bin_dir="${script_dir}/../../packaging/engine-wheel/lilbee_engine/bin"
-version="${LLAMA_CPP_VERSION:-${_DEFAULT_LLAMA_CPP_VERSION}}"
+
+# Pinned engine sources live in engine-versions.env at the repo root (shared
+# with CI's engine-helper install). LLAMA_CPP_VERSION from the environment
+# still overrides the pin.
+source "${script_dir}/../../engine-versions.env"
+version="${LLAMA_CPP_VERSION:-${ENGINE_LLAMA_CPP_VERSION}}"
 
 # rpath so the binary and libs find each other from the same dir at runtime.
 case "$(uname -s)" in
@@ -236,11 +229,11 @@ case "$(uname -s)" in MINGW* | MSYS* | CYGWIN*) exe_suffix=".exe" ;; esac
 
 rm -rf "${go_build_dir}"
 mkdir -p "${go_build_dir}"
-clone_with_retry -q --depth 1 --branch "${_LLAMA_SWAP_VERSION}" https://github.com/mostlygeek/llama-swap.git "${go_build_dir}/llama-swap"
+clone_with_retry -q --depth 1 --branch "${ENGINE_LLAMA_SWAP_VERSION}" https://github.com/mostlygeek/llama-swap.git "${go_build_dir}/llama-swap"
 ( cd "${go_build_dir}/llama-swap" && go build -trimpath -o "${pkg_bin_dir}/llama-swap${exe_suffix}" . )
 
 # gguf-parser's cmd has a nested go.mod, so build from inside cmd/gguf-parser.
-clone_with_retry -q --depth 1 --branch "${_GGUF_PARSER_REF}" https://github.com/gpustack/gguf-parser-go.git "${go_build_dir}/gguf-parser-go"
+clone_with_retry -q --depth 1 --branch "${ENGINE_GGUF_PARSER_REF}" https://github.com/gpustack/gguf-parser-go.git "${go_build_dir}/gguf-parser-go"
 ( cd "${go_build_dir}/gguf-parser-go/cmd/gguf-parser" && go build -trimpath -o "${pkg_bin_dir}/gguf-parser${exe_suffix}" . )
 
 echo "Built self-contained engine (${backend}: llama-server + llama-swap + gguf-parser) -> ${pkg_bin_dir}/"


### PR DESCRIPTION
## Problem

The engine source pins (llama.cpp via llama-cpp-python, llama-swap, gguf-parser) were hardcoded inside `tools/wheel-build/build_llama_server.sh`, and CI's engine-helper install carried its own copies behind a keep-in-sync comment that had already drifted: CI built gguf-parser from `main` while release builds pinned v0.24.1. On top of that, v0.24.1 badly inflates VRAM estimates for some multimodal projectors, which gpustack/gguf-parser-go#22 fixed upstream.

## Solution

A single `engine-versions.env` at the repo root now owns all three pins. The build script and CI's engine-helper install both source it, the engine cache keys hash it, and the cache-warming and flatpak-validate push triggers watch it, so a pin bump rebuilds and revalidates the engine everywhere. The file is pinned to LF via `.gitattributes` since bash sources it on Windows runners too, and a CRLF checkout would embed a carriage return in the pin values.

gguf-parser steps up from v0.24.1 to v0.25.0, which fixes multimodal projector VRAM estimates (unknown projector types, flash attention handling, type detection, audio and undeclared-image-size sizing). The tag builds the same way the script builds it (nested go.mod under `cmd/gguf-parser`), and the estimate JSON lilbee parses (`estimate.items` with `ram`/`vrams` `uma`/`nonuma`) is unchanged between the two tags.