### PR TITLE
Keep chat answers through the markdown toggle and report chat_ready only when the engine can serve

### DIFF
--- a/src/lilbee/cli/tui/widgets/message.py
+++ b/src/lilbee/cli/tui/widgets/message.py
@@ -104,8 +104,12 @@ class AssistantMessage(Vertical):
         self._thinking_header = header
         self.mount(header, before=self._content_widget)
 
-    def _build_content_widget(self) -> Markdown | Static:
+    def _build_content_widget(self, text: str = "") -> Markdown | Static:
         """Create the content widget based on the current rendering mode.
+
+        *text* must be passed at construction rather than via a later
+        ``update()``: Textual's Markdown re-renders from its constructor
+        argument on mount, discarding any pre-mount update.
 
         ``open_links=False``: clicks route to the chat screen's link handler,
         which opens ``file:`` citations with the OS opener instead of the
@@ -113,12 +117,12 @@ class AssistantMessage(Vertical):
         """
         if self._use_markdown:
             return Markdown(
-                "",
+                text,
                 classes="response-md",
                 parser_factory=_answer_markdown_parser,
                 open_links=False,
             )
-        return Static("", classes="response-md")
+        return Static(Content(text), classes="response-md")
 
     @property
     def use_markdown(self) -> bool:
@@ -131,9 +135,7 @@ class AssistantMessage(Vertical):
             return
         self._use_markdown = use_markdown
         old = self._content_widget
-        new_widget = self._build_content_widget()
-        text = "".join(self._content_parts)
-        self._set_content(new_widget, text)
+        new_widget = self._build_content_widget("".join(self._content_parts))
         await self.mount(new_widget, after=old)
         self._content_widget = new_widget
         await old.remove()

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -329,13 +329,15 @@ class RoutingProvider(LLMProvider):
 
         A role whose configured ref routes to the SDK backend needs no local
         server, so it is always ready; the local fleet's readiness is
-        irrelevant to it. Native refs report the fleet's readiness without
-        building one (True when no local engine exists yet).
+        irrelevant to it. A native ref with no local engine built yet cannot
+        serve a token, so it reports not-ready (without building the engine);
+        health's ``chat_ready`` and the cold-start waits all rely on this
+        being positive readiness, not reachability.
         """
         if self._role_routes_remote(role):
             return True
         if self._local is None:
-            return True
+            return False
         return self._local.role_ready(role)
 
     @staticmethod

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3755,13 +3755,16 @@ class TestRoutingLifecycleForwarding:
         assert rp.role_ready(WorkerRole.CHAT) is False
         local.role_ready.assert_called_once_with(WorkerRole.CHAT)
 
-    def test_role_ready_true_without_local(self) -> None:
+    def test_role_ready_false_without_local_for_native_ref(self) -> None:
+        from lilbee.core.config import cfg
         from lilbee.providers.roles import WorkerRole
         from lilbee.providers.routing_provider import RoutingProvider
 
-        # No local engine yet: treat as reachable so callers don't show a stuck
-        # warming state before the fleet is ever constructed.
-        assert RoutingProvider().role_ready(WorkerRole.CHAT) is True
+        # No local engine yet means no native ref can serve a token: reporting
+        # ready here let health's chat_ready go true before the engine existed,
+        # and the first /api/chat then 503'd from the backend.
+        cfg.chat_model = "org/repo/chat-Q4_K_M.gguf"
+        assert RoutingProvider().role_ready(WorkerRole.CHAT) is False
 
 
 def test_gguf_scalar_str_array_field_returns_none() -> None:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -318,6 +318,43 @@ class TestAssistantMessageAsync:
             assert not isinstance(am._content_widget, Markdown)
             assert am.use_markdown is False
 
+    async def test_append_content_in_plain_text_mode_is_literal(self) -> None:
+        """Streaming into a plain-text message stores the text as literal
+        Content: console-markup-looking answers (``[/path]``) must not parse."""
+        cfg.markdown_rendering = False
+        app = _MsgApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            am = app._am
+            am.append_content("see [/usr/bin] for details")
+            assert isinstance(am._content_widget, Static)
+            assert "[/usr/bin]" in am._content_widget.content.plain
+
+    async def test_rebuild_content_widget_preserves_text_round_trip(self) -> None:
+        """Toggling markdown off and back on keeps the answer text.
+
+        Regression: the rebuilt Markdown widget was updated before mounting,
+        and Textual's Markdown re-renders from its constructor argument on
+        mount, wiping the pre-mount update and blanking every answer.
+        """
+        from textual.widgets import Markdown
+
+        cfg.markdown_rendering = True
+        app = _MsgApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            am = app._am
+            am.append_content("The 9C1 arrived in **1986**.")
+            await am.rebuild_content_widget(use_markdown=False)
+            assert isinstance(am._content_widget, Static)
+            assert "1986" in am._content_widget.content.plain
+            await am.rebuild_content_widget(use_markdown=True)
+            await pilot.pause()
+            md = am._content_widget
+            assert isinstance(md, Markdown)
+            assert "1986" in md.source
+            assert list(md.query("MarkdownBlock"))
+
     async def test_rebuild_content_widget_noop_when_no_widget(self) -> None:
         from lilbee.cli.tui.widgets.message import AssistantMessage
 


### PR DESCRIPTION
## Problem

Two readiness-and-rendering bugs observed live:

1. In the TUI, toggling chat rendering with ctrl+r from Markdown to plain text and back blanked every assistant answer. The rebuilt Markdown widget was filled via update() before being mounted, and Textual's Markdown re-renders from its constructor argument on mount, which wiped the pre-mount update and left an empty bubble.

2. On a fresh `lilbee serve`, /api/health reported chat_ready:true before any engine existed. RoutingProvider.role_ready returned True for native refs when no local engine had been built yet, so a client that gated on the flag and then POSTed /api/chat got a 503 from the backend while llama-swap was still coming up.

## Solution

1. Pass the accumulated answer text to the content widget's constructor instead of updating it pre-mount, so the mount lifecycle renders it. A regression test covers the plain-to-markdown round trip, and streaming into a plain-text message is pinned as literal content.

2. role_ready is now positive readiness: a native ref with no local engine reports False instead of True. Health's chat_ready and chat_status become truthful during startup (loading, then ready), the RAG stream emits its warming notice when the engine is genuinely cold, the CLI announces cold starts, and the TUI's first prompt lands on its designed warm-wait path. Verified live: a fresh serve holds chat_ready:false while warming, and the first /api/chat sent the moment the flag flips returns a cited answer instead of 503.