### PR TITLE
Fix agent launcher chat window and hermes grounding

### DIFF
--- a/src/lilbee/cli/launchers/hermes.py
+++ b/src/lilbee/cli/launchers/hermes.py
@@ -60,13 +60,10 @@ def _upsert_env_token(path: Path, token: str) -> None:
 
 
 def warn_hermes_ungrounded() -> None:
-    """State the consequence when hermes could not connect lilbee's MCP search.
+    """Say plainly that hermes will run ungrounded when its MCP search did not connect.
 
-    Without the ``mcp`` extra hermes never calls ``lilbee_search``, so it answers
-    from its own training instead of the indexed docs -- silently, at exit 0. The
-    launcher just wrote the provider config and installed the guidance skill, so a
-    run looks wired up; say plainly that it is not grounded rather than leaving
-    only the buried install hint, so the output is not mistaken for a grounded one.
+    Without the ``mcp`` extra hermes never calls ``lilbee_search`` and answers from
+    its own training, silently at exit 0, so the install hint alone is easy to miss.
     """
     typer.secho(
         "Warning: hermes could not connect lilbee's search (MCP), so it will run "
@@ -144,8 +141,7 @@ class HermesLauncher:
                 mcp_ready = ensure_hermes_http_mcp(
                     self._binary, allow_lazy_installs=allow_lazy, echo=typer.echo
                 )
-                # MCP was requested but could not connect: don't hand off a hermes
-                # that will silently run ungrounded (no lilbee_search) -- say so.
+                # Requested but not connected: don't hand off a silently ungrounded hermes.
                 if not mcp_ready:
                     warn_hermes_ungrounded()
         return ([], {**os.environ, LILBEE_TOKEN_ENV_VAR: token})

--- a/src/lilbee/cli/launchers/hermes.py
+++ b/src/lilbee/cli/launchers/hermes.py
@@ -59,6 +59,25 @@ def _upsert_env_token(path: Path, token: str) -> None:
         path.chmod(0o600)
 
 
+def warn_hermes_ungrounded() -> None:
+    """State the consequence when hermes could not connect lilbee's MCP search.
+
+    Without the ``mcp`` extra hermes never calls ``lilbee_search``, so it answers
+    from its own training instead of the indexed docs -- silently, at exit 0. The
+    launcher just wrote the provider config and installed the guidance skill, so a
+    run looks wired up; say plainly that it is not grounded rather than leaving
+    only the buried install hint, so the output is not mistaken for a grounded one.
+    """
+    typer.secho(
+        "Warning: hermes could not connect lilbee's search (MCP), so it will run "
+        "WITHOUT grounding -- it will not call lilbee_search and its answers come "
+        "from its own training, not your indexed docs. Install hermes's mcp extra "
+        "(shown above) and relaunch to ground it.",
+        err=True,
+        fg=typer.colors.YELLOW,
+    )
+
+
 def warn_if_below_hermes_minimum(chat_ctx: int | None) -> None:
     """Tell the user up front when hermes will reject the window lilbee serves."""
     if chat_ctx is None or chat_ctx >= _HERMES_MIN_CTX:
@@ -122,9 +141,13 @@ class HermesLauncher:
                 allow_lazy = bool(
                     (config.get(_SECURITY_KEY) or {}).get(_ALLOW_LAZY_INSTALLS_KEY, True)
                 )
-                ensure_hermes_http_mcp(
+                mcp_ready = ensure_hermes_http_mcp(
                     self._binary, allow_lazy_installs=allow_lazy, echo=typer.echo
                 )
+                # MCP was requested but could not connect: don't hand off a hermes
+                # that will silently run ungrounded (no lilbee_search) -- say so.
+                if not mcp_ready:
+                    warn_hermes_ungrounded()
         return ([], {**os.environ, LILBEE_TOKEN_ENV_VAR: token})
 
 

--- a/src/lilbee/cli/launchers/hermes_mcp.py
+++ b/src/lilbee/cli/launchers/hermes_mcp.py
@@ -95,9 +95,8 @@ def _mcp_extra_requirements(interpreter: str) -> list[str]:
 def _install_failure_reason(proc: subprocess.CompletedProcess[str]) -> str:
     """A one-line reason a pip install did not make MCP importable, or ``""``.
 
-    The common causes are a pip-less uv/pipx tool environment and an
-    externally-managed environment (PEP 668); both land on the last line of
-    pip's output, which is what we surface.
+    The usual causes (a pip-less tool env, a PEP 668 externally-managed env) land
+    on pip's last output line, which is what we surface.
     """
     text = (proc.stderr or proc.stdout or "").strip()
     if not text:
@@ -113,10 +112,8 @@ def ensure_hermes_http_mcp(
 
     When support is missing: auto-installs hermes's pinned ``[mcp]`` extra into
     hermes's own environment (only if ``allow_lazy_installs``), otherwise echoes
-    hermes's documented install command. When an install runs but does not take,
-    surfaces the reason (a pip-less tool env, an externally-managed environment)
-    so the caller is not left silently ungrounded. Idempotent and cheap when
-    already present."""
+    hermes's documented install command; when an install does not take, surfaces
+    why. Idempotent and cheap when already present."""
     interpreter = hermes_interpreter(binary)
     if interpreter is None:
         echo(MCP_EXTRA_HINT)

--- a/src/lilbee/cli/launchers/hermes_mcp.py
+++ b/src/lilbee/cli/launchers/hermes_mcp.py
@@ -92,6 +92,20 @@ def _mcp_extra_requirements(interpreter: str) -> list[str]:
     return reqs or ["mcp"]
 
 
+def _install_failure_reason(proc: subprocess.CompletedProcess[str]) -> str:
+    """A one-line reason a pip install did not make MCP importable, or ``""``.
+
+    The common causes are a pip-less uv/pipx tool environment and an
+    externally-managed environment (PEP 668); both land on the last line of
+    pip's output, which is what we surface.
+    """
+    text = (proc.stderr or proc.stdout or "").strip()
+    if not text:
+        return ""
+    last = text.splitlines()[-1].strip()
+    return f"hermes's pip could not install the mcp extra (exit {proc.returncode}): {last}"
+
+
 def ensure_hermes_http_mcp(
     binary: str, *, allow_lazy_installs: bool, echo: Callable[[str], None]
 ) -> bool:
@@ -99,7 +113,10 @@ def ensure_hermes_http_mcp(
 
     When support is missing: auto-installs hermes's pinned ``[mcp]`` extra into
     hermes's own environment (only if ``allow_lazy_installs``), otherwise echoes
-    hermes's documented install command. Idempotent and cheap when already present."""
+    hermes's documented install command. When an install runs but does not take,
+    surfaces the reason (a pip-less tool env, an externally-managed environment)
+    so the caller is not left silently ungrounded. Idempotent and cheap when
+    already present."""
     interpreter = hermes_interpreter(binary)
     if interpreter is None:
         echo(MCP_EXTRA_HINT)
@@ -112,16 +129,21 @@ def ensure_hermes_http_mcp(
         return False
     echo("Setting up hermes MCP support (installing hermes's mcp extra)...")
     try:
-        subprocess.run(  # noqa: S603 - hermes's own resolved interpreter, fixed argv
+        proc = subprocess.run(  # noqa: S603 - hermes's own resolved interpreter, fixed argv
             [interpreter, "-m", "pip", "install", *_mcp_extra_requirements(interpreter)],
             capture_output=True,
+            text=True,
             check=False,
         )
-    except OSError:
+    except OSError as exc:
+        echo(f"Could not run hermes's pip to install the mcp extra: {exc}")
         echo(MCP_EXTRA_HINT)
         return False
     if has_http_mcp(interpreter):
         echo("hermes MCP support ready.")
         return True
+    reason = _install_failure_reason(proc)
+    if reason:
+        echo(reason)
     echo(MCP_EXTRA_HINT)
     return False

--- a/src/lilbee/cli/launchers/launcher.py
+++ b/src/lilbee/cli/launchers/launcher.py
@@ -25,16 +25,10 @@ LILBEE_TOKEN_ENV_VAR = "LILBEE_TOKEN"  # noqa: S105 (env var name, not a secret)
 _CHAT_CTX_TARGET_ENV_VAR = "LILBEE_CHAT_N_CTX_TARGET"
 
 # Floor on the served chat window for a launched agent. Agent clients open with
-# a large baseline prompt -- system prompt, AGENTS.md, and tool schemas
-# (including lilbee_search) -- and reserve output tokens from the window, so the
-# RAM-derived default (core.system.chat_ctx_target_for_total_bytes tops out at
-# 24576) leaves too little input budget and the first turn overflows before the
-# agent does any work. lilbee_search can also return a large result (a full
-# Godot class XML), which pushed even 32768 over, and hermes refuses a window
-# under 64000 outright, so an agent launch reaches for this floor. The n_ctx
-# picker still clamps it to the model's trained context and the host's VRAM
-# (providers.model_cache.compute_dynamic_ctx never over-allocates), and
-# client_chat_ctx() / warn_if_below_hermes_minimum() warn when it cannot be met.
+# a large baseline prompt (system prompt, tool schemas) and reserve output, so
+# the RAM-derived default (tops out at 24576) overflows on the first turn; hermes
+# also refuses a window under 64000. The picker still clamps to the model's
+# trained context and host VRAM, so this never over-allocates.
 _AGENT_CHAT_CTX_FLOOR = 65536
 
 
@@ -104,11 +98,9 @@ def run_launcher(launcher: Launcher) -> None:
     # here doesn't start a second llama-swap that races the server's for the model
     # port (the loser gets connection-refused). The spawned serve warms its own.
     cfg.worker_pool_eager_start = False
-    # Size the served chat window for the agent's large baseline prompt before the
-    # server spawns. Set it in-process so the warm wait and the client-window
-    # warning use the same target, and pass it to the spawned `lilbee serve` via
-    # its env (LILBEE_ overrides config.toml) so the served window actually grows.
-    # A reused server keeps its own window; client_chat_ctx() then warns if small.
+    # Size the served window for the agent before the server spawns: in-process so
+    # the warm wait and window warning agree, and via the child's env (LILBEE_
+    # overrides config.toml) so the spawned serve actually grows it.
     agent_target = agent_chat_ctx_target(cfg.chat_n_ctx_target)
     cfg.chat_n_ctx_target = agent_target
     (token, port), spawned = ensure_server_running(

--- a/src/lilbee/cli/launchers/launcher.py
+++ b/src/lilbee/cli/launchers/launcher.py
@@ -20,6 +20,28 @@ from lilbee.providers.model_ref import with_configured_remote_chat
 # references it (opencode `{env:...}`, hermes `${...}`) so no literal lands on disk.
 LILBEE_TOKEN_ENV_VAR = "LILBEE_TOKEN"  # noqa: S105 (env var name, not a secret)
 
+# Config key the spawned `lilbee serve` reads for its working chat window; a
+# LILBEE_ env var overrides config.toml, so the launcher raises it per launch.
+_CHAT_CTX_TARGET_ENV_VAR = "LILBEE_CHAT_N_CTX_TARGET"
+
+# Floor on the served chat window for a launched agent. Agent clients open with
+# a large baseline prompt -- system prompt, AGENTS.md, and tool schemas
+# (including lilbee_search) -- and reserve output tokens from the window, so the
+# RAM-derived default (core.system.chat_ctx_target_for_total_bytes tops out at
+# 24576) leaves too little input budget and the first turn overflows before the
+# agent does any work. lilbee_search can also return a large result (a full
+# Godot class XML), which pushed even 32768 over, and hermes refuses a window
+# under 64000 outright, so an agent launch reaches for this floor. The n_ctx
+# picker still clamps it to the model's trained context and the host's VRAM
+# (providers.model_cache.compute_dynamic_ctx never over-allocates), and
+# client_chat_ctx() / warn_if_below_hermes_minimum() warn when it cannot be met.
+_AGENT_CHAT_CTX_FLOOR = 65536
+
+
+def agent_chat_ctx_target(configured: int) -> int:
+    """Lift a configured chat-context target to the agent floor, never lowering a larger one."""
+    return max(configured, _AGENT_CHAT_CTX_FLOOR)
+
 
 class Launcher(Protocol):
     """A third-party AI client that lilbee knows how to launch."""
@@ -82,7 +104,16 @@ def run_launcher(launcher: Launcher) -> None:
     # here doesn't start a second llama-swap that races the server's for the model
     # port (the loser gets connection-refused). The spawned serve warms its own.
     cfg.worker_pool_eager_start = False
-    (token, port), spawned = ensure_server_running()
+    # Size the served chat window for the agent's large baseline prompt before the
+    # server spawns. Set it in-process so the warm wait and the client-window
+    # warning use the same target, and pass it to the spawned `lilbee serve` via
+    # its env (LILBEE_ overrides config.toml) so the served window actually grows.
+    # A reused server keeps its own window; client_chat_ctx() then warns if small.
+    agent_target = agent_chat_ctx_target(cfg.chat_n_ctx_target)
+    cfg.chat_n_ctx_target = agent_target
+    (token, port), spawned = ensure_server_running(
+        env_overrides={_CHAT_CTX_TARGET_ENV_VAR: str(agent_target)}
+    )
     # Everything after the spawn runs under the finally so a raise from prepare()
     # (e.g. the user declining opencode setup) or the warm wait can't leak the
     # spawned `lilbee serve` process.

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -232,12 +232,18 @@ def _poll_chat_ready(port: int, timeout_s: float) -> bool:
     return False
 
 
-def spawn_server(port: int) -> subprocess.Popen[bytes]:
+def spawn_server(
+    port: int, *, env_overrides: dict[str, str] | None = None
+) -> subprocess.Popen[bytes]:
     """Spawn ``lilbee serve --port <port>`` as a background subprocess.
 
     Prefers the ``lilbee`` binary on PATH so frozen builds (Nuitka standalone)
     spawn the binary directly. Falls back to ``sys.executable -m lilbee`` for
     pip / editable installs where the entry point shims to the same form.
+
+    ``env_overrides`` are layered onto the inherited environment for the child
+    (e.g. ``LILBEE_CHAT_N_CTX_TARGET`` to size the served window for a launched
+    agent); ``None`` inherits the parent environment unchanged.
 
     Stdout/stderr go to ``cfg.data_dir / "logs" / "launcher-serve.log"`` (size
     capped at 5 MB) so a crash mid-session leaves a trace instead of disappearing.
@@ -275,12 +281,17 @@ def spawn_server(port: int) -> subprocess.Popen[bytes]:
         stdout = log_file
         stderr = subprocess.STDOUT
 
+    # None inherits the parent environment; a dict replaces it wholesale, so
+    # merge the overrides onto a copy of os.environ to keep PATH and the rest.
+    child_env = {**os.environ, **env_overrides} if env_overrides else None
+
     try:
         # Only caller-controlled value is the validated integer port; no shell.
         return subprocess.Popen(  # noqa: S603
             cmd,
             stdout=stdout,
             stderr=stderr,
+            env=child_env,
         )
     finally:
         # Popen dups the fd into the child; the parent's handle is no longer
@@ -301,13 +312,18 @@ def stop_spawned_server(proc: subprocess.Popen[bytes]) -> None:
         proc.wait(timeout=_KILL_GRACE_S)
 
 
-def ensure_server_running() -> tuple[tuple[str, int], subprocess.Popen[bytes] | None]:
+def ensure_server_running(
+    *, env_overrides: dict[str, str] | None = None
+) -> tuple[tuple[str, int], subprocess.Popen[bytes] | None]:
     """Return ``(session, spawned_proc)`` for a usable lilbee server.
 
     Reuses an already-running server when its session files are healthy.
     Otherwise spawns a fresh server on a free port. The returned ``spawned_proc``
     is ``None`` when an existing server was reused; the caller is responsible
     for stopping a spawned process when it is done with it.
+
+    ``env_overrides`` reach a freshly spawned child (e.g. a launcher sizing the
+    served window); a reused server keeps whatever window it booted with.
     """
     existing = running_server_session()
     if existing is not None and health_ok(existing[1]):
@@ -317,7 +333,7 @@ def ensure_server_running() -> tuple[tuple[str, int], subprocess.Popen[bytes] | 
         # Honor a user-pinned port so a persisted agent config keeps a valid URL;
         # fall back to a free port when unset (0).
         last_port = cfg.server_port or free_port()
-        spawned = _spawn_and_wait(last_port)
+        spawned = _spawn_and_wait(last_port, env_overrides=env_overrides)
         if spawned is not None:
             return _session_for_spawned(spawned), spawned
     typer.secho(
@@ -328,9 +344,11 @@ def ensure_server_running() -> tuple[tuple[str, int], subprocess.Popen[bytes] | 
     raise typer.Exit(1)
 
 
-def _spawn_and_wait(port: int) -> subprocess.Popen[bytes] | None:
+def _spawn_and_wait(
+    port: int, *, env_overrides: dict[str, str] | None = None
+) -> subprocess.Popen[bytes] | None:
     """Spawn a server on *port* and wait for health; None when it never comes up."""
-    spawned = spawn_server(port)
+    spawned = spawn_server(port, env_overrides=env_overrides)
     with console.status(f"Starting lilbee server on port {port}..."):
         healthy = wait_for_health(port)
     if healthy:

--- a/tests/cli/test_hermes_mcp.py
+++ b/tests/cli/test_hermes_mcp.py
@@ -96,13 +96,30 @@ def test_ensure_respects_security_gate_and_guides(tmp_path):
 def test_ensure_guides_when_install_did_not_take(tmp_path):
     binary = _script(tmp_path, "#!/opt/venv/bin/python")
     msgs: list[str] = []
+    proc = SimpleNamespace(returncode=1, stderr="error: externally-managed-environment", stdout="")
     with (
         patch.object(hermes_mcp, "has_http_mcp", side_effect=[False, False]),
         patch.object(hermes_mcp, "_mcp_extra_requirements", return_value=["mcp"]),
-        patch.object(hermes_mcp.subprocess, "run"),
+        patch.object(hermes_mcp.subprocess, "run", return_value=proc),
     ):
         assert _ensure(binary, msgs) is False
+    # Surfaces WHY the install did not take (the common pip-less / externally-managed
+    # tool env), so the operator can fix it instead of running silently ungrounded.
+    assert any("externally-managed-environment" in m for m in msgs)
+    assert any("exit 1" in m for m in msgs)
     assert any("hermes-agent[mcp]" in m for m in msgs)
+
+
+def test_install_failure_reason_empty_when_no_output():
+    proc = SimpleNamespace(returncode=1, stderr="", stdout="")
+    assert hermes_mcp._install_failure_reason(proc) == ""
+
+
+def test_install_failure_reason_uses_last_stderr_line():
+    proc = SimpleNamespace(returncode=2, stderr="noise\nfinal cause line\n", stdout="")
+    reason = hermes_mcp._install_failure_reason(proc)
+    assert "final cause line" in reason
+    assert "exit 2" in reason
 
 
 def test_ensure_guides_when_interpreter_unknown(tmp_path):

--- a/tests/cli/test_launch_agent_ctx_floor.py
+++ b/tests/cli/test_launch_agent_ctx_floor.py
@@ -1,0 +1,120 @@
+"""A launched agent gets a chat window large enough for its baseline prompt.
+
+Agent clients (opencode, hermes) open with a big system prompt + tool schemas
+and reserve output tokens, so the RAM-derived default chat context (tops out at
+24576) overflows on the first turn. ``run_launcher`` raises the served-context
+target to an agent floor before the server spawns; these tests pin that.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from lilbee.core.config import cfg
+
+
+def test_agent_floor_raises_a_small_configured_target() -> None:
+    from lilbee.cli.launchers.launcher import _AGENT_CHAT_CTX_FLOOR, agent_chat_ctx_target
+
+    assert agent_chat_ctx_target(24576) == _AGENT_CHAT_CTX_FLOOR
+
+
+def test_agent_floor_never_lowers_a_larger_configured_target() -> None:
+    from lilbee.cli.launchers.launcher import agent_chat_ctx_target
+
+    assert agent_chat_ctx_target(131072) == 131072
+
+
+def test_agent_floor_is_at_least_the_hermes_minimum() -> None:
+    # hermes refuses to start under this window, so the generic agent floor must
+    # clear it or a hermes launch is dead on arrival.
+    from lilbee.cli.launchers.hermes import _HERMES_MIN_CTX
+    from lilbee.cli.launchers.launcher import _AGENT_CHAT_CTX_FLOOR
+
+    assert _AGENT_CHAT_CTX_FLOOR >= _HERMES_MIN_CTX
+
+
+def _run_launcher_capturing(monkeypatch) -> dict:
+    """Drive run_launcher with every side effect stubbed, capturing the spawn state."""
+    from lilbee.cli.launchers import launcher as launcher_mod
+
+    captured: dict = {}
+
+    def fake_ensure(*, env_overrides=None):
+        captured["env_overrides"] = env_overrides
+        captured["cfg_target_at_spawn"] = cfg.chat_n_ctx_target
+        return ("tok", 8080), None
+
+    monkeypatch.setattr(launcher_mod, "ensure_server_running", fake_ensure)
+    monkeypatch.setattr(launcher_mod, "installed_chat_model_refs", lambda: [])
+    monkeypatch.setattr(launcher_mod, "wait_for_chat_warm", lambda _p: True)
+    monkeypatch.setattr(
+        launcher_mod.subprocess, "run", lambda *_a, **_k: MagicMock(returncode=0)
+    )
+
+    fake = MagicMock()
+    fake.name = "opencode"
+    fake.find_binary.return_value = "/usr/bin/opencode"
+    fake.prepare.return_value = ([], {})
+    with pytest.raises(typer.Exit):
+        launcher_mod.run_launcher(fake)
+    return captured
+
+
+def test_run_launcher_raises_the_target_to_the_agent_floor(monkeypatch) -> None:
+    from lilbee.cli.launchers.launcher import _AGENT_CHAT_CTX_FLOOR
+
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 24576)
+    captured = _run_launcher_capturing(monkeypatch)
+
+    # In-process (the launcher's own warm wait + window warning) sees the floor,
+    assert captured["cfg_target_at_spawn"] == _AGENT_CHAT_CTX_FLOOR
+    # and the spawned `lilbee serve` child is told to serve it via LILBEE_ env.
+    assert captured["env_overrides"]["LILBEE_CHAT_N_CTX_TARGET"] == str(_AGENT_CHAT_CTX_FLOOR)
+
+
+def test_run_launcher_preserves_a_larger_configured_target(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 131072)
+    captured = _run_launcher_capturing(monkeypatch)
+
+    assert captured["cfg_target_at_spawn"] == 131072
+    assert captured["env_overrides"]["LILBEE_CHAT_N_CTX_TARGET"] == "131072"
+
+
+def test_spawn_server_applies_env_overrides_over_inherited_env(monkeypatch) -> None:
+    """spawn_server merges its overrides onto the inherited environment."""
+    from lilbee.cli.launchers import server as server_mod
+
+    monkeypatch.setenv("LILBEE_LAUNCHER_SERVE_QUIET", "1")  # route output to DEVNULL
+    captured: dict = {}
+
+    def fake_popen(cmd, *, stdout, stderr, env):
+        captured["env"] = env
+        return MagicMock()
+
+    monkeypatch.setattr(server_mod.subprocess, "Popen", fake_popen)
+    server_mod.spawn_server(8080, env_overrides={"LILBEE_CHAT_N_CTX_TARGET": "65536"})
+
+    assert captured["env"]["LILBEE_CHAT_N_CTX_TARGET"] == "65536"
+    # Inherited vars survive the merge (not replaced by the overrides dict).
+    assert captured["env"]["LILBEE_LAUNCHER_SERVE_QUIET"] == "1"
+
+
+def test_spawn_server_without_overrides_inherits_process_env(monkeypatch) -> None:
+    from lilbee.cli.launchers import server as server_mod
+
+    monkeypatch.setenv("LILBEE_LAUNCHER_SERVE_QUIET", "1")
+    captured: dict = {}
+
+    def fake_popen(cmd, *, stdout, stderr, env):
+        captured["env"] = env
+        return MagicMock()
+
+    monkeypatch.setattr(server_mod.subprocess, "Popen", fake_popen)
+    server_mod.spawn_server(8080)
+
+    # None means Popen inherits the parent environment unchanged.
+    assert captured["env"] is None

--- a/tests/cli/test_launch_hermes.py
+++ b/tests/cli/test_launch_hermes.py
@@ -146,10 +146,43 @@ def test_launch_hermes_no_mcp_prunes_stale_entry(tmp_path):
         patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
         patch("lilbee.cli.launchers.server.spawn_server"),
     ):
-        runner.invoke(app, ["launch", "hermes", "--no-mcp"])
+        result = runner.invoke(app, ["launch", "hermes", "--no-mcp"])
     config = _hermes_config(tmp_path)
     assert "lilbee" not in config.get("mcp_servers", {})
     assert "lilbee" in config["providers"]  # provider stays; only MCP removed
+    # --no-mcp is a deliberate opt-out, so no ungrounded warning.
+    assert "without grounding" not in result.stderr.lower()
+
+
+def test_launch_hermes_warns_when_mcp_cannot_connect(tmp_path):
+    """A hermes whose MCP extra will not connect must not launch silently ungrounded."""
+    _write_server_session()
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+        patch("lilbee.cli.launchers.server.spawn_server"),
+        patch("lilbee.cli.launchers.hermes.ensure_hermes_http_mcp", return_value=False),
+    ):
+        result = runner.invoke(app, ["launch", "hermes"])
+    assert result.exit_code == 0  # the launch still proceeds
+    err = result.stderr.lower()
+    assert "without grounding" in err  # names the consequence, not just an install hint
+    assert "lilbee_search" in result.stderr
+
+
+def test_launch_hermes_quiet_when_mcp_connects(tmp_path):
+    _write_server_session()
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+        patch("lilbee.cli.launchers.server.spawn_server"),
+        patch("lilbee.cli.launchers.hermes.ensure_hermes_http_mcp", return_value=True),
+    ):
+        result = runner.invoke(app, ["launch", "hermes"])
+    assert result.exit_code == 0
+    assert "without grounding" not in result.stderr.lower()
 
 
 def test_launch_hermes_installs_skill(tmp_path):

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -143,7 +143,7 @@ def test_launch_opencode_spawns_fresh_server_when_session_files_are_stale(tmp_pa
     fake_proc = MagicMock()
     fake_proc.poll.return_value = None
 
-    def _spawn_and_rewrite_session(_port: int):
+    def _spawn_and_rewrite_session(_port: int, **_kw):
         # Real server would write fresh session files on boot; simulate that
         # so running_server_session() returns the spawned (fresh) port/token.
         _write_server_session()
@@ -514,7 +514,7 @@ def test_launch_opencode_spawns_server_when_none_running():
     fake_proc = MagicMock()
     fake_proc.poll.return_value = None
 
-    def _spawn_and_write(_port: int):
+    def _spawn_and_write(_port: int, **_kw):
         _write_server_session()
         return fake_proc
 

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -23,10 +23,11 @@ def _capture_popen():
     """Patch Popen to record the stdout/stderr kwargs without spawning."""
     captured: dict = {}
 
-    def fake_popen(cmd, *, stdout, stderr):
+    def fake_popen(cmd, *, stdout, stderr, env=None):
         captured["cmd"] = cmd
         captured["stdout"] = stdout
         captured["stderr"] = stderr
+        captured["env"] = env
         return mock.MagicMock()
 
     with mock.patch.object(server_mod.subprocess, "Popen", side_effect=fake_popen):
@@ -205,7 +206,10 @@ class TestEnsureServerRunningRetries:
 
         assert session == ("tok", 2222)
         assert spawned is second
-        assert spawn.call_args_list == [mock.call(1111), mock.call(2222)]
+        assert spawn.call_args_list == [
+            mock.call(1111, env_overrides=None),
+            mock.call(2222, env_overrides=None),
+        ]
         first.terminate.assert_called_once()
         second.terminate.assert_not_called()
 
@@ -234,7 +238,9 @@ class TestEnsureServerRunningRetries:
         monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
         monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[1, 2, 3]))
         seen: list[int] = []
-        monkeypatch.setattr(server_mod, "_spawn_and_wait", lambda port: seen.append(port) or None)
+        monkeypatch.setattr(
+            server_mod, "_spawn_and_wait", lambda port, **_kw: seen.append(port) or None
+        )
         with pytest.raises(typer.Exit):
             server_mod.ensure_server_running()
         # The pinned port is used every attempt so a persisted URL stays valid.
@@ -247,7 +253,9 @@ class TestEnsureServerRunningRetries:
         monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
         monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[7, 8, 9]))
         seen: list[int] = []
-        monkeypatch.setattr(server_mod, "_spawn_and_wait", lambda port: seen.append(port) or None)
+        monkeypatch.setattr(
+            server_mod, "_spawn_and_wait", lambda port, **_kw: seen.append(port) or None
+        )
         with pytest.raises(typer.Exit):
             server_mod.ensure_server_running()
         assert seen == [7, 8, 9]


### PR DESCRIPTION
## Problem

Launched agents (opencode, hermes) failed in ways that looked like the model's fault but were the launcher's:

- The served chat window was sized from host RAM and capped low (16384 to 24576), so an agent's large baseline prompt (system prompt, tool schemas) plus reserved output overflowed on the first turn, even with headroom to spare.
- hermes launched without grounding: the launcher ignored whether lilbee_search connected over hermes's optional MCP extra, so hermes ran to exit 0 without ever calling it, answering from its own training instead of the indexed docs.

## Solution

- Raise the served-context target to an agent-sized floor before the server starts. The picker still clamps to the model's trained window and host memory, so it never over-allocates and a smaller configured target or explicit pin is preserved.
- Use the MCP setup result: warn clearly when hermes will run ungrounded, and surface why an auto-install failed (a pip-less or externally-managed environment) instead of swallowing it.
