### PR TITLE
Fix chunk fetch loading the entire index into memory

### DIFF
--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from lilbee.core.config import (
     CHUNK_CONCEPTS_TABLE,
@@ -1098,29 +1097,28 @@ class Store:
         return table.count_rows() if table is not None else 0
 
     def get_chunks_by_source(self, source: str) -> list[SearchChunk]:
-        """Return every chunk whose ``source`` equals *source*."""
+        """Return every chunk whose ``source`` equals *source*.
+
+        The database does the filtering, so only the matching rows are read.
+        A query failure raises rather than falling back to a whole-table scan:
+        a document's chunks are a bounded read, and the scan that would rescue
+        it costs the entire index, vectors included, in memory.
+        """
         table = self.open_table(CHUNKS_TABLE)
         if table is None:
             return []
         escaped = escape_sql_string(source)
-        try:
-            rows = table.search().where(f"source = '{escaped}'").limit(None).to_list()
-        except Exception:
-            # FTS-enabled tables return a query builder that cannot
-            # handle .where() on arbitrary columns; fall through to a
-            # pyarrow.compute filter on the Arrow table so the source
-            # match runs in C++ without materializing non-matching rows.
-            log.debug("get_chunks_by_source search() failed, using Arrow fallback", exc_info=True)
-            arrow_tbl = table.to_arrow()
-            filtered = arrow_tbl.filter(pc.equal(arrow_tbl["source"], source))
-            rows = filtered.to_pylist()
+        rows = table.search().where(f"source = '{escaped}'").limit(None).to_list()
         return [SearchChunk(**r) for r in rows]
 
     def get_chunks_by_indices(self, source: str, indices: Sequence[int]) -> list[SearchChunk]:
         """Return *source*'s chunks whose ``chunk_index`` is in *indices*.
 
         Rows come back in ``chunk_index`` order; indices past either end of
-        the document are simply absent from the result.
+        the document are simply absent from the result. Filtering happens in
+        the database for the same reason as :meth:`get_chunks_by_source`:
+        neighbor expansion runs once per hit source per query, so a
+        whole-table rescue would spike memory on the hottest path there is.
         """
         if not indices:
             return []
@@ -1129,19 +1127,8 @@ class Store:
             return []
         escaped = escape_sql_string(source)
         wanted = ", ".join(str(int(i)) for i in indices)
-        try:
-            predicate = f"source = '{escaped}' AND chunk_index IN ({wanted})"
-            rows = table.search().where(predicate).limit(None).to_list()
-        except Exception:
-            # Same FTS-enabled query-builder limitation as get_chunks_by_source;
-            # fall through to a pyarrow.compute filter on the Arrow table.
-            log.debug("get_chunks_by_indices search() failed, using Arrow fallback", exc_info=True)
-            arrow_tbl = table.to_arrow()
-            mask = pc.and_(
-                pc.equal(arrow_tbl["source"], source),
-                pc.is_in(arrow_tbl["chunk_index"], value_set=pa.array(list(indices), pa.int32())),
-            )
-            rows = arrow_tbl.filter(mask).to_pylist()
+        predicate = f"source = '{escaped}' AND chunk_index IN ({wanted})"
+        rows = table.search().where(predicate).limit(None).to_list()
         return sorted((SearchChunk(**r) for r in rows), key=lambda c: c.chunk_index)
 
     def _delete_by_sources_unlocked(self, sources: list[str]) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1481,31 +1481,17 @@ class TestChunkTypeField:
         results = store.get_chunks_by_source("doc0.md")
         assert results[0].chunk_type == "raw"
 
-    def test_get_chunks_by_source_fallback(self, store):
-        """Fallback path when table.search() raises (e.g. incompatible FTS builder)."""
-        from unittest.mock import patch
+    def test_get_chunks_by_source_filters_with_fts_index_built(self, store):
+        """The filtered query still selects rows once the chunks table is FTS-indexed.
 
-        records = _make_records(n=2)
-        store.add_chunks(records)
-
-        # Make table.search() raise to trigger the Arrow fallback
-        original_open = store.open_table
-
-        def _broken_open(name):
-            table = original_open(name)
-            if table is None:
-                return None
-
-            def _raise_search(*args, **kwargs):
-                raise AttributeError("LanceFtsQueryBuilder has no attribute 'metric'")
-
-            table.search = _raise_search
-            return table
-
-        with patch.object(store, "open_table", side_effect=_broken_open):
-            results = store.get_chunks_by_source("doc0.md")
-        assert len(results) == 1
-        assert results[0].source == "doc0.md"
+        Both chunk-fetch paths rely on the database doing the filtering, so an
+        FTS-indexed table that rejected ``.where()`` would silently regress them
+        into whole-table reads. Pin the behavior the fetch paths depend on.
+        """
+        store.add_chunks(_make_records(n=3))
+        store.ensure_fts_index()
+        results = store.get_chunks_by_source("doc1.md")
+        assert [r.source for r in results] == ["doc1.md"]
 
 
 def _one_source_records(source: str, n: int) -> list[dict]:
@@ -1540,26 +1526,13 @@ class TestGetChunksByIndices:
     def test_no_table_returns_empty(self, store):
         assert store.get_chunks_by_indices("a.md", [0]) == []
 
-    def test_fallback_when_search_raises(self, store):
-        """Same Arrow fallback as get_chunks_by_source when table.search() raises."""
-        from unittest.mock import patch
-
-        store.add_chunks(_one_source_records("a.md", 3))
-
-        original_open = store.open_table
-
-        def _broken_open(name):
-            table = original_open(name)
-
-            def _raise_search(*args, **kwargs):
-                raise AttributeError("LanceFtsQueryBuilder has no attribute 'metric'")
-
-            table.search = _raise_search
-            return table
-
-        with patch.object(store, "open_table", side_effect=_broken_open):
-            results = store.get_chunks_by_indices("a.md", [0, 2])
+    def test_filters_with_fts_index_built(self, store):
+        """The compound source+index predicate survives an FTS-indexed table."""
+        store.add_chunks(_one_source_records("a.md", 3) + _one_source_records("b.md", 3))
+        store.ensure_fts_index()
+        results = store.get_chunks_by_indices("a.md", [0, 2])
         assert [r.chunk_index for r in results] == [0, 2]
+        assert {r.source for r in results} == {"a.md"}
 
     def test_search_chunk_default_is_raw(self):
         chunk = SearchChunk(

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Never
 from unittest import mock
 
 import pytest
@@ -2755,15 +2755,23 @@ class TestGetCompletions:
         assert any("testfile.txt" in x for x in r)
 
     def test_path_exists_swallows_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A path the OS refuses to stat must read as missing, not raise."""
-        from pathlib import Path as P
+        """A path the OS refuses to stat must read as missing, not raise.
 
+        Patches this module's ``Path`` rather than ``pathlib.Path.expanduser``
+        itself: a global patch also breaks the config validator, which expands
+        the data root on every field assignment, and so blows up in the
+        cfg-restoring fixture's teardown before monkeypatch unwinds.
+        """
         from lilbee.cli.tui.widgets import autocomplete
 
-        def _boom(self: P) -> P:
-            raise OSError("bad path")
+        class _BoomPath:
+            def __init__(self, *_args: object) -> None:
+                pass
 
-        monkeypatch.setattr(P, "expanduser", _boom)
+            def expanduser(self) -> Never:
+                raise OSError("bad path")
+
+        monkeypatch.setattr(autocomplete, "Path", _BoomPath)
         assert autocomplete._path_exists("~oops") is False
 
     def test_add_complete_path_collapses_so_enter_submits(self, tmp_path: object) -> None:


### PR DESCRIPTION
## Problem

`get_chunks_by_source` and `get_chunks_by_indices` normally filter in the database. If that query raised, both fell back to `table.to_arrow()`, which loads every chunk of every document into memory, embedding vectors included, then filters in Python. Multi-gigabyte spike on a large library, and neighbor expansion hits it once per hit source per query.

Closes #565.

## Solution

The fallback guarded old LanceDB behavior where FTS-indexed tables rejected `.where()`. That no longer reproduces on the pinned version, so it was dead code kept alive by tests that mocked `search()` into raising.

Both functions now let a query failure propagate. An exception names the problem; the rescue scan just gets the process OOM-killed. The mocked tests are replaced by ones that build the FTS index for real, so a future LanceDB bump that breaks the query fails CI instead of silently reading everything.