### PR TITLE
Harden the executable build cells against uv-cache corruption and disk exhaustion

### DIFF
--- a/.github/workflows/build-cuda-executables.yml
+++ b/.github/workflows/build-cuda-executables.yml
@@ -139,7 +139,19 @@ jobs:
       - name: Verify extras installed in build venv
         shell: bash
         # --no-sync is load-bearing: re-syncing reinstalls python-multipart and shadows the shim.
-        run: uv run --no-sync python -c "import crawl4ai, litellm, spacy, graspologic_native; print('extras OK')"
+        # One retry with a purged uv cache: a hardlink-fallback race can leave a
+        # mixed-version package on disk (one litellm's redis_cache.py beside an
+        # older constants.py) that only an import catches. Without the purge the
+        # re-sync relinks the same corrupted cache entries.
+        run: |
+          check() { uv run --no-sync python -c "import crawl4ai, litellm, spacy, graspologic_native; print('extras OK')"; }
+          if ! check; then
+            echo "extras import failed; purging the uv cache and re-syncing once"
+            uv cache clean
+            uv sync --reinstall --extra release
+            uv pip install 'nuitka[onefile]>=4.0,<5' pip
+            check
+          fi
 
       # compat cell only: replace the stock lancedb the sync installed with the
       # pre-Haswell build from the private index. --no-deps leaves the rest of the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,19 @@ jobs:
       - name: Verify extras installed in build venv
         shell: bash
         # --no-sync is load-bearing: re-syncing reinstalls python-multipart and shadows the shim.
-        run: uv run --no-sync python -c "import crawl4ai, litellm, spacy, graspologic_native; print('extras OK')"
+        # One retry with a purged uv cache: a hardlink-fallback race can leave a
+        # mixed-version package on disk (one litellm's redis_cache.py beside an
+        # older constants.py) that only an import catches. Without the purge the
+        # re-sync relinks the same corrupted cache entries.
+        run: |
+          check() { uv run --no-sync python -c "import crawl4ai, litellm, spacy, graspologic_native; print('extras OK')"; }
+          if ! check; then
+            echo "extras import failed; purging the uv cache and re-syncing once"
+            uv cache clean
+            uv sync --reinstall --extra release
+            uv pip install 'nuitka[onefile]>=4.0,<5' pip
+            check
+          fi
 
       # compat cell only: swap the synced stock lancedb for the pre-Haswell build.
       # --no-deps leaves the rest of the venv intact, so nothing leaves this cell.
@@ -299,6 +311,18 @@ jobs:
           dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
           dnf install -y gh
           gh --version
+
+      # The onefile build leaves multi-GB intermediates beside the final binary,
+      # and a runner has died of a full disk while restoring the smoke models
+      # after a SUCCESSFUL build. Drop them before the models come down; runs
+      # after the Windows Nuitka cache save so nothing cache-worthy is lost.
+      # ccache stays: its post-job hook still has to save it.
+      - name: Reclaim build-intermediate disk before the smoke models
+        shell: bash
+        run: |
+          df -h . 2>/dev/null || true
+          rm -rf dist/*.build dist/*.dist dist/*.onefile-build nuitka-cache
+          df -h . 2>/dev/null || true
 
       - name: Restore CI models (inference smoke)
         uses: ./.github/actions/restore-ci-models


### PR DESCRIPTION
## Problem

Two runner failure modes each cost a 2.5 hour cell rerun on the last release. A corrupted uv cache (the hardlink-fallback race) installed a litellm whose files came from two different versions, which only the import check catches; and the onefile build's multi-GB intermediates filled the runner's disk while the smoke models restored, after the build itself had succeeded.

## Solution

The extras import check now purges the uv cache and re-syncs once before failing the cell, in both the release and CUDA build workflows. The release build drops the Nuitka intermediates (keeping the final binary) before restoring smoke models, after the Windows Nuitka cache save so nothing cache-worthy is lost; ccache is untouched since its post-job hook still saves it.