### PR TITLE
Wait for async effects in TUI tests instead of pumping the bus once

### DIFF
--- a/tests/_lilbee_app_test_host.py
+++ b/tests/_lilbee_app_test_host.py
@@ -15,6 +15,33 @@ class LilbeeAppHost(LilbeeApp):
 
 _GATE_HANDOVER_TIMEOUT_S = 20.0
 _GATE_POLL_S = 0.02
+_PUMP_TIMEOUT_S = 5.0
+
+
+async def pump_until(pilot, predicate, *, timeout_s: float = _PUMP_TIMEOUT_S) -> bool:
+    """Pump Textual's message bus until *predicate* holds; return whether it did.
+
+    One ``pilot.pause()`` flushes a single hop of the bus. An effect that spans
+    two or more hops (focus change, the widget's blur handler, the message it
+    posts, the screen's handler, the write) is not guaranteed to have landed
+    after one pause, which is why a bare pause passes locally and fails on a
+    loaded runner. Bounded by wall clock rather than a pump count so a slow
+    runner gets more attempts rather than the same fixed few.
+
+    Returns a bool instead of asserting so the caller keeps its own assertion,
+    and with it the failure message that says what was actually expected.
+    """
+    import asyncio
+    import time
+
+    deadline = time.monotonic() + timeout_s
+    while True:
+        await pilot.pause()
+        if predicate():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(_GATE_POLL_S)
 
 
 async def await_chat(app, pilot) -> object:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -20,7 +20,7 @@ from lilbee.catalog.types import ModelTask
 from lilbee.cli.tui import messages as msg_module
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat, pump_until
 
 
 @pytest.fixture(autouse=True)
@@ -1681,10 +1681,7 @@ class TestCatalogInteractions:
                 # spawns a download worker that would outlive the test.
                 with mock.patch.object(app.screen, "_enqueue_download"):
                     await search.action_submit()
-                    for _ in range(10):
-                        await pilot.pause()
-                        if app.screen._list_widget.has_focus:
-                            break
+                    await pump_until(pilot, lambda: app.screen._list_widget.has_focus)
                     assert app.screen._list_widget.has_focus
 
     async def test_grid_card_count_matches_families(self, _mock_resolve):

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -23,7 +23,7 @@ from lilbee.cli.tui.screens.status import StatusScreen
 from lilbee.cli.tui.screens.task_center import TaskCenter
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import await_chat
+from tests._lilbee_app_test_host import await_chat, pump_until
 
 
 @pytest.fixture(autouse=True)
@@ -96,7 +96,7 @@ async def test_bracket_keys_cycle_all_screens():
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await await_chat(app, pilot)
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, ChatScreen))
         assert isinstance(app.screen, ChatScreen)
 
         # Chat starts in insert mode: Escape to normal mode first
@@ -139,7 +139,7 @@ async def test_view_switch_guard_held_until_transition_completes():
         assert app._switching is False
         assert isinstance(app.screen, CatalogScreen)
         app.switch_view("Settings")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, SettingsScreen))
         assert isinstance(app.screen, SettingsScreen)
 
 
@@ -148,7 +148,7 @@ async def test_bracket_keys_typed_literally_when_chat_input_focused():
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await await_chat(app, pilot)
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, ChatScreen))
         assert isinstance(app.screen, ChatScreen)
 
         chat_input = app.screen.query_one("#chat-input", ChatInput)
@@ -196,11 +196,11 @@ async def test_bracket_keys_work_from_settings():
         await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, SettingsScreen))
         assert isinstance(app.screen, SettingsScreen)
 
         await pilot.press("right_square_bracket")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, TaskCenter))
         assert isinstance(app.screen, TaskCenter)
 
 
@@ -241,7 +241,7 @@ async def test_settings_escape_returns_to_chat():
         await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, SettingsScreen))
         assert isinstance(app.screen, SettingsScreen)
 
         await pilot.press("escape")
@@ -292,7 +292,7 @@ async def test_slash_catalog_routes_through_switch_view_under_lilbee_app():
         chat = app.screen
         assert isinstance(chat, ChatScreen)
         chat._handle_slash("/models")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, CatalogScreen))
         assert isinstance(app.screen, CatalogScreen)
 
 
@@ -305,7 +305,7 @@ async def test_slash_settings_routes_through_switch_view_under_lilbee_app():
         chat = app.screen
         assert isinstance(chat, ChatScreen)
         chat._handle_slash("/settings")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, SettingsScreen))
         assert isinstance(app.screen, SettingsScreen)
 
 
@@ -318,7 +318,7 @@ async def test_slash_status_routes_through_switch_view_under_lilbee_app():
         chat = app.screen
         assert isinstance(chat, ChatScreen)
         chat._handle_slash("/status")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, StatusScreen))
         assert isinstance(app.screen, StatusScreen)
 
 
@@ -332,7 +332,7 @@ async def test_grid_arrows_stay_on_catalog():
         await pilot.pause()
 
         await pilot.press("right")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, CatalogScreen))
         assert isinstance(app.screen, CatalogScreen)
 
 
@@ -475,31 +475,31 @@ async def test_backward_nav_from_catalog_after_visiting_tasks():
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await await_chat(app, pilot)
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, ChatScreen))
         assert isinstance(app.screen, ChatScreen)
         await pilot.press("escape")
         await pilot.pause()
 
         # Forward to Catalog
         await pilot.press("right_square_bracket")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, CatalogScreen))
         assert isinstance(app.screen, CatalogScreen)
 
         # Forward past Catalog to Tasks (Catalog > Status > Settings > Tasks)
         for _ in range(3):
             await pilot.press("right_square_bracket")
-            await pilot.pause()
+            await pump_until(pilot, lambda: isinstance(app.screen, TaskCenter))
         assert isinstance(app.screen, TaskCenter)
 
         # Backward back to Catalog (Tasks > Settings > Status > Catalog)
         for _ in range(3):
             await pilot.press("left_square_bracket")
-            await pilot.pause()
+            await pump_until(pilot, lambda: isinstance(app.screen, CatalogScreen))
         assert isinstance(app.screen, CatalogScreen)
 
         # The critical step: backward from Catalog to Chat
         await pilot.press("left_square_bracket")
-        await pilot.pause()
+        await pump_until(pilot, lambda: isinstance(app.screen, ChatScreen))
         assert isinstance(app.screen, ChatScreen), (
             f"Expected ChatScreen after [ from Catalog, got {type(app.screen).__name__}"
         )

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -46,7 +46,7 @@ from lilbee.core.config import cfg
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.modelhub.model_manager import RemoteModel
 from lilbee.wiki.shared import PENDING_MARKER_KEYWORD_COLLISION
-from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat, pump_until
 
 _EMPTY_CATALOG = CatalogResult(total=0, limit=25, offset=0, models=[])
 
@@ -1123,10 +1123,7 @@ async def test_settings_checkbox_persist():
         # Windows CI runners tick the textual event loop slower than one
         # pilot.pause() can drain. Poll for the setattr from the event
         # handler rather than asserting after a single pause.
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.show_reasoning != original:
-                break
+        await pump_until(pilot, lambda: cfg.show_reasoning != original)
         assert cfg.show_reasoning != original
 
 
@@ -1153,10 +1150,7 @@ async def test_settings_tab_reaches_checkbox_and_space_toggles():
                 break
         assert app.focused is cb, "Tab failed to reach show_reasoning checkbox"
         await pilot.press("space")
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.show_reasoning != original:
-                break
+        await pump_until(pilot, lambda: cfg.show_reasoning != original)
         assert cfg.show_reasoning != original
 
 
@@ -1232,10 +1226,7 @@ async def test_settings_list_editor_saves_on_blur():
         await pilot.pause()
         ta.load_text("foo\nbar")
         ta.blur()
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.crawl_exclude_patterns == ["foo", "bar"]:
-                break
+        await pump_until(pilot, lambda: cfg.crawl_exclude_patterns == ["foo", "bar"])
         assert cfg.crawl_exclude_patterns == ["foo", "bar"]
 
 
@@ -1251,10 +1242,7 @@ async def test_settings_list_editor_strips_blanks():
         await pilot.pause()
         ta.load_text("a\n\nb\n")
         ta.blur()
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.crawl_exclude_patterns == ["a", "b"]:
-                break
+        await pump_until(pilot, lambda: cfg.crawl_exclude_patterns == ["a", "b"])
         assert cfg.crawl_exclude_patterns == ["a", "b"]
 
 
@@ -1276,10 +1264,7 @@ async def test_settings_list_editor_invalid_regex_blocks_save():
         # Focus change → blur handler → regex validation → error widget
         # class toggle are all async. Single pilot.pause is not enough on
         # slower runners; poll until the -visible class lands.
-        for _ in range(10):
-            await pilot.pause()
-            if err.has_class("-visible"):
-                break
+        await pump_until(pilot, lambda: err.has_class("-visible"))
         assert err.has_class("-visible")
         assert "line 1" in str(err.render())
         assert cfg.crawl_exclude_patterns == ["keep"]
@@ -1300,10 +1285,9 @@ async def test_settings_list_editor_restore_defaults():
         # Button.Pressed flows through Textual's async message bus; poll until
         # the handler updates cfg. A single pilot.pause is not enough on
         # slower runners (Windows, in particular).
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.crawl_exclude_patterns == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS):
-                break
+        await pump_until(
+            pilot, lambda: cfg.crawl_exclude_patterns == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
+        )
         assert cfg.crawl_exclude_patterns == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
         ta = app.screen.query_one("#ed-crawl_exclude_patterns", ListTextArea)
         assert ta.text == "\n".join(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
@@ -1342,7 +1326,12 @@ async def test_settings_list_editor_persists_through_toml_round_trip(tmp_path):
         await pilot.pause()
         ta.load_text("pat-a\npat-b")
         ta.blur()
-        await pilot.pause()
+        # The blur handler posts Blurred, the screen handles it, and only then
+        # is the value written, so wait for the write rather than one pause.
+        landed = await pump_until(
+            pilot, lambda: "crawl_exclude_patterns" in settings.load(tmp_path)
+        )
+        assert landed, "the blur never reached the settings store"
 
     # Raw TOML value is a newline-joined string (not Python repr of the list).
     reloaded = settings.load(tmp_path)
@@ -1586,10 +1575,7 @@ async def test_reset_button_resets_scalar():
         button = app.screen.query_one("#reset-wiki_clusterer_k", Button)
         button.press()
         target = get_default("wiki_clusterer_k")
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.wiki_clusterer_k == target:
-                break
+        await pump_until(pilot, lambda: cfg.wiki_clusterer_k == target)
         assert cfg.wiki_clusterer_k == target
         editor = app.screen.query_one("#ed-wiki_clusterer_k", Input)
         assert editor.value == str(target)
@@ -1673,10 +1659,7 @@ async def test_refresh_editor_updates_checkbox():
 
         button = app.screen.query_one("#reset-show_reasoning", Button)
         button.press()
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.show_reasoning == default:
-                break
+        await pump_until(pilot, lambda: cfg.show_reasoning == default)
         assert cfg.show_reasoning == default
         assert checkbox.value == default
 
@@ -1690,10 +1673,7 @@ async def test_reset_nullable_to_none():
     async with app.run_test(size=(120, 40)) as pilot:
         button = app.screen.query_one("#reset-seed", Button)
         button.press()
-        for _ in range(10):
-            await pilot.pause()
-            if cfg.seed is None:
-                break
+        await pump_until(pilot, lambda: cfg.seed is None)
         assert cfg.seed is None
         editor = app.screen.query_one("#ed-seed", Input)
         assert editor.value == ""
@@ -6187,10 +6167,7 @@ async def test_chat_sync_file_done_bad_type():
             await _pilot.pause()
             while app.screen.workers:
                 await _pilot.pause()
-            for _ in range(10):
-                await _pilot.pause()
-                if app.screen._sync_active is False:
-                    break
+            await pump_until(_pilot, lambda: app.screen._sync_active is False)
             # Worker catches the TypeError via the except Exception handler
             assert app.screen._sync_active is False
 
@@ -6214,10 +6191,7 @@ async def test_chat_sync_file_start_bad_type():
             await _pilot.pause()
             while app.screen.workers:
                 await _pilot.pause()
-            for _ in range(10):
-                await _pilot.pause()
-                if app.screen._sync_active is False:
-                    break
+            await pump_until(_pilot, lambda: app.screen._sync_active is False)
             # Worker catches the TypeError via the except Exception handler
             assert app.screen._sync_active is False
 
@@ -8270,10 +8244,7 @@ async def test_chat_tab_cycles_through_all_four_model_buttons():
             await pilot.press("tab")
             # Poll: the tab keypress travels through several refresh ticks
             # before the focus watcher updates has_focus on a slow xdist shard.
-            for _ in range(10):
-                await pilot.pause()
-                if target.has_focus:
-                    break
+            await pump_until(pilot, lambda t=target: t.has_focus)
             assert target.has_focus, f"Tab did not reach #{next_id}"
 
 
@@ -8293,10 +8264,7 @@ async def test_chat_tab_in_normal_mode_advances_focus():
         await pilot.pause()
         before = app.focused
         await pilot.press("tab")
-        for _ in range(10):
-            await pilot.pause()
-            if app.focused is not before:
-                break
+        await pump_until(pilot, lambda: app.focused is not before)
         assert app.focused is not before, "Tab did not move focus in normal mode"
 
 
@@ -10269,10 +10237,7 @@ async def test_catalog_grid_leave_down_focuses_next():
             grids[0].focus()
             await pilot.pause()
             grids[0].post_message(ModelGrid.LeaveDown(grids[0]))
-            for _ in range(10):
-                await pilot.pause()
-                if screen.focused is not grids[0]:
-                    break
+            await pump_until(pilot, lambda: screen.focused is not grids[0])
             assert screen.focused is not grids[0]
 
 


### PR DESCRIPTION
## Problem

`test_settings_list_editor_persists_through_toml_round_trip` read the TOML right after `ta.blur()` plus a single `pilot.pause()`. The blur handler persists by posting a message, so delivery and the write are both async and one pause flushes one hop. It failed a loaded gate with `KeyError: 'crawl_exclude_patterns'`.

The same file already hand-rolled `for _ in range(10): await pilot.pause()` fourteen times for this same class of flake, and this test was the one place that missed it. A navigation test then failed the same way mid-review: `switch_screen` is async, so a lone pause after a keypress does not guarantee the switch landed.

## Solution

Add a `pump_until` helper next to `await_chat`, bounded by wall clock so a slow runner gets more attempts rather than the same fixed few, returning a bool so callers keep their own assertion messages.

Use it where the flakes were: the settings test now waits for the write, and 15 sites in the navigation tests wait for the screen switch. Replace the 14 hand-rolled copies plus one in the e2e tests so the pattern has one owner.

Test-only; no production code touched.