### PR TITLE
Fix a crash when the data root is set via LILBEE_DATA_ROOT

### DIFF
--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -966,7 +966,10 @@ class Config(BaseSettings):
             else:
                 local = find_local_root()
                 data["data_root"] = local if local is not None else default_data_dir()
-        root = data["data_root"]
+        # data_root may arrive as a raw string (e.g. from LILBEE_DATA_ROOT); the
+        # child-path derivations below use ``/``, so coerce to Path first.
+        root = Path(data["data_root"])
+        data["data_root"] = root
         if data.get("documents_dir") in (None, _UNSET_PATH):
             data["documents_dir"] = root / "documents"
         if data.get("data_dir") in (None, _UNSET_PATH):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -747,6 +747,17 @@ class TestResolveDefaultsValidator:
         with mock.patch.dict(os.environ, env, clear=True):
             assert Config().semantic_chunking is True
 
+    def test_data_root_env_var_is_coerced_to_path(self, tmp_path) -> None:
+        """LILBEE_DATA_ROOT sets the data_root field directly as a string;
+        deriving the child paths from it must not raise on str / str."""
+        env = _clean_env()
+        env["LILBEE_DATA_ROOT"] = str(tmp_path)
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.data_root == tmp_path
+            assert c.documents_dir == tmp_path / "documents"
+            assert c.data_dir == tmp_path / "data"
+
 
 class TestTopicThresholdConfig:
     def test_default_is_0_75(self, tmp_path) -> None:


### PR DESCRIPTION
## Problem

Setting the data root through the `LILBEE_DATA_ROOT` environment variable crashes at startup. The variable maps straight onto the `data_root` field as a string, and the config resolver then derives the documents, data, and lancedb directories from it with the `/` operator, which raises `TypeError: unsupported operand type(s) for /: 'str' and 'str'`. Every other way of setting the data root passes a `Path`, so this path was the only one that broke.

## Solution

Coerce `data_root` to a `Path` before deriving the child directories, and write the coerced value back so the field is consistently a `Path`. Coercing an existing `Path` is a no-op, so nothing else changes. Added a regression test that sets `LILBEE_DATA_ROOT` and asserts the child paths resolve without raising.