### PR TITLE
Wait out a cold embed replica instead of dropping files on 429

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -392,9 +392,16 @@ class LlamaServerClient:
         timeout: float = _DEFAULT_TIMEOUT_S,
         rerank_mode: RerankMode | None = None,
         inline_reasoning: bool = False,
+        embed_busy_deadline_s: float | None = None,
     ) -> None:
         self._base = base_url.rstrip("/")
         self._model = model
+        # Cold-load budget (seconds) the embed path waits out a still-warming replica
+        # before dropping the input, in place of the short attempt cap. Set on the
+        # EMBED-role client to the same ceiling llama-swap keeps the server alive for,
+        # so a bulk ingest never gives up while the replica is legitimately loading.
+        # None (rerank, chat, vision, self-check) keeps the fixed interactive budget.
+        self._embed_busy_deadline_s = embed_busy_deadline_s
         self._http = http or httpx.Client(
             base_url=self._base, timeout=timeout, verify=_LOOPBACK_SSL_CONTEXT
         )
@@ -900,7 +907,13 @@ class LlamaServerClient:
                 )
             return list(data)
 
-        # Bulk ingest can afford to wait out a cold-start warmup rather than drop files.
+        # Bulk ingest can afford to wait out a cold-start warmup rather than drop
+        # files. With a cold-load deadline (the EMBED-role client) the retry waits
+        # out a still-loading replica for the full budget llama-swap keeps it alive,
+        # instead of dropping the file after the fixed attempt cap; without one the
+        # fixed count bounds an interactive caller.
+        if self._embed_busy_deadline_s is not None:
+            return retry_on_busy(_call, deadline=time.monotonic() + self._embed_busy_deadline_s)
         return retry_on_busy(_call, retries=_EMBED_BUSY_RETRIES)
 
     def _truncate_and_subbatch(self, texts: list[str], *, estimate: bool) -> list[list[str]]:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -794,6 +794,14 @@ class FleetProvider:
                     timeout=_request_timeout_s(launch.weights_bytes),
                     rerank_mode=launch.rerank_mode,
                     inline_reasoning=role is WorkerRole.CHAT,
+                    # A cold embed replica 429s bulk ingest until its slots load; wait
+                    # out the same cold-load budget llama-swap keeps it alive for so a
+                    # burst never drops files while the server is legitimately warming.
+                    embed_busy_deadline_s=(
+                        cold_load_timeout_s(launch.weights_bytes)
+                        if role is WorkerRole.EMBED
+                        else None
+                    ),
                 )
                 for launch in role_launches
             ]

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -197,6 +197,33 @@ def test_embed_rides_out_cold_start_past_interactive_budget(monkeypatch) -> None
     assert calls["n"] == warmup + 1
 
 
+def test_embed_with_cold_load_deadline_rides_out_more_429s_than_attempt_cap(monkeypatch) -> None:
+    # An EMBED client built with a cold-load deadline waits out the embedder's full
+    # warm even when the replica 429s more times than the fixed attempt cap tolerates:
+    # llama-swap keeps the still-loading server alive for the whole cold-load budget,
+    # so ingest must not give up (and drop the file) before that budget passes.
+    from lilbee.providers.fleet.client import _EMBED_BUSY_RETRIES
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    # Pin the clock so the deadline never actually passes: the retry rides out the
+    # warmup on the deadline branch, never on the attempt count.
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: 0.0)
+    warmup = _EMBED_BUSY_RETRIES + 5  # more 429s than the fixed attempt cap tolerates
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] <= warmup:
+            return httpx.Response(429, json={"error": "warming"})
+        return httpx.Response(200, json={"data": [{"embedding": [0.3]}]})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://gpu0")
+    client = LlamaServerClient("http://gpu0", "test-model", http=http, embed_busy_deadline_s=600.0)
+    client._needs_alternation = False
+    assert client.embed(["x"]) == [[0.3]]
+    assert calls["n"] == warmup + 1
+
+
 def test_retry_on_busy_deadline_retries_past_attempt_cap(monkeypatch) -> None:
     # Under deep-queue contention the queue drains far slower than the fixed
     # attempt budget, so a deadline-bound retry must keep waiting past

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -345,6 +345,37 @@ def test_adopt_group_threads_rerank_mode(monkeypatch) -> None:
     assert captured["rerank_mode"] is RerankMode.LLM
 
 
+def test_adopt_group_gives_embed_client_cold_load_deadline_only(monkeypatch) -> None:
+    # The EMBED client waits out a still-warming replica for the full cold-load
+    # budget (so a cold-start burst never drops files); rerank/chat/vision keep the
+    # short interactive attempt cap (deadline None).
+    from lilbee.providers.fleet.swap_config import cold_load_timeout_s
+
+    weights = 6_000_000_000
+    launches = [
+        _fake_launch(WorkerRole.EMBED, weights_bytes=weights),
+        _fake_launch(WorkerRole.RERANK, weights_bytes=weights),
+    ]
+    for launch in launches:
+        launch.rerank_mode = None
+    captured: dict[WorkerRole, object] = {}
+
+    def _capture(_endpoint, model, **kw):
+        captured[model] = kw.get("embed_busy_deadline_s")
+        return _fake_client()
+
+    for launch in launches:
+        launch.model_id = launch.role
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: _FakeSwap())
+    monkeypatch.setattr(prov_mod, "LlamaServerClient", _capture)
+    monkeypatch.setattr(
+        planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(tuple(launches))
+    )
+    FleetProvider()._ensure_fleet()
+    assert captured[WorkerRole.EMBED] == cold_load_timeout_s(weights)
+    assert captured[WorkerRole.RERANK] is None
+
+
 def test_embed_without_server_raises() -> None:
     from lilbee.providers.base import ProviderError
 


### PR DESCRIPTION
## Problem

Running `lilbee add <dir>` right after pulling an embedder silently dropped files while the embed server was still warming.

Every dropped file hit HTTP 429 ("replicas may still be warming") and got written off as a permanent failure. You end up with a partial index and no error, so a query for a dropped file returns "no information" even though it's there.

## Cause

The embed retry gave up after ~80s. But llama-swap keeps a loading replica alive for much longer (600s+), so we were dropping files the server was still busy loading.

## Fix

Let the embed retry wait out the full load window instead of quitting early. The first request absorbs the warmup, then the rest of the batch goes through.

Rerank still fails fast, so a query never hangs on a cold rerank server.
