### PR TITLE
Add the towing-limits reel to the README and the tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Point lilbee at a folder of PDFs, notes, ebooks, or code and it builds a searcha
 
 ![chat with an indexed PDF manual: a cited markdown table extracted from the source](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
 
+Ask it something with a real answer at stake and you get the answer, not a paraphrase of the question. Here it's a vehicle manual, and the trailer is too heavy: lilbee says so, gives the weight it *is* rated for, and cites the page it read that on. The fleet panel on the right is the GPU doing it, on this machine.
+
+![ask whether a car can tow a 3,500 lb boat trailer; lilbee says no, gives the real limits, and cites the manual page](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.gif)
+
 ### Already using an MCP-aware agent? Hand setup to it.
 
 If you've already got an MCP-aware coding agent running, it can do the setup: browse the catalog, pull picks, assign them to the embedding / reranker / vision roles, and tune retrieval. No TUI, no config file, no restart. Agents already understand search engines, so the right knobs are obvious to them. See the [`lilbee-mcp` skill](src/lilbee/skills/lilbee_mcp/SKILL.md) for the workflow and example prompts.

--- a/README.md
+++ b/README.md
@@ -181,9 +181,7 @@ Point lilbee at a folder of PDFs, notes, ebooks, or code and it builds a searcha
 
 ![/add a PDF, watch the Task Center, ask a cited question](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-add.gif)
 
-![chat with an indexed PDF manual: a cited markdown table extracted from the source](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
-
-Ask it something with a real answer at stake and you get the answer, not a paraphrase of the question. Here it's a vehicle manual, and the trailer is too heavy: lilbee says so, gives the weight it *is* rated for, and cites the page it read that on. The fleet panel on the right is the GPU doing it, on this machine.
+Ask it something with a real answer at stake and you get the answer, not a paraphrase of the question. Here the trailer is too heavy for the car: lilbee says so, gives the weight it *is* rated for, and cites the page it read that on. The panel on the right is the GPU doing it, on this machine.
 
 ![ask whether a car can tow a 3,500 lb boat trailer; lilbee says no, gives the real limits, and cites the manual page](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.gif)
 

--- a/docs/tutorial-reel.md
+++ b/docs/tutorial-reel.md
@@ -40,6 +40,14 @@ at the exact spot.
 
 ![chat with cited answers](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
 
+## A straight answer, with the page it came from
+
+A customer wants to tow a 3,500 lb boat trailer. The car can't, and lilbee says so: the
+weight it *is* rated for, the combined limit, what to check before towing, and the page
+each of those came from. The fleet panel on the right is the GPU answering.
+
+![ask whether a car can tow a 3,500 lb boat trailer; lilbee says no, gives the real limits, and cites the manual page](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.gif)
+
 ## Add files
 
 `/add <path>` copies the file into your library and embeds it. Switching to the Task

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -59,6 +59,7 @@
           <li><a href="#command-surface">Command surface</a></li>
           <li class="toc-group"><a href="#tui-ask">Ask your library</a></li>
           <li><a href="#chat">Chat with cited answers</a></li>
+          <li><a href="#tow-limits">A straight answer, with the page</a></li>
           <li><a href="#add">Add files</a></li>
           <li><a href="#crawl">Crawl a URL</a></li>
           <li><a href="#crawl-site">Crawl a whole site</a></li>
@@ -147,6 +148,17 @@
           <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.png">
             <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.mp4" type="video/mp4">
             <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.mp4">chat with cited answers (MP4)</a>
+          </video>
+        </div>
+      </section>
+
+      <section class="tutorial-section" id="tow-limits">
+        <h4><a href="#tow-limits">Get a straight answer, with the page it came from</a></h4>
+        <p>A customer wants to tow a 3,500 lb boat trailer. The Crown Vic can't, and lilbee says so: it gives the weight the car <em>is</em> rated for, the combined limit, what to check before towing, and the page it read each of those on. The fleet panel on the right is the GPU answering, on this machine.</p>
+        <div class="tutorial-clip">
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.mp4">towing limits, cited (MP4)</a>
           </video>
         </div>
       </section>


### PR DESCRIPTION
## Problem

The chat reels show that answers come back cited, not that they come back useful. Pulling a table out of a PDF is a retrieval result; nobody has to act on it.

## Solution

A reel where the answer costs something: the trailer is too heavy, so lilbee says no, gives the 1,500 lb the car is rated for and the 6,600 lb combined limit, and cites the page each came from. The fleet panel stays open, so the GPU answering is on screen next to the answer.

Goes in the README's library section and the tutorial under Ask your library. Assets are on `gh-pages` as `demos/tui-tow-limits.{gif,mp4,png}`, at the same display size as the other reels.

Needs the scroll fix in #537: on `main` the answer never reaches its end, so the `Sources:` line the reel is about sits below the fold.
