### PR TITLE
Hint at igt-gpu-tools when an Intel GPU's utilization has no readable source

### DIFF
--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 
 from lilbee.app.services import peek_services
 from lilbee.core import settings
 from lilbee.core.config import cfg
+from lilbee.providers.fleet.gpu_stats import intel_util_hint, probe_gpu_stats
 from lilbee.providers.fleet.placement_spec import PlacementSpec
 from lilbee.providers.fleet.planning import (
     ResolvedPlacement,
@@ -130,6 +131,14 @@ def get_placement() -> PlacementView:
     spec = _active_spec()
     resolved = resolve_placement_plan(spec)
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
+
+
+def intel_util_notice(devices: Sequence[GpuInfo]) -> str | None:
+    """The localized Intel utilization fix, or None when every Intel GPU reads fine."""
+    from lilbee.cli.tui import messages as msg
+
+    hint = intel_util_hint(devices, probe_gpu_stats(devices))
+    return msg.intel_util_hint_text(hint) if hint else None
 
 
 def preview_placement(spec: PlacementSpec | None = None) -> PlacementView:

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 
 from lilbee.app.services import peek_services
 from lilbee.core import settings
 from lilbee.core.config import cfg
-from lilbee.providers.fleet.gpu_stats import intel_util_hint, probe_gpu_stats
 from lilbee.providers.fleet.placement_spec import PlacementSpec
 from lilbee.providers.fleet.planning import (
     ResolvedPlacement,
@@ -131,14 +130,6 @@ def get_placement() -> PlacementView:
     spec = _active_spec()
     resolved = resolve_placement_plan(spec)
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
-
-
-def intel_util_notice(devices: Sequence[GpuInfo]) -> str | None:
-    """The localized Intel utilization fix, or None when every Intel GPU reads fine."""
-    from lilbee.cli.tui import messages as msg
-
-    hint = intel_util_hint(devices, probe_gpu_stats(devices))
-    return msg.intel_util_hint_text(hint) if hint else None
 
 
 def preview_placement(spec: PlacementSpec | None = None) -> PlacementView:

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 
 from lilbee.core.config import cfg
+from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
 from lilbee.wiki.shared import WIKI_TYPE_HEADINGS as _WIKI_TYPE_HEADINGS
 
 log = logging.getLogger(__name__)
@@ -496,8 +497,24 @@ FLEET_MODEL_NOT_DOWNLOADED = "{role}: {model} not downloaded, pull it to place i
 # lacks the CAP_PERFMON grant, so the muted "--" reads as a fixable state.
 FLEET_INTEL_UTIL_GRANT = (
     "Intel GPU utilization needs a one-time grant: "
-    "sudo setcap cap_perfmon+ep {binary}  (or Linux 6.2+ reads it with no setup)"
+    "sudo setcap cap_perfmon+ep {binary}  (or Linux 6.5+ reads it with no setup)"
 )
+# Shown when intel_gpu_top is not installed at all: the i915 PMU covers kernels
+# too old to publish fdinfo engine counters, so installing igt-gpu-tools is the
+# only path to utilization there.
+FLEET_INTEL_UTIL_INSTALL = (
+    "Intel GPU utilization needs the igt-gpu-tools package "
+    "(then: sudo setcap cap_perfmon+ep $(command -v intel_gpu_top))"
+)
+
+
+def intel_util_hint_text(hint: IntelUtilHint) -> str:
+    """Localized fix instruction for an unreadable Intel util reading."""
+    if hint.kind is IntelHintKind.GRANT and hint.binary is not None:
+        return FLEET_INTEL_UTIL_GRANT.format(binary=hint.binary)
+    return FLEET_INTEL_UTIL_INSTALL
+
+
 FLEET_CMD_PREVIEW = "Preview"
 FLEET_CMD_APPLY = "Apply"
 FLEET_CMD_AUTO = "Auto"

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -18,7 +18,7 @@ from textual.widgets import Static
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.thread_safe import call_from_thread
-from lilbee.providers.fleet.gpu_stats import GpuStat, intel_grant_binary, probe_gpu_stats
+from lilbee.providers.fleet.gpu_stats import GpuStat, intel_util_hint, probe_gpu_stats
 
 if TYPE_CHECKING:
     from lilbee.providers.fleet.gpu_stats import DeviceLike
@@ -267,9 +267,8 @@ class GpuFleetPanel(Static):
             return
         theme = self._resolve_theme()
         markup = _render_stats(stats, labels, roles, theme, probed=self._probed)
-        binary = intel_grant_binary(self._devices, stats)
-        if binary:
+        hint = intel_util_hint(self._devices, stats)
+        if hint:
             muted = _theme_color(theme, "text-muted")
-            hint = msg.FLEET_INTEL_UTIL_GRANT.format(binary=binary)
-            markup += f"\n[{muted}]  {hint}[/]"
+            markup += f"\n[{muted}]  {msg.intel_util_hint_text(hint)}[/]"
         self.update(markup)

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -32,6 +32,7 @@ from lilbee.app.memory import (
 from lilbee.app.placement import (
     PlacementView,
     get_placement,
+    intel_util_notice,
     placement_refused_message,
     preview_placement,
     set_placement,
@@ -1299,7 +1300,15 @@ def _parse_spec(spec: dict[str, Any] | None) -> PlacementSpec | None:
 @_tool_named("get_gpus")
 def get_gpus_tool() -> dict[str, Any]:
     """List detected GPUs with free/total VRAM (the placement HTTP /api/gpus equivalent)."""
-    return _placement_guard(lambda: {"gpus": _placement_dict(get_placement())["gpus"]})
+
+    def _body() -> dict[str, Any]:
+        view = get_placement()
+        return {
+            "gpus": _placement_dict(view)["gpus"],
+            "notice": intel_util_notice(view.gpus),
+        }
+
+    return _placement_guard(_body)
 
 
 @_tool_named("get_placement")

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -32,7 +32,6 @@ from lilbee.app.memory import (
 from lilbee.app.placement import (
     PlacementView,
     get_placement,
-    intel_util_notice,
     placement_refused_message,
     preview_placement,
     set_placement,
@@ -1302,10 +1301,14 @@ def get_gpus_tool() -> dict[str, Any]:
     """List detected GPUs with free/total VRAM (the placement HTTP /api/gpus equivalent)."""
 
     def _body() -> dict[str, Any]:
+        from lilbee.cli.tui import messages as msg
+        from lilbee.providers.fleet.gpu_stats import probe_intel_util_hint
+
         view = get_placement()
+        hint = probe_intel_util_hint(view.gpus)
         return {
             "gpus": _placement_dict(view)["gpus"],
-            "notice": intel_util_notice(view.gpus),
+            "notice": msg.intel_util_hint_text(hint) if hint else None,
         }
 
     return _placement_guard(_body)

--- a/src/lilbee/providers/fleet/gpu_backends/__init__.py
+++ b/src/lilbee/providers/fleet/gpu_backends/__init__.py
@@ -14,7 +14,12 @@ from lilbee.providers.fleet.gpu_backends.amd import AmdBackend
 from lilbee.providers.fleet.gpu_backends.apple import BACKEND_KEY as _APPLE_KEY
 from lilbee.providers.fleet.gpu_backends.apple import AppleBackend
 from lilbee.providers.fleet.gpu_backends.base import UtilBackend, UtilSample
-from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, intel_gpu_top_grant_binary
+from lilbee.providers.fleet.gpu_backends.intel import (
+    IntelBackend,
+    IntelHintKind,
+    IntelUtilHint,
+    intel_util_hint,
+)
 from lilbee.providers.fleet.gpu_backends.nvidia import NvidiaBackend
 
 # Maps the backend string that llama-server --list-devices emits to the backend
@@ -67,9 +72,11 @@ def util_backend_name(backend: str, name: str) -> str:
 
 
 __all__ = [
+    "IntelHintKind",
+    "IntelUtilHint",
     "UtilBackend",
     "UtilSample",
-    "intel_gpu_top_grant_binary",
+    "intel_util_hint",
     "resolve_backend",
     "util_backend_name",
 ]

--- a/src/lilbee/providers/fleet/gpu_backends/fdinfo.py
+++ b/src/lilbee/providers/fleet/gpu_backends/fdinfo.py
@@ -16,7 +16,8 @@ so a workload split across processes still reads correctly.
 
 This needs no elevated privileges (a process can read its own and same-user
 clients' fdinfo) and no extra tool, but the engine counters only exist on kernels
-new enough to publish them (i915 landed them in ~6.2); older kernels omit the
+new enough to publish them (i915 landed them in 5.19 for execlists submission,
+6.5 where GuC submission is active); older kernels omit the
 ``drm-engine-*`` lines and this reader reports nothing, letting a caller fall back.
 """
 

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -8,7 +8,7 @@ kernel, and privileges. We try them in order and take the first that reports:
    xpum_stats_type_enum names. One device per call, no root.
 2. DRM ``fdinfo`` -- the kernel's per-client engine-busy counters. Covers
    consumer iGPUs with no root and no extra tool, but only on kernels new enough
-   to publish i915 engine stats (~6.2+).
+   to publish i915 engine stats (5.19+, or 6.5+ under GuC submission).
 3. ``intel_gpu_top`` (Intel GPU Tools) -- reads the i915 PMU, so it covers
    essentially every consumer iGPU on kernel 4.16+, but needs CAP_PERFMON (or
    root); it falls through cleanly when the permission isn't granted.
@@ -24,6 +24,8 @@ import functools
 import json
 import shutil
 import subprocess
+from dataclasses import dataclass
+from enum import StrEnum
 
 from lilbee.providers.fleet.gpu_backends import fdinfo
 from lilbee.providers.fleet.gpu_backends.base import UtilSample, extract_int, run_smi
@@ -49,6 +51,21 @@ _I915 = "i915"
 # unprivileged, the util reads back empty. A working PMU streams, so the check
 # hits the timeout and reports usable.
 _IGT_PERM_CHECK_S = 1.0
+
+
+class IntelHintKind(StrEnum):
+    """Which fix would make an Intel GPU's utilization readable."""
+
+    GRANT = "grant"  # intel_gpu_top is installed but the i915 PMU is permission-blocked
+    INSTALL = "install"  # intel_gpu_top is not installed at all
+
+
+@dataclass(frozen=True)
+class IntelUtilHint:
+    """An actionable fix for an unreadable Intel GPU utilization reading."""
+
+    kind: IntelHintKind
+    binary: str | None  # the intel_gpu_top path when installed, else None
 
 
 class IntelBackend:
@@ -214,18 +231,20 @@ def _single(indices: frozenset[int], util: int) -> dict[int, UtilSample]:
 
 
 @functools.cache
-def intel_gpu_top_grant_binary() -> str | None:
-    """The intel_gpu_top path a CAP_PERFMON grant would unblock, or None.
+def intel_util_hint() -> IntelUtilHint | None:
+    """The fix that would make Intel GPU util readable, or None when nothing is blocked.
 
-    Returns the binary when it is installed but the i915 PMU is permission-blocked
-    (the caller turns this into a user-facing grant hint); None when the tool is
-    absent or already usable. Cached: the permission state does not change within
-    a run.
+    INSTALL when intel_gpu_top is absent (igt-gpu-tools reads the i915 PMU on
+    kernels too old to publish fdinfo engine counters), GRANT when it is
+    installed but permission-blocked, None when the tool already works. Cached:
+    the install/permission state does not change within a run.
     """
     binary = shutil.which(_TOOL_IGT)
     if binary is None:
-        return None
-    return binary if _igt_permission_denied(binary) else None
+        return IntelUtilHint(IntelHintKind.INSTALL, None)
+    if _igt_permission_denied(binary):
+        return IntelUtilHint(IntelHintKind.GRANT, binary)
+    return None
 
 
 def _igt_permission_denied(binary: str) -> bool:

--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -123,3 +123,8 @@ def intel_util_hint(
         if stat is not None and stat.utilization_pct is None:
             return _detect_intel_util_hint()
     return None
+
+
+def probe_intel_util_hint(devices: Sequence[DeviceLike]) -> IntelUtilHint | None:
+    """Probe live stats and evaluate the Intel util hint in one call."""
+    return intel_util_hint(devices, probe_gpu_stats(devices))

--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -17,10 +17,13 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from lilbee.providers.fleet.gpu_backends import (
+    IntelUtilHint,
     UtilSample,
-    intel_gpu_top_grant_binary,
     resolve_backend,
     util_backend_name,
+)
+from lilbee.providers.fleet.gpu_backends import (
+    intel_util_hint as _detect_intel_util_hint,
 )
 
 
@@ -104,20 +107,19 @@ def probe_gpu_stats(devices: Sequence[DeviceLike]) -> dict[int, GpuStat]:
     return {i: stats[i] for i in sorted(stats)}
 
 
-def intel_grant_binary(devices: Sequence[DeviceLike], stats: dict[int, GpuStat]) -> str | None:
-    """The intel_gpu_top path a grant would unblock when an Intel GPU's util is
-    missing only for that reason, else None.
+def intel_util_hint(
+    devices: Sequence[DeviceLike], stats: dict[int, GpuStat]
+) -> IntelUtilHint | None:
+    """The fix that would unblock an Intel GPU's missing util reading, else None.
 
-    A surface turns the binary into the localized grant hint. Modern kernels read
-    util with no grant, so this stays silent there, and the None-util gate clears
-    it once a grant makes util read.
+    Fires only when an Intel device's util is actually missing; a surface turns
+    the hint into a localized message (grant when intel_gpu_top is installed but
+    blocked, install when it is absent, e.g. kernels too old for fdinfo).
     """
     for d in devices:
         if util_backend_name(d.backend, d.name) != "SYCL":
             continue
         stat = stats.get(d.index)
         if stat is not None and stat.utilization_pct is None:
-            binary = intel_gpu_top_grant_binary()
-            if binary is not None:
-                return binary
+            return _detect_intel_util_hint()
     return None

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -75,13 +75,14 @@ from lilbee.server.handlers.sse import (
     sse_event,
 )
 from lilbee.server.models import (
-    GpuInfoResponse,
+    GpusResponse,
     HealthResponse,
     PlacementResponse,
     StatusResponse,
 )
 
 if TYPE_CHECKING:
+    from lilbee.app.placement import PlacementView
     from lilbee.providers.base import LLMProvider
 
 # How often the warm stream re-snapshots provider state; sub-second so the read
@@ -203,16 +204,16 @@ async def placement() -> PlacementResponse:
     """Current effective placement."""
     from lilbee.app.placement import get_placement
 
-    return PlacementResponse.from_view(get_placement())
+    return _placement_response(get_placement())
 
 
 async def placement_preview(spec_json: str | None) -> PlacementResponse:
-    """Preview a candidate spec (or auto when spec_json is None). No persistence."""
+    """Preview a candidate spec (or auto when no spec). No persistence."""
     from lilbee.app.placement import preview_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
 
     spec = PlacementSpec.from_json(spec_json) if spec_json else None
-    return PlacementResponse.from_view(preview_placement(spec))
+    return _placement_response(preview_placement(spec))
 
 
 async def placement_set(spec_json: str) -> PlacementResponse:
@@ -220,21 +221,34 @@ async def placement_set(spec_json: str) -> PlacementResponse:
     from lilbee.app.placement import set_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
 
-    return PlacementResponse.from_view(set_placement(PlacementSpec.from_json(spec_json)))
+    return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
 
 
 async def placement_clear() -> PlacementResponse:
     """Clear manual placement; returns to the auto planner and rebuilds the fleet."""
     from lilbee.app.placement import set_placement
 
-    return PlacementResponse.from_view(set_placement(None))
+    return _placement_response(set_placement(None))
 
 
-async def gpus() -> list[GpuInfoResponse]:
-    """Detected GPUs with free/total VRAM."""
-    from lilbee.app.placement import get_placement
+def _placement_response(view: PlacementView) -> PlacementResponse:
+    """Serialize a placement view with the host-level Intel util notice attached."""
+    from lilbee.app.placement import intel_util_notice
 
-    return PlacementResponse.from_view(get_placement()).gpus
+    resp = PlacementResponse.from_view(view)
+    resp.notice = intel_util_notice(view.gpus)
+    return resp
+
+
+async def gpus() -> GpusResponse:
+    """Detected GPUs with free/total VRAM, plus the host-level Intel util notice."""
+    from lilbee.app.placement import get_placement, intel_util_notice
+
+    view = get_placement()
+    return GpusResponse(
+        gpus=PlacementResponse.from_view(view).gpus,
+        notice=intel_util_notice(view.gpus),
+    )
 
 
 __all__ = [

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -82,7 +82,7 @@ from lilbee.server.models import (
 )
 
 if TYPE_CHECKING:
-    from lilbee.app.placement import PlacementView
+    from lilbee.app.placement import GpuInfo, PlacementView
     from lilbee.providers.base import LLMProvider
 
 # How often the warm stream re-snapshots provider state; sub-second so the read
@@ -233,21 +233,28 @@ async def placement_clear() -> PlacementResponse:
 
 def _placement_response(view: PlacementView) -> PlacementResponse:
     """Serialize a placement view with the host-level Intel util notice attached."""
-    from lilbee.app.placement import intel_util_notice
-
     resp = PlacementResponse.from_view(view)
-    resp.notice = intel_util_notice(view.gpus)
+    resp.notice = _intel_notice_text(view.gpus)
     return resp
+
+
+def _intel_notice_text(devices: Sequence[GpuInfo]) -> str | None:
+    """Formatted Intel util fix for the JSON surfaces, or None when util reads fine."""
+    from lilbee.cli.tui import messages as msg
+    from lilbee.providers.fleet.gpu_stats import probe_intel_util_hint
+
+    hint = probe_intel_util_hint(devices)
+    return msg.intel_util_hint_text(hint) if hint else None
 
 
 async def gpus() -> GpusResponse:
     """Detected GPUs with free/total VRAM, plus the host-level Intel util notice."""
-    from lilbee.app.placement import get_placement, intel_util_notice
+    from lilbee.app.placement import get_placement
 
     view = get_placement()
     return GpusResponse(
         gpus=PlacementResponse.from_view(view).gpus,
-        notice=intel_util_notice(view.gpus),
+        notice=_intel_notice_text(view.gpus),
     )
 
 

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -172,16 +172,16 @@ async def gpu_stats_stream(
     clients don't time out.
     """
     from lilbee.cli.tui import messages as msg
-    from lilbee.providers.fleet.gpu_stats import intel_grant_binary, probe_gpu_stats
+    from lilbee.providers.fleet.gpu_stats import intel_util_hint, probe_gpu_stats
 
     last_heartbeat = time.monotonic()
     tick = 0
     while max_ticks is None or tick < max_ticks:
         stats = probe_gpu_stats(devices)  # type: ignore[arg-type]
         payload: dict[str, object] = {"gpus": [dataclasses.asdict(s) for s in stats.values()]}
-        binary = intel_grant_binary(devices, stats)  # type: ignore[arg-type]
-        if binary:
-            payload["notice"] = msg.FLEET_INTEL_UTIL_GRANT.format(binary=binary)
+        hint = intel_util_hint(devices, stats)  # type: ignore[arg-type]
+        if hint:
+            payload["notice"] = msg.intel_util_hint_text(hint)
         yield sse_event(SseEvent.GPU_STATS, payload)
         tick += 1
         if max_ticks is None or tick < max_ticks:

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -159,7 +159,7 @@ _GPU_STATS_INTERVAL_S = 1.0
 
 
 async def gpu_stats_stream(
-    devices: Sequence[object],
+    devices: Sequence[GpuInfo],
     interval_s: float = _GPU_STATS_INTERVAL_S,
     max_ticks: int | None = None,
 ) -> AsyncGenerator[str, None]:
@@ -178,9 +178,9 @@ async def gpu_stats_stream(
     last_heartbeat = time.monotonic()
     tick = 0
     while max_ticks is None or tick < max_ticks:
-        stats = probe_gpu_stats(devices)  # type: ignore[arg-type]
+        stats = probe_gpu_stats(devices)
         payload: dict[str, object] = {"gpus": [dataclasses.asdict(s) for s in stats.values()]}
-        hint = intel_util_hint(devices, stats)  # type: ignore[arg-type]
+        hint = intel_util_hint(devices, stats)
         if hint:
             payload["notice"] = msg.intel_util_hint_text(hint)
         yield sse_event(SseEvent.GPU_STATS, payload)

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -620,6 +620,13 @@ class GpuInfoResponse(BaseModel):
     free_bytes: int
 
 
+class GpusResponse(BaseModel):
+    """GET /api/gpus envelope: detected GPUs plus the host-level util notice."""
+
+    gpus: list[GpuInfoResponse]
+    notice: str | None = None
+
+
 class RolePlacementResponse(BaseModel):
     """Where one role's model is placed in the resolved plan."""
 
@@ -647,6 +654,7 @@ class PlacementResponse(BaseModel):
     spec_json: str | None
     skipped_not_installed: list[SkippedRoleResponse] = []
     co_tenants: list[str] = []
+    notice: str | None = None
 
     @classmethod
     def from_view(cls, view: PlacementView) -> PlacementResponse:

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -21,7 +21,7 @@ from lilbee.core.config import cfg
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
-from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
+from lilbee.server.models import GpusResponse, PlacementResponse, PlacementSpecBody
 
 _HTTP_UNPROCESSABLE = 422
 _HTTP_CONFLICT = 409
@@ -89,8 +89,8 @@ async def placement_clear_route() -> PlacementResponse:
 
 
 @get("/api/gpus")
-async def gpus_route() -> list[GpuInfoResponse]:
-    """Detected GPUs with free/total VRAM."""
+async def gpus_route() -> GpusResponse:
+    """Detected GPUs with free/total VRAM, plus the host-level Intel util notice."""
     try:
         return await handlers.gpus()
     except ProviderError as exc:

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -37,10 +37,15 @@ def test_get_gpus_tool(monkeypatch):
 
 def test_get_gpus_tool_includes_intel_notice(monkeypatch):
     """An Intel host with unreadable utilization surfaces the fix, matching HTTP /api/gpus."""
+    from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
+
+    hint = IntelUtilHint(IntelHintKind.GRANT, "/usr/bin/intel_gpu_top")
     monkeypatch.setattr(mcp_server, "get_placement", lambda: _view())
-    monkeypatch.setattr(mcp_server, "intel_util_notice", lambda devices: "INSTALL HINT")
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.gpu_stats.probe_intel_util_hint", lambda devices: hint
+    )
     out = mcp_server.get_gpus_tool()
-    assert out["notice"] == "INSTALL HINT"
+    assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in out["notice"]
 
 
 def test_get_gpus_tool_returns_error_on_provider_failure(monkeypatch):

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -32,6 +32,15 @@ def test_get_gpus_tool(monkeypatch):
     out = mcp_server.get_gpus_tool()
     assert [g["label"] for g in out["gpus"]] == ["CUDA0"]
     assert out["gpus"][0]["free_bytes"] == 72 * GIB
+    assert out["notice"] is None
+
+
+def test_get_gpus_tool_includes_intel_notice(monkeypatch):
+    """An Intel host with unreadable utilization surfaces the fix, matching HTTP /api/gpus."""
+    monkeypatch.setattr(mcp_server, "get_placement", lambda: _view())
+    monkeypatch.setattr(mcp_server, "intel_util_notice", lambda devices: "INSTALL HINT")
+    out = mcp_server.get_gpus_tool()
+    assert out["notice"] == "INSTALL HINT"
 
 
 def test_get_gpus_tool_returns_error_on_provider_failure(monkeypatch):

--- a/tests/providers/fleet/gpu_backends/test_intel.py
+++ b/tests/providers/fleet/gpu_backends/test_intel.py
@@ -13,7 +13,11 @@ import pytest
 
 from lilbee.providers.fleet import gpu_backends
 from lilbee.providers.fleet.gpu_backends import intel as intel_mod
-from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, _parse_xpu_smi
+from lilbee.providers.fleet.gpu_backends.intel import (
+    IntelBackend,
+    IntelHintKind,
+    _parse_xpu_smi,
+)
 
 # Real xpu-smi device_level shape.
 _XPU_JSON = """\
@@ -279,58 +283,64 @@ def test_registry_maps_sycl_to_intel_backend() -> None:
 
 
 # ---------------------------------------------------------------------------
-# intel_gpu_top_grant_binary (the binary a CAP_PERFMON grant would unblock)
+# intel_util_hint (the fix that would unblock a missing util reading)
 # ---------------------------------------------------------------------------
 
 _PMU_DENIED = "Failed to initialize PMU! (Permission denied)\nCAP_PERFMON is required\n"
 
 
-def test_grant_binary_tool_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_gpu_top_grant_binary.cache_clear()
+def test_util_hint_tool_absent_is_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: None)
-    assert intel_mod.intel_gpu_top_grant_binary() is None
+    hint = intel_mod.intel_util_hint()
+    assert hint is not None
+    assert hint.kind is IntelHintKind.INSTALL
+    assert hint.binary is None
 
 
-def test_grant_binary_permission_denied_returns_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_gpu_top_grant_binary.cache_clear()
+def test_util_hint_permission_denied_is_grant(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     class _Proc:
         stderr = _PMU_DENIED
 
     monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
-    assert intel_mod.intel_gpu_top_grant_binary() == "/usr/bin/intel_gpu_top"
+    hint = intel_mod.intel_util_hint()
+    assert hint is not None
+    assert hint.kind is IntelHintKind.GRANT
+    assert hint.binary == "/usr/bin/intel_gpu_top"
 
 
-def test_grant_binary_none_when_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A working PMU streams, so the probe times out and reports usable (no grant)."""
-    intel_mod.intel_gpu_top_grant_binary.cache_clear()
+def test_util_hint_none_when_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A working PMU streams, so the probe times out and reports usable (no hint)."""
+    intel_mod.intel_util_hint.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     def _raise(*_a: object, **_k: object) -> None:
         raise subprocess.TimeoutExpired(cmd="intel_gpu_top", timeout=1.0)
 
     monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
-    assert intel_mod.intel_gpu_top_grant_binary() is None
+    assert intel_mod.intel_util_hint() is None
 
 
-def test_grant_binary_no_permission_marker(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_gpu_top_grant_binary.cache_clear()
+def test_util_hint_no_permission_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     class _Proc:
         stderr = "some unrelated diagnostic"
 
     monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
-    assert intel_mod.intel_gpu_top_grant_binary() is None
+    assert intel_mod.intel_util_hint() is None
 
 
-def test_grant_binary_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_gpu_top_grant_binary.cache_clear()
+def test_util_hint_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     def _raise(*_a: object, **_k: object) -> None:
         raise OSError("boom")
 
     monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
-    assert intel_mod.intel_gpu_top_grant_binary() is None
+    assert intel_mod.intel_util_hint() is None

--- a/tests/providers/fleet/test_gpu_stats.py
+++ b/tests/providers/fleet/test_gpu_stats.py
@@ -15,7 +15,8 @@ from lilbee.providers.fleet import gpu_stats as stats_mod
 from lilbee.providers.fleet.devices import MIB, FleetDevice
 from lilbee.providers.fleet.gpu_backends import util_backend_name
 from lilbee.providers.fleet.gpu_backends.base import UtilSample
-from lilbee.providers.fleet.gpu_stats import GpuStat, intel_grant_binary, probe_gpu_stats
+from lilbee.providers.fleet.gpu_backends.intel import IntelHintKind, IntelUtilHint
+from lilbee.providers.fleet.gpu_stats import GpuStat, intel_util_hint, probe_gpu_stats
 
 _CUDA = (
     FleetDevice("CUDA", 0, "NVIDIA A40", 48 * 1024 * MIB, 47 * 1024 * MIB),
@@ -238,47 +239,47 @@ def test_util_backend_name_unknown_backend_unchanged() -> None:
 
 
 # ---------------------------------------------------------------------------
-# intel_grant_binary (the binary a grant would unblock, for the surfaces to format)
+# intel_util_hint (the fix a surface formats when an Intel GPU's util is missing)
 # ---------------------------------------------------------------------------
 
-
-def _hint(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    monkeypatch.setattr(stats_mod, "intel_gpu_top_grant_binary", lambda: value)
+_GRANT_HINT = IntelUtilHint(IntelHintKind.GRANT, "/usr/bin/intel_gpu_top")
 
 
-def test_intel_grant_binary_intel_missing_util_returns_hint(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _hint(monkeypatch, "GRANT ME")
+def _hint(monkeypatch: pytest.MonkeyPatch, value: IntelUtilHint | None) -> None:
+    monkeypatch.setattr(stats_mod, "_detect_intel_util_hint", lambda: value)
+
+
+def test_intel_util_hint_missing_util_returns_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, _GRANT_HINT)
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
+    assert intel_util_hint([dev], {0: GpuStat(0, None, 0, 0)}) == _GRANT_HINT
 
 
-def test_intel_grant_binary_vulkan_intel_routes_to_hint(monkeypatch: pytest.MonkeyPatch) -> None:
-    _hint(monkeypatch, "GRANT ME")
+def test_intel_util_hint_vulkan_intel_routes_to_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, _GRANT_HINT)
     dev = FleetDevice("Vulkan", 0, "Intel(R) UHD Graphics", 0, 0)
-    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
+    assert intel_util_hint([dev], {0: GpuStat(0, None, 0, 0)}) == _GRANT_HINT
 
 
-def test_intel_grant_binary_silent_when_util_present(monkeypatch: pytest.MonkeyPatch) -> None:
-    _hint(monkeypatch, "GRANT ME")
+def test_intel_util_hint_silent_when_util_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, _GRANT_HINT)
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert intel_grant_binary([dev], {0: GpuStat(0, 50, 0, 0)}) is None
+    assert intel_util_hint([dev], {0: GpuStat(0, 50, 0, 0)}) is None
 
 
-def test_intel_grant_binary_silent_for_non_intel(monkeypatch: pytest.MonkeyPatch) -> None:
-    _hint(monkeypatch, "GRANT ME")
+def test_intel_util_hint_silent_for_non_intel(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, _GRANT_HINT)
     dev = FleetDevice("CUDA", 0, "NVIDIA A40", 0, 0)
-    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) is None
+    assert intel_util_hint([dev], {0: GpuStat(0, None, 0, 0)}) is None
 
 
-def test_intel_grant_binary_silent_when_no_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_util_hint_silent_when_no_hint(monkeypatch: pytest.MonkeyPatch) -> None:
     _hint(monkeypatch, None)
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) is None
+    assert intel_util_hint([dev], {0: GpuStat(0, None, 0, 0)}) is None
 
 
-def test_intel_grant_binary_skips_index_absent_from_stats(monkeypatch: pytest.MonkeyPatch) -> None:
-    _hint(monkeypatch, "GRANT ME")
+def test_intel_util_hint_skips_index_absent_from_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, _GRANT_HINT)
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert intel_grant_binary([dev], {}) is None
+    assert intel_util_hint([dev], {}) is None

--- a/tests/providers/fleet/test_gpu_stats.py
+++ b/tests/providers/fleet/test_gpu_stats.py
@@ -16,7 +16,12 @@ from lilbee.providers.fleet.devices import MIB, FleetDevice
 from lilbee.providers.fleet.gpu_backends import util_backend_name
 from lilbee.providers.fleet.gpu_backends.base import UtilSample
 from lilbee.providers.fleet.gpu_backends.intel import IntelHintKind, IntelUtilHint
-from lilbee.providers.fleet.gpu_stats import GpuStat, intel_util_hint, probe_gpu_stats
+from lilbee.providers.fleet.gpu_stats import (
+    GpuStat,
+    intel_util_hint,
+    probe_gpu_stats,
+    probe_intel_util_hint,
+)
 
 _CUDA = (
     FleetDevice("CUDA", 0, "NVIDIA A40", 48 * 1024 * MIB, 47 * 1024 * MIB),
@@ -283,3 +288,21 @@ def test_intel_util_hint_skips_index_absent_from_stats(monkeypatch: pytest.Monke
     _hint(monkeypatch, _GRANT_HINT)
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
     assert intel_util_hint([dev], {}) is None
+
+
+# ---------------------------------------------------------------------------
+# probe_intel_util_hint (probe + gate in one call, for the JSON surfaces)
+# ---------------------------------------------------------------------------
+
+
+def test_probe_intel_util_hint_composes_probe_and_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, _GRANT_HINT)
+    monkeypatch.setattr(stats_mod, "probe_gpu_stats", lambda devices: {0: GpuStat(0, None, 0, 0)})
+    dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
+    assert probe_intel_util_hint([dev]) == _GRANT_HINT
+
+
+def test_probe_intel_util_hint_silent_when_util_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(stats_mod, "probe_gpu_stats", lambda devices: {0: GpuStat(0, 50, 0, 0)})
+    dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
+    assert probe_intel_util_hint([dev]) is None

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -242,25 +242,29 @@ def test_delete_provider_error_returns_503_when_enabled(monkeypatch):
 
 
 def test_get_gpus(monkeypatch):
-    from lilbee.server.models import GpuInfoResponse
+    from lilbee.server.models import GpuInfoResponse, GpusResponse
 
     async def _gpus():
-        return [
-            GpuInfoResponse(
-                index=0,
-                backend="CUDA",
-                label="CUDA0",
-                name="A100",
-                total_bytes=80 * GIB,
-                free_bytes=72 * GIB,
-            )
-        ]
+        return GpusResponse(
+            gpus=[
+                GpuInfoResponse(
+                    index=0,
+                    backend="CUDA",
+                    label="CUDA0",
+                    name="A100",
+                    total_bytes=80 * GIB,
+                    free_bytes=72 * GIB,
+                )
+            ],
+            notice="INSTALL HINT",
+        )
 
     monkeypatch.setattr(handlers, "gpus", _gpus)
     with create_test_client([gpus_route]) as client:
         r = client.get("/api/gpus")
         assert r.status_code == 200
-        assert r.json()[0]["label"] == "CUDA0"
+        assert r.json()["gpus"][0]["label"] == "CUDA0"
+        assert r.json()["notice"] == "INSTALL HINT"
 
 
 def test_gpu_stats_stream_provider_error_returns_503(monkeypatch):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4764,6 +4764,7 @@ class TestPlacementHandlers:
 
     async def test_gpu_stats_stream_includes_intel_grant_notice(self):
         from lilbee.app.placement import GpuInfo
+        from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
         from lilbee.providers.fleet.gpu_stats import GpuStat
 
         gpu = GpuInfo(
@@ -4775,12 +4776,10 @@ class TestPlacementHandlers:
             free_bytes=200,
         )
         stat = {0: GpuStat(0, None, 200, 200)}
+        hint = IntelUtilHint(IntelHintKind.GRANT, "/usr/bin/intel_gpu_top")
         with (
             patch("lilbee.providers.fleet.gpu_stats.probe_gpu_stats", return_value=stat),
-            patch(
-                "lilbee.providers.fleet.gpu_stats.intel_grant_binary",
-                return_value="/usr/bin/intel_gpu_top",
-            ),
+            patch("lilbee.providers.fleet.gpu_stats.intel_util_hint", return_value=hint),
         ):
             chunks = [c async for c in handlers.gpu_stats_stream((gpu,), interval_s=0, max_ticks=1)]
         events = [
@@ -4790,6 +4789,34 @@ class TestPlacementHandlers:
             if line.startswith("data:")
         ]
         assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in events[0]["notice"]
+
+    async def test_gpu_stats_stream_includes_intel_install_notice(self):
+        from lilbee.app.placement import GpuInfo
+        from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
+        from lilbee.providers.fleet.gpu_stats import GpuStat
+
+        gpu = GpuInfo(
+            index=0,
+            backend="SYCL",
+            label="SYCL0",
+            name="Intel Arc",
+            total_bytes=200,
+            free_bytes=200,
+        )
+        stat = {0: GpuStat(0, None, 200, 200)}
+        hint = IntelUtilHint(IntelHintKind.INSTALL, None)
+        with (
+            patch("lilbee.providers.fleet.gpu_stats.probe_gpu_stats", return_value=stat),
+            patch("lilbee.providers.fleet.gpu_stats.intel_util_hint", return_value=hint),
+        ):
+            chunks = [c async for c in handlers.gpu_stats_stream((gpu,), interval_s=0, max_ticks=1)]
+        events = [
+            json.loads(line[len("data:") :].strip())
+            for chunk in chunks
+            for line in chunk.splitlines()
+            if line.startswith("data:")
+        ]
+        assert "igt-gpu-tools" in events[0]["notice"]
 
     async def test_gpu_stats_stream_emits_heartbeat_when_interval_elapsed(self):
         """A heartbeat event is emitted when the configured interval elapses."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4672,13 +4672,17 @@ class TestPlacementHandlers:
         assert resp.notice is None
 
     async def test_placement_includes_intel_notice_when_hint_fires(self):
+        from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
+
         view = _stub_placement_view()
+        hint = IntelUtilHint(IntelHintKind.GRANT, "/usr/bin/intel_gpu_top")
         with (
             patch("lilbee.app.placement.get_placement", return_value=view),
-            patch("lilbee.app.placement.intel_util_notice", return_value="INSTALL HINT"),
+            patch("lilbee.providers.fleet.gpu_stats.probe_intel_util_hint", return_value=hint),
         ):
             resp = await handlers.placement()
-        assert resp.notice == "INSTALL HINT"
+        assert resp.notice is not None
+        assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in resp.notice
 
     async def test_placement_surfaces_co_tenant_roles(self):
         # Co-tenants are placed but not co-resident; a surface that omits them
@@ -4745,6 +4749,7 @@ class TestPlacementHandlers:
 
     async def test_gpus_includes_intel_notice_when_hint_fires(self):
         from lilbee.app.placement import GpuInfo, PlacementView
+        from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
 
         gpu = GpuInfo(
             index=0,
@@ -4755,12 +4760,14 @@ class TestPlacementHandlers:
             free_bytes=200,
         )
         view = PlacementView(gpus=(gpu,), roles=(), unplaceable=(), manual=False, spec_json=None)
+        hint = IntelUtilHint(IntelHintKind.INSTALL, None)
         with (
             patch("lilbee.app.placement.get_placement", return_value=view),
-            patch("lilbee.app.placement.intel_util_notice", return_value="INSTALL HINT"),
+            patch("lilbee.providers.fleet.gpu_stats.probe_intel_util_hint", return_value=hint),
         ):
             result = await handlers.gpus()
-        assert result.notice == "INSTALL HINT"
+        assert result.notice is not None
+        assert "igt-gpu-tools" in result.notice
 
     async def test_gpu_stats_stream_emits_live_snapshots(self):
         from lilbee.app.placement import GpuInfo

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4669,6 +4669,16 @@ class TestPlacementHandlers:
         assert resp.manual is False
         assert resp.gpus == []
         assert resp.roles == []
+        assert resp.notice is None
+
+    async def test_placement_includes_intel_notice_when_hint_fires(self):
+        view = _stub_placement_view()
+        with (
+            patch("lilbee.app.placement.get_placement", return_value=view),
+            patch("lilbee.app.placement.intel_util_notice", return_value="INSTALL HINT"),
+        ):
+            resp = await handlers.placement()
+        assert resp.notice == "INSTALL HINT"
 
     async def test_placement_surfaces_co_tenant_roles(self):
         # Co-tenants are placed but not co-resident; a surface that omits them
@@ -4715,7 +4725,7 @@ class TestPlacementHandlers:
         assert resp.manual is False
         mock_set.assert_called_once_with(None)
 
-    async def test_gpus_returns_list(self):
+    async def test_gpus_returns_envelope(self):
         from lilbee.app.placement import GpuInfo, PlacementView
 
         gpu = GpuInfo(
@@ -4729,8 +4739,28 @@ class TestPlacementHandlers:
         view = PlacementView(gpus=(gpu,), roles=(), unplaceable=(), manual=False, spec_json=None)
         with patch("lilbee.app.placement.get_placement", return_value=view):
             result = await handlers.gpus()
-        assert len(result) == 1
-        assert result[0].name == "A100"
+        assert len(result.gpus) == 1
+        assert result.gpus[0].name == "A100"
+        assert result.notice is None
+
+    async def test_gpus_includes_intel_notice_when_hint_fires(self):
+        from lilbee.app.placement import GpuInfo, PlacementView
+
+        gpu = GpuInfo(
+            index=0,
+            backend="SYCL",
+            label="SYCL0",
+            name="Intel Arc",
+            total_bytes=200,
+            free_bytes=200,
+        )
+        view = PlacementView(gpus=(gpu,), roles=(), unplaceable=(), manual=False, spec_json=None)
+        with (
+            patch("lilbee.app.placement.get_placement", return_value=view),
+            patch("lilbee.app.placement.intel_util_notice", return_value="INSTALL HINT"),
+        ):
+            result = await handlers.gpus()
+        assert result.notice == "INSTALL HINT"
 
     async def test_gpu_stats_stream_emits_live_snapshots(self):
         from lilbee.app.placement import GpuInfo

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -248,11 +248,14 @@ async def test_panel_shows_intel_grant_hint_when_present(monkeypatch: pytest.Mon
     """An Intel GPU needing the CAP_PERFMON grant renders the localized setcap line."""
     import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
     from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+    from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
 
     stat = _make_stat(0, utilization_pct=None)
     monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
     monkeypatch.setattr(
-        panel_mod, "intel_grant_binary", lambda devices, stats: "/usr/bin/intel_gpu_top"
+        panel_mod,
+        "intel_util_hint",
+        lambda devices, stats: IntelUtilHint(IntelHintKind.GRANT, "/usr/bin/intel_gpu_top"),
     )
 
     app = _PanelHost()
@@ -264,6 +267,34 @@ async def test_panel_shows_intel_grant_hint_when_present(monkeypatch: pytest.Mon
         await app.workers.wait_for_complete()
         await pilot.pause()
         assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in str(panel.render())
+
+
+@pytest.mark.asyncio
+async def test_panel_shows_intel_install_hint_when_tool_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An Intel GPU with no util source and no intel_gpu_top renders the install line."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+    from lilbee.providers.fleet.gpu_backends import IntelHintKind, IntelUtilHint
+
+    stat = _make_stat(0, utilization_pct=None)
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
+    monkeypatch.setattr(
+        panel_mod,
+        "intel_util_hint",
+        lambda devices, stats: IntelUtilHint(IntelHintKind.INSTALL, None),
+    )
+
+    app = _PanelHost()
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([_make_device(0, backend="SYCL")], labels={0: "SYCL0"})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "igt-gpu-tools" in str(panel.render())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

On Intel hosts where no utilization source can report (kernel older than 5.19, igt-gpu-tools not installed; xpu-smi never covers consumer iGPUs), GPU monitoring showed "--" with no guidance. The hint only covered intel_gpu_top being installed but CAP_PERFMON-blocked, and only rode the SSE stream; the plain JSON endpoints had nothing.

## Solution

The hint now distinguishes grant (installed but blocked) from install (tool absent), and every GPU surface carries it: the fleet panel, the SSE stream, all placement routes (new notice field), GET /api/gpus (now an envelope {gpus, notice}), and the MCP get_gpus tool. Also fixes the grant text's no-setup kernel version (6.5, not 6.2) and two stale comments.