### PR TITLE
Fix the chat not scrolling to the end of an answer

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -94,26 +94,17 @@ fraction so the assembled prompt never approaches ``n_ctx`` and the chat
 server never rejects the request for exceeding the context window.
 """
 
-# Auto-follow tolerance, in lines: the user counts as "at the bottom" within
-# this many lines of it, so a tiny stray scroll doesn't disable auto-follow and
-# scrolling back near the bottom re-engages it.
-_AUTO_SCROLL_TAIL_LINES = 5
-
 # Coalesce per-token UI updates into ~50 ms windows. Tiny reasoning models can
 # emit 100+ tokens/sec; one ``call_from_thread`` per token saturates Textual's
 # message queue and makes key events visibly lag.
 _STREAM_FLUSH_INTERVAL = 0.05
 
-# Auto-scroll throttle. ~6 fps so heavy token streams don't peg the renderer.
-_STREAM_SCROLL_INTERVAL = 0.15
-
 
 @dataclass
 class _StreamTimings:
-    """Last-fired monotonic timestamps for the stream flush and auto-scroll."""
+    """Last-fired monotonic timestamp for the stream flush."""
 
     last_flush: float
-    last_scroll: float = 0.0
 
 
 # ``/crawl`` command flags.
@@ -297,8 +288,6 @@ class ChatScreen(Screen[None]):
         self._sync_active: bool = False
         self._input_history: list[str] = []
         self._history_index: int = -1
-        self._tail_scroll_y: float = 0.0
-        self._auto_follow: bool = True
         # The warm tip is worth one toast per session, on the first prompt that
         # has to wait out a cold engine load.
         self._warm_tip_shown: bool = False
@@ -1306,11 +1295,9 @@ class ChatScreen(Screen[None]):
         assistant_msg = AssistantMessage()
         self._active_assistant = assistant_msg
         log.mount(assistant_msg)
-        log.scroll_end(animate=False)
         # A fresh turn always follows its own answer, even if the user had
-        # scrolled up during the previous response.
-        self._auto_follow = True
-        self._tail_scroll_y = 0.0
+        # scrolled up during the previous response and released the anchor.
+        log.anchor()
 
         with self._history_lock:
             self._history.append({"role": "user", "content": text})
@@ -1540,7 +1527,7 @@ class ChatScreen(Screen[None]):
                 break
             try:
                 self._buffer_token(token, reason_buf, content_buf, response_parts)
-                self._maybe_flush_and_scroll(flush, timings)
+                self._maybe_flush(flush, timings)
             except Exception:
                 break  # App shutting down (Ctrl-C) -- stop streaming
         with contextlib.suppress(Exception):
@@ -1560,15 +1547,14 @@ class ChatScreen(Screen[None]):
             response_parts.append(token.content)
             content_buf.append(token.content)
 
-    def _maybe_flush_and_scroll(self, flush: Callable[[], None], timings: _StreamTimings) -> None:
-        """Run *flush* and the auto-scroll on their respective intervals."""
+    def _maybe_flush(self, flush: Callable[[], None], timings: _StreamTimings) -> None:
+        """Run *flush* on its interval. The chat log is anchored, so Textual
+        keeps the answer's tail in view as it grows without a scroll of ours.
+        """
         now = time.monotonic()
         if now - timings.last_flush >= _STREAM_FLUSH_INTERVAL:
             flush()
             timings.last_flush = now
-        if now - timings.last_scroll >= _STREAM_SCROLL_INTERVAL:
-            call_from_thread(self, self._scroll_to_bottom)
-            timings.last_scroll = now
 
     def _finalize_stream(
         self, widget: AssistantMessage, sources: list[str], response_parts: list[str]
@@ -1583,7 +1569,6 @@ class ChatScreen(Screen[None]):
                 self._history.append({"role": "assistant", "content": full_response})
                 self._trim_history()
         call_from_thread(self, widget.finish, sources)
-        call_from_thread(self, self._scroll_to_bottom)
         if (
             cfg.chat_mode == ChatMode.SEARCH.value
             and self._embedding_ready()
@@ -1604,22 +1589,6 @@ class ChatScreen(Screen[None]):
         """
         budget = int(cfg.chat_n_ctx_target * _HISTORY_TOKEN_BUDGET_FRACTION)
         self._history[:] = windowed_history(self._history, max_tokens=budget)
-
-    def _scroll_to_bottom(self) -> None:
-        log_widget = self._chat_log
-        # Re-engage auto-follow when the user is at the live bottom; disengage
-        # when they scroll up from where the last auto-scroll parked them. The
-        # disengage test compares against that parked position, not the live
-        # max_scroll_y: content is appended between scroll ticks, so max_scroll_y
-        # races ahead of a parked scroll_y, and a live-gap test would read that
-        # as a scroll-up and stop auto-follow for the rest of the response.
-        if log_widget.scroll_y >= log_widget.max_scroll_y - _AUTO_SCROLL_TAIL_LINES:
-            self._auto_follow = True
-        elif log_widget.scroll_y < self._tail_scroll_y - _AUTO_SCROLL_TAIL_LINES:
-            self._auto_follow = False
-        if self._auto_follow:
-            log_widget.scroll_end(animate=False)
-            self._tail_scroll_y = log_widget.max_scroll_y
 
     def action_scroll_up(self) -> None:
         self._chat_log.scroll_page_up()

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -3573,10 +3573,9 @@ class TestStreamFlushCoalescing:
         def fake_flush() -> None:
             flush_calls.append(None)
 
-        # Past timings: long enough ago that both the flush and the scroll fire.
-        timings = _StreamTimings(last_flush=0.0, last_scroll=0.0)
-        with mock.patch("lilbee.cli.tui.screens.chat.call_from_thread"):
-            ChatScreen._maybe_flush_and_scroll(screen, fake_flush, timings)
+        # A past timing: long enough ago that the flush fires.
+        timings = _StreamTimings(last_flush=0.0)
+        ChatScreen._maybe_flush(screen, fake_flush, timings)
         assert len(flush_calls) == 1
         assert timings.last_flush > 0  # last_flush bumped
 
@@ -3595,8 +3594,7 @@ class TestStreamFlushCoalescing:
 
         # Set timings to 'right now' so the interval check fails.
         now = time.monotonic()
-        timings = _StreamTimings(last_flush=now, last_scroll=now)
-        with mock.patch("lilbee.cli.tui.screens.chat.call_from_thread"):
-            ChatScreen._maybe_flush_and_scroll(screen, fake_flush, timings)
+        timings = _StreamTimings(last_flush=now)
+        ChatScreen._maybe_flush(screen, fake_flush, timings)
         assert flush_calls == []
-        assert timings.last_flush == now and timings.last_scroll == now
+        assert timings.last_flush == now

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3893,6 +3893,18 @@ async def test_chat_input_handler_uses_on_decorator():
     )
 
 
+async def _settle(pilot):
+    """Wait for the bubble to compose, the log to re-lay-out, and the scroll to land.
+
+    A bare ``pause`` covers none of the three, and each one reads back as a
+    plausible number rather than an error: the scroll bindings animate, so
+    ``scroll_y`` samples mid-curve at whatever wall-clock allowed, and a bubble
+    only buffers until ``compose`` hands it a content widget, leaving
+    ``max_scroll_y`` at 0 for an answer grown before that lands.
+    """
+    await pilot.wait_for_scheduled_animations()
+
+
 async def _start_turn(pilot, screen):
     """Ask a question the way the user does, and hand back the log and bubble.
 
@@ -3905,9 +3917,12 @@ async def _start_turn(pilot, screen):
     log = screen.query_one("#chat-log", VerticalScroll)
     with patch.object(screen, "_stream_response"):
         screen._send_message("a question")
-    await pilot.pause()
+    await _settle(pilot)
     widget = screen._active_assistant
     assert widget is not None
+    # Composed, so append_content renders instead of only buffering. Without
+    # this the answer never grows and the scroll assertions all pass vacuously.
+    assert widget._content_widget is not None
     return log, widget
 
 
@@ -3915,7 +3930,7 @@ async def _grow_answer(pilot, widget, paragraphs: int):
     """Render *paragraphs* more of the answer, as a stream's flushes do."""
     widget._last_md_update = 0.0
     widget.append_content("\n\n".join(f"line {i}" for i in range(paragraphs)))
-    await pilot.pause()
+    await _settle(pilot)
 
 
 async def test_chat_log_follows_the_answer_as_it_grows():
@@ -3946,7 +3961,7 @@ async def test_chat_log_stops_following_when_the_user_scrolls_up():
         await _grow_answer(pilot, widget, 80)
 
         screen.action_scroll_up()  # the real binding, not a raw scroll_to
-        await pilot.pause()
+        await _settle(pilot)
         assert log.scroll_y < log.max_scroll_y, "precondition: the reader scrolled up"
 
         await _grow_answer(pilot, widget, 160)
@@ -3963,12 +3978,12 @@ async def test_chat_log_follows_again_once_the_user_returns_to_the_bottom():
         await _grow_answer(pilot, widget, 80)
 
         screen.action_scroll_up()
-        await pilot.pause()
+        await _settle(pilot)
         assert log.scroll_y < log.max_scroll_y
 
         screen._insert_mode = False
         screen.action_vim_scroll_end()  # vim G jumps to the bottom
-        await pilot.pause()
+        await _settle(pilot)
 
         await _grow_answer(pilot, widget, 160)
         assert log.scroll_y == log.max_scroll_y, "following did not resume at the bottom"
@@ -3990,13 +4005,13 @@ async def test_chat_log_does_not_follow_again_from_part_way_back_down():
         was_the_bottom = log.max_scroll_y
 
         screen.action_scroll_up()
-        await pilot.pause()
+        await _settle(pilot)
         await _grow_answer(pilot, widget, 160)
         assert log.max_scroll_y > was_the_bottom, "precondition: the answer outgrew that spot"
 
         # Back to where the bottom used to be -- short of where it is now.
         log.scroll_to(y=was_the_bottom, animate=False)
-        await pilot.pause()
+        await _settle(pilot)
         await _grow_answer(pilot, widget, 160)
 
         assert log.scroll_y < log.max_scroll_y, "following resumed short of the bottom"
@@ -4013,7 +4028,7 @@ async def test_chat_send_message_follows_the_answer_it_is_about_to_get():
 
         # The reader scrolls up during this answer and leaves it there.
         screen.action_scroll_up()
-        await pilot.pause()
+        await _settle(pilot)
         assert log.scroll_y < log.max_scroll_y
 
         # The next question must follow its own answer regardless.
@@ -11573,21 +11588,24 @@ async def test_chat_finalize_stream_scrolls_to_the_end_of_the_finished_answer():
         # the log up to follow it. Anchoring by hand here would mask the bug.
         with patch.object(screen, "_stream_response"):
             screen._send_message("a question")
-        await pilot.pause()
+        await _settle(pilot)
         widget = screen._active_assistant
         assert widget is not None
+        # Composed, so the appends below render rather than silently buffering
+        # and leaving both preconditions to pass against an empty bubble.
+        assert widget._content_widget is not None
 
         # What is rendered mid-stream still fits the pane, so every scroll up to
         # this point is a no-op against a zero-height overflow.
         widget.append_content("intro paragraph")
-        await pilot.pause()
+        await _settle(pilot)
         assert log.max_scroll_y == 0, "precondition: the answer still fits the pane"
         # Hold the debounce open so the rest stays buffered however long the
         # pause above took: a slow host must not quietly turn this into a test
         # of an answer that already overflowed before it finished.
         widget._last_md_update = time.monotonic()
         widget.append_content("\n\n".join(f"answer paragraph {i}" for i in range(300)))
-        await pilot.pause()
+        await _settle(pilot)
         assert log.max_scroll_y == 0, "precondition: the tail is still buffered"
 
         # _finalize_stream runs on the streaming worker thread in production;
@@ -11595,7 +11613,7 @@ async def test_chat_finalize_stream_scrolls_to_the_end_of_the_finished_answer():
         await asyncio.to_thread(
             screen._finalize_stream, widget, ["cv-manual.pdf", "specs.pdf"], ["done"]
         )
-        await pilot.pause()
+        await _settle(pilot)
 
         assert log.scroll_y == log.max_scroll_y, (
             f"answer parked at {log.scroll_y} with the bottom at {log.max_scroll_y}: "

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3933,6 +3933,17 @@ async def _grow_answer(pilot, widget, paragraphs: int):
     await _settle(pilot)
 
 
+async def _reader_scrolls_up(pilot):
+    """Scroll up off the bottom the way the reader does, with the real keys.
+
+    Escape first: in insert mode the input holds focus and takes PgUp itself,
+    which is the point of the mode rather than a binding that missed.
+    """
+    await pilot.press("escape")
+    await pilot.press("pageup")
+    await _settle(pilot)
+
+
 async def test_chat_log_follows_the_answer_as_it_grows():
     """The answer's tail stays in view while it streams.
 
@@ -3960,8 +3971,7 @@ async def test_chat_log_stops_following_when_the_user_scrolls_up():
         log, widget = await _start_turn(pilot, screen)
         await _grow_answer(pilot, widget, 80)
 
-        screen.action_scroll_up()  # the real binding, not a raw scroll_to
-        await _settle(pilot)
+        await _reader_scrolls_up(pilot)
         assert log.scroll_y < log.max_scroll_y, "precondition: the reader scrolled up"
 
         await _grow_answer(pilot, widget, 160)
@@ -3977,12 +3987,10 @@ async def test_chat_log_follows_again_once_the_user_returns_to_the_bottom():
         log, widget = await _start_turn(pilot, screen)
         await _grow_answer(pilot, widget, 80)
 
-        screen.action_scroll_up()
-        await _settle(pilot)
+        await _reader_scrolls_up(pilot)
         assert log.scroll_y < log.max_scroll_y
 
-        screen._insert_mode = False
-        screen.action_vim_scroll_end()  # vim G jumps to the bottom
+        await pilot.press("G")  # vim G jumps to the bottom
         await _settle(pilot)
 
         await _grow_answer(pilot, widget, 160)
@@ -4004,8 +4012,7 @@ async def test_chat_log_does_not_follow_again_from_part_way_back_down():
         await _grow_answer(pilot, widget, 80)
         was_the_bottom = log.max_scroll_y
 
-        screen.action_scroll_up()
-        await _settle(pilot)
+        await _reader_scrolls_up(pilot)
         await _grow_answer(pilot, widget, 160)
         assert log.max_scroll_y > was_the_bottom, "precondition: the answer outgrew that spot"
 
@@ -4027,8 +4034,7 @@ async def test_chat_send_message_follows_the_answer_it_is_about_to_get():
         await _grow_answer(pilot, widget, 80)
 
         # The reader scrolls up during this answer and leaves it there.
-        screen.action_scroll_up()
-        await _settle(pilot)
+        await _reader_scrolls_up(pilot)
         assert log.scroll_y < log.max_scroll_y
 
         # The next question must follow its own answer regardless.

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3893,112 +3893,133 @@ async def test_chat_input_handler_uses_on_decorator():
     )
 
 
-async def test_chat_scroll_to_bottom():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.containers import VerticalScroll
+async def _start_turn(pilot, screen):
+    """Ask a question the way the user does, and hand back the log and bubble.
 
-        log = app.screen.query_one("#chat-log", VerticalScroll)
-        with patch.object(log, "scroll_end") as mock_end:
-            app.screen._scroll_to_bottom()
-            # scroll_end called only when near bottom (within 5 lines)
-            assert mock_end.called or log.max_scroll_y - log.scroll_y >= 5
-
-
-async def test_chat_auto_scroll_stays_pinned_as_content_grows():
-    """Regression: streamed content grows between scroll ticks. scroll_end does
-    not move scroll_y synchronously and Textual keeps scroll_y put as content
-    grows above it, so max_scroll_y races ahead of scroll_y. Auto-follow must
-    stay pinned to the bottom instead of disabling itself once that gap exceeds
-    the tail tolerance.
+    Every following test sets up through here rather than anchoring the log by
+    hand: anchoring in the test is what production is on the hook for, and doing
+    it in the test would hide it going missing.
     """
     from textual.containers import VerticalScroll
 
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        log = app.screen.query_one("#chat-log", VerticalScroll)
-        with (
-            patch.object(type(log), "max_scroll_y", new_callable=PropertyMock) as max_y,
-            patch.object(type(log), "scroll_y", new_callable=PropertyMock) as scroll_y,
-            patch.object(log, "scroll_end") as mock_end,
-        ):
-            # Tick 1: user parked at the bottom (10/10), auto-scroll fires.
-            max_y.return_value = 10
-            scroll_y.return_value = 10.0
-            app.screen._scroll_to_bottom()
-            assert mock_end.call_count == 1
-
-            # 70 more lines stream in before the next tick. scroll_y stays at
-            # the parked spot (10) while max_scroll_y races to 80.
-            max_y.return_value = 80
-            scroll_y.return_value = 10.0
-            app.screen._scroll_to_bottom()
-            # Comparing the live gap (80 - 10 = 70 >= 5) would suppress this and
-            # never recover. The user never scrolled up, so we must still follow.
-            assert mock_end.call_count == 2
+    log = screen.query_one("#chat-log", VerticalScroll)
+    with patch.object(screen, "_stream_response"):
+        screen._send_message("a question")
+    await pilot.pause()
+    widget = screen._active_assistant
+    assert widget is not None
+    return log, widget
 
 
-async def test_chat_auto_scroll_stops_when_user_scrolls_up():
-    """Auto-follow must release the bottom once the user scrolls up to read."""
-    from textual.containers import VerticalScroll
-
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        log = app.screen.query_one("#chat-log", VerticalScroll)
-        with (
-            patch.object(type(log), "max_scroll_y", new_callable=PropertyMock) as max_y,
-            patch.object(type(log), "scroll_y", new_callable=PropertyMock) as scroll_y,
-            patch.object(log, "scroll_end") as mock_end,
-        ):
-            # Park at the bottom.
-            max_y.return_value = 80
-            scroll_y.return_value = 80.0
-            app.screen._scroll_to_bottom()
-            assert mock_end.call_count == 1
-
-            # User scrolls well up from the parked bottom; more content arrives.
-            max_y.return_value = 120
-            scroll_y.return_value = 20.0
-            app.screen._scroll_to_bottom()
-            # We must not yank the reader back down.
-            assert mock_end.call_count == 1
+async def _grow_answer(pilot, widget, paragraphs: int):
+    """Render *paragraphs* more of the answer, as a stream's flushes do."""
+    widget._last_md_update = 0.0
+    widget.append_content("\n\n".join(f"line {i}" for i in range(paragraphs)))
+    await pilot.pause()
 
 
-async def test_chat_auto_scroll_resumes_only_at_live_bottom():
-    """After a scroll-up, auto-follow re-engages only at the live bottom, not at
-    the stale position the previous response was parked at.
+async def test_chat_log_follows_the_answer_as_it_grows():
+    """The answer's tail stays in view while it streams.
+
+    Textual anchors the log, so growth re-pins the scroll during the same layout
+    pass that measures it: there is no window in which the view can be left
+    behind a taller document.
     """
-    from textual.containers import VerticalScroll
-
     app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        log = app.screen.query_one("#chat-log", VerticalScroll)
-        with (
-            patch.object(type(log), "max_scroll_y", new_callable=PropertyMock) as max_y,
-            patch.object(type(log), "scroll_y", new_callable=PropertyMock) as scroll_y,
-            patch.object(log, "scroll_end") as mock_end,
-        ):
-            # Park at the bottom (80), then the user scrolls up while more
-            # content streams in and pushes the bottom to 120.
-            max_y.return_value = 80
-            scroll_y.return_value = 80.0
-            app.screen._scroll_to_bottom()
-            assert mock_end.call_count == 1
-            max_y.return_value = 120
-            scroll_y.return_value = 20.0
-            app.screen._scroll_to_bottom()
-            assert mock_end.call_count == 1
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        log, widget = await _start_turn(pilot, app.screen)
 
-            # Scrolling back to the old parked spot (80) must NOT resume: the
-            # live bottom is now 120, so 80 is still 40 lines short.
-            scroll_y.return_value = 80.0
-            app.screen._scroll_to_bottom()
-            assert mock_end.call_count == 1
+        await _grow_answer(pilot, widget, 40)
+        assert log.scroll_y == log.max_scroll_y
+        await _grow_answer(pilot, widget, 120)
+        assert log.scroll_y == log.max_scroll_y, "the view fell behind the answer"
 
-            # Reaching the live bottom re-engages auto-follow.
-            scroll_y.return_value = 118.0
-            app.screen._scroll_to_bottom()
-            assert mock_end.call_count == 2
+
+async def test_chat_log_stops_following_when_the_user_scrolls_up():
+    """Scrolling up to read must not be undone by the answer still growing."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        log, widget = await _start_turn(pilot, screen)
+        await _grow_answer(pilot, widget, 80)
+
+        screen.action_scroll_up()  # the real binding, not a raw scroll_to
+        await pilot.pause()
+        assert log.scroll_y < log.max_scroll_y, "precondition: the reader scrolled up"
+
+        await _grow_answer(pilot, widget, 160)
+        assert log.scroll_y < log.max_scroll_y, "the reader was yanked back down"
+
+
+async def test_chat_log_follows_again_once_the_user_returns_to_the_bottom():
+    """Coming back to the bottom resumes following for the rest of the answer."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        log, widget = await _start_turn(pilot, screen)
+        await _grow_answer(pilot, widget, 80)
+
+        screen.action_scroll_up()
+        await pilot.pause()
+        assert log.scroll_y < log.max_scroll_y
+
+        screen._insert_mode = False
+        screen.action_vim_scroll_end()  # vim G jumps to the bottom
+        await pilot.pause()
+
+        await _grow_answer(pilot, widget, 160)
+        assert log.scroll_y == log.max_scroll_y, "following did not resume at the bottom"
+
+
+async def test_chat_log_does_not_follow_again_from_part_way_back_down():
+    """Scrolling part of the way back is still reading, not catching up.
+
+    Following resumes at the live bottom only. Coming back to where the answer
+    used to end, while it has since grown past that, must not start yanking the
+    reader down again.
+    """
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        log, widget = await _start_turn(pilot, screen)
+        await _grow_answer(pilot, widget, 80)
+        was_the_bottom = log.max_scroll_y
+
+        screen.action_scroll_up()
+        await pilot.pause()
+        await _grow_answer(pilot, widget, 160)
+        assert log.max_scroll_y > was_the_bottom, "precondition: the answer outgrew that spot"
+
+        # Back to where the bottom used to be -- short of where it is now.
+        log.scroll_to(y=was_the_bottom, animate=False)
+        await pilot.pause()
+        await _grow_answer(pilot, widget, 160)
+
+        assert log.scroll_y < log.max_scroll_y, "following resumed short of the bottom"
+
+
+async def test_chat_send_message_follows_the_answer_it_is_about_to_get():
+    """A turn follows its own answer, whatever the previous turn was left at."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        log, widget = await _start_turn(pilot, screen)
+        await _grow_answer(pilot, widget, 80)
+
+        # The reader scrolls up during this answer and leaves it there.
+        screen.action_scroll_up()
+        await pilot.pause()
+        assert log.scroll_y < log.max_scroll_y
+
+        # The next question must follow its own answer regardless.
+        _, next_widget = await _start_turn(pilot, screen)
+        await _grow_answer(pilot, next_widget, 160)
+        assert log.scroll_y == log.max_scroll_y, "the new turn did not follow its answer"
 
 
 async def test_chat_trim_history_drops_oldest_pairs_over_token_budget():
@@ -11500,7 +11521,8 @@ async def test_chat_notify_no_results_uses_warning_severity():
 
 async def test_chat_finalize_stream_emits_no_results_toast_when_search_finds_nothing():
     """In Search mode, a response without a Sources block triggers the toast."""
-    from unittest.mock import MagicMock
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
 
     from lilbee.core.config import cfg
 
@@ -11511,20 +11533,74 @@ async def test_chat_finalize_stream_emits_no_results_toast_when_search_finds_not
             await _pilot.pause()
             screen = app.screen
             widget = MagicMock()
+            widget.finish = AsyncMock()
             with (
                 patch.object(screen, "_embedding_ready", return_value=True),
-                patch(
-                    "lilbee.cli.tui.screens.chat.call_from_thread",
-                    side_effect=lambda *args, **_kw: (
-                        args[1](*args[2:]) if callable(args[1]) else None
-                    ),
-                ),
                 patch.object(screen, "_notify_no_results") as mock_notify,
             ):
-                screen._finalize_stream(widget, [], ["I couldn't find that in your docs."])
+                # From a worker thread, as the streaming worker calls it: the
+                # real call_from_thread then runs each hop on the main thread.
+                await asyncio.to_thread(
+                    screen._finalize_stream, widget, [], ["I couldn't find that in your docs."]
+                )
+                await _pilot.pause()
                 mock_notify.assert_called_once()
     finally:
         cfg.chat_mode = "search"
+
+
+async def test_chat_finalize_stream_scrolls_to_the_end_of_the_finished_answer():
+    """Regression: the answer must end scrolled to the bottom, citations included.
+
+    A stream's last tokens sit unrendered in the debounce buffer, so ``finish``
+    is what renders the tail and mounts the citations -- and Markdown mounts
+    those blocks asynchronously, after ``finish`` returns. The answer can fit
+    the pane right up until that lands, which is the case that used to strand
+    the citations below the fold with no further stream tick to recover.
+    """
+    import asyncio
+    import time
+
+    from textual.containers import VerticalScroll
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        log = screen.query_one("#chat-log", VerticalScroll)
+
+        # Go through the real entry point: it mounts the answer bubble and sets
+        # the log up to follow it. Anchoring by hand here would mask the bug.
+        with patch.object(screen, "_stream_response"):
+            screen._send_message("a question")
+        await pilot.pause()
+        widget = screen._active_assistant
+        assert widget is not None
+
+        # What is rendered mid-stream still fits the pane, so every scroll up to
+        # this point is a no-op against a zero-height overflow.
+        widget.append_content("intro paragraph")
+        await pilot.pause()
+        assert log.max_scroll_y == 0, "precondition: the answer still fits the pane"
+        # Hold the debounce open so the rest stays buffered however long the
+        # pause above took: a slow host must not quietly turn this into a test
+        # of an answer that already overflowed before it finished.
+        widget._last_md_update = time.monotonic()
+        widget.append_content("\n\n".join(f"answer paragraph {i}" for i in range(300)))
+        await pilot.pause()
+        assert log.max_scroll_y == 0, "precondition: the tail is still buffered"
+
+        # _finalize_stream runs on the streaming worker thread in production;
+        # driving it from one keeps its call_from_thread hops real.
+        await asyncio.to_thread(
+            screen._finalize_stream, widget, ["cv-manual.pdf", "specs.pdf"], ["done"]
+        )
+        await pilot.pause()
+
+        assert log.scroll_y == log.max_scroll_y, (
+            f"answer parked at {log.scroll_y} with the bottom at {log.max_scroll_y}: "
+            "the tail of the answer is below the fold"
+        )
 
 
 async def test_chat_f5_opens_setup():


### PR DESCRIPTION
## Problem

When an answer finished, the chat stopped short of the end of it. The last part, usually the sources, sat below the visible area and you had to scroll down by hand to read it.

## Solution

Textual can keep a view pinned to the bottom as content arrives, and let go once the reader scrolls away. The chat now uses that, replacing the hand-written scrolling it had, which measured the answer at the wrong moment and left the end of it off screen.

This is the second bug in that scrolling code, after #294, so it is replaced rather than patched again.
