### PR TITLE
Give agent sessions their own flag, off by default

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -236,18 +236,24 @@ current model and says so.
 
 Sessions are append-only JSONL files under `<data_dir>/sessions/`, one per
 conversation. No database; back them up or sync them like any other file.
-The same surface exists over HTTP and MCP (list, read, create, append,
-rename, delete), so a script or agent can own a conversation the way the
-TUI does. The TUI, HTTP server, and CLI are one conversation space: start
-a chat in Obsidian, continue it in the terminal. Agent (MCP) sessions are
-separate: they never appear in your session list, and agents cannot list
-or read yours. The one bridge is explicit: an agent can take over a
-session whose id you hand it (`claim=true`, which moves it to the agent's
-space), and `POST /api/sessions/{id}/claim` brings one back.
+The same surface exists over HTTP (list, read, create, append, rename,
+delete), so a script can own a conversation the way the TUI does. The TUI,
+HTTP server, and CLI are one conversation space: start a chat in Obsidian,
+continue it in the terminal.
+
+Agents get the same tools over MCP, but they are off by default: most agent
+hosts already track their own history, and the tools cost context on every
+request. Turn on `mcp_sessions_enabled` if you want an agent keeping its own
+saved conversations. Agent sessions stay separate from yours: they never
+appear in your session list, and agents cannot list or read yours. The one
+bridge is explicit: an agent can take over a session whose id you hand it
+(`claim=true`, which moves it to the agent's space), and
+`POST /api/sessions/{id}/claim` brings one back.
 
 To keep nothing, turn `sessions_enabled` off in Settings: nothing is written
 to disk, `ctrl+o` leaves the footer, and the Sessions view says sessions are
-off instead of showing an empty list.
+off instead of showing an empty list. That covers the TUI, HTTP server, and
+CLI; `mcp_sessions_enabled` governs the agent half independently.
 
 ### When a conversation outgrows the model
 

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -336,7 +336,20 @@ SETTINGS_MAP: dict[str, SettingDef] = {
             "Sessions tab, and the /sessions command. Off: nothing is written to disk, "
             "the ctrl+o binding leaves the footer, and opening the Sessions view shows a "
             "notice that sessions are turned off. Turn it off if you would rather your "
-            "chats not persist."
+            "chats not persist. Covers the TUI, the HTTP server, and the CLI; agent "
+            "sessions have their own setting."
+        ),
+    ),
+    "mcp_sessions_enabled": SettingDef(
+        bool,
+        nullable=False,
+        group=SettingGroup.GENERATION,
+        help_text=(
+            "Off (default): the session tools are not offered over MCP, and a connected "
+            "agent cannot create or read agent sessions. On: an agent can keep its own "
+            "saved conversations, separate from yours. Most agent hosts already track "
+            "their own history, and the tools cost context on every request, so this "
+            "stays off unless you want an agent owning conversations."
         ),
     ),
     "chat_mode": SettingDef(

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -429,7 +429,14 @@ class Config(BaseSettings):
     # Persist conversations and expose the Sessions drawer, tab, and commands.
     # On by default; turning it off stops chats being written to disk, hides the
     # ctrl+o binding from the footer, and gates the Sessions view behind a notice.
+    # Governs the human surfaces (TUI, HTTP, CLI); agent sessions have their own
+    # flag below, so the two domains the store already separates stay separate.
     sessions_enabled: bool = ConfigField(default=True, writable=True)
+
+    # The agent (MCP) half of the same feature, off by default: agent hosts
+    # generally track their own conversation history, and the seven session
+    # tools cost schema on every request whether or not anything uses them.
+    mcp_sessions_enabled: bool = ConfigField(default=False, writable=True)
 
     # Explicit ceiling for the dynamic n_ctx picker. ``None`` (default)
     # lets the model's training_ctx from GGUF metadata be the ceiling,

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -63,7 +63,7 @@ from lilbee.data.store import (
     scope_to_chunk_type,
 )
 from lilbee.sessions import (
-    SESSIONS_DISABLED_HINT,
+    AGENT_SESSIONS_DISABLED_HINT,
     MessageRole,
     Session,
     SessionMessage,
@@ -71,7 +71,7 @@ from lilbee.sessions import (
     SessionOrigin,
     SessionOwnershipError,
     TitleSource,
-    sessions_enabled,
+    agent_sessions_enabled,
 )
 from lilbee.wiki.shared import (
     INVALID_DRAFT_SLUG_ERROR,
@@ -469,20 +469,20 @@ def _require_agent_session(session_id: str) -> Session:
     return session
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def sessions_list() -> dict[str, Any]:
     """List the agent's sessions, newest first."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     metas = get_services().session_store.list(origins=_AGENT_ORIGINS)
     return {"sessions": [asdict(meta) for meta in metas], "total": len(metas)}
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def session_get(session_id: str) -> dict[str, Any]:
     """Return one agent session: metadata, transcript, summary."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     try:
         session = _require_agent_session(session_id)
     except SessionNotFoundError as exc:
@@ -505,18 +505,18 @@ def session_get(session_id: str) -> dict[str, Any]:
     }
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def session_create(model_ref: str, scope: str = "both") -> dict[str, Any]:
     """Start a saved chat session; returns its id."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     session_id = get_services().session_store.create(
         model_ref=model_ref, scope=scope, origin=SessionOrigin.MCP
     )
     return {"id": session_id, "model_ref": model_ref, "scope": scope}
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def session_add_message(
     session_id: str,
     role: MessageRole,
@@ -525,8 +525,8 @@ def session_add_message(
     claim: bool = False,
 ) -> dict[str, Any]:
     """Append one turn; a foreign session errors unless claim=True (ask first)."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     store = get_services().session_store
     try:
         # Re-coerce: the MCP layer passes the enum, but a raw string still
@@ -544,11 +544,11 @@ def session_add_message(
     return {"id": session_id, "added": True}
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def session_set_summary(session_id: str, summary: str) -> dict[str, Any]:
     """Replace an agent session's compaction summary."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     try:
         _require_agent_session(session_id)
         get_services().session_store.set_summary(session_id, summary)
@@ -557,11 +557,11 @@ def session_set_summary(session_id: str, summary: str) -> dict[str, Any]:
     return {"id": session_id, "summary": summary}
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def session_rename(session_id: str, title: str) -> dict[str, Any]:
     """Rename an agent session."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     try:
         _require_agent_session(session_id)
         get_services().session_store.set_title(session_id, title, TitleSource.CUSTOM)
@@ -570,11 +570,11 @@ def session_rename(session_id: str, title: str) -> dict[str, Any]:
     return {"id": session_id, "title": title}
 
 
-@_tool_if(sessions_enabled())
+@_tool_if(agent_sessions_enabled())
 def session_delete(session_id: str) -> dict[str, Any]:
     """Delete an agent session."""
-    if not sessions_enabled():
-        return _error(SESSIONS_DISABLED_HINT)
+    if not agent_sessions_enabled():
+        return _error(AGENT_SESSIONS_DISABLED_HINT)
     try:
         _require_agent_session(session_id)
         get_services().session_store.delete(session_id)

--- a/src/lilbee/sessions/__init__.py
+++ b/src/lilbee/sessions/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from lilbee.sessions.store import (
+    AGENT_SESSIONS_DISABLED_HINT,
     HUMAN_ORIGINS,
     SESSIONS_DISABLED_HINT,
     MessageRole,
@@ -14,11 +15,13 @@ from lilbee.sessions.store import (
     SessionOwnershipError,
     SessionStore,
     TitleSource,
+    agent_sessions_enabled,
     derive_title,
     sessions_enabled,
 )
 
 __all__ = [
+    "AGENT_SESSIONS_DISABLED_HINT",
     "HUMAN_ORIGINS",
     "SESSIONS_DISABLED_HINT",
     "MessageRole",
@@ -30,6 +33,7 @@ __all__ = [
     "SessionOwnershipError",
     "SessionStore",
     "TitleSource",
+    "agent_sessions_enabled",
     "derive_title",
     "sessions_enabled",
 ]

--- a/src/lilbee/sessions/store.py
+++ b/src/lilbee/sessions/store.py
@@ -30,6 +30,11 @@ SESSIONS_DISABLED_HINT = (
     "Sessions are off. Turn them on with /set sessions_enabled true in the TUI, "
     "settings_set via MCP, or sessions_enabled = true in config.toml."
 )
+AGENT_SESSIONS_DISABLED_HINT = (
+    "Agent sessions are off. Turn them on with settings_set mcp_sessions_enabled "
+    "true, /set mcp_sessions_enabled true in the TUI, or mcp_sessions_enabled = "
+    "true in config.toml."
+)
 # Bounds a wedged lock holder; a healthy append holds the lock for milliseconds.
 _APPEND_LOCK_TIMEOUT_S = 10
 UNTITLED_SESSION_TITLE = "Untitled chat"
@@ -38,8 +43,17 @@ TITLE_ELLIPSIS = "…"
 
 
 def sessions_enabled() -> bool:
-    """True when session persistence is switched on (on by default)."""
+    """True when session persistence is on for the human surfaces (default on)."""
     return cfg.sessions_enabled
+
+
+def agent_sessions_enabled() -> bool:
+    """True when agent (MCP) sessions are on (default off).
+
+    Independent of ``sessions_enabled``: the two govern separate domains, so an
+    agent's working state can be off while a human's conversations are saved.
+    """
+    return cfg.mcp_sessions_enabled
 
 
 class SessionEventType(StrEnum):

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -382,6 +382,19 @@ class TestSettingsFeatureGating:
         missing = writable_memory - set(SETTINGS_MAP)
         assert missing == set(), f"memory fields missing from SETTINGS_MAP: {missing}"
 
+    def test_both_session_toggles_have_a_settings_map_entry(self) -> None:
+        """Both session flags must be in SETTINGS_MAP, for the same reason the
+        memory fields are: without the entry ``/set`` rejects the key and the
+        Settings screen never renders it, even though the field is writable.
+        """
+        from lilbee.app.settings import WRITABLE_CONFIG_FIELDS
+        from lilbee.app.settings_map import SETTINGS_MAP
+
+        toggles = {"sessions_enabled", "mcp_sessions_enabled"}
+        assert toggles <= set(WRITABLE_CONFIG_FIELDS)  # sanity: both writable
+        missing = toggles - set(SETTINGS_MAP)
+        assert missing == set(), f"session toggles missing from SETTINGS_MAP: {missing}"
+
     def test_no_setting_help_text_mentions_obsidian(self) -> None:
         """Obsidian is one host of the HTTP API; it must not leak into setting labels."""
         from lilbee.app.settings_map import SETTINGS_MAP

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1686,12 +1686,13 @@ class TestCatalogBrowseMcp:
 
 
 # Tool families whose registration depends on ambient state: ``wiki_`` on
-# ``cfg.wiki``, ``memory_`` on ``cfg.memory_enabled``, ``crawl`` on whether the
-# crawl4ai extra is installed. They are excluded from the budget so it measures
+# ``cfg.wiki``, ``memory_`` on ``cfg.memory_enabled``, ``session`` on
+# ``cfg.mcp_sessions_enabled``, ``crawl`` on whether the crawl4ai extra is
+# installed. They are excluded from the budget so it measures
 # one fixed surface. Counting them made the same commit measure 9672 bytes in
 # the docs-site job and 10143 on a developer box, which is how a schema
 # regression took down a website deploy while every release job stayed green.
-_AMBIENT_TOOL_PREFIXES = ("wiki_", "memory_", "crawl")
+_AMBIENT_TOOL_PREFIXES = ("wiki_", "memory_", "session", "crawl")
 
 # Every tool a default install puts on the wire. Pinned by name so an
 # unconditionally-registered addition fails here and names itself, rather than
@@ -1715,13 +1716,6 @@ _DEFAULT_TOOL_NAMES = frozenset(
         "remove",
         "reset",
         "search",
-        "session_add_message",
-        "session_create",
-        "session_delete",
-        "session_get",
-        "session_rename",
-        "session_set_summary",
-        "sessions_list",
         "set_placement",
         "settings_get",
         "settings_list",
@@ -1784,10 +1778,8 @@ class TestToolsSchemaSize:
         lands here first, named, instead of surfacing as a byte overflow in
         whichever job happens to register the most tools.
         """
-        from lilbee.core.config import cfg as _cfg
         from lilbee.mcp_server import mcp as _mcp
 
-        assert _cfg.sessions_enabled is True, "budget measures the default config"
         tools = await _mcp.list_tools()
         registered = {t.name for t in tools if not t.name.startswith(_AMBIENT_TOOL_PREFIXES)}
         assert registered == _DEFAULT_TOOL_NAMES, (
@@ -1816,13 +1808,12 @@ class TestToolsSchemaSize:
         ]
         total_bytes = len(_json.dumps(payload))
         # 8_800 originally, measured over whatever the environment registered.
-        # Pinned to the default surface it reads 8_799, so sessions never
-        # actually breached the budget; an ambient memory_* family did. 9_500
-        # keeps the intent and replaces one byte of headroom with room for a
-        # tool or two before the next deliberate look. Each tool's docstring
-        # becomes its schema description, so trim verbose Args sections before
-        # bumping this again.
-        ceiling = 9_500
+        # Pinning the surface put it at 8_799; moving the session tools behind
+        # mcp_sessions_enabled (off by default) takes them off the default wire
+        # and drops it to 6_996. 7_500 leaves room for a tool or two. Each
+        # tool's docstring becomes its schema description, so trim verbose Args
+        # sections before raising this.
+        ceiling = 7_500
         assert total_bytes <= ceiling, (
             f"Default OpenAI tools schema is {total_bytes} bytes, exceeds {ceiling}."
         )

--- a/tests/test_mcp_sessions.py
+++ b/tests/test_mcp_sessions.py
@@ -234,17 +234,20 @@ def test_disabled_session_tools_write_nothing(store):
     assert [meta.id for meta in store.list(origins=(SessionOrigin.MCP,))] == [session_id]
 
 
-def test_session_tools_are_off_the_wire_by_default(monkeypatch):
+async def test_session_tools_are_off_the_wire_by_default():
     """A default install offers no session tools over MCP.
 
-    ``isolated_env`` turns them on for this file, so this asserts against the
-    declared default rather than the fixture's override. Registration is
-    import-time, so the flag decides whether the tools reach the wire at all;
-    the runtime refusals above cover a toggle flipped mid-process.
+    Registration is import-time, so the tools were gated out when this process
+    imported ``mcp_server`` under the real default. ``isolated_env`` flips the
+    flag at runtime for the rest of this file, which cannot re-register them,
+    so the wire still reflects the default here.
     """
     from lilbee.core.config import Config
+    from lilbee.mcp_server import mcp as _mcp
 
     assert Config.model_fields["mcp_sessions_enabled"].default is False
     assert Config.model_fields["sessions_enabled"].default is True, (
         "the human surfaces stay on by default; only the agent half is opt-in"
     )
+    on_the_wire = sorted(t.name for t in await _mcp.list_tools() if t.name.startswith("session"))
+    assert on_the_wire == [], f"session tools reached the default wire: {on_the_wire}"

--- a/tests/test_mcp_sessions.py
+++ b/tests/test_mcp_sessions.py
@@ -23,6 +23,9 @@ from tests.conftest import make_mock_services
 def isolated_env(tmp_path):
     snapshot = cfg.model_copy()
     cfg.data_dir = tmp_path / "data"
+    # Agent sessions are off by default; this file exercises the tools, so it
+    # turns them on and the toggle tests below switch them back off.
+    cfg.mcp_sessions_enabled = True
     yield
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
@@ -185,7 +188,7 @@ def test_claim_flag_on_unknown_session_errors(store):
     assert "error" in session_add_message("nope", "user", "x", claim=True)
 
 
-# --- the sessions_enabled toggle -----------------------------------------
+# --- the mcp_sessions_enabled toggle -----------------------------------------
 
 
 _DISABLED_CALLS = {
@@ -204,28 +207,44 @@ def test_session_tool_refuses_when_sessions_disabled(store, tool):
     """Every session tool refuses once the toggle goes off mid-process.
 
     ``_tool_if`` keeps them off the wire when sessions are off at import, but
-    ``sessions_enabled`` is writable at runtime, so a tool registered at start
+    ``mcp_sessions_enabled`` is writable at runtime, so a tool registered at start
     can still be called after the user turns sessions off. Without this each
     one would keep writing to disk.
     """
     session_id = _seed(store)
-    cfg.sessions_enabled = False
+    cfg.mcp_sessions_enabled = False
     result = _DISABLED_CALLS[tool](session_id)
     assert "error" in result
-    assert "sessions are off" in result["error"].lower()
+    assert "agent sessions are off" in result["error"].lower()
 
 
 def test_disabled_session_tools_write_nothing(store):
     """The refusal is real: the transcript and the session list are untouched."""
     session_id = _seed(store)
     before = len(store.get(session_id).messages)
-    cfg.sessions_enabled = False
+    cfg.mcp_sessions_enabled = False
 
     session_add_message(session_id, "user", "should not land")
     session_rename(session_id, "should not rename")
     session_delete(session_id)
     session_create("m")
 
-    cfg.sessions_enabled = True
+    cfg.mcp_sessions_enabled = True
     assert len(store.get(session_id).messages) == before
     assert [meta.id for meta in store.list(origins=(SessionOrigin.MCP,))] == [session_id]
+
+
+def test_session_tools_are_off_the_wire_by_default(monkeypatch):
+    """A default install offers no session tools over MCP.
+
+    ``isolated_env`` turns them on for this file, so this asserts against the
+    declared default rather than the fixture's override. Registration is
+    import-time, so the flag decides whether the tools reach the wire at all;
+    the runtime refusals above cover a toggle flipped mid-process.
+    """
+    from lilbee.core.config import Config
+
+    assert Config.model_fields["mcp_sessions_enabled"].default is False
+    assert Config.model_fields["sessions_enabled"].default is True, (
+        "the human surfaces stay on by default; only the agent half is opt-in"
+    )


### PR DESCRIPTION
## Problem

`sessions_enabled` governed all four surfaces, so saving conversations in the TUI also put the seven session tools on the MCP wire. Agent hosts generally track their own conversation history, and the tools cost ~1.8KB of schema on every request whether or not anything uses them.

## Solution

Add `mcp_sessions_enabled` (default off) for the agent domain, leaving `sessions_enabled` for the human one (TUI/HTTP/CLI). This mirrors the split the store already makes between `HUMAN_ORIGINS` and MCP. The two are independent, so an agent's working state can be off while your conversations are saved.

With the tools off the default wire they become ambient like `memory_`, so the schema budget drops them from the pinned set: 8799 -> 6996 bytes, and the ceiling comes down from 9500 to 7500 rather than leaving headroom the tools no longer occupy.

Docs updated: the MCP surface is no longer described as available by default.