### PR TITLE
Fix resuming a session from the drawer by click or enter

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -58,6 +58,7 @@ from lilbee.cli.tui.widgets.autocomplete import (
 )
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.cli.tui.widgets.context_chip import ContextChip
+from lilbee.cli.tui.widgets.drawer import Drawer
 from lilbee.cli.tui.widgets.fleet_body import FleetBody
 from lilbee.cli.tui.widgets.fleet_drawer import FleetDrawer
 from lilbee.cli.tui.widgets.help_hint import HelpHint
@@ -487,7 +488,7 @@ class ChatScreen(Screen[None]):
             # mean nothing to those widgets, so they always return to INSERT.
             if event.key == "enter" and isinstance(self.focused, (Select, ModelPickerButton)):
                 return
-            if self._focus_in_fleet_drawer():
+            if self._focus_in_drawer():
                 return
             self._enter_insert_mode()
             if event.key == "enter" and inp.value.strip():
@@ -2153,12 +2154,16 @@ class ChatScreen(Screen[None]):
             return
         self._preview_next()
 
-    def _focus_in_fleet_drawer(self) -> bool:
-        """True when keyboard focus is inside the open Fleet drawer, so Enter /
-        i / a / o activate the focused toggle instead of entering insert mode."""
+    def _focus_in_drawer(self) -> bool:
+        """True when keyboard focus is inside an open drawer, so Enter / i / a / o
+        reach that drawer's own controls instead of entering insert mode.
+
+        Asked of the Drawer base rather than one drawer class: a drawer that had
+        to name itself here would otherwise swallow its own Enter until someone
+        noticed.
+        """
         focused = self.focused
-        drawers = self.screen.query(FleetDrawer)
-        return bool(focused and drawers and drawers.first() in focused.ancestors_with_self)
+        return bool(focused and any(isinstance(n, Drawer) for n in focused.ancestors_with_self))
 
     def _tab_into_fleet_or_next(self) -> None:
         """Jump Tab into the open Fleet drawer's first toggle so the placement

--- a/src/lilbee/cli/tui/widgets/drawer.py
+++ b/src/lilbee/cli/tui/widgets/drawer.py
@@ -1,0 +1,15 @@
+"""Common base for the non-modal side drawers."""
+
+from __future__ import annotations
+
+from textual.containers import Vertical
+
+
+class Drawer(Vertical):
+    """A non-modal side drawer that owns the keyboard while focus is inside it.
+
+    The chat screen's vim mode treats enter / i / a / o as conversation keys and
+    swallows them. A drawer's own controls need those keys, so the chat screen
+    asks whether focus sits under a Drawer rather than naming each drawer class:
+    a new drawer inherits the exemption instead of silently eating its own enter.
+    """

--- a/src/lilbee/cli/tui/widgets/fleet_drawer.py
+++ b/src/lilbee/cli/tui/widgets/fleet_drawer.py
@@ -7,9 +7,9 @@ from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Vertical
 from textual.screen import Screen
 
+from lilbee.cli.tui.widgets.drawer import Drawer
 from lilbee.cli.tui.widgets.fleet_body import FleetBody
 
 _CSS_FILE = Path(__file__).parent / "fleet_drawer.tcss"
@@ -20,7 +20,7 @@ _DRAWER_CSS = _CSS_FILE.read_text(encoding="utf-8")
 _HOST_OPEN_CLASS = "fleet-open"
 
 
-class FleetDrawer(Vertical):
+class FleetDrawer(Drawer):
     """GPU fleet panel as a non-modal right-side drawer; closed with esc or ctrl+g.
 
     Docked to the right so the screen underneath reflows to the left and stays

--- a/src/lilbee/cli/tui/widgets/session_list.py
+++ b/src/lilbee/cli/tui/widgets/session_list.py
@@ -161,9 +161,23 @@ class SessionListPanel(Vertical):
         if self._renaming_id is not None:
             self._commit_rename()
             return
-        selected = self._selected()
-        if selected is not None:
-            self.post_message(self.Resumed(selected.id))
+        self._resume(self._selected())
+
+    @on(ListView.Selected, "#sessions-list")
+    def _on_row_selected(self, event: ListView.Selected) -> None:
+        """Resume the row the list itself reports as chosen.
+
+        ListView posts this both for a click and for enter while it holds focus,
+        and a click also moves focus off the filter box. Resuming only from the
+        filter's Submitted leaves a click inert and then strands the panel with
+        no working key to resume from.
+        """
+        if self._renaming_id is None:
+            self._resume(event.item.meta if isinstance(event.item, SessionRow) else None)
+
+    def _resume(self, meta: SessionMeta | None) -> None:
+        if meta is not None:
+            self.post_message(self.Resumed(meta.id))
 
     def action_cursor_down(self) -> None:
         self.query_one("#sessions-list", ListView).action_cursor_down()

--- a/src/lilbee/cli/tui/widgets/sessions_drawer.py
+++ b/src/lilbee/cli/tui/widgets/sessions_drawer.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, ClassVar
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Vertical
 from textual.screen import Screen
 
+from lilbee.cli.tui.widgets.drawer import Drawer
 from lilbee.cli.tui.widgets.session_list import SessionListPanel
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ _DRAWER_CSS = (Path(__file__).parent / "sessions_drawer.tcss").read_text(encodin
 _HOST_OPEN_CLASS = "sessions-open"
 
 
-class SessionsDrawer(Vertical):
+class SessionsDrawer(Drawer):
     """Session switcher as a non-modal left-side drawer; closed with esc or ctrl+o."""
 
     DEFAULT_CSS: ClassVar[str] = _DRAWER_CSS

--- a/tests/test_tui_sessions.py
+++ b/tests/test_tui_sessions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from textual.widgets import ListView
 
 from lilbee.app.services import get_services, set_services
 from lilbee.cli.tui.app import LilbeeApp
@@ -220,6 +221,75 @@ async def test_resume_from_drawer_loads_and_closes(sessions):
         assert not screen.query(SessionsDrawer)
 
 
+@pytest.mark.parametrize("count", [1, 2])
+async def test_clicking_a_row_resumes_it(sessions, count):
+    """A mouse click on a row resumes it, whether or not the list is the only one."""
+    for i in range(count):
+        _seed(sessions, f"Session {i}")
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _open_drawer(app, pilot)
+        row = screen.query(SessionRow)[0]
+        clicked_id = row.meta.id
+        await pilot.click(row)
+        await pilot.pause()
+        assert app.chat_screen().session_id == clicked_id
+        assert not screen.query(SessionsDrawer)
+
+
+async def test_enter_resumes_while_chat_is_in_normal_mode(sessions):
+    """The chat screen must not eat the drawer's enter while it sits in NORMAL mode.
+
+    Clicking a row moves focus off the chat input, which drops chat out of INSERT;
+    the screen-level vim handler then swallowed every later enter in the drawer.
+    """
+    session_id = _seed(sessions, "Torque specs")
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        chat = await await_chat(app, pilot)
+        chat._insert_mode = False
+        screen = await _open_drawer(app, pilot)
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.chat_screen().session_id == session_id
+        assert not screen.query(SessionsDrawer)
+
+
+async def test_enter_resumes_after_filtering(sessions):
+    """Enter must resume the row a filter narrowed to, not just an unfiltered list."""
+    _seed(sessions, "Alpha")
+    _seed(sessions, "Beta")
+    wanted = _seed(sessions, "Gamma")
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _open_drawer(app, pilot)
+        for ch in "Gamma":
+            await pilot.press(ch)
+        await pilot.pause()
+        assert len(screen.query(SessionRow)) == 1
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.chat_screen().session_id == wanted
+
+
+async def test_enter_on_the_focused_list_resumes(sessions):
+    """Enter resumes when the list holds focus, not just when the filter does.
+
+    Clicking a row moves focus off the filter box, so a resume path that only
+    listens on the filter's Submitted leaves Enter dead for the rest of the visit.
+    """
+    session_id = _seed(sessions, "Torque specs")
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _open_drawer(app, pilot)
+        screen.query_one("#sessions-list", ListView).focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.chat_screen().session_id == session_id
+        assert not screen.query(SessionsDrawer)
+
+
 async def test_new_chat_from_drawer(sessions):
     session_id = _seed(sessions, "Torque specs")
     app = LilbeeApp()
@@ -360,6 +430,20 @@ async def test_sessions_tab_resume_switches_to_chat(sessions):
         app.switch_view("Sessions")
         await pilot.pause()
         app.screen.query_one(SessionListPanel).post_message(SessionListPanel.Resumed(session_id))
+        await pilot.pause()
+        assert app.active_view == "Chat"
+        assert app.chat_screen().session_id == session_id
+
+
+async def test_sessions_tab_enter_resumes(sessions):
+    """The tab focuses the list rather than the filter, so Enter must work there."""
+    session_id = _seed(sessions, "Torque specs")
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
+        app.switch_view("Sessions")
+        await pilot.pause()
+        await pilot.press("enter")
         await pilot.pause()
         assert app.active_view == "Chat"
         assert app.chat_screen().session_id == session_id

--- a/tests/test_tui_sessions.py
+++ b/tests/test_tui_sessions.py
@@ -338,6 +338,10 @@ async def test_delete_confirmed_removes_session(sessions):
         drawer = await _open_drawer(app, pilot)
         panel = drawer.query_one(SessionListPanel)
         meta = sessions.list()[0]
+        # The filter and chat inputs both eat ctrl+d as delete-right; the list
+        # leaves it to bubble to the panel binding, so press from there.
+        drawer.query_one("#sessions-list", ListView).focus()
+        await pilot.pause()
         await pilot.press("ctrl+d")
         await pilot.pause()
         assert isinstance(app.screen, ConfirmDialog)


### PR DESCRIPTION
## Problem

Opening the sessions drawer with `ctrl+o` and clicking a conversation did nothing, and after a click, pressing enter also did nothing. The drawer was only usable by typing into the filter box first and then pressing enter, so with a single saved session it looked completely dead. The full-screen Sessions tab had the same problem: enter never resumed anything there.

Two separate causes. Resume was wired only to the filter box's submit event, so the list's own click and enter (which Textual already reports) were never handled, and a click also moves keyboard focus off the filter box, leaving no working key to resume with. On top of that, once focus left the chat input the chat screen dropped into normal mode, where its key handling swallowed enter for every drawer except the fleet one, which had a hardcoded exemption.

## Solution

Resume now comes from the list's own selection event, so a click and enter both resume the highlighted row, on the drawer and the full-screen tab alike. The chat screen's normal-mode check now asks whether focus sits inside any drawer through a shared base rather than naming a single drawer class, so a drawer keeps its own enter without having to opt in by name and a future drawer can't silently regress the same way.

Verified live in a real terminal across single and multiple sessions on both surfaces (click, click then filter then enter, and the tab), and covered by tests that fail on the old behavior.