### PR TITLE
Fix a cold start failing when the model server loses its port to a passing connection

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -75,6 +75,12 @@ _EMBED_N_SEQ_MAX = 64
 _EMBED_EST_CHARS_PER_TOKEN = 3
 # llama-swap's error body when the spawned llama-server exited before serving.
 _UPSTREAM_DIED_MARKER = "exited prematurely"
+# llama-server's exit line when the port lilbee picked was taken by the time
+# the server bound it (the pick-then-bind gap spans the whole lazy-spawn wait,
+# so a passing ephemeral connection can occupy it). The occupation is
+# transient: llama-swap re-spawns on the next request against the same port
+# and normally binds.
+_BIND_FAILURE_MARKER = "couldn't bind HTTP server socket"
 # llama-server's 500 body when one input exceeds the physical batch (n_batch).
 _BATCH_OVERFLOW_MARKER = "too large to process"
 
@@ -199,6 +205,7 @@ def _raise_for_status(resp: httpx.Response) -> None:
             kind=ProviderErrorKind.RATE_LIMIT,
         )
     detail = f": {body[:600]}" if body else ""
+    kind = _classify_error(resp.status_code, body)
     # llama-swap masks a dead server as "exited prematurely"; surface the server's
     # own captured output (a missing CUDA runtime, a model load failure, a bind
     # error) so the real exit reason reaches the caller, not only the log.
@@ -206,10 +213,15 @@ def _raise_for_status(resp: httpx.Response) -> None:
         tail = _upstream_failure_tail(resp)
         if tail:
             detail = f"{detail}\nupstream server output:\n{tail}"
+        if _BIND_FAILURE_MARKER in tail:
+            # A death from losing the port-bind race is transient, not a dead
+            # replica: the retry re-drives llama-swap's spawn, which normally
+            # binds once the passing connection has released the port.
+            kind = ProviderErrorKind.SERVER
     raise ProviderError(
         f"llama-server returned HTTP {resp.status_code}{detail}",
         provider=_PROVIDER_NAME,
-        kind=_classify_error(resp.status_code, body),
+        kind=kind,
     )
 
 
@@ -221,7 +233,9 @@ def _classify_error(status_code: int, body: str) -> ProviderErrorKind:
     upstream is CONNECTION, so the router can mark the replica unhealthy. The
     body markers win over the status: llama-swap reports a died upstream under
     gateway statuses too, and that case needs the failover path, not a retry
-    against the same dead server. A bare gateway error (502/503/504) is a
+    against the same dead server (except a bind-race death, which
+    ``_raise_for_status`` upgrades to SERVER once the upstream tail proves it).
+    A bare gateway error (502/503/504) is a
     momentarily-unreachable upstream -- restarting, OOM-killed, mid-swap -- so
     it is SERVER, which the busy retry treats as transient.
     """

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -835,6 +835,44 @@ def test_raise_for_status_surfaces_upstream_tail_on_premature_exit(monkeypatch, 
     assert "exited prematurely" in str(excinfo.value)
 
 
+def test_raise_for_status_bind_race_death_is_transient(monkeypatch) -> None:
+    # A member that died because it lost the pick-then-bind port race is not a
+    # dead server: llama-swap re-spawns it on the next request and the port is
+    # normally free again by then (a passing ephemeral connection took it). The
+    # death must classify as transient so retry_on_busy re-drives the spawn,
+    # instead of CONNECTION which writes the only replica off as unhealthy.
+    import lilbee.providers.fleet.client as client_mod
+    from lilbee.providers.base import ProviderErrorKind
+    from lilbee.providers.fleet.client import _raise_for_status
+
+    monkeypatch.setattr(
+        client_mod,
+        "_upstream_failure_tail",
+        lambda resp: "E srv start: couldn't bind HTTP server socket, port: 58425",
+    )
+    with pytest.raises(ProviderError) as excinfo:
+        _raise_for_status(_premature_exit_response())
+    assert excinfo.value.kind is ProviderErrorKind.SERVER
+    assert "couldn't bind HTTP server socket" in str(excinfo.value)
+
+
+def test_raise_for_status_non_bind_death_stays_connection(monkeypatch) -> None:
+    # Any other exit reason (model load failure, missing CUDA runtime) keeps the
+    # CONNECTION kind, so the failover path still marks the replica unhealthy.
+    import lilbee.providers.fleet.client as client_mod
+    from lilbee.providers.base import ProviderErrorKind
+    from lilbee.providers.fleet.client import _raise_for_status
+
+    monkeypatch.setattr(
+        client_mod,
+        "_upstream_failure_tail",
+        lambda resp: "cudaMalloc failed: out of memory",
+    )
+    with pytest.raises(ProviderError) as excinfo:
+        _raise_for_status(_premature_exit_response())
+    assert excinfo.value.kind is ProviderErrorKind.CONNECTION
+
+
 def test_raise_for_status_premature_exit_survives_log_fetch_failure(monkeypatch) -> None:
     # A dead log stream must not mask the original ProviderError.
     import lilbee.providers.fleet.client as client_mod


### PR DESCRIPTION
## Problem

A model server could fail its first request with "The model server is not responding and no healthy replica is available" on a machine with busy ports. The fleet picks each member's port at start, but llama-swap only spawns the member on its first request, so the port sits unclaimed for the whole wait and a passing connection can take it. The server exits "couldn't bind HTTP server socket", and the client wrote the replica off as dead even though the next spawn binds fine seconds later. This failed a release verify run's ingest.

## Solution

When the dead member's captured output shows the bind failure, classify the death as transient instead of dead-replica, so the existing busy-retry backoff re-drives llama-swap's spawn. Every other exit reason keeps the failover path.
