### PR TITLE
Fix macOS/Vulkan engine index pointing at never-uploaded wheels

### DIFF
--- a/tests/test_build_pep503_indexes.py
+++ b/tests/test_build_pep503_indexes.py
@@ -29,7 +29,8 @@ _RAW = "lilbee_engine-0.6.90b420.dev721-py3-none-macosx_11_0_arm64.whl"
 
 
 def test_every_backend_gets_a_build_tag() -> None:
-    # No backend is exempt: the release tags them all, so the index must too.
+    # No backend is exempt: the release tags them all (the index links those
+    # tagged release assets), so build_tag_for_backend never returns None.
     for backend in ("metal", "vulkan", "cu124", "cu125", "cu121", "cpu", "rocm"):
         assert bpi.build_tag_for_backend(backend) == f"1.{backend}"
 
@@ -63,4 +64,4 @@ def test_index_href_targets_the_tagged_asset(tmp_path: Path) -> None:
     assert "dev721-1.metal-py3-none-macosx_11_0_arm64.whl" in index
     # the plain (never-uploaded) name must not appear
     assert "dev721-py3-none-macosx_11_0_arm64.whl</a>" not in index
-    assert "dev721-py3-none-macosx_11_0_arm64.whl\"" not in index
+    assert 'dev721-py3-none-macosx_11_0_arm64.whl"' not in index

--- a/tests/test_build_pep503_indexes.py
+++ b/tests/test_build_pep503_indexes.py
@@ -1,0 +1,66 @@
+"""Regression tests for the per-backend engine-wheel index generator.
+
+The GH release build-tags EVERY engine wheel (``-1.<backend>``); the index must
+link to those exact filenames. An earlier version exempted vulkan/metal, whose
+indexes then pointed at untagged filenames that were never uploaded -- a 404 for
+every Mac (metal) and Vulkan user installing the engine.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "build_pep503_indexes.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("build_pep503_indexes", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bpi = _load()
+
+_RAW = "lilbee_engine-0.6.90b420.dev721-py3-none-macosx_11_0_arm64.whl"
+
+
+def test_every_backend_gets_a_build_tag() -> None:
+    # No backend is exempt: the release tags them all, so the index must too.
+    for backend in ("metal", "vulkan", "cu124", "cu125", "cu121", "cpu", "rocm"):
+        assert bpi.build_tag_for_backend(backend) == f"1.{backend}"
+
+
+def test_metal_and_vulkan_are_not_treated_as_untagged_defaults() -> None:
+    # The exact regression: these two must NOT keep the plain filename.
+    for backend in ("metal", "vulkan"):
+        renamed = bpi.rename_for_release(_RAW, backend)
+        assert f"-1.{backend}-" in renamed, renamed
+        assert renamed != _RAW
+
+
+def test_rename_matches_release_asset_layout() -> None:
+    assert (
+        bpi.rename_for_release(_RAW, "metal")
+        == "lilbee_engine-0.6.90b420.dev721-1.metal-py3-none-macosx_11_0_arm64.whl"
+    )
+
+
+def test_index_href_targets_the_tagged_asset(tmp_path: Path) -> None:
+    art = tmp_path / "artifacts"
+    (art / "wheel-multigpu-macos-metal").mkdir(parents=True)
+    (art / "wheel-multigpu-macos-metal" / _RAW).write_bytes(b"x")
+    site = tmp_path / "site"
+    bpi.write_backend_indexes(
+        site,
+        bpi.collect_wheels(art),
+        "https://github.com/tobocop2/lilbee/releases/download",
+    )
+    index = (site / "metal" / "lilbee-engine" / "index.html").read_text()
+    assert "dev721-1.metal-py3-none-macosx_11_0_arm64.whl" in index
+    # the plain (never-uploaded) name must not appear
+    assert "dev721-py3-none-macosx_11_0_arm64.whl</a>" not in index
+    assert "dev721-py3-none-macosx_11_0_arm64.whl\"" not in index

--- a/tools/build_pep503_indexes.py
+++ b/tools/build_pep503_indexes.py
@@ -49,15 +49,6 @@ WHEEL_FILENAME_RE = re.compile(r"^lilbee_engine-(?P<version>[^-]+)-")
 _PROJECT = "lilbee-engine"
 _DEFAULT_RELEASE_BASE_URL = "https://github.com/tobocop2/lilbee/releases/download"
 
-# EVERY engine wheel on the release carries a ``1.<backend>`` PEP 427 build tag:
-# attach-release-artifacts.yml (and release-candidate.yml) rename every wheel to
-# ``...-1.<backend>-...`` with no exception, so all same-platform variants coexist
-# in the release's flat namespace. There is no plain (untagged) engine wheel to
-# link to -- lilbee-engine ships only via these per-backend indexes, never PyPI.
-# An earlier version exempted vulkan/metal here, which pointed their indexes at
-# untagged filenames that were never uploaded (404 for every Mac/Vulkan user).
-_DEFAULT_BACKENDS: frozenset[str] = frozenset()
-
 # Wheel filename layout (PEP 427): project-version[-buildtag]-python-abi-platform.whl
 _WHEEL_FILENAME_PARTS_NO_BUILDTAG = 5
 
@@ -80,22 +71,23 @@ def version_from_wheel_filename(name: str) -> str | None:
     return m.group("version") if m else None
 
 
-def build_tag_for_backend(backend: str) -> str | None:
-    """PEP 427 build tag used to disambiguate non-default backend variants."""
-    if backend in _DEFAULT_BACKENDS:
-        return None
+def build_tag_for_backend(backend: str) -> str:
+    """PEP 427 build tag that disambiguates the same-platform engine variants.
+
+    EVERY backend gets one. attach-release-artifacts.yml (and release-candidate.yml)
+    rename every ``lilbee_engine`` wheel to ``...-1.<backend>-...`` with no exception,
+    so all same-platform variants coexist in the GH release's flat namespace. These
+    indexes link those release assets, so they must use the tagged names -- there is
+    no plain (untagged) engine wheel in the release to point at. (An earlier version
+    exempted vulkan/metal as "PyPI defaults that ship plain", but lilbee-engine is
+    not on PyPI at all, so those indexes 404'd for every Mac/Vulkan user.)
+    """
     return f"1.{backend}"
 
 
 def rename_for_release(wheel_name: str, backend: str) -> str:
-    """Return the wheel filename as published on the GH release.
-
-    Default backends (vulkan/metal) keep their original name. Extra backends
-    get a build tag inserted after the version per PEP 427.
-    """
-    build_tag = build_tag_for_backend(backend)
-    if build_tag is None:
-        return wheel_name
+    """Return the wheel filename as published on the GH release: the raw wheel
+    with a ``-1.<backend>-`` build tag inserted after the version, per PEP 427."""
     parts = wheel_name.removesuffix(".whl").split("-")
     if len(parts) != _WHEEL_FILENAME_PARTS_NO_BUILDTAG:
         raise ValueError(
@@ -103,7 +95,7 @@ def rename_for_release(wheel_name: str, backend: str) -> str:
             f"(project-version-python-abi-platform.whl)"
         )
     project, version, python, abi, platform = parts
-    return f"{project}-{version}-{build_tag}-{python}-{abi}-{platform}.whl"
+    return f"{project}-{version}-{build_tag_for_backend(backend)}-{python}-{abi}-{platform}.whl"
 
 
 def collect_wheels(input_dir: Path) -> dict[str, list[Path]]:

--- a/tools/build_pep503_indexes.py
+++ b/tools/build_pep503_indexes.py
@@ -49,10 +49,14 @@ WHEEL_FILENAME_RE = re.compile(r"^lilbee_engine-(?P<version>[^-]+)-")
 _PROJECT = "lilbee-engine"
 _DEFAULT_RELEASE_BASE_URL = "https://github.com/tobocop2/lilbee/releases/download"
 
-# Backends whose wheels ship under the default filename (also on PyPI; renaming
-# would break the PyPI pin). Everything else gets a PEP 427 build tag inserted
-# so the GH release can hold every variant without filename collisions.
-_DEFAULT_BACKENDS: frozenset[str] = frozenset({"vulkan", "metal"})
+# EVERY engine wheel on the release carries a ``1.<backend>`` PEP 427 build tag:
+# attach-release-artifacts.yml (and release-candidate.yml) rename every wheel to
+# ``...-1.<backend>-...`` with no exception, so all same-platform variants coexist
+# in the release's flat namespace. There is no plain (untagged) engine wheel to
+# link to -- lilbee-engine ships only via these per-backend indexes, never PyPI.
+# An earlier version exempted vulkan/metal here, which pointed their indexes at
+# untagged filenames that were never uploaded (404 for every Mac/Vulkan user).
+_DEFAULT_BACKENDS: frozenset[str] = frozenset()
 
 # Wheel filename layout (PEP 427): project-version[-buildtag]-python-abi-platform.whl
 _WHEEL_FILENAME_PARTS_NO_BUILDTAG = 5


### PR DESCRIPTION
The per-backend PEP 503 index generator exempted `vulkan` and `metal` from the `-1.<backend>` build tag, treating them as defaults that ship under a plain filename. But the release workflow build-tags **every** engine wheel with no exception, and there is no plain engine wheel to link to. So the metal and vulkan indexes linked filenames that were never uploaded, giving every Mac and Vulkan user a 404 when pip resolved the engine (`pip install lilbee --extra-index-url https://lilbee.sh/metal/`).

This tags all backends in the index, matching the release assets, and adds a regression test that pins the tagged URL and asserts the plain name never appears.

Verified end to end: installing dev721 on macOS via the correctly-tagged asset URL pulls the Metal engine and lilbee runs (`lilbee version` -> 0.6.90b420.dev721, engine binary present).