### PR TITLE
Fix two servers being able to run against the same data directory

### DIFF
--- a/src/lilbee/api.py
+++ b/src/lilbee/api.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from lilbee.app.ingest import copy_files
 from lilbee.app.services import build_services, services_scope
 from lilbee.core.config import Config, cfg, config_scope
+from lilbee.core.system import canonical_data_root
 from lilbee.data.store import LOCAL_OWNER, MemoryKind, MemoryRow
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ class Lilbee:
         if config is not None:
             self._config = config
         elif documents_dir is not None:
-            root = Path(documents_dir).resolve()
+            root = canonical_data_root(documents_dir)
             self._config = cfg.model_copy(
                 update={
                     "data_root": root,

--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -66,10 +66,10 @@ def _apply_data_root(root: Path) -> None:
     Exporting the env var keeps spawn-context worker subprocesses on the
     same data root after their fresh ``import lilbee``.
 
-    The root is canonicalized first: this bypasses ``Config._resolve_defaults``
-    entirely, so a ``--data-dir`` given as a symlink or a relative path would
-    otherwise derive lock paths that no longer match the ones another process
-    derived for the same directory.
+    The root is canonicalized here because this path bypasses
+    ``Config._resolve_defaults`` and derives its own children: a ``--data-dir``
+    given as a symlink or relative path would otherwise key different locks
+    than another process opening the same directory.
     """
     from lilbee.core.system import canonical_data_root
 

--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -65,7 +65,15 @@ def _apply_data_root(root: Path) -> None:
 
     Exporting the env var keeps spawn-context worker subprocesses on the
     same data root after their fresh ``import lilbee``.
+
+    The root is canonicalized first: this bypasses ``Config._resolve_defaults``
+    entirely, so a ``--data-dir`` given as a symlink or a relative path would
+    otherwise derive lock paths that no longer match the ones another process
+    derived for the same directory.
     """
+    from lilbee.core.system import canonical_data_root
+
+    root = canonical_data_root(root)
     cfg.data_root = root
     cfg.documents_dir = root / "documents"
     cfg.data_dir = root / "data"

--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -66,10 +66,9 @@ def _apply_data_root(root: Path) -> None:
     Exporting the env var keeps spawn-context worker subprocesses on the
     same data root after their fresh ``import lilbee``.
 
-    The root is canonicalized here because this path bypasses
-    ``Config._resolve_defaults`` and derives its own children: a ``--data-dir``
-    given as a symlink or relative path would otherwise key different locks
-    than another process opening the same directory.
+    Canonicalized here because this bypasses ``Config._resolve_defaults`` and
+    derives its own children, so a symlinked or relative ``--data-dir`` would
+    otherwise key a different lock than another process on the same directory.
     """
     from lilbee.core.system import canonical_data_root
 

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -1040,15 +1040,9 @@ class Config(BaseSettings):
             else:
                 local = find_local_root()
                 data["data_root"] = local if local is not None else default_data_dir()
-        # data_root may arrive as a raw string (e.g. from LILBEE_DATA_ROOT); the
-        # child-path derivations below use ``/``, so coerce to Path first.
-        # Canonicalizing here is what makes one directory key one lock: every
-        # path below is derived from this value, and the server-lock layer keys
-        # on those, so a symlinked or relative spelling that stayed distinct
-        # would let a second server start against data a first one owns. It also
-        # subsumes the bare expanduser this replaced, including its guarantee
-        # that an unresolvable home still loads: the os.path call it delegates
-        # to returns the path unchanged instead of raising.
+        # Every child path below derives from this, and the server lock keys on
+        # those, so canonicalizing here is what makes one directory key one lock.
+        # Also coerces a raw string (LILBEE_DATA_ROOT) to Path.
         root = canonical_data_root(data["data_root"])
         data["data_root"] = root
         if data.get("documents_dir") in (None, _UNSET_PATH):
@@ -1073,18 +1067,16 @@ class Config(BaseSettings):
     ) -> tuple[Any, ...]:
         from lilbee.core.system import canonical_data_root, default_data_dir, find_local_root
 
-        # .strip() to match _resolve_defaults: the two must read the env var
-        # identically, or a padded value sends the root and its config.toml to
-        # different directories.
+        # .strip() to match _resolve_defaults; a padded value would otherwise
+        # send the root and its config.toml to different directories.
         data_env = os.environ.get("LILBEE_DATA", "").strip()
         if data_env:
             toml_dir = Path(data_env)
         else:
             local = find_local_root()
             toml_dir = local if local else default_data_dir()
-        # Canonicalized through the same call as the root itself, so this
-        # looks in the directory the root will resolve to: a "~/lilbee" value
-        # would otherwise search a literal ./~ tree and silently find nothing.
+        # Same call as the root itself, so this looks where the root resolves to;
+        # a "~/lilbee" value would otherwise search a literal ./~ and find nothing.
         toml_path = canonical_data_root(toml_dir) / "config.toml"
 
         plain_env = _PlainEnvSource(settings_cls, env_prefix="LILBEE_", env_ignore_empty=True)

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -1070,9 +1070,12 @@ class Config(BaseSettings):
     ) -> tuple[Any, ...]:
         from lilbee.core.system import canonical_data_root, default_data_dir, find_local_root
 
-        data_env = os.environ.get("LILBEE_DATA", "")
+        # .strip() to match _resolve_defaults: the two must read the env var
+        # identically, or a padded value sends the root and its config.toml to
+        # different directories.
+        data_env = os.environ.get("LILBEE_DATA", "").strip()
         if data_env:
-            toml_dir: Path | str = data_env
+            toml_dir = Path(data_env)
         else:
             local = find_local_root()
             toml_dir = local if local else default_data_dir()

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -1019,7 +1019,12 @@ class Config(BaseSettings):
     @model_validator(mode="before")
     @classmethod
     def _resolve_defaults(cls, data: Any) -> Any:
-        from lilbee.core.system import canonical_models_dir, default_data_dir, find_local_root
+        from lilbee.core.system import (
+            canonical_data_root,
+            canonical_models_dir,
+            default_data_dir,
+            find_local_root,
+        )
 
         if not isinstance(data, dict):
             return data
@@ -1037,10 +1042,11 @@ class Config(BaseSettings):
                 data["data_root"] = local if local is not None else default_data_dir()
         # data_root may arrive as a raw string (e.g. from LILBEE_DATA_ROOT); the
         # child-path derivations below use ``/``, so coerce to Path first.
-        # expanduser() so a "~/lilbee" value from a systemd unit or .env (which
-        # do not expand ~) points at the home dir instead of creating a literal
-        # ./~ tree that a server lock keyed on this path would then diverge on.
-        root = Path(data["data_root"]).expanduser()
+        # Canonicalizing here is what makes one directory key one lock: every
+        # path below is derived from this value, and the server-lock layer keys
+        # on those, so a symlinked or relative spelling that stayed distinct
+        # would let a second server start against data a first one owns.
+        root = canonical_data_root(data["data_root"])
         data["data_root"] = root
         if data.get("documents_dir") in (None, _UNSET_PATH):
             data["documents_dir"] = root / "documents"
@@ -1062,11 +1068,14 @@ class Config(BaseSettings):
         dotenv_settings: Any,
         file_secret_settings: Any,
     ) -> tuple[Any, ...]:
-        from lilbee.core.system import default_data_dir, find_local_root
+        from lilbee.core.system import canonical_data_root, default_data_dir, find_local_root
 
         data_env = os.environ.get("LILBEE_DATA", "")
         if data_env:
-            toml_dir = Path(data_env)
+            # Canonical for the same reason the root itself is: a "~/lilbee"
+            # env value would otherwise look for config.toml under a literal
+            # ./~ tree and silently find nothing.
+            toml_dir = canonical_data_root(data_env)
         else:
             local = find_local_root()
             toml_dir = local if local else default_data_dir()

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -1072,14 +1072,14 @@ class Config(BaseSettings):
 
         data_env = os.environ.get("LILBEE_DATA", "")
         if data_env:
-            # Canonical for the same reason the root itself is: a "~/lilbee"
-            # env value would otherwise look for config.toml under a literal
-            # ./~ tree and silently find nothing.
-            toml_dir = canonical_data_root(data_env)
+            toml_dir: Path | str = data_env
         else:
             local = find_local_root()
             toml_dir = local if local else default_data_dir()
-        toml_path = toml_dir / "config.toml"
+        # Canonicalized through the same call as the root itself, so this
+        # looks in the directory the root will resolve to: a "~/lilbee" value
+        # would otherwise search a literal ./~ tree and silently find nothing.
+        toml_path = canonical_data_root(toml_dir) / "config.toml"
 
         plain_env = _PlainEnvSource(settings_cls, env_prefix="LILBEE_", env_ignore_empty=True)
         sources: list[Any] = [init_settings, plain_env]

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -78,8 +78,15 @@ def canonical_data_root(root: Path | str) -> Path:
     Every entry point that takes a raw root calls this, so the config and lock
     layers agree by construction. A root that does not exist yet resolves to
     where it will be created.
+
+    Expansion and resolution go through ``os.path`` rather than
+    ``Path.expanduser().resolve()`` so the work happens on strings and only one
+    Path is built, at the end. ``Path.resolve`` rebuilds itself through
+    ``type(self)(...)``, which raises for a ``PosixPath`` that exists on Windows
+    -- reachable because ``Path()`` picks its flavour from ``os.name``, so any
+    code that patches that global mints paths this would then choke on.
     """
-    return Path(root).expanduser().resolve()
+    return Path(os.path.realpath(os.path.expanduser(os.fspath(root))))
 
 
 def canonical_models_dir() -> Path:

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -67,24 +67,16 @@ def find_local_root(start: Path | None = None) -> Path | None:
 
 
 def canonical_data_root(root: Path | str) -> Path:
-    """Return the one true spelling of a data-root path.
+    """Resolve a data root to one canonical path.
 
-    The server session file, the port file, and the store's write lock all sit
-    at paths derived from the data root, so two spellings of one directory key
-    two locks and let two servers run against the same data. Symlinks, relative
-    paths, a leading ``~`` (systemd units and .env files deliver it literally),
-    and macOS's ``/var`` vs ``/private/var`` each produce such a pair.
+    Session file, port file, and write lock all derive from the data root, so
+    two spellings of one directory key two locks. Symlinks, relative paths, a
+    leading ``~``, and macOS ``/var`` vs ``/private/var`` each produce a pair.
+    A root that does not exist yet resolves to where it will be created.
 
-    Every entry point that takes a raw root calls this, so the config and lock
-    layers agree by construction. A root that does not exist yet resolves to
-    where it will be created.
-
-    Expansion and resolution go through ``os.path`` rather than
-    ``Path.expanduser().resolve()`` so the work happens on strings and only one
-    Path is built, at the end. ``Path.resolve`` rebuilds itself through
-    ``type(self)(...)``, which raises for a ``PosixPath`` that exists on Windows
-    -- reachable because ``Path()`` picks its flavour from ``os.name``, so any
-    code that patches that global mints paths this would then choke on.
+    Uses ``os.path`` rather than ``Path.expanduser().resolve()``: ``resolve``
+    rebuilds via ``type(self)``, which raises for a ``PosixPath`` that exists
+    on Windows (``Path()`` picks its flavour from ``os.name``, which tests patch).
     """
     return Path(os.path.realpath(os.path.expanduser(os.fspath(root))))
 

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -66,6 +66,25 @@ def find_local_root(start: Path | None = None) -> Path | None:
     return None
 
 
+def canonical_data_root(root: Path | str) -> Path:
+    """Return the one true spelling of a data-root path.
+
+    Server session files, the port file, and the store's write lock are all
+    keyed on paths derived from the data root, so two spellings of the same
+    directory key two different locks and let two servers run against the
+    same data. Symlinks, relative paths, a leading ``~`` (which systemd units
+    and .env files do not expand), and macOS's ``/var`` vs ``/private/var``
+    all produce such a pair. Resolving here collapses them to one key.
+
+    Every entry point that accepts a raw root -- the environment, ``--data-dir``,
+    ``--global``, the local walk-up -- passes through this, so the config and
+    lock layers agree by construction rather than by both remembering to
+    normalize. ``strict=False`` is implicit: a root that does not exist yet
+    resolves to where it will be created.
+    """
+    return Path(root).expanduser().resolve()
+
+
 def canonical_models_dir() -> Path:
     """Return the shared models directory (always in the platform default, never per-project).
     Multiple lilbee instances share this directory so models are downloaded once.

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -69,18 +69,15 @@ def find_local_root(start: Path | None = None) -> Path | None:
 def canonical_data_root(root: Path | str) -> Path:
     """Return the one true spelling of a data-root path.
 
-    Server session files, the port file, and the store's write lock are all
-    keyed on paths derived from the data root, so two spellings of the same
-    directory key two different locks and let two servers run against the
-    same data. Symlinks, relative paths, a leading ``~`` (which systemd units
-    and .env files do not expand), and macOS's ``/var`` vs ``/private/var``
-    all produce such a pair. Resolving here collapses them to one key.
+    The server session file, the port file, and the store's write lock all sit
+    at paths derived from the data root, so two spellings of one directory key
+    two locks and let two servers run against the same data. Symlinks, relative
+    paths, a leading ``~`` (systemd units and .env files deliver it literally),
+    and macOS's ``/var`` vs ``/private/var`` each produce such a pair.
 
-    Every entry point that accepts a raw root -- the environment, ``--data-dir``,
-    ``--global``, the local walk-up -- passes through this, so the config and
-    lock layers agree by construction rather than by both remembering to
-    normalize. ``strict=False`` is implicit: a root that does not exist yet
-    resolves to where it will be created.
+    Every entry point that takes a raw root calls this, so the config and lock
+    layers agree by construction. A root that does not exist yet resolves to
+    where it will be created.
     """
     return Path(root).expanduser().resolve()
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -408,8 +408,8 @@ def init(path: str = "") -> dict[str, Any]:
             "init is unavailable on the HTTP server: it is bound to one vault and "
             "shared by every connected client. Start a separate server for another vault."
         )
-    # Canonical so the vault this session switches to keys the same lock paths
-    # a CLI or server process would derive for the same directory.
+    # Canonical so this vault keys the same lock paths a CLI or server process
+    # would derive for the same directory.
     base = canonical_data_root(path) if path else canonical_data_root(Path.cwd())
     root = base / LOCAL_ROOT_DIRNAME
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -51,7 +51,7 @@ from lilbee.catalog.types import ModelSource
 from lilbee.core.config import cfg
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.core.settings import overlay_persisted_settings
-from lilbee.core.system import LOCAL_ROOT_DIRNAME
+from lilbee.core.system import LOCAL_ROOT_DIRNAME, canonical_data_root
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
 from lilbee.crawler.task import get_task, start_crawl
 from lilbee.data.store import (
@@ -408,7 +408,9 @@ def init(path: str = "") -> dict[str, Any]:
             "init is unavailable on the HTTP server: it is bound to one vault and "
             "shared by every connected client. Start a separate server for another vault."
         )
-    base = Path(path) if path else Path.cwd()
+    # Canonical so the vault this session switches to keys the same lock paths
+    # a CLI or server process would derive for the same directory.
+    base = canonical_data_root(path) if path else canonical_data_root(Path.cwd())
     root = base / LOCAL_ROOT_DIRNAME
 
     created = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,10 +63,11 @@ class TestCreate:
         """A "~/vault" root must reach the home directory, not a literal ./~ tree."""
         from lilbee import Lilbee
 
+        # POSIX expanduser reads HOME; the Windows one reads USERPROFILE.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         bee = Lilbee("~/tilde_vault")
         assert bee.config.data_root == (tmp_path / "tilde_vault").resolve()
-        assert not (Path.cwd() / "~").exists()
 
     def test_create_with_config(self, tmp_path):
         from lilbee import Lilbee

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,15 @@ class TestCreate:
         assert bee.config.data_dir.exists()
         assert "myproject" in str(bee.config.data_root)
 
+    def test_documents_dir_tilde_expands_instead_of_literal_dir(self, tmp_path, monkeypatch):
+        """A "~/vault" root must reach the home directory, not a literal ./~ tree."""
+        from lilbee import Lilbee
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        bee = Lilbee("~/tilde_vault")
+        assert bee.config.data_root == (tmp_path / "tilde_vault").resolve()
+        assert not (Path.cwd() / "~").exists()
+
     def test_create_with_config(self, tmp_path):
         from lilbee import Lilbee
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,6 +116,36 @@ class TestEnvVarOverrides:
             assert c.data_root == Path.home() / "lilbee_expanduser_probe"
             assert c.lancedb_dir == Path.home() / "lilbee_expanduser_probe" / "data" / "lancedb"
 
+    def test_symlinked_data_root_keys_the_same_paths_as_its_target(self, tmp_path):
+        """Two spellings of one directory must derive one set of lock paths.
+
+        Session file, port file, and store write lock are all keyed on paths
+        under the data root, so a symlinked spelling that stayed distinct
+        would let a second server start against data a first one already owns.
+        """
+        real = tmp_path / "real_root"
+        real.mkdir()
+        link = tmp_path / "link_root"
+        link.symlink_to(real)
+
+        with mock.patch.dict(os.environ, {"LILBEE_DATA": str(real)}):
+            direct = Config()
+        with mock.patch.dict(os.environ, {"LILBEE_DATA": str(link)}):
+            through_link = Config()
+
+        assert through_link.data_root == direct.data_root
+        assert through_link.data_dir == direct.data_dir
+        assert through_link.lancedb_dir == direct.lancedb_dir
+
+    def test_relative_data_root_resolves_absolute(self, tmp_path, monkeypatch):
+        """A relative root must not re-key on the process working directory."""
+        (tmp_path / "kb").mkdir()
+        monkeypatch.chdir(tmp_path)
+        with mock.patch.dict(os.environ, {"LILBEE_DATA": "kb"}):
+            c = Config()
+        assert c.data_root.is_absolute()
+        assert c.data_root == (tmp_path / "kb").resolve()
+
     def test_empty_data_root_falls_back_to_default_not_cwd(self):
         """An empty LILBEE_DATA_ROOT must resolve to the platform default, not
         the process cwd (which would make the data dir move with the launcher)."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,6 +137,21 @@ class TestEnvVarOverrides:
         assert through_link.data_dir == direct.data_dir
         assert through_link.lancedb_dir == direct.lancedb_dir
 
+    def test_padded_data_env_finds_the_same_dir_for_root_and_config(
+        self, tmp_path, overlay_reads_config_toml
+    ):
+        """A whitespace-padded LILBEE_DATA must not split the root from its config.
+
+        The root resolution and the config.toml lookup read the same env var;
+        if only one of them strips, a padded value points them at two
+        different directories and the settings file is silently not found.
+        """
+        (tmp_path / "config.toml").write_text("top_k = 7\n", encoding="utf-8")
+        with mock.patch.dict(os.environ, {"LILBEE_DATA": f"  {tmp_path}  "}):
+            c = Config()
+        assert c.data_root == tmp_path
+        assert c.top_k == 7
+
     def test_relative_data_root_resolves_absolute(self, tmp_path, monkeypatch):
         """A relative root must not re-key on the process working directory."""
         (tmp_path / "kb").mkdir()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,12 +117,7 @@ class TestEnvVarOverrides:
             assert c.lancedb_dir == Path.home() / "lilbee_expanduser_probe" / "data" / "lancedb"
 
     def test_symlinked_data_root_keys_the_same_paths_as_its_target(self, tmp_path):
-        """Two spellings of one directory must derive one set of lock paths.
-
-        Session file, port file, and store write lock are all keyed on paths
-        under the data root, so a symlinked spelling that stayed distinct
-        would let a second server start against data a first one already owns.
-        """
+        """Two spellings of one directory derive one set of lock paths."""
         real = tmp_path / "real_root"
         real.mkdir()
         link = tmp_path / "link_root"
@@ -140,12 +135,7 @@ class TestEnvVarOverrides:
     def test_padded_data_env_finds_the_same_dir_for_root_and_config(
         self, tmp_path, overlay_reads_config_toml
     ):
-        """A whitespace-padded LILBEE_DATA must not split the root from its config.
-
-        The root resolution and the config.toml lookup read the same env var;
-        if only one of them strips, a padded value points them at two
-        different directories and the settings file is silently not found.
-        """
+        """A padded LILBEE_DATA sends the root and its config.toml to one dir."""
         (tmp_path / "config.toml").write_text("top_k = 7\n", encoding="utf-8")
         with mock.patch.dict(os.environ, {"LILBEE_DATA": f"  {tmp_path}  "}):
             c = Config()
@@ -181,12 +171,10 @@ class TestEnvVarOverrides:
             assert str(c2.data_root).endswith("lilbee")
 
     def test_unresolvable_home_still_loads_config(self):
-        """A ~ the OS cannot resolve must not take config construction down.
+        """An unresolvable ~ still yields a usable root instead of raising.
 
-        Canonicalization delegates to ``os.path.expanduser``, which returns an
-        unknown ``~user`` unchanged rather than raising the way
-        ``Path.expanduser`` does, so the root still resolves to a usable
-        absolute path and the process keeps running.
+        os.path.expanduser returns an unknown ~user unchanged; Path.expanduser
+        raises.
         """
         from lilbee.core.system import canonical_data_root
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -165,10 +165,18 @@ class TestDisplaySourcePath:
         from lilbee.retrieval.query import display_source_path
 
         cfg.documents_dir = tmp_path / "docs"
+        target = cfg.documents_dir / "anything.md"
 
-        # Force resolve() to raise so the fallback path runs.
+        # Raise only for the path under test, delegating everything else to the
+        # real resolve(): an unconditional patch also breaks the config
+        # validator, which resolves the data root on every field assignment,
+        # and so blows up in the cfg-restoring fixture's teardown.
+        real_resolve = _Path.resolve
+
         def _raise(self, strict=False):
-            raise OSError("simulated")
+            if self == target:
+                raise OSError("simulated")
+            return real_resolve(self, strict=strict)
 
         monkeypatch.setattr(_Path, "resolve", _raise)
         assert display_source_path("anything.md") == "anything.md"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -178,10 +178,8 @@ class TestDisplaySourcePath:
         cfg.documents_dir = tmp_path / "docs"
         target = cfg.documents_dir / "anything.md"
 
-        # Raise only for the path under test, delegating everything else to the
-        # real resolve(): an unconditional patch also breaks the config
-        # validator, which resolves the data root on every field assignment,
-        # and so blows up in the cfg-restoring fixture's teardown.
+        # Raise only for the path under test; an unconditional patch also hits
+        # the config validator and blows up in fixture teardown.
         real_resolve = _Path.resolve
 
         def _raise(self, strict=False):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -67,9 +67,8 @@ class TestNetworkPath:
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mount-path semantics")
     def test_is_network_path_uses_raw_path_when_resolve_fails(self, mounts_file, monkeypatch):
         # Path.resolve has no injectable seam, so this one branch patches it.
-        # Raise only for the path under test: an unconditional patch also breaks
-        # the config validator, which resolves the data root on every field
-        # assignment, and so blows up in the cfg-restoring fixture's teardown.
+        # Raise only for the path under test; an unconditional patch also hits
+        # the config validator and blows up in fixture teardown.
         target = Path("/workspace/models/m.gguf")
         real_resolve = Path.resolve
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -67,11 +67,19 @@ class TestNetworkPath:
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mount-path semantics")
     def test_is_network_path_uses_raw_path_when_resolve_fails(self, mounts_file, monkeypatch):
         # Path.resolve has no injectable seam, so this one branch patches it.
-        def _raise(self):
-            raise OSError("resolve failed")
+        # Raise only for the path under test: an unconditional patch also breaks
+        # the config validator, which resolves the data root on every field
+        # assignment, and so blows up in the cfg-restoring fixture's teardown.
+        target = Path("/workspace/models/m.gguf")
+        real_resolve = Path.resolve
+
+        def _raise(self, strict=False):
+            if self == target:
+                raise OSError("resolve failed")
+            return real_resolve(self, strict=strict)
 
         monkeypatch.setattr(Path, "resolve", _raise)
-        assert is_network_path(Path("/workspace/models/m.gguf")) is True
+        assert is_network_path(target) is True
 
 
 class TestHelpers:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Never
 from unittest import mock
 
 import pytest
@@ -2755,15 +2755,23 @@ class TestGetCompletions:
         assert any("testfile.txt" in x for x in r)
 
     def test_path_exists_swallows_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A path the OS refuses to stat must read as missing, not raise."""
-        from pathlib import Path as P
+        """A path the OS refuses to stat must read as missing, not raise.
 
+        Patches this module's ``Path`` rather than ``pathlib.Path.expanduser``
+        itself: a global patch also breaks the config validator, which expands
+        the data root on every field assignment, and so blows up in the
+        cfg-restoring fixture's teardown before monkeypatch unwinds.
+        """
         from lilbee.cli.tui.widgets import autocomplete
 
-        def _boom(self: P) -> P:
-            raise OSError("bad path")
+        class _BoomPath:
+            def __init__(self, *_args: object) -> None:
+                pass
 
-        monkeypatch.setattr(P, "expanduser", _boom)
+            def expanduser(self) -> Never:
+                raise OSError("bad path")
+
+        monkeypatch.setattr(autocomplete, "Path", _BoomPath)
         assert autocomplete._path_exists("~oops") is False
 
     def test_add_complete_path_collapses_so_enter_submits(self, tmp_path: object) -> None:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2755,12 +2755,10 @@ class TestGetCompletions:
         assert any("testfile.txt" in x for x in r)
 
     def test_path_exists_swallows_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A path the OS refuses to stat must read as missing, not raise.
+        """A path the OS refuses to stat reads as missing, not raise.
 
-        Patches this module's ``Path`` rather than ``pathlib.Path.expanduser``
-        itself: a global patch also breaks the config validator, which expands
-        the data root on every field assignment, and so blows up in the
-        cfg-restoring fixture's teardown before monkeypatch unwinds.
+        Patches this module's Path, not pathlib.Path.expanduser: a global patch
+        also hits the config validator and blows up in fixture teardown.
         """
         from lilbee.cli.tui.widgets import autocomplete
 


### PR DESCRIPTION
## Problem

The "one server per data directory" lock keys on the data-directory path as written. The same directory spelled two ways keys two locks, so two servers can run against the same data. Happens with a symlink, a relative path, a leading `~` (systemd and `.env` deliver it literally), and macOS `/var` vs `/private/var`.

Closes #566.

## Solution

`canonical_data_root()` resolves a root to one path. Every entry point that takes a raw one now calls it: the env var and local walk-up in the config validator, `--data-dir` and `--global` in the CLI, the MCP `init` vault switch, and the `Lilbee` constructor. The CLI and MCP paths needed it separately since both bypass the validator and build their own child paths. Config.toml lookup is canonicalized too, so a `~/lilbee` root finds its settings instead of looking under a literal `./~`.

Expansion and resolution run through `os.path` rather than `Path.expanduser().resolve()`. `Path.resolve` rebuilds itself via `type(self)`, which raises for a `PosixPath` that exists on Windows, reachable because `Path()` picks its flavour from `os.name` and two tests patch that global.

One visible change: a symlinked or relative data dir now displays as its resolved path, and `/var/...` shows as `/private/var/...` on macOS.