### PR TITLE
Fix the inert integration timeout opt-in and give the RAG ask tests headroom

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -40,7 +40,11 @@ _INTEGRATION_TIMEOUT_SECONDS = 180
 
 def pytest_collection_modifyitems(items):
     for item in items:
-        item.add_marker(pytest.mark.timeout(_INTEGRATION_TIMEOUT_SECONDS))
+        # Only default items that carry no timeout of their own: add_marker
+        # prepends, so adding unconditionally makes the default the closest
+        # marker and silently overrides every per-test opt-in.
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(_INTEGRATION_TIMEOUT_SECONDS))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_interactive_integration.py
+++ b/tests/integration/test_interactive_integration.py
@@ -258,7 +258,15 @@ class TestSearch:
         assert any("specs.md" in s for s in sources), f"Expected specs.md in {sources}"
 
 
+@pytest.mark.timeout(300)
 class TestAsk:
+    """Full RAG asks: a sync (embed everything) plus retrieval plus a chat
+    generation, the heaviest work in the suite. The 180s default has been
+    exhausted by a slow virtualized macOS runner mid-teardown with the test
+    itself passing, so these opt in to more headroom; a genuine hang still
+    dies well short of the job timeout.
+    """
+
     def test_ask_known_fact(self, isolated_env, sync_with_docs):
         sync_with_docs()
         result = runner.invoke(app, ["--json", "ask", "What is the oil capacity?"])


### PR DESCRIPTION
## Problem

The macos integration leg intermittently failed test_ask_known_fact with a 180s pytest-timeout, the test itself passing: a full sync plus a RAG ask is the heaviest work in the suite, and a slow virtualized runner spent the entire budget on it.

Worse, the conftest's documented escape hatch (opt in with pytest.mark.timeout) has been inert all along: add_marker prepends, so the injected 180s default was always the closest marker and silently overrode every per-test opt-in. A probe test sleeping past a class-level cap survived to prove it.

## Solution

The collection hook now only defaults items that carry no timeout marker of their own, which makes the opt-in real, and TestAsk opts in to 300 seconds. Unmarked tests keep the 180s default; a genuine hang still dies well short of the job timeout.