### PR TITLE
Fail loud when the GPU device probe wedges instead of hanging serve forever

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,6 +285,10 @@ flowchart LR
   `llama-server --list-devices`, so enumeration and pinning share one backend-native
   index space. A device index from one API (Vulkan) is meaningless to another (CUDA),
   so we never cross them; the Vulkan VRAM probe (`gpu_select`) is only a fallback.
+  The probe runs in its own process group with a hard timeout: a probe wedged in
+  GPU-driver I/O is killed (and abandoned if unkillable) and surfaces as a named
+  error through the warm tracker, health, and the TUI, never as an empty device
+  list or a silent never-ready fleet.
 - **Pinning** (`devices.visible_env`): per backend, never by a foreign index —
   CUDA via `CUDA_VISIBLE_DEVICES` with `CUDA_DEVICE_ORDER` (`PCI_BUS_ID` unless the
   environment presets another order), ROCm via

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -422,6 +422,9 @@ FLEET_STATE_REBUILDING = "rebuilding fleet…"
 FLEET_SINGLE_GPU_NOTE = "One graphics card: everything runs here."
 FLEET_GPU_PROBING = "probing GPUs…"
 FLEET_NO_GPUS = "(no GPUs detected)"
+# Shown when the device probe failed outright (e.g. a wedged GPU driver), so the
+# panel names the problem instead of sitting on the probing placeholder forever.
+FLEET_GPU_PROBE_FAILED = "GPU probe failed: {reason}"
 # Shown for a role that has no placement because its model isn't downloaded, so the
 # empty slot reads as a fixable state instead of "GPU placement is broken".
 FLEET_MODEL_NOT_DOWNLOADED = "{role}: {model} not downloaded, pull it to place it"

--- a/src/lilbee/cli/tui/widgets/fleet_body.py
+++ b/src/lilbee/cli/tui/widgets/fleet_body.py
@@ -233,9 +233,14 @@ class FleetBody(Widget):
             view = get_placement()
         except Exception as exc:
             log.debug("Failed to load placement", exc_info=True)
-            call_from_thread(self, self.notify, str(exc), severity="error")
+            call_from_thread(self, self._render_load_failure, str(exc))
             return
         call_from_thread(self, self._render_view, view)
+
+    def _render_load_failure(self, reason: str) -> None:
+        """Name the placement-load failure in the panel instead of probing forever."""
+        self.query_one(_FLEET_PANEL_ID, GpuFleetPanel).set_probe_failed(reason)
+        self.notify(reason, severity="error")
 
     # -- rendering -------------------------------------------------------
 

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -178,6 +178,9 @@ class GpuFleetPanel(Static):
         # False until the parent device probe reports its result via set_devices;
         # gates the empty-GPUs text so a cold start holds the probing placeholder.
         self._probed = False
+        # The device probe's failure reason; while set, ticks pause and the panel
+        # shows the failure instead of stats.
+        self._probe_error: str | None = None
 
     def set_devices(
         self,
@@ -195,6 +198,15 @@ class GpuFleetPanel(Static):
         self._labels = dict(labels)
         self._roles = dict(roles) if roles is not None else {}
         self._probed = True
+        self._probe_error = None
+
+    def set_probe_failed(self, reason: str) -> None:
+        """Render the device probe's failure instead of the probing placeholder."""
+        self._probed = True
+        self._probe_error = reason
+        theme = self._resolve_theme()
+        error = _theme_color(theme, "error")
+        self.update(f"[{error}]  {msg.FLEET_GPU_PROBE_FAILED.format(reason=reason)}[/]")
 
     def on_mount(self) -> None:
         self._timer = self.set_interval(_TICK_INTERVAL_S, self._request_stats)
@@ -208,7 +220,7 @@ class GpuFleetPanel(Static):
 
     def _request_stats(self) -> None:
         """Kick off an off-thread stats probe unless one is already in flight."""
-        if self._probing:
+        if self._probing or self._probe_error is not None:
             return
         self._probing = True
         self._probe_worker(

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -261,6 +261,10 @@ class GpuFleetPanel(Static):
         roles: dict[int, str],
     ) -> None:
         """Update the rendered content with fresh stat data (main thread)."""
+        if self._probe_error is not None:
+            # A stats worker already in flight when the probe failure landed
+            # must not repaint the empty state over the failure message.
+            return
         theme = self._resolve_theme()
         markup = _render_stats(stats, labels, roles, theme, probed=self._probed)
         binary = intel_grant_binary(self._devices, stats)

--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -65,10 +65,16 @@ def resolve_engine_tool(tool: EngineTool) -> Path:
     if found is not None:
         return Path(found)
 
-    raise ProviderError(
-        f"{tool.value} binary not found. {_INSTALL_HINT}",
-        kind=ProviderErrorKind.NOT_FOUND,
+    # Only llama-server carries NOT_FOUND: it marks the engine-less host that
+    # legitimately serves nothing. A missing sibling tool (gguf-parser) must not
+    # take that kind, or the sizing fallback would misreport it as a model that
+    # isn't installed.
+    kind = (
+        ProviderErrorKind.NOT_FOUND
+        if tool is EngineTool.LLAMA_SERVER
+        else ProviderErrorKind.UNKNOWN
     )
+    raise ProviderError(f"{tool.value} binary not found. {_INSTALL_HINT}", kind=kind)
 
 
 def resolve_llama_server() -> Path:

--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -6,7 +6,7 @@ import shutil
 from enum import StrEnum
 from pathlib import Path
 
-from lilbee.providers.base import ProviderError
+from lilbee.providers.base import ProviderError, ProviderErrorKind
 
 _INSTALL_HINT = (
     "Reinstall lilbee to get the bundled engine, or set LILBEE_LLAMA_SERVER_PATH "
@@ -65,7 +65,10 @@ def resolve_engine_tool(tool: EngineTool) -> Path:
     if found is not None:
         return Path(found)
 
-    raise ProviderError(f"{tool.value} binary not found. {_INSTALL_HINT}")
+    raise ProviderError(
+        f"{tool.value} binary not found. {_INSTALL_HINT}",
+        kind=ProviderErrorKind.NOT_FOUND,
+    )
 
 
 def resolve_llama_server() -> Path:

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -42,7 +42,6 @@ _CUDA_SONAMES: tuple[str, ...] = ("libcudart.so.12", "libcublas.so.12", "libnvrt
 # Substrings that mark a CUDA init failure in the engine's --list-devices output.
 _CUDA_ERROR_MARKERS: tuple[str, ...] = ("error", "fail", "no cuda")
 _LDD_TIMEOUT_S = 10
-_LIST_DEVICES_TIMEOUT_S = 60
 # How much of the probe output to quote when no specific error line is found.
 _DIAGNOSTIC_TAIL_CHARS = 300
 
@@ -125,20 +124,9 @@ def _links_cuda_runtime(binary: Path, env: dict[str, str]) -> bool:
     return any(soname in out for soname in _CUDA_SONAMES)
 
 
-def _device_probe_diagnostic(binary: Path, env: dict[str, str]) -> str:
-    """The engine's own ``--list-devices`` CUDA error line, or a short tail of its output."""
-    try:
-        proc = subprocess.run(  # noqa: S603 - the resolved llama-server binary
-            [str(binary), "--list-devices"],
-            capture_output=True,
-            text=True,
-            timeout=_LIST_DEVICES_TIMEOUT_S,
-            env=env,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return "(the engine's device probe could not be run)"
-    out = f"{proc.stderr}\n{proc.stdout}".strip()
+def _device_probe_diagnostic(probe_output: str) -> str:
+    """The probe's CUDA error line, or a short tail of its output."""
+    out = probe_output.strip()
     for line in out.splitlines():
         lowered = line.lower()
         if "cuda" in lowered and any(marker in lowered for marker in _CUDA_ERROR_MARKERS):
@@ -146,13 +134,14 @@ def _device_probe_diagnostic(binary: Path, env: dict[str, str]) -> str:
     return out[-_DIAGNOSTIC_TAIL_CHARS:] if out else "(the engine's device probe printed nothing)"
 
 
-def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice]) -> None:
+def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice], probe_output: str) -> None:
     """Fail loud when a CUDA build links a runtime it cannot initialize a GPU with.
 
-    *devices* is the engine's own ``--list-devices`` result. When it is empty yet
-    *binary* is a CUDA build and the host has an NVIDIA GPU, the runtime loaded but
-    enumerated no device. The engine's own diagnostic is surfaced and the likely causes
-    are listed (rather than asserting one), so placement does not silently fall to CPU.
+    *devices* and *probe_output* are the engine's own ``--list-devices`` result.
+    When the list is empty yet *binary* is a CUDA build and the host has an NVIDIA
+    GPU, the runtime loaded but enumerated no device. The probe's own diagnostic is
+    surfaced and the likely causes are listed (rather than asserting one), so
+    placement does not silently fall to CPU.
     """
     if not sys.platform.startswith("linux"):
         return
@@ -163,7 +152,7 @@ def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice]) -> None
         return
     if not model_cache.has_nvidia_gpu():
         return
-    diagnostic = _device_probe_diagnostic(binary, env)
+    diagnostic = _device_probe_diagnostic(probe_output)
     raise ProviderError(
         "The engine links the CUDA runtime and this host has an NVIDIA GPU, but it "
         "enumerated no CUDA-capable device, so GPU work would silently fall back to CPU.\n"

--- a/src/lilbee/providers/fleet/devices.py
+++ b/src/lilbee/providers/fleet/devices.py
@@ -9,13 +9,24 @@ fallback when the binary can't enumerate. See docs/architecture.md.
 
 from __future__ import annotations
 
+import contextlib
+import logging
 import os
 import re
+import signal
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+log = logging.getLogger(__name__)
+
+_PROVIDER = "llama-server"
 _LIST_DEVICES_TIMEOUT_S = 60.0
+# How long to wait for a killed probe to be reaped before abandoning it: a child
+# wedged in uninterruptible GPU-driver I/O ignores even SIGKILL.
+_PROBE_KILL_WAIT_S = 5.0
 _TOPO_TIMEOUT_S = 15.0
 _GPU_LABEL_RE = re.compile(r"^GPU(\d+)$")
 # nvidia-smi emits SGR escapes (e.g. an underlined header) even when stdout is
@@ -53,6 +64,14 @@ class FleetDevice:
     name: str
     total_bytes: int
     free_bytes: int
+
+
+@dataclass(frozen=True)
+class DeviceProbe:
+    """The device probe's parsed devices plus its raw output for diagnostics."""
+
+    devices: list[FleetDevice]
+    output: str
 
 
 def _parse_topo_matrix(topo_text: str) -> tuple[set[int], set[frozenset[int]]]:
@@ -123,24 +142,68 @@ def _probe_env() -> dict[str, str]:
     return env
 
 
-def probe_devices(binary: Path) -> list[FleetDevice]:
-    """Parse ``<binary> --list-devices``; ``[]`` when unavailable/unparseable.
+def probe_devices(binary: Path, *, timeout_s: float = _LIST_DEVICES_TIMEOUT_S) -> DeviceProbe:
+    """Parse ``<binary> --list-devices``; empty devices when unavailable/unparseable.
 
     Filtered to a single GPU backend (the highest-ranked one present) so device
-    indices are unambiguous when a build exposes several backends.
+    indices are unambiguous when a build exposes several backends. A probe that
+    does not respond within *timeout_s* raises a ``ProviderError`` naming the
+    stuck probe: that is a wedged GPU driver, not a GPU-less host, and treating
+    it as "no devices" would silently plan a CPU fleet on a GPU box.
     """
     try:
-        proc = subprocess.run(  # noqa: S603 - binary is the resolved llama-server
-            [str(binary), "--list-devices"],
-            capture_output=True,
-            text=True,
-            timeout=_LIST_DEVICES_TIMEOUT_S,
-            env=_probe_env(),
-            check=False,
-        )
+        output = _run_list_devices(binary, timeout_s)
     except (OSError, subprocess.SubprocessError):
-        return []
-    return _select_backend(_parse_devices(proc.stdout + proc.stderr))
+        return DeviceProbe([], "")
+    return DeviceProbe(_select_backend(_parse_devices(output)), output)
+
+
+def _run_list_devices(binary: Path, timeout_s: float) -> str:
+    """Run the probe in its own process group; kill the group and raise on timeout.
+
+    ``subprocess.run``'s timeout path waits indefinitely for the killed child to
+    be reaped, so a probe wedged in uninterruptible GPU-driver I/O would hang the
+    caller forever; this bounds the reap and abandons an unkillable child.
+    """
+    proc = subprocess.Popen(  # noqa: S603 - binary is the resolved llama-server
+        [str(binary), "--list-devices"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=_probe_env(),
+        start_new_session=True,
+    )
+    try:
+        output, _ = proc.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        _kill_probe(proc)
+        raise ProviderError(
+            f"The GPU device probe ({binary.name} --list-devices) did not respond "
+            f"within {timeout_s:.0f}s, so the engine cannot start. The GPU driver "
+            "may be in a bad state: check that 'nvidia-smi' responds, and reboot "
+            "the host if it hangs.",
+            provider=_PROVIDER,
+            kind=ProviderErrorKind.SERVER,
+        ) from None
+    return output or ""
+
+
+def _kill_probe(proc: subprocess.Popen[str]) -> None:
+    """SIGKILL the timed-out probe's process group; abandon it if it cannot be reaped."""
+    if os.name == "posix":
+        # start_new_session made the probe its own group leader.
+        with contextlib.suppress(OSError):
+            os.killpg(proc.pid, signal.SIGKILL)
+    else:  # pragma: no cover - Windows has no process groups to kill
+        proc.kill()
+    try:
+        proc.communicate(timeout=_PROBE_KILL_WAIT_S)
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "The GPU device probe (pid %d) ignored SIGKILL and was abandoned; "
+            "it is likely stuck in the GPU driver.",
+            proc.pid,
+        )
 
 
 def _parse_devices(text: str) -> list[FleetDevice]:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from lilbee.core.config.enums import KvCacheType
 from lilbee.core.system import is_network_path
 from lilbee.providers import model_cache
+from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.adapters import (
     LLM_RERANK_CONCURRENCY,
     ROLE_SPECS,
@@ -946,15 +947,18 @@ def resolve_devices(binary: Path) -> list[FleetDevice]:
     """Enumerate devices in the binary's index space, or the Vulkan VRAM probe.
 
     The binary's ``--list-devices`` is authoritative; when it enumerates nothing,
-    fall back to the Vulkan VRAM probe, which reports the same index space.
+    fall back to the Vulkan VRAM probe, which reports the same index space. A
+    probe that times out raises instead (a wedged GPU driver); falling through
+    to the in-process Vulkan probe there could hang this thread unkillably.
     """
     from lilbee.providers.fleet.cuda_runtime import assert_cuda_devices_usable
     from lilbee.providers.fleet.gpu_select import enumerate_gpu_vram
 
-    devices = probe_devices(binary)
+    probe = probe_devices(binary)
+    devices = probe.devices
     # A CUDA build that links a runtime it cannot init a GPU with must fail loud,
     # not silently fall back to CPU (the Vulkan VRAM probe below would mask it).
-    assert_cuda_devices_usable(binary, devices)
+    assert_cuda_devices_usable(binary, devices, probe.output)
     if not devices and model_cache.has_nvidia_gpu():
         log.warning(
             "This host has an NVIDIA GPU but the engine's device probe "
@@ -971,6 +975,10 @@ def resolve_devices(binary: Path) -> list[FleetDevice]:
 
 
 _DEVICE_PROBE_TTL_S = 2.0
+# A failed probe is cached much longer than a good one: each retry against a
+# wedged GPU driver costs a full probe timeout, so a per-poll retry would stall
+# every placement read for a minute at a time.
+_DEVICE_PROBE_FAILURE_TTL_S = 60.0
 
 
 class _ReadDeviceCache:
@@ -978,32 +986,45 @@ class _ReadDeviceCache:
 
     Inspecting placement (GET placement/gpus, preview, ``placement show``)
     resolves devices on every call, which spawns a ``llama-server --list-devices``
-    subprocess; a brief TTL collapses a burst of reads onto one probe. The launch
-    path is never served from here -- it sizes against the clean-box plan
-    snapshot below (captured after stale-server reaping).
+    subprocess; a brief TTL collapses a burst of reads onto one probe. A probe
+    failure is cached too (with its own TTL) and re-raised to every read in the
+    window. The launch path is never served from here -- it sizes against the
+    clean-box plan snapshot below (captured after stale-server reaping).
     """
 
-    def __init__(self, ttl_s: float) -> None:
+    def __init__(self, ttl_s: float, failure_ttl_s: float) -> None:
         self._ttl_s = ttl_s
+        self._failure_ttl_s = failure_ttl_s
         self._lock = threading.Lock()
         self._at: float | None = None
         self._devices: list[FleetDevice] | None = None
+        self._failure: ProviderError | None = None
 
     def get(self, binary: Path) -> list[FleetDevice]:
         with self._lock:
-            fresh = self._at is not None and time.monotonic() - self._at < self._ttl_s
+            ttl = self._ttl_s if self._failure is None else self._failure_ttl_s
+            fresh = self._at is not None and time.monotonic() - self._at < ttl
+            if fresh and self._failure is not None:
+                raise self._failure
             if self._devices is None or not fresh:
-                self._devices = resolve_devices(binary)
                 self._at = time.monotonic()
+                try:
+                    self._devices = resolve_devices(binary)
+                except ProviderError as exc:
+                    self._devices = None
+                    self._failure = exc
+                    raise
+                self._failure = None
             return self._devices
 
     def clear(self) -> None:
         with self._lock:
             self._at = None
             self._devices = None
+            self._failure = None
 
 
-_read_device_cache = _ReadDeviceCache(_DEVICE_PROBE_TTL_S)
+_read_device_cache = _ReadDeviceCache(_DEVICE_PROBE_TTL_S, _DEVICE_PROBE_FAILURE_TTL_S)
 
 
 def clear_read_device_cache() -> None:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -692,10 +692,15 @@ class FleetProvider:
             # ctx, slots, and budgets against it (a live probe under a loaded
             # fleet would report our own residency as unavailable). Inside the
             # try: capturing resolves the engine binary, and a binary-less
-            # host must serve nothing, not raise.
+            # host must serve nothing, not raise. Every other planning failure
+            # (a wedged GPU probe, an unusable CUDA runtime) propagates so the
+            # warm tracker and the caller report the real reason instead of a
+            # silent never-ready fleet.
             planning.capture_plan_probe()
             plan = planning.plan_all_launches()
-        except ProviderError:
+        except ProviderError as exc:
+            if exc.kind is not ProviderErrorKind.NOT_FOUND:
+                raise
             log.debug("Engine binary unavailable; no swap started")
             plan = None
         self._skipped_not_installed = dict(plan.skipped_not_installed) if plan else {}
@@ -1453,7 +1458,7 @@ class FleetProvider:
                 # keep the full traceback at debug: a WARNING carrying exc_info
                 # reads like a crash for a condition the next real call recovers
                 # from.
-                log.warning("Engine warm-up failed; roles will load on first use: %s", exc)
+                log.warning("Engine warm-up failed: %s", exc)
                 log.debug("Engine warm-up failure detail.", exc_info=True)
             self._fail_warm_unless_ready(str(exc))
         finally:

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -93,30 +93,36 @@ _WARM_POLL_INTERVAL_S = 0.25
 _WARM_STREAM_TIMEOUT_S = 1800.0
 
 
-def _chat_status(provider: LLMProvider) -> Literal["ready", "loading", "not_started", "error"]:
-    """Classify the chat engine's readiness for /api/health.
+def _chat_status(
+    provider: LLMProvider,
+) -> tuple[Literal["ready", "loading", "not_started", "error"], str | None]:
+    """Classify the chat engine's readiness for /api/health, with the error reason.
 
-    ``ready`` once the role serves; ``error`` when warm-up failed; ``loading``
-    while a warm is in flight; ``not_started`` when nothing is warming and the role
-    isn't up (no chat model planned, or chat is swapped out for its co-tenant; the
-    next chat request loads it).
+    ``ready`` once the role serves; ``error`` when warm-up failed (paired with the
+    warm tracker's reason); ``loading`` while a warm is in flight; ``not_started``
+    when nothing is warming and the role isn't up (no chat model planned, or chat
+    is swapped out for its co-tenant; the next chat request loads it).
     """
     if provider.role_ready(WorkerRole.CHAT):
-        return "ready"
+        return "ready", None
     snapshot = provider.warm_progress()
     if snapshot is None:
-        return "not_started"
-    return "error" if snapshot.phase is WarmPhase.ERROR else "loading"
+        return "not_started", None
+    if snapshot.phase is WarmPhase.ERROR:
+        return "error", snapshot.error
+    return "loading", None
 
 
 async def health() -> HealthResponse:
     """Return service health, version, and whether the chat engine is warm."""
     provider = get_services().provider
+    chat_status, chat_error = _chat_status(provider)
     return HealthResponse(
         status="ok",
         version=get_version(),
         chat_ready=provider.role_ready(WorkerRole.CHAT),
-        chat_status=_chat_status(provider),
+        chat_status=chat_status,
+        chat_error=chat_error,
         chat_ctx=provider.served_chat_ctx(),
     )
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -199,6 +199,10 @@ class HealthResponse(BaseModel):
     so it will not come up on its own) or failed (``error``). Without this a bare
     ``chat_ready:false`` reads the same for "loading" and "hung", which looked like a
     silent hang on a fresh box with no chat model installed."""
+    chat_error: str | None = None
+    """The reason the chat engine failed to come up when ``chat_status`` is
+    ``error`` (e.g. a wedged GPU device probe), so a polling client can report
+    the cause instead of retrying forever."""
     chat_ctx: int | None = None
     """Per-slot context the chat engine serves, so a launcher can tell the client
     its window and the client trims history to fit. None until the engine is up."""

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -11,7 +11,7 @@ GIB = 1024**3
 
 def test_read_device_cache_collapses_repeat_probes(monkeypatch):
     """A burst of reads within the TTL probes the engine once."""
-    cache = planning._ReadDeviceCache(ttl_s=1000)
+    cache = planning._ReadDeviceCache(ttl_s=1000, failure_ttl_s=1000)
     calls = {"n": 0}
 
     def fake(_binary):
@@ -30,7 +30,7 @@ def test_read_device_cache_collapses_repeat_probes(monkeypatch):
 
 def test_read_device_cache_ttl_zero_always_probes(monkeypatch):
     """A zero TTL disables caching (every read re-probes)."""
-    cache = planning._ReadDeviceCache(ttl_s=0)
+    cache = planning._ReadDeviceCache(ttl_s=0, failure_ttl_s=0)
     calls = {"n": 0}
 
     def fake(_binary):

--- a/tests/test_fleet_binary.py
+++ b/tests/test_fleet_binary.py
@@ -128,6 +128,24 @@ def test_llama_server_raises_with_install_hint_when_not_found(
         resolve_llama_server()
 
 
+def test_missing_llama_server_is_not_found_but_aux_tools_are_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the llama-server resolution carries NOT_FOUND (the quiet engine-less
+    host path). A missing gguf-parser must not, or the sizing fallback would
+    misreport it as a model that isn't installed."""
+    from lilbee.providers.base import ProviderErrorKind
+
+    cfg.llama_server_path = ""
+    monkeypatch.setattr(_WHICH, lambda _name: None)
+    with pytest.raises(ProviderError) as server_exc:
+        resolve_llama_server()
+    assert server_exc.value.kind is ProviderErrorKind.NOT_FOUND
+    with pytest.raises(ProviderError) as parser_exc:
+        resolve_gguf_parser()
+    assert parser_exc.value.kind is ProviderErrorKind.UNKNOWN
+
+
 def test_aux_tools_ignore_llama_server_path_and_use_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -107,7 +107,7 @@ def test_assert_devices_noop_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
         raise AssertionError("must not probe off Linux")
 
     monkeypatch.setattr(cuda_runtime.subprocess, "run", _boom)
-    assert_cuda_devices_usable(Path("/bin/llama-server"), [])  # no raise
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [], "")  # no raise
 
 
 def test_assert_devices_passes_when_a_device_enumerated(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -116,7 +116,7 @@ def test_assert_devices_passes_when_a_device_enumerated(monkeypatch: pytest.Monk
     monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
     device = FleetDevice("CUDA", 0, "gpu", 1, 1)
-    assert_cuda_devices_usable(Path("/bin/llama-server"), [device])  # no raise
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [device], "")  # no raise
 
 
 def test_assert_devices_passes_for_non_cuda_build(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -124,7 +124,7 @@ def test_assert_devices_passes_for_non_cuda_build(monkeypatch: pytest.MonkeyPatc
     _ldd_returns(monkeypatch, _NO_CUDA)
     monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
-    assert_cuda_devices_usable(Path("/bin/llama-server"), [])  # no raise
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [], "")  # no raise
 
 
 def test_assert_devices_passes_when_no_nvidia_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -132,7 +132,7 @@ def test_assert_devices_passes_when_no_nvidia_gpu(monkeypatch: pytest.MonkeyPatc
     _ldd_returns(monkeypatch, _LINKS_CUDA)
     monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: False)
     monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
-    assert_cuda_devices_usable(Path("/bin/llama-server"), [])  # no raise
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [], "")  # no raise
 
 
 def test_assert_devices_raises_with_engine_diagnostic(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -143,15 +143,9 @@ def test_assert_devices_raises_with_engine_diagnostic(monkeypatch: pytest.Monkey
     monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
     cuda_err = "ggml_cuda_init: failed to initialize CUDA: no CUDA-capable device is detected"
-
-    def _run(cmd: list[str], *_a: object, **_k: object) -> SimpleNamespace:
-        if "--list-devices" in cmd:
-            return SimpleNamespace(stdout="", stderr=cuda_err + "\n")
-        return SimpleNamespace(stdout=_LINKS_CUDA, stderr="")  # ldd resolves the soname
-
-    monkeypatch.setattr(cuda_runtime.subprocess, "run", _run)
+    _ldd_returns(monkeypatch, _LINKS_CUDA)
     with pytest.raises(ProviderError) as exc:
-        assert_cuda_devices_usable(Path("/bin/llama-server"), [])
+        assert_cuda_devices_usable(Path("/bin/llama-server"), [], cuda_err + "\n")
     message = str(exc.value)
     assert "failed to initialize CUDA" in message  # the engine's own diagnostic, surfaced
     assert "nvidia-smi" in message
@@ -241,32 +235,19 @@ def test_ldd_output_none_when_subprocess_raises(monkeypatch: pytest.MonkeyPatch)
     assert cuda_runtime._ldd_output(Path("/bin/llama-server"), {}) is None
 
 
-def test_device_probe_diagnostic_returns_tail_when_no_error_line(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        cuda_runtime.subprocess,
-        "run",
-        lambda *_a, **_k: SimpleNamespace(stdout="CUDA0: NVIDIA L40 (45 GiB)\n", stderr=""),
-    )
-    out = cuda_runtime._device_probe_diagnostic(Path("/bin/llama-server"), {})
+def test_device_probe_diagnostic_returns_tail_when_no_error_line() -> None:
+    out = cuda_runtime._device_probe_diagnostic("CUDA0: NVIDIA L40 (45 GiB)\n")
     assert "NVIDIA L40" in out  # no error marker -> falls through to the output tail
 
 
-def test_device_probe_diagnostic_when_no_output(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        cuda_runtime.subprocess,
-        "run",
-        lambda *_a, **_k: SimpleNamespace(stdout="", stderr=""),
+def test_device_probe_diagnostic_picks_the_cuda_error_line() -> None:
+    output = "loading backends\nggml_cuda_init: CUDA error: unknown error\ntrailing noise\n"
+    assert (
+        cuda_runtime._device_probe_diagnostic(output) == "ggml_cuda_init: CUDA error: unknown error"
     )
-    out = cuda_runtime._device_probe_diagnostic(Path("/bin/llama-server"), {})
-    assert out == "(the engine's device probe printed nothing)"
 
 
-def test_device_probe_diagnostic_when_probe_cannot_run(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _raise(*_a: object, **_k: object) -> None:
-        raise OSError("binary not found")
-
-    monkeypatch.setattr(cuda_runtime.subprocess, "run", _raise)
-    out = cuda_runtime._device_probe_diagnostic(Path("/bin/llama-server"), {})
-    assert out == "(the engine's device probe could not be run)"
+def test_device_probe_diagnostic_when_no_output() -> None:
+    assert (
+        cuda_runtime._device_probe_diagnostic("") == "(the engine's device probe printed nothing)"
+    )

--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -162,6 +162,7 @@ def test_probe_returns_empty_on_subprocess_failure(monkeypatch: pytest.MonkeyPat
     assert probe.output == ""
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="shell-script fake binary")
 def test_probe_runs_the_real_binary(tmp_path: Path) -> None:
     # End to end through Popen: a real script's stdout is parsed into devices.
     script = tmp_path / "llama-server"
@@ -169,6 +170,15 @@ def test_probe_runs_the_real_binary(tmp_path: Path) -> None:
     script.chmod(0o755)
     probe = probe_devices(script)
     assert [d.index for d in probe.devices] == [0, 1]
+
+
+def test_run_list_devices_returns_the_child_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _HealthyProc:
+        def communicate(self, timeout: float | None = None) -> tuple[str, None]:
+            return (_CUDA_LISTING, None)
+
+    monkeypatch.setattr(dev_mod.subprocess, "Popen", lambda *_a, **_k: _HealthyProc())
+    assert dev_mod._run_list_devices(Path("/bin/llama-server"), 1.0) == _CUDA_LISTING
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
@@ -190,7 +200,11 @@ def test_probe_abandons_an_unreapable_child(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A child that survives SIGKILL (uninterruptible driver I/O) is abandoned
-    after a bounded reap instead of blocking the caller forever."""
+    after a bounded reap instead of blocking the caller forever.
+
+    The POSIX group-kill path is forced (repo pattern: simulate the platform)
+    so the same lines are exercised on every CI host, Windows included.
+    """
 
     class _WedgedProc:
         pid = 12345
@@ -199,7 +213,9 @@ def test_probe_abandons_an_unreapable_child(
             raise subprocess.TimeoutExpired(cmd="llama-server", timeout=timeout or 0)
 
     monkeypatch.setattr(dev_mod.subprocess, "Popen", lambda *_a, **_k: _WedgedProc())
+    monkeypatch.setattr(dev_mod.os, "name", "posix")
     monkeypatch.setattr(dev_mod.os, "killpg", lambda *_a: None, raising=False)
+    monkeypatch.setattr(dev_mod.signal, "SIGKILL", 9, raising=False)
     monkeypatch.setattr(dev_mod, "_PROBE_KILL_WAIT_S", 0.01)
     with caplog.at_level("WARNING"), pytest.raises(ProviderError, match="did not respond"):
         probe_devices(Path("/bin/llama-server"), timeout_s=0.01)

--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet import devices as dev_mod
 from lilbee.providers.fleet.devices import (
     FleetDevice,
@@ -101,13 +103,18 @@ class TestNvlinkTopology:
         assert dev_mod.host_lacks_nvlink() is False
 
 
+def _fake_listing(monkeypatch: pytest.MonkeyPatch, output: str) -> None:
+    monkeypatch.setattr(dev_mod, "_run_list_devices", lambda _binary, _timeout: output)
+
+
 def test_probe_parses_cuda_devices(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(_CUDA_LISTING))
-    devices = probe_devices(Path("/bin/llama-server"))
-    assert devices == [
+    _fake_listing(monkeypatch, _CUDA_LISTING)
+    probe = probe_devices(Path("/bin/llama-server"))
+    assert probe.devices == [
         FleetDevice("CUDA", 0, "NVIDIA GeForce RTX 3090", 24268 * _MIB, 23500 * _MIB),
         FleetDevice("CUDA", 1, "NVIDIA GeForce RTX 4090", 24564 * _MIB, 24000 * _MIB),
     ]
+    assert probe.output == _CUDA_LISTING
 
 
 def test_probe_drops_cpu_and_keeps_gpu_backend(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -116,15 +123,15 @@ def test_probe_drops_cpu_and_keeps_gpu_backend(monkeypatch: pytest.MonkeyPatch) 
         "  CPU0: some cpu (64000 MiB)\n"
         "  Vulkan0: NVIDIA (24268 MiB, 23000 MiB free)\n"
     )
-    monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(listing))
-    devices = probe_devices(Path("/bin/llama-server"))
+    _fake_listing(monkeypatch, listing)
+    devices = probe_devices(Path("/bin/llama-server")).devices
     # CUDA outranks Vulkan; CPU dropped entirely.
     assert [d.backend for d in devices] == ["CUDA"]
 
 
 def test_probe_defaults_free_to_total_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run("  Vulkan0: AMD (16000 MiB)\n"))
-    (device,) = probe_devices(Path("/bin/llama-server"))
+    _fake_listing(monkeypatch, "  Vulkan0: AMD (16000 MiB)\n")
+    (device,) = probe_devices(Path("/bin/llama-server")).devices
     assert device.free_bytes == device.total_bytes == 16000 * _MIB
 
 
@@ -134,23 +141,69 @@ def test_probe_returns_a_single_backend(monkeypatch: pytest.MonkeyPatch) -> None
     listing = (
         "  CUDA0: NVIDIA (24268 MiB, 23000 MiB free)\n  ROCm0: AMD (24268 MiB, 23000 MiB free)\n"
     )
-    monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(listing))
-    backends = {d.backend for d in probe_devices(Path("/bin/llama-server"))}
+    _fake_listing(monkeypatch, listing)
+    backends = {d.backend for d in probe_devices(Path("/bin/llama-server")).devices}
     assert len(backends) == 1
 
 
 def test_probe_returns_empty_when_no_gpu_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     # Only a CPU device listed -> no GPU backend to pin -> empty.
-    monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run("  CPU0: host cpu (64000 MiB)\n"))
-    assert probe_devices(Path("/bin/llama-server")) == []
+    _fake_listing(monkeypatch, "  CPU0: host cpu (64000 MiB)\n")
+    assert probe_devices(Path("/bin/llama-server")).devices == []
 
 
 def test_probe_returns_empty_on_subprocess_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _boom(*_a: object, **_k: object) -> subprocess.CompletedProcess:
+    def _boom(*_a: object, **_k: object) -> str:
         raise OSError("no such binary")
 
-    monkeypatch.setattr(dev_mod.subprocess, "run", _boom)
-    assert probe_devices(Path("/bin/llama-server")) == []
+    monkeypatch.setattr(dev_mod, "_run_list_devices", _boom)
+    probe = probe_devices(Path("/bin/llama-server"))
+    assert probe.devices == []
+    assert probe.output == ""
+
+
+def test_probe_runs_the_real_binary(tmp_path: Path) -> None:
+    # End to end through Popen: a real script's stdout is parsed into devices.
+    script = tmp_path / "llama-server"
+    script.write_text(f"#!/bin/sh\ncat <<'EOF'\n{_CUDA_LISTING}EOF\n")
+    script.chmod(0o755)
+    probe = probe_devices(script)
+    assert [d.index for d in probe.devices] == [0, 1]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+def test_probe_timeout_raises_and_kills_the_child(tmp_path: Path) -> None:
+    """A probe wedged past the timeout raises a named error instead of hanging.
+
+    The bug class this pins: on a host with a wedged GPU driver, --list-devices
+    never returns, and treating that as 'no devices' (or waiting forever) turned
+    the whole serve into a silent never-ready fleet (bb-0yf0).
+    """
+    script = tmp_path / "llama-server"
+    script.write_text("#!/bin/sh\nsleep 30\n")
+    script.chmod(0o755)
+    with pytest.raises(ProviderError, match="did not respond"):
+        probe_devices(script, timeout_s=0.2)
+
+
+def test_probe_abandons_an_unreapable_child(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A child that survives SIGKILL (uninterruptible driver I/O) is abandoned
+    after a bounded reap instead of blocking the caller forever."""
+
+    class _WedgedProc:
+        pid = 12345
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+            raise subprocess.TimeoutExpired(cmd="llama-server", timeout=timeout or 0)
+
+    monkeypatch.setattr(dev_mod.subprocess, "Popen", lambda *_a, **_k: _WedgedProc())
+    monkeypatch.setattr(dev_mod.os, "killpg", lambda *_a: None, raising=False)
+    monkeypatch.setattr(dev_mod, "_PROBE_KILL_WAIT_S", 0.01)
+    with caplog.at_level("WARNING"), pytest.raises(ProviderError, match="did not respond"):
+        probe_devices(Path("/bin/llama-server"), timeout_s=0.01)
+    assert "abandoned" in caplog.text
 
 
 def test_probe_env_sets_pci_bus_order() -> None:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -10,7 +10,7 @@ import pytest
 from lilbee.core.config import cfg
 from lilbee.core.config.enums import KvCacheType, RerankerType
 from lilbee.providers.fleet import planning as planning_mod
-from lilbee.providers.fleet.devices import FleetDevice, visible_env
+from lilbee.providers.fleet.devices import DeviceProbe, FleetDevice, visible_env
 from lilbee.providers.fleet.placement import InstancePlan, ModelPlacementInput, Placement
 from lilbee.providers.fleet.vram import GgufVramEstimate
 from lilbee.providers.roles import RerankMode, WorkerRole
@@ -1249,7 +1249,9 @@ class TestBuildFleetWiring:
     def test_plan_all_launches_resolves_devices_and_plans(self, monkeypatch) -> None:
         device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [device])
+        monkeypatch.setattr(
+            planning_mod, "probe_devices", lambda _binary: DeviceProbe([device], "")
+        )
         monkeypatch.setattr(
             planning_mod,
             "_server_model_inputs",
@@ -1276,7 +1278,9 @@ class TestBuildFleetWiring:
         # warm path can fail with a named reason instead of spinning.
         device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [device])
+        monkeypatch.setattr(
+            planning_mod, "probe_devices", lambda _binary: DeviceProbe([device], "")
+        )
         monkeypatch.setattr(
             planning_mod,
             "_server_model_inputs",
@@ -1305,7 +1309,9 @@ class TestBuildFleetWiring:
 
         device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [device])
+        monkeypatch.setattr(
+            planning_mod, "probe_devices", lambda _binary: DeviceProbe([device], "")
+        )
         monkeypatch.setattr(
             planning_mod,
             "_server_model_inputs",
@@ -1336,7 +1342,9 @@ class TestBuildFleetWiring:
 
     def test_plan_all_launches_falls_back_to_vulkan_probe(self, monkeypatch) -> None:
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])  # can't enumerate
+        monkeypatch.setattr(
+            planning_mod, "probe_devices", lambda _binary: DeviceProbe([], "")
+        )  # can't enumerate
         monkeypatch.setattr(
             "lilbee.providers.fleet.gpu_select.enumerate_gpu_vram",
             lambda: [(0, 24 * _GB)],
@@ -1433,7 +1441,7 @@ class TestResolveDevicesProbeFailureWarning:
     def test_warns_when_probe_finds_nothing_on_an_nvidia_host(self, monkeypatch, caplog) -> None:
         # A driver hiccup on a CUDA pod must not silently fall into the unified
         # shared-memory path; the operator needs a loud signal of what to check.
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: DeviceProbe([], ""))
         monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
         monkeypatch.setattr("lilbee.providers.fleet.gpu_select.enumerate_gpu_vram", lambda: [])
         with caplog.at_level("WARNING", logger=planning_mod.__name__):
@@ -1442,7 +1450,7 @@ class TestResolveDevicesProbeFailureWarning:
         assert any("shared-memory mode" in record.message for record in caplog.records)
 
     def test_no_warning_without_an_nvidia_gpu(self, monkeypatch, caplog) -> None:
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: DeviceProbe([], ""))
         monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: False)
         monkeypatch.setattr("lilbee.providers.fleet.gpu_select.enumerate_gpu_vram", lambda: [])
         with caplog.at_level("WARNING", logger=planning_mod.__name__):
@@ -1451,7 +1459,9 @@ class TestResolveDevicesProbeFailureWarning:
 
     def test_no_warning_when_probe_succeeds(self, monkeypatch, caplog) -> None:
         device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [device])
+        monkeypatch.setattr(
+            planning_mod, "probe_devices", lambda _binary: DeviceProbe([device], "")
+        )
         with caplog.at_level("WARNING", logger=planning_mod.__name__):
             assert planning_mod.resolve_devices(Path("/bin/llama-server")) == [device]
         assert not caplog.records
@@ -1463,11 +1473,87 @@ class TestResolveDevicesProbeFailureWarning:
         from lilbee.providers.fleet import cuda_runtime
 
         monkeypatch.setattr(cuda_runtime.sys, "platform", "linux")
-        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: DeviceProbe([], ""))
         monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
         monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: True)
         with pytest.raises(ProviderError, match="no CUDA-capable device"):
             planning_mod.resolve_devices(Path("/bin/llama-server"))
+
+    def test_probe_timeout_propagates_without_vulkan_fallback(self, monkeypatch) -> None:
+        # A wedged probe raises; falling into the in-process Vulkan probe there
+        # could hang this thread unkillably against the same wedged driver.
+        from lilbee.providers.base import ProviderError
+
+        def _wedged(_binary: Path) -> DeviceProbe:
+            raise ProviderError("The GPU device probe did not respond")
+
+        def _must_not_run() -> list[tuple[int, int]]:
+            raise AssertionError("Vulkan fallback must not run after a probe timeout")
+
+        monkeypatch.setattr(planning_mod, "probe_devices", _wedged)
+        monkeypatch.setattr("lilbee.providers.fleet.gpu_select.enumerate_gpu_vram", _must_not_run)
+        with pytest.raises(ProviderError, match="did not respond"):
+            planning_mod.resolve_devices(Path("/bin/llama-server"))
+
+
+class TestReadDeviceCacheFailure:
+    """A probe failure is cached and re-raised so a wedged host is not re-probed per poll."""
+
+    def _cache(self) -> planning_mod._ReadDeviceCache:
+        return planning_mod._ReadDeviceCache(ttl_s=0.0, failure_ttl_s=60.0)
+
+    def test_failure_is_cached_and_reraised(self, monkeypatch) -> None:
+        from lilbee.providers.base import ProviderError
+
+        calls = {"n": 0}
+
+        def _wedged(_binary: Path) -> list[FleetDevice]:
+            calls["n"] += 1
+            raise ProviderError("probe wedged")
+
+        monkeypatch.setattr(planning_mod, "resolve_devices", _wedged)
+        cache = self._cache()
+        for _ in range(3):
+            with pytest.raises(ProviderError, match="probe wedged"):
+                cache.get(Path("/bin/llama-server"))
+        assert calls["n"] == 1  # later reads served from the cached failure
+
+    def test_clear_drops_the_cached_failure(self, monkeypatch) -> None:
+        from lilbee.providers.base import ProviderError
+
+        device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
+        outcomes: list[object] = [ProviderError("probe wedged"), [device]]
+
+        def _next(_binary: Path) -> list[FleetDevice]:
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        monkeypatch.setattr(planning_mod, "resolve_devices", _next)
+        cache = self._cache()
+        with pytest.raises(ProviderError):
+            cache.get(Path("/bin/llama-server"))
+        cache.clear()
+        assert cache.get(Path("/bin/llama-server")) == [device]
+
+    def test_success_after_expired_failure_clears_it(self, monkeypatch) -> None:
+        from lilbee.providers.base import ProviderError
+
+        device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
+        outcomes: list[object] = [ProviderError("probe wedged"), [device]]
+
+        def _next(_binary: Path) -> list[FleetDevice]:
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        monkeypatch.setattr(planning_mod, "resolve_devices", _next)
+        cache = planning_mod._ReadDeviceCache(ttl_s=0.0, failure_ttl_s=0.0)
+        with pytest.raises(ProviderError):
+            cache.get(Path("/bin/llama-server"))
+        assert cache.get(Path("/bin/llama-server")) == [device]
 
 
 def _parse_flags(argv: list[str]) -> dict[str, str | None]:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1212,13 +1212,13 @@ def test_ensure_fleet_spawns_nothing_when_no_models(monkeypatch) -> None:
 
 
 def test_ensure_fleet_returns_none_when_engine_binary_unavailable(monkeypatch) -> None:
-    """plan_all_launches raising ProviderError (no engine binary) yields no swap."""
-    from lilbee.providers.base import ProviderError
+    """plan_all_launches raising NOT_FOUND (no engine binary) yields no swap."""
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
 
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: _FakeSwap())
 
     def _no_binary() -> list:
-        raise ProviderError("Engine binary unavailable")
+        raise ProviderError("llama-server binary not found.", kind=ProviderErrorKind.NOT_FOUND)
 
     monkeypatch.setattr(planning_mod, "plan_all_launches", _no_binary)
     p = FleetProvider()
@@ -1506,6 +1506,65 @@ def test_warm_up_blocking_stamps_error_with_the_real_reason(monkeypatch) -> None
     assert snap is not None
     assert snap.phase is WarmPhase.ERROR
     assert "engine exited before it was ready" in (snap.error or "")
+
+
+def test_warm_up_blocking_surfaces_a_probe_failure(monkeypatch) -> None:
+    """A planning ProviderError (e.g. a wedged GPU probe) must not be swallowed.
+
+    The bb-0yf0 silent hang: the old catch logged every planning ProviderError at
+    DEBUG as "binary unavailable" and cleared the warm tracker, so the fleet sat
+    never-ready with no error anywhere. The failure now reaches the tracker (and
+    with it health's chat_status/chat_error and the TUI's warm line).
+    """
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+    from lilbee.providers.warm_progress import WarmPhase
+
+    def _wedged() -> list:
+        raise ProviderError(
+            "The GPU device probe (llama-server --list-devices) did not respond within 60s",
+            kind=ProviderErrorKind.SERVER,
+        )
+
+    monkeypatch.setattr(planning_mod, "plan_all_launches", _wedged)
+    p = FleetProvider()
+    p._warm_up_blocking()
+    snap = p.warm_progress()
+    assert snap is not None
+    assert snap.phase is WarmPhase.ERROR
+    assert "GPU device probe" in (snap.error or "")
+    assert p._warming is False  # guard cleared so a later warm-up can retry
+
+
+def test_ensure_fleet_propagates_a_probe_failure_to_on_demand_callers(monkeypatch) -> None:
+    # A chat/embed call that triggers the build must see the real reason (the
+    # route layer maps it to a 503), not a generic "no server running".
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _data_dir, **_kw: None)
+
+    def _wedged() -> None:
+        raise ProviderError("The GPU device probe did not respond", kind=ProviderErrorKind.SERVER)
+
+    monkeypatch.setattr(planning_mod, "capture_plan_probe", _wedged)
+    p = FleetProvider()
+    with pytest.raises(ProviderError, match="GPU device probe"):
+        p._ensure_fleet()
+
+
+def test_ensure_fleet_stays_quiet_when_the_binary_is_missing(monkeypatch) -> None:
+    # A host without the engine binary legitimately serves nothing; only the
+    # NOT_FOUND binary resolution keeps the quiet no-fleet path.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _data_dir, **_kw: None)
+
+    def _no_binary() -> None:
+        raise ProviderError("llama-server binary not found.", kind=ProviderErrorKind.NOT_FOUND)
+
+    monkeypatch.setattr(planning_mod, "capture_plan_probe", _no_binary)
+    p = FleetProvider()
+    assert p._ensure_fleet() is False
+    assert p._swaps == {}
 
 
 def test_warm_up_blocking_reports_starting_before_fleet_spawn(monkeypatch) -> None:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -141,6 +141,23 @@ class TestHealth:
         mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.ERROR)
         assert (await handlers.health()).chat_status == "error"
 
+    async def test_chat_error_carries_the_warm_failure_reason(self, mock_svc):
+        """A failed warm (e.g. a wedged GPU probe) names its cause in health, so a
+        polling client reports why instead of retrying forever (bb-0yf0)."""
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        mock_svc.provider.role_ready.return_value = False
+        mock_svc.provider.warm_progress.return_value = WarmProgress(
+            phase=WarmPhase.ERROR, error="The GPU device probe did not respond within 60s"
+        )
+        result = await handlers.health()
+        assert result.chat_status == "error"
+        assert result.chat_error == "The GPU device probe did not respond within 60s"
+
+    async def test_chat_error_absent_outside_the_error_state(self, mock_svc):
+        mock_svc.provider.role_ready.return_value = True
+        assert (await handlers.health()).chat_error is None
+
 
 def _parse_warm_events(chunks: list[str]) -> list[dict]:
     """Pull the JSON payloads off ``warm`` SSE chunks, ignoring the [DONE] tail."""

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -351,6 +351,21 @@ class TestChatRoute:
         assert "downstream broke" in resp.text
 
     @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)
+    def test_engine_that_cannot_start_returns_503_with_the_reason(self, mock_chat, client):
+        """A fleet that failed to start (e.g. a wedged GPU probe) 503s with the
+        cause instead of answering 2xx with a polite refusal a scripted caller
+        cannot tell from a real answer (bb-0yf0)."""
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        mock_chat.side_effect = ProviderError(
+            "The GPU device probe (llama-server --list-devices) did not respond within 60s",
+            kind=ProviderErrorKind.SERVER,
+        )
+        resp = client.post("/api/chat", json={"question": "q", "history": []})
+        assert resp.status_code == 503
+        assert "GPU device probe" in resp.text
+
+    @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)
     def test_upstream_auth_error_stays_503(self, mock_chat, client):
         """An upstream AUTH failure keeps the generic 503, never the /v1 401: the
         shipped /api client reads 401/403 as a lilbee session-token failure and

--- a/tests/test_tui_fleet_drawer.py
+++ b/tests/test_tui_fleet_drawer.py
@@ -68,6 +68,34 @@ async def test_ctrl_g_opens_drawer_and_esc_closes(_patched):
 
 
 @pytest.mark.asyncio
+async def test_drawer_renders_probe_failure_instead_of_probing_forever(monkeypatch) -> None:
+    """A placement load failure lands in the GPU panel as a named error (bb-0yf0);
+    the old behavior left 'probing GPUs…' up for the life of the session."""
+    from lilbee.cli.tui.widgets import fleet_body as fbm
+    from lilbee.cli.tui.widgets import gpu_fleet_panel as gfp
+    from lilbee.cli.tui.widgets.fleet_drawer import FleetDrawer
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+    from lilbee.providers.base import ProviderError
+
+    def _wedged():  # type: ignore[no-untyped-def]
+        raise ProviderError("The GPU device probe did not respond within 60s")
+
+    monkeypatch.setattr(fbm, "get_placement", _wedged)
+    monkeypatch.setattr(gfp, "probe_gpu_stats", lambda devices: {})
+
+    app = _DrawerApp()
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+g")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        panel = app.screen.query_one(FleetDrawer).query_one(GpuFleetPanel)
+        rendered = str(panel.render())
+        assert "GPU device probe" in rendered
+        assert "probing" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_ctrl_g_toggles_drawer_closed(_patched):
     """A second ctrl+g closes the open drawer rather than stacking another."""
     from lilbee.cli.tui.widgets.fleet_drawer import FleetDrawer

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -133,6 +133,66 @@ async def test_panel_holds_probing_until_devices_probed(
 
 
 @pytest.mark.asyncio
+async def test_panel_renders_probe_failure_and_pauses_ticks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed device probe names its reason instead of probing forever (bb-0yf0),
+    and the stat timer stops re-painting over it."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui import messages as msg
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    probes = {"n": 0}
+
+    def _count(devices: object) -> dict:
+        probes["n"] += 1
+        return {}
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", _count)
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_probe_failed("GPU driver did not respond")
+        rendered = str(panel.render())
+        assert "GPU driver did not respond" in rendered
+        assert msg.FLEET_GPU_PROBING not in rendered
+
+        before = probes["n"]
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert probes["n"] == before  # ticks paused while the failure stands
+        assert "GPU driver did not respond" in str(panel.render())
+
+
+@pytest.mark.asyncio
+async def test_panel_recovers_from_probe_failure_on_set_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later successful device probe clears the failure state and resumes stats."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    device = _make_device(0)
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: _make_stat(0)})
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_probe_failed("GPU driver did not respond")
+        panel.set_devices([device], labels={0: "CUDA0"})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(panel.render())
+        assert "CUDA0" in rendered
+        assert "GPU driver did not respond" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_panel_renders_card_label_and_vram(monkeypatch: pytest.MonkeyPatch) -> None:
     """With one CUDA GPU the panel renders the label and VRAM figures."""
     import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -168,6 +168,29 @@ async def test_panel_renders_probe_failure_and_pauses_ticks(
 
 
 @pytest.mark.asyncio
+async def test_panel_keeps_the_failure_when_an_in_flight_probe_lands_late(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stats worker started before the failure landed must not repaint the
+    empty state over the failure message (the set_probe_failed/_apply_stats race)."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {})
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_probe_failed("GPU driver did not respond")
+        # Simulate the racing worker's completion callback arriving afterwards.
+        panel._apply_stats({}, {}, {})
+        rendered = str(panel.render())
+        assert "GPU driver did not respond" in rendered
+        assert "no GPUs detected" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_panel_recovers_from_probe_failure_on_set_devices(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

On a RunPod 3x RTX 4090 pod the chat model never started loading: the Placement panel sat on "probing GPUs…" for the life of the session, all three GPUs stayed at 0 MiB, `chat_ready` never became true, and the serve log was completely silent. The same build and models worked on 1x A100 and 2x RTX 5090 boxes.

Two layered defects turned an environmental GPU-probe failure into that silent forever-hang:

1. `llama-server --list-devices` can wedge in GPU-driver I/O on a broken host. `subprocess.run`'s timeout path kills the child and then waits **unboundedly** for the reap, so a child stuck in uninterruptible driver I/O hangs the fleet warm-up thread forever, and every placement read stacks up behind the same probe.
2. Even when the probe fails cleanly, `_plan_and_spawn` swallowed every planning `ProviderError` at DEBUG as "engine binary unavailable", including the deliberately loud "CUDA build enumerated no device" assertion. The warm tracker was cleared, health reported `not_started`, and nothing anywhere named the failure.

## Solution

The probe now runs in its own process group with a structurally bounded timeout: on expiry the group is SIGKILLed, the reap is bounded, an unkillable child is abandoned with a warning, and a named error tells the user to check the GPU driver. A timed-out probe no longer re-runs `--list-devices` for diagnostics or falls into the in-process Vulkan probe (which could hang unkillably against the same wedged driver), and the read-path device cache stores the failure so placement reads report it instead of re-probing on every poll.

`_plan_and_spawn` now swallows only the genuinely-missing-binary case; every other planning failure propagates to the warm tracker and to on-demand callers. The result: `/api/health` reports `chat_status: "error"` with a new `chat_error` reason, `/api/chat` returns 503 with the real cause, the TUI fleet panel renders the probe failure instead of probing forever, and the chat bubble names the failure instead of suggesting an endless retry.

## Validation

Validated end to end on two fresh 3x RTX 4090 RunPod community pods. One arrived with the failure this PR exists for: `nvidia-smi` healthy but CUDA init broken pod-wide (`ggml_cuda_init: failed to initialize CUDA: unknown error`, `torch.cuda.is_available()` false) — the same class as the original report, hit twice in three rentals. On that pod the fix surfaces the fault in 3 seconds: `chat_status: "error"` with the engine's own diagnostic in `chat_error`, a WARNING in the serve log, and a loud sync failure, where before it sat on "probing GPUs…" forever with a silent log. A deliberately hanging `--list-devices` (simulating the wedged-driver case) is killed, not leaked, and reported the same way within the 60s timeout on both pods.

On the healthy pod the original scenario runs clean: the 35B Q8 chat model tensor-splits across all three cards (~19/19/18 GB resident), `chat_ready` goes true in 32 seconds, and `/api/chat` returns a grounded, cited answer.
