### PR TITLE
Fix a chat-mode toggle crash and the flaky TUI tests

### DIFF
--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -387,19 +387,26 @@ class ChatModeToggle(Widget, can_focus=False):
 
     def __init__(self) -> None:
         super().__init__(id=_CHAT_MODE_TOGGLE_ID)
+        self._search_pill: ChatModePill | None = None
+        self._chat_pill: ChatModePill | None = None
 
     def compose(self) -> ComposeResult:
+        # Keep direct references: on_mount can run while the composed pills
+        # are still being attached to the DOM, so a query there raises
+        # NoMatches on a slow mount. Attributes carry no such ordering.
+        self._search_pill = ChatModePill(
+            msg.CHAT_MODE_SEARCH_LABEL,
+            id=_CHAT_MODE_SEARCH_PILL_ID,
+            classes=_CHAT_MODE_PILL_CLASS,
+        )
+        self._chat_pill = ChatModePill(
+            msg.CHAT_MODE_CHAT_LABEL,
+            id=_CHAT_MODE_CHAT_PILL_ID,
+            classes=_CHAT_MODE_PILL_CLASS,
+        )
         with Horizontal():
-            yield ChatModePill(
-                msg.CHAT_MODE_SEARCH_LABEL,
-                id=_CHAT_MODE_SEARCH_PILL_ID,
-                classes=_CHAT_MODE_PILL_CLASS,
-            )
-            yield ChatModePill(
-                msg.CHAT_MODE_CHAT_LABEL,
-                id=_CHAT_MODE_CHAT_PILL_ID,
-                classes=_CHAT_MODE_PILL_CLASS,
-            )
+            yield self._search_pill
+            yield self._chat_pill
 
     def on_mount(self) -> None:
         self._refresh()
@@ -416,8 +423,10 @@ class ChatModeToggle(Widget, can_focus=False):
         ready = self._embedding_ready()
         mode = cfg.chat_mode if ready else ChatMode.CHAT.value
         active_search = mode == ChatMode.SEARCH.value
-        search_pill = self.query_one(f"#{_CHAT_MODE_SEARCH_PILL_ID}", ChatModePill)
-        chat_pill = self.query_one(f"#{_CHAT_MODE_CHAT_PILL_ID}", ChatModePill)
+        search_pill = self._search_pill
+        chat_pill = self._chat_pill
+        if search_pill is None or chat_pill is None:
+            return
         # Search half is disabled whenever embedding isn't ready; Chat is
         # always reachable so it never carries the disabled class.
         search_pill.set_class(active_search, _CHAT_MODE_ACTIVE_CLASS)

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1261,10 +1261,13 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 search = app.screen.query_one("#catalog-search", Input)
                 search.value = "test"
-                await search.action_submit()
-                await pilot.pause()
-                grid = app.screen.query("#grid-chat ModelGrid").first()
-                assert grid.has_focus
+                # Enter installs the first match; stop the chain before it
+                # spawns a download worker that would outlive the test.
+                with mock.patch.object(app.screen, "_enqueue_download"):
+                    await search.action_submit()
+                    await pilot.pause()
+                    grid = app.screen.query("#grid-chat ModelGrid").first()
+                    assert grid.has_focus
 
     async def test_search_filters_list_view(self, _mock_resolve):
         """Typing in the filter narrows the visible row count in list view."""
@@ -1646,12 +1649,15 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 search = app.screen.query_one("#catalog-search", Input)
                 search.value = "test"
-                await search.action_submit()
-                for _ in range(10):
-                    await pilot.pause()
-                    if app.screen._list_widget.has_focus:
-                        break
-                assert app.screen._list_widget.has_focus
+                # Enter installs the first match; stop the chain before it
+                # spawns a download worker that would outlive the test.
+                with mock.patch.object(app.screen, "_enqueue_download"):
+                    await search.action_submit()
+                    for _ in range(10):
+                        await pilot.pause()
+                        if app.screen._list_widget.has_focus:
+                            break
+                    assert app.screen._list_widget.has_focus
 
     async def test_grid_card_count_matches_families(self, _mock_resolve):
         """The Chat task tab surfaces the chat featured family as a card.

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -282,23 +282,22 @@ async def test_panel_updates_on_second_tick(monkeypatch: pytest.MonkeyPatch) -> 
 async def test_panel_graceful_on_probe_exception(monkeypatch: pytest.MonkeyPatch) -> None:
     """A failing probe leaves the previous content intact and does not crash.
 
-    The initial on_mount probe returns an empty dict (no devices set yet).
-    The first explicit tick returns good stats with the right labels set.
-    The second explicit tick raises; the panel must keep the previous content.
+    The fake probe answers by the test's current phase, not by call count:
+    the panel's own interval timer can slip extra ticks in between the
+    explicit ones on a slow host, and a counter-keyed fake then hands the
+    good-stats answer to a tick that snapshotted labels before
+    ``set_devices`` ran, rendering the default GPU0 label.
     """
     import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
     from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
 
     good_stat = _make_stat(0, utilization_pct=50)
-    probe_calls: list[int] = []
+    probe_phase = {"answer": "empty"}
 
     def _probe(devices: object) -> object:  # type: ignore[no-untyped-def]
-        idx = len(probe_calls)
-        probe_calls.append(idx)
-        if idx == 0:
-            # on_mount probe: no devices registered yet
+        if probe_phase["answer"] == "empty":
             return {}
-        if idx == 1:
+        if probe_phase["answer"] == "good":
             return {0: good_stat}
         raise OSError("nvidia-smi not found")
 
@@ -313,14 +312,16 @@ async def test_panel_graceful_on_probe_exception(monkeypatch: pytest.MonkeyPatch
         panel.set_devices([device], labels={0: "CUDA0"})
         await app.workers.wait_for_complete()
 
-        # First explicit tick returns good stats
+        # Devices and labels are in, so a probe may now answer with stats.
+        probe_phase["answer"] = "good"
         panel._request_stats()
         await app.workers.wait_for_complete()
         await pilot.pause()
         content_after_good = str(panel.render())
         assert "CUDA0" in content_after_good
 
-        # Second explicit tick raises; content must remain unchanged
+        # Every probe from here on raises; content must remain unchanged.
+        probe_phase["answer"] = "raise"
         panel._request_stats()
         await app.workers.wait_for_complete()
         await pilot.pause()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -10305,9 +10305,11 @@ async def test_catalog_grid_leave_up_focuses_previous():
             if len(grids) < 2:
                 pytest.skip("test requires at least two grids mounted")
             grids[1].focus()
-            await pilot.pause()
+            await pilot.wait_for_scheduled_animations()
             grids[1].post_message(ModelGrid.LeaveUp(grids[1]))
-            await pilot.pause()
+            # The focus move lands with the message and any scroll it starts;
+            # a bare pause reads back mid-flight on a slow host.
+            await pilot.wait_for_scheduled_animations()
             assert screen.focused is not grids[1]
 
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -853,6 +853,27 @@ class TestModelBar:
                 chat_pill = toggle.query_one("#chat-mode-chat", Static)
                 assert "-active" in chat_pill.classes
 
+    async def test_chat_mode_toggle_refresh_survives_pills_not_in_dom(self) -> None:
+        """Regression: on_mount's refresh can run while the composed pills are
+        not yet attached to the DOM; querying for them there raised NoMatches
+        and took the screen down. The refresh reads the references compose
+        created instead, which exist whether or not the DOM does. Pills
+        removed from the DOM stand in for pills not yet attached to it.
+        """
+        from lilbee.cli.tui.widgets.model_bar import ChatModePill, ChatModeToggle
+
+        cfg.chat_mode = "chat"
+        with mock.patch("lilbee.cli.tui.widgets.model_bar.is_model_available", return_value=True):
+            app = _ModelBarApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                toggle = app.query_one(ChatModeToggle)
+                for pill in list(toggle.query(ChatModePill)):
+                    await pill.remove()
+                toggle.refresh_state()
+                assert toggle._chat_pill is not None
+                assert "-active" in toggle._chat_pill.classes
+
     async def test_chat_mode_toggle_flips_on_click(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ChatModeToggle
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -853,6 +853,16 @@ class TestModelBar:
                 chat_pill = toggle.query_one("#chat-mode-chat", Static)
                 assert "-active" in chat_pill.classes
 
+    def test_chat_mode_toggle_refresh_before_compose_is_noop(self) -> None:
+        """A refresh on a toggle whose compose has not produced the pills yet
+        returns without touching them."""
+        from lilbee.cli.tui.widgets.model_bar import ChatModeToggle
+
+        with mock.patch("lilbee.cli.tui.widgets.model_bar.is_model_available", return_value=True):
+            toggle = ChatModeToggle()
+            toggle._refresh()
+            assert toggle._search_pill is None and toggle._chat_pill is None
+
     async def test_chat_mode_toggle_refresh_survives_pills_not_in_dom(self) -> None:
         """Regression: on_mount's refresh can run while the composed pills are
         not yet attached to the DOM; querying for them there raised NoMatches


### PR DESCRIPTION
## Problem

The chat-mode toggle could crash the screen while mounting: its refresh queries the pills in the DOM, and when it ran before they finished attaching, the NoMatches took the screen down.

Beyond that, CI's red was flaky tests. The catalog search focus tests started a real model download every run (never stubbed), and on a loaded runner that worker starves the other TUI tests on its xdist worker, failing a different one each time. The GPU panel test keyed its fake probe on call count, so an extra timer tick drew the wrong answer.

## Solution

The toggle keeps the pill references its compose creates and refreshes through them, so mount order no longer matters; a regression test pins it. The search tests stub the download enqueue, the GPU panel fake answers by phase, and the LeaveUp focus test waits for animations to settle before reading focus.
