### PR TITLE
Give HTTP chat context management: windowing, compaction, and a compaction event

### DIFF
--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -228,10 +228,10 @@ def _coerce_value(key: str, value: Any) -> Any:
 
 def _apply_with_rollback(
     updates: dict[str, Any],
-) -> tuple[dict[str, str], list[str], dict[str, Any]]:
+) -> tuple[dict[str, Any], list[str], dict[str, Any]]:
     """Set each key on cfg with snapshot/rollback. Returns (persist, delete, snapshot)."""
     snapshot = {k: getattr(cfg, k) for k in updates}
-    to_persist: dict[str, str] = {}
+    to_persist: dict[str, Any] = {}
     to_delete: list[str] = []
     try:
         for key, raw in updates.items():
@@ -244,7 +244,9 @@ def _apply_with_rollback(
             if isinstance(normalized, list):
                 to_persist[key] = "\n".join(str(x) for x in normalized)
             else:
-                to_persist[key] = str(normalized)
+                # Hand the scalar over with its type intact so config.toml holds
+                # `true` and `2560`, not `"True"` and `"2560"`.
+                to_persist[key] = normalized
     except Exception:
         _restore_snapshot(snapshot)
         raise

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -83,6 +83,7 @@ from lilbee.retrieval.query import SOURCES_BLOCK_MARKER, ChatMessage
 from lilbee.retrieval.query.compaction import (
     compaction_due,
     foldable,
+    history_budget,
     overflow,
     prompt_history,
     summary_messages,
@@ -106,16 +107,6 @@ from lilbee.sessions import (
 if TYPE_CHECKING:
     from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
 log = logging.getLogger(__name__)
-
-_HISTORY_TOKEN_BUDGET_FRACTION = 0.5
-"""Fraction of ``cfg.chat_n_ctx_target`` reserved for prior conversation history.
-
-The other half of the working context is for the system prompt, the current
-turn's RAG context (~8 chunks), the user question, and reasoning headroom.
-The windower drops oldest user/assistant pairs once history exceeds this
-fraction so the assembled prompt never approaches ``n_ctx`` and the chat
-server never rejects the request for exceeding the context window.
-"""
 
 # Coalesce per-token UI updates into ~50 ms windows. Tiny reasoning models can
 # emit 100+ tokens/sec; one ``call_from_thread`` per token saturates Textual's
@@ -1751,13 +1742,8 @@ class ChatScreen(Screen[None]):
 
     @staticmethod
     def _history_budget() -> int:
-        """Token budget for everything this conversation carries into the prompt.
-
-        A fraction of ``cfg.chat_n_ctx_target`` so the assembled prompt (system +
-        history + RAG + user) stays under the loaded model's ``n_ctx`` regardless
-        of how many turns have run or were resumed.
-        """
-        return int(cfg.chat_n_ctx_target * _HISTORY_TOKEN_BUDGET_FRACTION)
+        """Token budget for everything this conversation carries into the prompt."""
+        return history_budget(cfg.chat_n_ctx_target)
 
     def _compact_history(self) -> None:
         """Fold turns that no longer fit into the rolling summary. Worker thread only.

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import tomllib
 from pathlib import Path
+from typing import Any
 
 from lilbee.config_meta import MODEL_ROLE_FIELDS, WRITABLE_CONFIG_FIELDS
 from lilbee.core.config import cfg
@@ -30,31 +31,46 @@ def _escape_toml_string(s: str) -> str:
     )
 
 
-def load(data_root: Path) -> dict[str, str]:
-    """Read all settings from config.toml. Returns {} if file is missing."""
+def load(data_root: Path) -> dict[str, Any]:
+    """Read all settings from config.toml. Returns {} if file is missing.
+
+    Values keep the types TOML gave them. Stringifying here used to turn a
+    ``true`` into ``"True"`` in memory, which the next save then wrote back
+    quoted, so the file drifted away from valid types for its own fields.
+    """
     path = _config_path(data_root)
     if not path.exists():
         return {}
     with path.open("rb") as f:
-        return {k: str(v) for k, v in tomllib.load(f).items()}
+        return dict(tomllib.load(f))
 
 
-def save(data_root: Path, settings: dict[str, str]) -> None:
+def _render_toml_value(value: Any) -> str:
+    """Render a scalar as TOML: booleans and numbers bare, everything else quoted."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    return f'"{_escape_toml_string(str(value))}"'
+
+
+def save(data_root: Path, settings: dict[str, Any]) -> None:
     """Write settings dict as simple TOML key-value pairs."""
     path = _config_path(data_root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [f'{k} = "{_escape_toml_string(v)}"\n' for k, v in sorted(settings.items())]
+    lines = [f"{k} = {_render_toml_value(v)}\n" for k, v in sorted(settings.items())]
     path.write_text("".join(lines), encoding="utf-8", newline="\n")
     if sys.platform != "win32":
         path.chmod(0o600)  # pragma: no cover - POSIX-only; Windows has no 0600 mode bits
 
 
 def get(data_root: Path, key: str) -> str | None:
-    """Look up a single key from config.toml."""
-    return load(data_root).get(key)
+    """Look up a single key from config.toml, as text for callers that want text."""
+    value = load(data_root).get(key)
+    return None if value is None else str(value)
 
 
-def set_value(data_root: Path, key: str, value: str) -> None:
+def set_value(data_root: Path, key: str, value: Any) -> None:
     """Read-modify-write a single key in config.toml (thread-safe)."""
     with _settings_lock:
         current = load(data_root)
@@ -70,7 +86,7 @@ def delete_value(data_root: Path, key: str) -> None:
         save(data_root, current)
 
 
-def update_values(data_root: Path, updates: dict[str, str]) -> None:
+def update_values(data_root: Path, updates: dict[str, Any]) -> None:
     """Batch update multiple keys in config.toml (single write)."""
     with _settings_lock:
         current = load(data_root)

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -20,6 +20,22 @@ T_co = TypeVar("T_co", covariant=True)
 # The inline reasoning markers lilbee's pipeline speaks. A provider whose server
 # extracts reasoning into a separate field re-inlines it with these tags at the
 # client boundary, so every downstream consumer parses one format.
+# What every provider holds back from the context window for the answer it is
+# about to generate, plus a small margin for the chat template's own framing.
+# One owner for both numbers: the fleet ENFORCES this budget and rejects a
+# prompt that exceeds it, while retrieval FITS its context to it. When the two
+# disagreed, retrieval assembled prompts up to the margin larger than the
+# engine would accept, and a grounded turn failed with a 400 the caller could
+# do nothing about.
+GENERATION_RESERVE_TOKENS = 1024
+CONTEXT_WINDOW_MARGIN_TOKENS = 128
+
+
+def prompt_token_budget(ctx: int, num_predict: int | None = None) -> int:
+    """Tokens a prompt may occupy in a *ctx*-token window, reserve and margin removed."""
+    return ctx - (num_predict or GENERATION_RESERVE_TOKENS) - CONTEXT_WINDOW_MARGIN_TOKENS
+
+
 THINK_OPEN_TAG = "<think>"
 THINK_CLOSE_TAG = "</think>"
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, overload
 from lilbee.catalog import clean_display_name
 from lilbee.core.config import cfg
 from lilbee.modelhub.registry import ModelRegistry
-from lilbee.providers.base import ProviderError, ProviderErrorKind
+from lilbee.providers.base import ProviderError, ProviderErrorKind, prompt_token_budget
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.client import (
     ChatDeadlineError,
@@ -68,8 +68,6 @@ if TYPE_CHECKING:
 _PROVIDER_NAME = "llama-server"
 # Tokens held back from the served context for the model's own generation when the
 # request does not cap it, plus a margin for chat-template overhead and estimate drift.
-_DEFAULT_GENERATION_RESERVE = 1024
-_CONTEXT_WINDOW_MARGIN = 128
 # Minimal input used to pre-load a role's upstream during warm-up (llama-swap
 # starts an upstream on its first request, so warming issues one cheap call).
 _WARM_PROMPT = "warm"
@@ -1143,8 +1141,7 @@ class FleetProvider:
         # a real per-slot context is always positive, so skip windowing.
         if not self._chat_ctx:
             return messages
-        reserve = (options or {}).get("num_predict") or _DEFAULT_GENERATION_RESERVE
-        budget = self._chat_ctx - reserve - _CONTEXT_WINDOW_MARGIN
+        budget = prompt_token_budget(self._chat_ctx, (options or {}).get("num_predict"))
         result = window_messages(messages, tools, budget)
         if not result.fits:
             raise ProviderError(

--- a/src/lilbee/retrieval/query/compaction.py
+++ b/src/lilbee/retrieval/query/compaction.py
@@ -87,6 +87,15 @@ COMPACT_TRIGGER_FRACTION = 0.8
 # Messages (not exchanges) kept verbatim when compaction clears the history.
 COMPACT_KEEP_RECENT = 4
 
+# Fraction of ``chat_n_ctx_target`` a conversation may spend on its history;
+# the rest is for the system prompt, RAG context, question, and reasoning.
+HISTORY_TOKEN_BUDGET_FRACTION = 0.5
+
+
+def history_budget(ctx_target: int) -> int:
+    """Token budget for everything a conversation carries into the prompt."""
+    return int(ctx_target * HISTORY_TOKEN_BUDGET_FRACTION)
+
 
 @dataclass(frozen=True)
 class CompactionResult:

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -652,7 +652,10 @@ class Searcher:
         return question
 
     def summarize_history(
-        self, messages: list[ChatMessage], previous_summary: str = ""
+        self,
+        messages: list[ChatMessage],
+        previous_summary: str = "",
+        on_batch: Callable[[int, int], None] | None = None,
     ) -> CompactionResult:
         """Condense turns being dropped from the prompt into carry-forward notes.
 
@@ -670,13 +673,16 @@ class Searcher:
 
         Returns the notes and how many turns they cover; ``stranded`` counts turns
         dropped without notes, which the caller must surface rather than hide.
+        ``on_batch`` hears ``(batch, total)`` before each model call, for progress UI.
         """
         ctx_target = self._config.chat_n_ctx_target
         plan = plan_compaction(messages, previous_summary, ctx_target=ctx_target)
         notes: list[str] = []
         condensed = 0
         stranded = plan.stranded
-        for batch in plan.batches:
+        for index, batch in enumerate(plan.batches):
+            if on_batch is not None:
+                on_batch(index + 1, len(plan.batches))
             note = self._summarize_batch(batch, "")
             if note:
                 notes.append(note)

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -23,7 +23,12 @@ from lilbee.data.store import (
     cosine_sim,
     human_recall_predicate,
 )
-from lilbee.providers.base import LLMProvider, ProviderError, ProviderErrorKind
+from lilbee.providers.base import (
+    LLMProvider,
+    ProviderError,
+    ProviderErrorKind,
+    prompt_token_budget,
+)
 from lilbee.retrieval.embedder import Embedder
 from lilbee.retrieval.language import noun_variants, query_language
 from lilbee.retrieval.query.compaction import (
@@ -175,8 +180,6 @@ SEARCH_NEEDS_EMBEDDER = (
     "Add one, or switch to chat mode for an ungrounded reply."
 )
 
-# Token reserve for the generated answer when budgeting RAG context to num_ctx.
-_ANSWER_RESERVE_TOKENS = 1024
 # Chars-per-token assumed when BUDGETING context. Deliberately harsher than
 # the display estimator's 4: dense OCR/legal text tokenizes at ~2.5-3 chars
 # per token, and budgeting at 4 let a document whose real cost exceeded the
@@ -950,14 +953,16 @@ class Searcher:
         configured = self._config.num_ctx or self._config.chat_n_ctx_target
         served = self._provider.served_chat_ctx()
         ctx = min(configured, served) if served else configured
-        reserve = (
+        # Fit inside what the provider will actually accept: prompt_token_budget
+        # already removes the generation reserve and the engine's margin, so the
+        # sources get what is left after the rest of the prompt.
+        non_source = (
             self._budget_tokens(system)
             + self._budget_tokens(question)
             + sum(self._budget_tokens(m["content"]) for m in history or [])
-            + _ANSWER_RESERVE_TOKENS
             + _CONTEXT_TEMPLATE_TOKENS
         )
-        budget = int((ctx - reserve) * scale)
+        budget = int((prompt_token_budget(ctx) - non_source) * scale)
         kept: list[SearchChunk] = []
         used = 0
         for r in results:

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -35,6 +35,8 @@ class SseEvent(StrEnum):
     ALREADY_INGESTING = "already_ingesting"
     WARMING = "warming"
     WARM = "warm"
+    COMPACTING = "compacting"
+    COMPACTION = "compaction"
     MEMORY_EXTRACTED = "memory_extracted"
     GPU_STATS = "gpu_stats"
 

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -393,20 +393,58 @@ def _compaction_pending(history: list[ChatMessage], summary: str) -> bool:
 
 
 def _manage_history(
-    history: list[ChatMessage], summary: str
+    history: list[ChatMessage],
+    summary: str,
+    on_batch: Callable[[int, int], None] | None = None,
 ) -> tuple[list[ChatMessage], CompactionInfo | None]:
     """Apply the TUI's pre-turn context discipline to an HTTP conversation."""
     budget = history_budget(cfg.chat_n_ctx_target)
     info: CompactionInfo | None = None
     if _compaction_pending(history, summary):
         dropped = foldable(history)
-        result = get_services().searcher.summarize_history(dropped, summary)
+        result = get_services().searcher.summarize_history(dropped, summary, on_batch=on_batch)
         history = history[len(dropped) :]
         summary = result.summary
         info = CompactionInfo(
             summary=result.summary, condensed=result.condensed, stranded=result.stranded
         )
     return prompt_history(history, summary, max_tokens=budget), info
+
+
+async def _context_management_frames(
+    history: list[ChatMessage], summary: str, session_id: str | None
+) -> AsyncGenerator[str | tuple[list[ChatMessage], CompactionInfo | None], None]:
+    """Manage this turn's history off-loop, yielding its SSE frames, then the result.
+
+    Yields the ``compacting`` announcement, per-batch progress frames, and the
+    closing ``compaction`` frame (str items), persisting a fresh summary along
+    the way; the ``(history, info)`` tuple arrives exactly once, last.
+    """
+    if _compaction_pending(history, summary):
+        # Condensing blocks this turn on model calls; announce it like warming,
+        # then relay per-batch progress while the condenser works.
+        yield sse_event(SseEvent.COMPACTING, {})
+    loop = asyncio.get_running_loop()
+    progress: asyncio.Queue[tuple[int, int]] = asyncio.Queue()
+
+    def _on_batch(batch: int, total: int) -> None:
+        loop.call_soon_threadsafe(progress.put_nowait, (batch, total))
+
+    manage = asyncio.ensure_future(asyncio.to_thread(_manage_history, history, summary, _on_batch))
+    while True:
+        get = asyncio.ensure_future(progress.get())
+        done, _ = await asyncio.wait({manage, get}, return_when=asyncio.FIRST_COMPLETED)
+        if get in done:
+            batch, total = get.result()
+            yield sse_event(SseEvent.COMPACTING, {"batch": batch, "batches": total})
+            continue
+        get.cancel()
+        break
+    managed_history, compaction = await manage
+    if compaction is not None:
+        _persist_summary(session_id, compaction)
+        yield sse_event(SseEvent.COMPACTION, compaction.model_dump())
+    yield (managed_history, compaction)
 
 
 def _persist_summary(session_id: str | None, info: CompactionInfo | None) -> None:
@@ -565,13 +603,11 @@ async def _stream_chat_response(
     session_id: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Drive ``dispatch_chat_stream`` and emit reasoning/token/sources/done SSE events."""
-    if _compaction_pending(history, summary):
-        # Condensing blocks this turn on model calls; announce it like warming.
-        yield sse_event(SseEvent.COMPACTING, {})
-    history, compaction = await asyncio.to_thread(_manage_history, history, summary)
-    if compaction is not None:
-        _persist_summary(session_id, compaction)
-        yield sse_event(SseEvent.COMPACTION, compaction.model_dump())
+    async for item in _context_management_frames(history, summary, session_id):
+        if isinstance(item, str):
+            yield item
+            continue
+        history, _compaction = item
     frames, ctx = _resolve_chat_stream_context(
         get_services().searcher, question, history, top_k, chunk_type
     )

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -319,7 +319,11 @@ async def _stream_rag_response(
         yield sse_event(SseEvent.SOURCES, [])
         yield sse_done({})
         return
-    results, messages, preempt = _resolve_stream_context(
+    # Retrieval embeds, searches, reranks, and can spend an LLM call expanding
+    # the query. On the loop it stalls every other admitted request for the whole
+    # turn; the non-streaming siblings already thread the same work.
+    results, messages, preempt = await asyncio.to_thread(
+        _resolve_stream_context,
         searcher,
         question,
         history,
@@ -620,8 +624,8 @@ async def _stream_chat_response(
             yield item
             continue
         history, _compaction = item
-    frames, ctx = _resolve_chat_stream_context(
-        get_services().searcher, question, history, top_k, chunk_type
+    frames, ctx = await asyncio.to_thread(
+        _resolve_chat_stream_context, get_services().searcher, question, history, top_k, chunk_type
     )
     for frame in frames:
         yield frame

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -420,27 +420,39 @@ async def _context_management_frames(
     closing ``compaction`` frame (str items), persisting a fresh summary along
     the way; the ``(history, info)`` tuple arrives exactly once, last.
     """
-    if _compaction_pending(history, summary):
-        # Condensing blocks this turn on model calls; announce it like warming,
-        # then relay per-batch progress while the condenser works.
-        yield sse_event(SseEvent.COMPACTING, {})
-    loop = asyncio.get_running_loop()
-    progress: asyncio.Queue[tuple[int, int]] = asyncio.Queue()
+    if not _compaction_pending(history, summary):
+        # Windowing only: pure arithmetic over the messages, no model call to wait on.
+        yield await asyncio.to_thread(_manage_history, history, summary)
+        return
+
+    # Condensing blocks this turn on model calls; announce it like warming, then
+    # relay per-batch progress. SseStream carries the heartbeats and the
+    # client-disconnect cancellation every other streaming endpoint here gets.
+    yield sse_event(SseEvent.COMPACTING, {})
+    stream = SseStream()
 
     def _on_batch(batch: int, total: int) -> None:
-        loop.call_soon_threadsafe(progress.put_nowait, (batch, total))
+        stream.put_threadsafe(sse_event(SseEvent.COMPACTING, {"batch": batch, "batches": total}))
 
-    manage = asyncio.ensure_future(asyncio.to_thread(_manage_history, history, summary, _on_batch))
-    while True:
-        get = asyncio.ensure_future(progress.get())
-        done, _ = await asyncio.wait({manage, get}, return_when=asyncio.FIRST_COMPLETED)
-        if get in done:
-            batch, total = get.result()
-            yield sse_event(SseEvent.COMPACTING, {"batch": batch, "batches": total})
-            continue
-        get.cancel()
-        break
-    managed_history, compaction = await manage
+    async def _condense() -> tuple[list[ChatMessage], CompactionInfo | None]:
+        try:
+            return await asyncio.to_thread(_manage_history, history, summary, _on_batch)
+        finally:
+            stream.put_threadsafe(None)
+
+    task = asyncio.ensure_future(_condense())
+    async for frame in stream.drain(task, "Compaction stream"):
+        yield frame
+    try:
+        managed_history, compaction = await task
+    except Exception:
+        # Condensing is best-effort: a failed fold degrades to plain windowing,
+        # which is what this turn would have done with compaction off. Losing the
+        # summary costs context; failing the turn costs the user their answer.
+        log.warning("Compaction failed; falling back to windowing", exc_info=True)
+        budget = history_budget(cfg.chat_n_ctx_target)
+        yield (prompt_history(history, summary, max_tokens=budget), None)
+        return
     if compaction is not None:
         _persist_summary(session_id, compaction)
         yield sse_event(SseEvent.COMPACTION, compaction.model_dump())

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -18,6 +18,12 @@ from lilbee.core.results import DocumentResult, group
 from lilbee.data.store import ChunkType, EmbeddingModelMismatchError
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.roles import WorkerRole
+from lilbee.retrieval.query.compaction import (
+    compaction_due,
+    foldable,
+    history_budget,
+    prompt_history,
+)
 from lilbee.retrieval.query.formatting import StreamingCitationFilter, cited_subset
 from lilbee.retrieval.query.searcher import (
     GROUNDED_REFUSAL,
@@ -62,9 +68,11 @@ from lilbee.server.handlers.sse import (
 from lilbee.server.models import (
     AskResponse,
     CleanedChunk,
+    CompactionInfo,
     MemoryExtractedEvent,
     MemoryExtractedItem,
 )
+from lilbee.sessions import SessionNotFoundError, sessions_enabled
 
 if TYPE_CHECKING:
     from lilbee.core.results import SearchChunk
@@ -374,12 +382,49 @@ def ask_stream(
     return _stream_rag_response(question, top_k=top_k, options=options, chunk_type=chunk_type)
 
 
+def _compaction_pending(history: list[ChatMessage], summary: str) -> bool:
+    """Whether this turn will fold turns into notes before answering."""
+    budget = history_budget(cfg.chat_n_ctx_target)
+    return bool(
+        cfg.chat_compaction
+        and compaction_due(history, summary, max_tokens=budget)
+        and foldable(history)
+    )
+
+
+def _manage_history(
+    history: list[ChatMessage], summary: str
+) -> tuple[list[ChatMessage], CompactionInfo | None]:
+    """Apply the TUI's pre-turn context discipline to an HTTP conversation."""
+    budget = history_budget(cfg.chat_n_ctx_target)
+    info: CompactionInfo | None = None
+    if _compaction_pending(history, summary):
+        dropped = foldable(history)
+        result = get_services().searcher.summarize_history(dropped, summary)
+        history = history[len(dropped) :]
+        summary = result.summary
+        info = CompactionInfo(
+            summary=result.summary, condensed=result.condensed, stranded=result.stranded
+        )
+    return prompt_history(history, summary, max_tokens=budget), info
+
+
+def _persist_summary(session_id: str | None, info: CompactionInfo | None) -> None:
+    """Store fresh notes on the session; a session deleted mid-chat is tolerated."""
+    if info is None or not session_id or not info.summary or not sessions_enabled():
+        return
+    with contextlib.suppress(SessionNotFoundError):
+        get_services().session_store.set_summary(session_id, info.summary)
+
+
 async def chat(
     question: str,
     history: list[ChatMessage],
     top_k: int | None = None,
     options: dict[str, Any] | None = None,
     chunk_type: ChunkType | None = None,
+    summary: str = "",
+    session_id: str | None = None,
 ) -> AskResponse:
     """Chat with history. Returns answer and sources via canonical dispatch."""
     searcher = get_services().searcher
@@ -387,6 +432,8 @@ async def chat(
         # Search mode with no embedder can't ground; refuse cleanly with the same
         # message ask returns instead of silently answering off-corpus.
         return AskResponse(answer=SEARCH_NEEDS_EMBEDDER, sources=[], cited_sources=[])
+    history, compaction = await asyncio.to_thread(_manage_history, history, summary)
+    _persist_summary(session_id, compaction)
     if _retrieval_off(searcher, top_k):
         # Chat-only mode or an explicit top_k:0 pure-LLM call.
         sources: list[SearchChunk] = []
@@ -396,14 +443,18 @@ async def chat(
         # library, count routing, memory-awareness) so surfaces cannot drift.
         pre_answer = searcher.pre_retrieval_answer(question)
         if pre_answer is not None:
-            return AskResponse(answer=pre_answer, sources=[], cited_sources=[])
+            return AskResponse(
+                answer=pre_answer, sources=[], cited_sources=[], compaction=compaction
+            )
         rag = searcher.build_rag_context(
             question, top_k=top_k or 0, history=history, chunk_type=chunk_type
         )
         if rag is None:
             # Refuse like every sibling surface; the old fallback silently
             # answered off-corpus with nothing telling the caller so.
-            return AskResponse(answer=GROUNDED_REFUSAL, sources=[], cited_sources=[])
+            return AskResponse(
+                answer=GROUNDED_REFUSAL, sources=[], cited_sources=[], compaction=compaction
+            )
         sources, messages = rag
     req = _build_canonical_request(messages, options)
     response = await asyncio.to_thread(dispatch_chat, req)
@@ -422,6 +473,7 @@ async def chat(
         answer=answer,
         sources=[CleanedChunk(**clean_result(s)) for s in sources],
         cited_sources=[CleanedChunk(**clean_result(s)) for s in cited_subset(answer, sources)],
+        compaction=compaction,
     )
 
 
@@ -431,10 +483,18 @@ def chat_stream(
     top_k: int | None = None,
     options: dict[str, Any] | None = None,
     chunk_type: ChunkType | None = None,
+    summary: str = "",
+    session_id: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Stream RAG chat tokens through canonical dispatch as token/sources/done events."""
     return _stream_chat_response(
-        question, history=history, top_k=top_k, options=options, chunk_type=chunk_type
+        question,
+        history=history,
+        top_k=top_k,
+        options=options,
+        chunk_type=chunk_type,
+        summary=summary,
+        session_id=session_id,
     )
 
 
@@ -501,8 +561,17 @@ async def _stream_chat_response(
     top_k: int | None,
     options: dict[str, Any] | None,
     chunk_type: ChunkType | None,
+    summary: str = "",
+    session_id: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Drive ``dispatch_chat_stream`` and emit reasoning/token/sources/done SSE events."""
+    if _compaction_pending(history, summary):
+        # Condensing blocks this turn on model calls; announce it like warming.
+        yield sse_event(SseEvent.COMPACTING, {})
+    history, compaction = await asyncio.to_thread(_manage_history, history, summary)
+    if compaction is not None:
+        _persist_summary(session_id, compaction)
+        yield sse_event(SseEvent.COMPACTION, compaction.model_dump())
     frames, ctx = _resolve_chat_stream_context(
         get_services().searcher, question, history, top_k, chunk_type
     )

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -61,6 +61,10 @@ class ChatRequest(BaseModel):
     top_k: int | None = Field(default=None, le=100)
     options: dict[str, Any] | None = None
     chunk_type: ChunkType | None = None
+    summary: str = ""
+    """Carry-forward notes from earlier compactions, folded into the prompt."""
+    session_id: str | None = None
+    """Session that receives the new summary when this turn compacts."""
 
     @field_validator("chunk_type", mode="before")
     @classmethod
@@ -209,6 +213,16 @@ class HealthResponse(BaseModel):
     its window and the client trims history to fit. None until the engine is up."""
 
 
+class CompactionInfo(BaseModel):
+    """What one pre-turn compaction folded out of a conversation."""
+
+    summary: str
+    condensed: int
+    """Turns folded into the notes."""
+    stranded: int
+    """Turns dropped with no notes; a client must say so rather than hide it."""
+
+
 class AskResponse(BaseModel):
     """Response for /api/ask and /api/chat.
 
@@ -219,6 +233,8 @@ class AskResponse(BaseModel):
     answer: str
     sources: list[CleanedChunk]
     cited_sources: list[CleanedChunk] = Field(default_factory=list)
+    compaction: CompactionInfo | None = None
+    """Set when a /api/chat turn compacted its history before answering."""
 
 
 class SetModelResponse(BaseModel):

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -206,6 +206,8 @@ async def chat_route(data: ChatRequest) -> AskResponse:
             top_k=data.top_k,
             options=data.options,
             chunk_type=data.chunk_type,
+            summary=data.summary,
+            session_id=data.session_id,
         )
     except EmbeddingModelMismatchError as exc:
         raise _embedding_mismatch_http(exc) from exc
@@ -229,6 +231,8 @@ async def chat_stream_route(data: ChatRequest) -> Stream:
             top_k=data.top_k,
             options=data.options,
             chunk_type=data.chunk_type,
+            summary=data.summary,
+            session_id=data.session_id,
         ),
         ChatSlotGuard(),
     )

--- a/tests/server/test_chat_compaction.py
+++ b/tests/server/test_chat_compaction.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import AsyncIterator
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,8 +11,8 @@ import pytest
 from lilbee.core.config import cfg
 from lilbee.retrieval.query.compaction import (
     COMPACT_KEEP_RECENT,
-    CompactionResult,
     HISTORY_TOKEN_BUDGET_FRACTION,
+    CompactionResult,
     history_budget,
     summary_messages,
 )

--- a/tests/server/test_chat_compaction.py
+++ b/tests/server/test_chat_compaction.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import dataclasses
+import time
 from collections.abc import AsyncIterator
 from unittest.mock import MagicMock
 
@@ -268,6 +271,62 @@ class TestChatStreamCompactionEvents:
         assert "compacting" not in names
         assert "compaction" not in names
         mock_svc.searcher.summarize_history.assert_not_called()
+
+
+class TestStreamKeepsTheLoopFree:
+    """bb-izsf: retrieval must not block the event loop for the whole turn."""
+
+    async def test_other_requests_are_served_while_retrieval_runs(
+        self, mock_svc, monkeypatch
+    ) -> None:
+        """A slow, blocking retrieval must not stall a concurrent coroutine.
+
+        The plugin appends each turn to its session while the answer streams. With
+        retrieval on the loop those appends queued behind the whole turn, timed out,
+        and split one conversation across two sessions during E2E recording.
+        """
+        monkeypatch.setattr(cfg, "chat_compaction", False)
+        monkeypatch.setattr(
+            _rag, "dispatch_chat_stream", lambda req: _async_stream(_events_from(["hi"]))
+        )
+
+        def _slow_context(question, top_k=0, history=None, chunk_type=None):
+            time.sleep(0.3)  # stands in for embed + search + rerank
+            return ([], [{"role": "user", "content": "q"}])
+
+        # Unset, skip_retrieval() returns a truthy MagicMock and the turn takes the
+        # direct path, never reaching retrieval at all.
+        mock_svc.searcher.skip_retrieval.return_value = False
+        mock_svc.searcher.library_empty.return_value = False
+        mock_svc.searcher.build_rag_context.side_effect = _slow_context
+
+        # Throughput is the signal, not the widest gap: while the loop is blocked
+        # every 10ms timer piles up and then fires back to back, so the stamps are
+        # bunched rather than spread. A free loop ticks steadily throughout.
+        ticks = 0
+
+        async def _heartbeat() -> None:
+            nonlocal ticks
+            for _ in range(60):
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        beat = asyncio.ensure_future(_heartbeat())
+        # Let it tick before the turn starts: with no stamp on record before the
+        # stall, the gap that proves the stall has nothing to measure from.
+        await asyncio.sleep(0.05)
+        frames = [frame async for frame in _rag.chat_stream("q", history=[], top_k=5)]
+        beat.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await beat
+
+        assert mock_svc.searcher.build_rag_context.called, "retrieval was never reached"
+        assert any("token" in f for f in frames), "the turn still answers"
+        # Blocking retrieval yields ~4 ticks across the turn; off the loop it is ~30.
+        assert ticks >= 15, (
+            f"the loop only ticked {ticks} times through a 0.3s retrieval; "
+            "it must not run on the event loop"
+        )
 
 
 class TestChatResponseCompaction:

--- a/tests/server/test_chat_compaction.py
+++ b/tests/server/test_chat_compaction.py
@@ -109,7 +109,9 @@ class TestManageHistory:
 
         managed, info = _rag._manage_history(history, "old notes")
 
-        mock_svc.searcher.summarize_history.assert_called_once_with(dropped, "old notes")
+        mock_svc.searcher.summarize_history.assert_called_once_with(
+            dropped, "old notes", on_batch=None
+        )
         assert info == CompactionInfo(summary="the notes", condensed=len(dropped), stranded=2)
         assert managed[:2] == summary_messages("the notes")
         assert managed[2:] == history[-COMPACT_KEEP_RECENT:]
@@ -207,6 +209,32 @@ class TestChatStreamCompactionEvents:
         compaction = dict(events)["compaction"]
         assert compaction == {"summary": "the notes", "condensed": 6, "stranded": 0}
         mock_svc.session_store.set_summary.assert_called_once_with("s1", "the notes")
+
+    async def test_relays_per_batch_progress_while_condensing(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        monkeypatch.setattr(cfg, "sessions_enabled", True)
+        monkeypatch.setattr(
+            _rag, "dispatch_chat_stream", lambda req: _async_stream(_events_from(["hi"]))
+        )
+
+        def _condense(dropped, summary, on_batch=None):
+            if on_batch is not None:
+                on_batch(1, 2)
+                on_batch(2, 2)
+            return CompactionResult(summary="the notes", condensed=len(dropped), stranded=0)
+
+        mock_svc.searcher.summarize_history.side_effect = _condense
+
+        frames = await self._frames(_msgs(40))
+
+        events = parse_sse_events("".join(frames).encode())
+        compacting = [data for name, data in events if name == "compacting"]
+        assert compacting[0] == {}
+        assert {"batch": 1, "batches": 2} in compacting
+        assert {"batch": 2, "batches": 2} in compacting
+        names = [name for name, _ in events]
+        assert names.index("compaction") < names.index("token")
 
     async def test_stays_silent_when_compaction_is_off(self, mock_svc, monkeypatch) -> None:
         monkeypatch.setattr(cfg, "chat_compaction", False)

--- a/tests/server/test_chat_compaction.py
+++ b/tests/server/test_chat_compaction.py
@@ -1,0 +1,262 @@
+"""HTTP chat context management: windowing, compaction, and its SSE events."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.core.config import cfg
+from lilbee.retrieval.query.compaction import (
+    COMPACT_KEEP_RECENT,
+    CompactionResult,
+    HISTORY_TOKEN_BUDGET_FRACTION,
+    history_budget,
+    summary_messages,
+)
+from lilbee.server.chat_dispatch.canonical import (
+    CanonicalStreamEvent,
+    ContentBlockDelta,
+    ContentBlockStart,
+    ContentBlockStop,
+    MessageStart,
+    MessageStop,
+    TextBlock,
+    TextDelta,
+)
+from lilbee.server.handlers import rag as _rag
+from lilbee.server.models import ChatRequest, CompactionInfo
+from lilbee.sessions import SessionNotFoundError
+from tests.server.conftest import parse_sse_events
+
+
+def _msgs(n: int, size: int = 400) -> list[dict[str, str]]:
+    return [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": "x" * size} for i in range(n)
+    ]
+
+
+def _events_from(texts: list[str]) -> list[CanonicalStreamEvent]:
+    return [
+        MessageStart(id="msg_test", model=cfg.chat_model),
+        ContentBlockStart(index=0, block=TextBlock(text="")),
+        *(ContentBlockDelta(index=0, delta=TextDelta(text=t)) for t in texts),
+        ContentBlockStop(index=0),
+        MessageStop(),
+    ]
+
+
+def _async_stream(events: list[CanonicalStreamEvent]) -> AsyncIterator[CanonicalStreamEvent]:
+    async def _gen():
+        for event in events:
+            yield event
+
+    return _gen()
+
+
+def _installed_manifest(ref: str) -> MagicMock:
+    m = MagicMock()
+    m.ref = ref
+    m.task = "chat"
+    return m
+
+
+@pytest.fixture
+def mock_svc():
+    """Mirror the lightweight services stub used by tests/test_server_handlers.py."""
+    from lilbee.app.services import set_services
+    from tests.conftest import make_mock_services
+
+    searcher = MagicMock()
+    searcher.build_rag_context.return_value = None
+    searcher.search_unavailable.return_value = False
+    searcher.pre_retrieval_answer.return_value = None
+    searcher.direct_messages.return_value = [{"role": "user", "content": "q"}]
+    services = dataclasses.replace(make_mock_services(searcher=searcher), session_store=MagicMock())
+    services.registry.list_installed = MagicMock(return_value=[_installed_manifest(cfg.chat_model)])
+    set_services(services)
+    yield services
+    set_services(None)
+
+
+def test_history_budget_is_the_tui_fraction() -> None:
+    assert history_budget(2048) == int(2048 * HISTORY_TOKEN_BUDGET_FRACTION)
+
+
+class TestManageHistory:
+    def test_windows_without_compacting_when_the_toggle_is_off(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", False)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        history = _msgs(40)
+
+        managed, info = _rag._manage_history(history, "")
+
+        assert info is None
+        mock_svc.searcher.summarize_history.assert_not_called()
+        assert len(managed) < len(history)
+        assert managed == history[-len(managed) :]
+
+    def test_compacts_when_due_and_returns_the_result(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        history = _msgs(40)
+        dropped = history[:-COMPACT_KEEP_RECENT]
+        mock_svc.searcher.summarize_history.return_value = CompactionResult(
+            summary="the notes", condensed=len(dropped), stranded=2
+        )
+
+        managed, info = _rag._manage_history(history, "old notes")
+
+        mock_svc.searcher.summarize_history.assert_called_once_with(dropped, "old notes")
+        assert info == CompactionInfo(summary="the notes", condensed=len(dropped), stranded=2)
+        assert managed[:2] == summary_messages("the notes")
+        assert managed[2:] == history[-COMPACT_KEEP_RECENT:]
+
+    def test_leaves_a_conversation_under_the_trigger_alone(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 8192)
+        history = _msgs(4)
+
+        managed, info = _rag._manage_history(history, "")
+
+        assert info is None
+        mock_svc.searcher.summarize_history.assert_not_called()
+        assert managed == history
+
+    def test_windows_when_only_the_tail_fills_the_budget(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        history = _msgs(COMPACT_KEEP_RECENT, size=4000)
+
+        managed, info = _rag._manage_history(history, "")
+
+        assert info is None
+        mock_svc.searcher.summarize_history.assert_not_called()
+        assert len(managed) < len(history)
+
+
+class TestPersistSummary:
+    def test_writes_fresh_notes_to_the_session(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "sessions_enabled", True)
+        info = CompactionInfo(summary="notes", condensed=3, stranded=0)
+
+        _rag._persist_summary("s1", info)
+
+        mock_svc.session_store.set_summary.assert_called_once_with("s1", "notes")
+
+    @pytest.mark.parametrize(
+        ("session_id", "info", "sessions_on"),
+        [
+            pytest.param("s1", None, True, id="no-compaction"),
+            pytest.param(
+                None, CompactionInfo(summary="n", condensed=1, stranded=0), True, id="no-session"
+            ),
+            pytest.param(
+                "s1", CompactionInfo(summary="", condensed=0, stranded=4), True, id="empty-summary"
+            ),
+            pytest.param(
+                "s1", CompactionInfo(summary="n", condensed=1, stranded=0), False, id="sessions-off"
+            ),
+        ],
+    )
+    def test_skips_when_there_is_nothing_or_nowhere_to_write(
+        self, mock_svc, monkeypatch, session_id, info, sessions_on
+    ) -> None:
+        monkeypatch.setattr(cfg, "sessions_enabled", sessions_on)
+
+        _rag._persist_summary(session_id, info)
+
+        mock_svc.session_store.set_summary.assert_not_called()
+
+    def test_tolerates_a_session_deleted_mid_chat(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "sessions_enabled", True)
+        mock_svc.session_store.set_summary.side_effect = SessionNotFoundError("s1")
+
+        _rag._persist_summary("s1", CompactionInfo(summary="n", condensed=1, stranded=0))
+
+
+class TestChatStreamCompactionEvents:
+    async def _frames(self, history: list[dict[str, str]], summary: str = "") -> list[str]:
+        return [
+            frame
+            async for frame in _rag.chat_stream(
+                "q", history=history, top_k=0, summary=summary, session_id="s1"
+            )
+        ]
+
+    async def test_emits_compacting_then_compaction_before_the_answer(
+        self, mock_svc, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        monkeypatch.setattr(cfg, "sessions_enabled", True)
+        monkeypatch.setattr(
+            _rag, "dispatch_chat_stream", lambda req: _async_stream(_events_from(["hi"]))
+        )
+        mock_svc.searcher.summarize_history.return_value = CompactionResult(
+            summary="the notes", condensed=6, stranded=0
+        )
+
+        frames = await self._frames(_msgs(40))
+
+        events = parse_sse_events("".join(frames).encode())
+        names = [name for name, _ in events]
+        assert names.index("compacting") < names.index("compaction") < names.index("token")
+        compaction = dict(events)["compaction"]
+        assert compaction == {"summary": "the notes", "condensed": 6, "stranded": 0}
+        mock_svc.session_store.set_summary.assert_called_once_with("s1", "the notes")
+
+    async def test_stays_silent_when_compaction_is_off(self, mock_svc, monkeypatch) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", False)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        monkeypatch.setattr(
+            _rag, "dispatch_chat_stream", lambda req: _async_stream(_events_from(["hi"]))
+        )
+
+        frames = await self._frames(_msgs(40))
+
+        names = [name for name, _ in parse_sse_events("".join(frames).encode())]
+        assert "compacting" not in names
+        assert "compaction" not in names
+        mock_svc.searcher.summarize_history.assert_not_called()
+
+
+class TestChatResponseCompaction:
+    async def test_non_stream_chat_carries_and_persists_the_result(
+        self, mock_svc, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        monkeypatch.setattr(cfg, "sessions_enabled", True)
+        response = MagicMock()
+        response.content = [TextBlock(text="an answer")]
+        monkeypatch.setattr(_rag, "dispatch_chat", lambda req: response)
+        mock_svc.searcher.summarize_history.return_value = CompactionResult(
+            summary="the notes", condensed=6, stranded=1
+        )
+
+        result = await _rag.chat("q", history=_msgs(40), top_k=0, summary="", session_id="s1")
+
+        assert result.compaction == CompactionInfo(summary="the notes", condensed=6, stranded=1)
+        mock_svc.session_store.set_summary.assert_called_once_with("s1", "the notes")
+
+    async def test_non_stream_chat_reports_no_compaction_when_none_ran(
+        self, mock_svc, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "chat_compaction", False)
+        response = MagicMock()
+        response.content = [TextBlock(text="an answer")]
+        monkeypatch.setattr(_rag, "dispatch_chat", lambda req: response)
+
+        result = await _rag.chat("q", history=_msgs(4), top_k=0)
+
+        assert result.compaction is None
+
+
+def test_chat_request_defaults_carry_no_conversation_state() -> None:
+    req = ChatRequest(question="q")
+    assert req.summary == ""
+    assert req.session_id is None

--- a/tests/server/test_chat_compaction.py
+++ b/tests/server/test_chat_compaction.py
@@ -236,6 +236,25 @@ class TestChatStreamCompactionEvents:
         names = [name for name, _ in events]
         assert names.index("compaction") < names.index("token")
 
+    async def test_a_failed_fold_degrades_to_windowing_and_still_answers(
+        self, mock_svc, monkeypatch
+    ) -> None:
+        """Condensing is best-effort: the turn survives a condenser that blows up."""
+        monkeypatch.setattr(cfg, "chat_compaction", True)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)
+        monkeypatch.setattr(
+            _rag, "dispatch_chat_stream", lambda req: _async_stream(_events_from(["hi"]))
+        )
+        mock_svc.searcher.summarize_history.side_effect = RuntimeError("engine died")
+
+        frames = await self._frames(_msgs(40))
+
+        events = parse_sse_events("".join(frames).encode())
+        names = [name for name, _ in events]
+        assert "token" in names, "the answer must still stream"
+        assert "compaction" not in names, "no fold to report"
+        assert "error" not in names
+
     async def test_stays_silent_when_compaction_is_off(self, mock_svc, monkeypatch) -> None:
         monkeypatch.setattr(cfg, "chat_compaction", False)
         monkeypatch.setattr(cfg, "chat_n_ctx_target", 2048)

--- a/tests/server/test_chat_compaction.py
+++ b/tests/server/test_chat_compaction.py
@@ -290,42 +290,46 @@ class TestStreamKeepsTheLoopFree:
             _rag, "dispatch_chat_stream", lambda req: _async_stream(_events_from(["hi"]))
         )
 
-        def _slow_context(question, top_k=0, history=None, chunk_type=None):
-            time.sleep(0.3)  # stands in for embed + search + rerank
-            return ([], [{"role": "user", "content": "q"}])
-
         # Unset, skip_retrieval() returns a truthy MagicMock and the turn takes the
         # direct path, never reaching retrieval at all.
         mock_svc.searcher.skip_retrieval.return_value = False
         mock_svc.searcher.library_empty.return_value = False
-        mock_svc.searcher.build_rag_context.side_effect = _slow_context
 
-        # Throughput is the signal, not the widest gap: while the loop is blocked
-        # every 10ms timer piles up and then fires back to back, so the stamps are
-        # bunched rather than spread. A free loop ticks steadily throughout.
-        ticks = 0
+        # Did the loop run *while* retrieval was running? A blocked loop cannot
+        # schedule anything between the call starting and returning, so record
+        # whether the heartbeat ticked inside that window. Counting ticks would
+        # be a clock-resolution bet: Windows timers land near 15ms, so a
+        # threshold tuned on macOS fails there for reasons unrelated to the bug.
+        entered = asyncio.Event()
+        ticked_during_retrieval = False
+        released = False
+
+        def _slow_context_signalling(question, top_k=0, history=None, chunk_type=None):
+            loop.call_soon_threadsafe(entered.set)
+            time.sleep(0.3)  # stands in for embed + search + rerank
+            return ([], [{"role": "user", "content": "q"}])
+
+        mock_svc.searcher.build_rag_context.side_effect = _slow_context_signalling
+        loop = asyncio.get_running_loop()
 
         async def _heartbeat() -> None:
-            nonlocal ticks
-            for _ in range(60):
+            nonlocal ticked_during_retrieval
+            await entered.wait()
+            while not released:
                 await asyncio.sleep(0.01)
-                ticks += 1
+                ticked_during_retrieval = True
 
         beat = asyncio.ensure_future(_heartbeat())
-        # Let it tick before the turn starts: with no stamp on record before the
-        # stall, the gap that proves the stall has nothing to measure from.
-        await asyncio.sleep(0.05)
         frames = [frame async for frame in _rag.chat_stream("q", history=[], top_k=5)]
+        released = True
         beat.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await beat
 
         assert mock_svc.searcher.build_rag_context.called, "retrieval was never reached"
         assert any("token" in f for f in frames), "the turn still answers"
-        # Blocking retrieval yields ~4 ticks across the turn; off the loop it is ~30.
-        assert ticks >= 15, (
-            f"the loop only ticked {ticks} times through a 0.3s retrieval; "
-            "it must not run on the event loop"
+        assert ticked_during_retrieval, (
+            "the loop never ran while retrieval was in flight; it must not run on the event loop"
         )
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -831,6 +831,34 @@ class TestContextBudget:
         assert 0 < len(kept) < len(results)
         assert kept == results[: len(kept)]  # keeps the top-ranked prefix
 
+    def test_fitted_context_survives_the_provider_that_enforces_the_window(self, mock_svc):
+        """bb-e0np: retrieval must fit inside what the engine will actually accept.
+
+        The fleet rejects a prompt above ``prompt_token_budget``; retrieval used
+        to fit to a ceiling one margin higher, so a grounded turn assembled a
+        prompt the engine refused with a 400 nothing downstream could fix.
+        """
+        from lilbee.providers.base import prompt_token_budget
+
+        ctx = 2560
+        cfg.num_ctx = ctx
+        system, question = "sys " * 40, "q " * 20
+        results = [_make_result(source=f"{i}.pdf", chunk="x" * 900) for i in range(5)]
+
+        kept = get_services().searcher._fit_context_budget(results, system, question, None)
+
+        searcher = get_services().searcher
+        assembled = (
+            searcher._budget_tokens(system)
+            + searcher._budget_tokens(question)
+            + sum(searcher._budget_tokens(r.chunk) for r in kept)
+        )
+        assert kept, "the top-ranked source is always kept"
+        assert assembled <= prompt_token_budget(ctx), (
+            f"assembled {assembled} tokens exceeds the provider ceiling "
+            f"{prompt_token_budget(ctx)}; the engine would reject this turn"
+        )
+
     def test_keeps_all_when_budget_ample(self, mock_svc):
         cfg.num_ctx = 100_000
         results = [_make_result(source=f"{i}.pdf", chunk="short") for i in range(5)]
@@ -843,9 +871,12 @@ class TestContextBudget:
         assert len(kept) == 1
 
     def test_history_counts_against_the_budget(self, mock_svc):
-        cfg.num_ctx = 1400
-        results = [_make_result(source=f"{i}.pdf", chunk="x" * 300) for i in range(5)]
-        history = [{"role": "user", "content": "h" * 600}]
+        # Sized so both cases have room to differ: the budget now excludes the
+        # provider's margin as well as its generation reserve, so a 1400-token
+        # window leaves too little for anything but the always-kept top source.
+        cfg.num_ctx = 3000
+        results = [_make_result(source=f"{i}.pdf", chunk="x" * 1200) for i in range(5)]
+        history = [{"role": "user", "content": "h" * 3000}]
         no_hist = get_services().searcher._fit_context_budget(results, "sys", "q", None)
         with_hist = get_services().searcher._fit_context_budget(results, "sys", "q", history)
         assert len(with_hist) < len(no_hist)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -3128,8 +3128,10 @@ class TestUpdateConfig:
         from lilbee.core import settings as s
 
         stored = s.load(cfg.data_root)
-        assert stored["temperature"] == "0.7"
-        assert stored["top_k"] == "5"
+        # Persisted with their real types, so config.toml stays valid for its
+        # own fields rather than holding "0.7" and "5" as quoted strings.
+        assert stored["temperature"] == 0.7
+        assert stored["top_k"] == 5
 
     async def test_api_key_update_injects_provider_keys(self, tmp_path):
         with patch("lilbee.providers.sdk_llm_provider.inject_provider_keys") as mock_inject:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -286,7 +286,13 @@ class TestChatRoute:
         resp = client.post("/api/chat", json={"question": "q", "history": history})
         assert resp.status_code == 201
         mock_chat.assert_awaited_once_with(
-            question="q", history=history, top_k=None, options=None, chunk_type=None
+            question="q",
+            history=history,
+            top_k=None,
+            options=None,
+            chunk_type=None,
+            summary="",
+            session_id=None,
         )
 
     @mock.patch(
@@ -297,7 +303,13 @@ class TestChatRoute:
     def test_default_empty_history(self, mock_chat, client):
         client.post("/api/chat", json={"question": "q"})
         mock_chat.assert_awaited_once_with(
-            question="q", history=[], top_k=None, options=None, chunk_type=None
+            question="q",
+            history=[],
+            top_k=None,
+            options=None,
+            chunk_type=None,
+            summary="",
+            session_id=None,
         )
 
     @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -56,6 +56,24 @@ class TestSave:
         assert (tmp_path / "config.toml").exists()
         assert 'chat_model = "llama3"' in (tmp_path / "config.toml").read_text()
 
+    def test_scalars_keep_their_toml_types(self, tmp_path):
+        """bb-s9xc: booleans and numbers must not be written as quoted strings."""
+        settings.save(tmp_path, {"chat_compaction": True, "chat_n_ctx_target": 2560})
+
+        written = (tmp_path / "config.toml").read_text()
+        assert "chat_compaction = true" in written
+        assert "chat_n_ctx_target = 2560" in written
+        assert '"True"' not in written
+        assert '"2560"' not in written
+
+    def test_a_load_save_round_trip_does_not_stringify(self, tmp_path):
+        """The drift path: load then save used to quote every value it had read."""
+        (tmp_path / "config.toml").write_text("chat_compaction = true\nchat_n_ctx_target = 2560\n")
+
+        settings.save(tmp_path, settings.load(tmp_path))
+
+        assert settings.load(tmp_path) == {"chat_compaction": True, "chat_n_ctx_target": 2560}
+
     def test_save_creates_parent_dirs(self, tmp_path):
         nested = tmp_path / "nested" / "dir"
         settings.save(nested, {"key": "value"})

--- a/tests/test_summarize_history.py
+++ b/tests/test_summarize_history.py
@@ -262,3 +262,14 @@ def test_nothing_to_summarize_makes_no_call() -> None:
     cfg.chat_n_ctx_target = 8192
     assert _searcher(provider).summarize_history([], "keep me").summary == "keep me"
     provider.chat.assert_not_called()
+
+
+def test_on_batch_hears_each_batch_before_its_model_call() -> None:
+    """Progress runs 1..total in order, so a client can tick a live indicator."""
+    heard: list[tuple[int, int]] = []
+    _searcher(_provider("notes")).summarize_history(
+        _msgs(6), "", on_batch=lambda batch, total: heard.append((batch, total))
+    )
+    assert heard, "at least one batch must be reported"
+    total = heard[0][1]
+    assert heard == [(index + 1, total) for index in range(len(heard))]


### PR DESCRIPTION
## Problem

The TUI manages conversation context before every turn: it windows history to a token budget and, with chat_compaction on, folds the overflow into a rolling summary. The HTTP surface had none of this. History went to the model verbatim, so long conversations eventually overflowed the context window, and any HTTP client wanting compaction would have had to rebuild it from scratch.

## What changed

/api/chat and /api/chat/stream now window incoming history to the same budget the TUI uses, and run the same compaction when the toggle is on and the conversation is over the trigger.

ChatRequest gains two optional fields: summary, the carry-forward notes folded into the prompt, and session_id, the session that receives a fresh summary when a turn compacts. A deleted session is tolerated, matching the TUI.

## How clients see it

Streaming turns announce the work: a compacting event fires before the condensing model calls start (same idea as warming/warm), then a compaction event carries the new summary plus how many turns were condensed and how many were dropped without notes. The non-stream route reports the same result on a new optional compaction field of the response.

## Notes

The history budget fraction moved out of the TUI screen into the shared compaction module, so both surfaces derive it from one place. With compaction off nothing new is emitted; the only behaviour change is that history is now windowed instead of overflowing.