### PR TITLE
Require the session token on every HTTP route

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1008,7 +1008,7 @@ tools (~10% of a 32K context, ~35% of Gemma 4's 7K).
   `cfg.wiki` is on or `lilbee[crawler]` is installed.
 - Tool docstrings stay at one or two sentences (FastMCP turns them
   into per-parameter schema descriptions).
-- `_strip_schema_noise` in `mcp_server.py` drops the FastMCP/Pydantic
+- `LilbeeMCP.list_tools` in `mcp_server.py` drops the FastMCP/Pydantic
   auto-generated `title` keys before the tools hit the wire.
 - `tests/test_mcp.py::TestToolsSchemaSize` caps the schema at 7 KB; new
   tools or doc bloat trip the cap and force a deliberate review.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -942,9 +942,13 @@ All chat-generating endpoints (`/api/ask`, `/api/chat`, both their `/stream` var
 
 ### Auth model
 
-All network surfaces, the `/v1/*` model runtime, the `/api/*` REST routes, and the `/mcp` streamable-http endpoint, share **one** bearer session token. The daemon generates it on startup, persists it to `server.json` (mode `0600`), and hands it to local clients through `lilbee agent-config` / `lilbee launch`. Clients send `Authorization: Bearer <token>`; `AuthMiddleware` (`src/lilbee/server/auth.py`) checks it on every mutating request.
+All network surfaces, the `/v1/*` model runtime, the `/api/*` REST routes, and the `/mcp` streamable-http endpoint, share **one** bearer session token. The daemon generates it on startup, persists it to `server.json` (mode `0600`), and hands it to local clients through `lilbee agent-config` / `lilbee launch`. Clients send `Authorization: Bearer <token>`; `AuthMiddleware` (`src/lilbee/server/auth.py`) checks it on **every** request, reads included. There is no unauthenticated route, `GET /api/health` included: health reports the chat engine's last error, which carries model paths and loader failures, so an open liveness probe would hand out the most useful reconnaissance on the box. A local probe runs as the user and reads the token out of `server.json` like every other local client.
+
+`/v1/models` and `/v1/chat/completions` are the only routes the middleware skips, and they are not exempt: they check the same token inside the handler so a bad one comes back in the OpenAI error envelope rather than Litestar's 401 shape. `tests/server/test_every_route_is_authenticated.py` walks the live route table and asserts every path answers 401 without a token, so a new route cannot quietly opt out.
 
 This is deliberately a single, unscoped token rather than a per-client or per-scope system. lilbee is a local-first, single-user tool: the daemon binds localhost only (with DNS-rebinding protection), and any process running as the user can read `server.json` regardless, so a per-agent token would not add a boundary that the filesystem doesn't already remove. The token exists to keep out other local users and drive-by browser requests, not to isolate the user's own agents from each other.
+
+That purpose is why reads are gated too. Reads used to be open on the reasoning that they only exposed local state, but `server.json` is `0600` precisely so another local user cannot act as the daemon, and leaving `GET /api/export` open handed that same user the entire corpus without it. The boundary only means something if it covers the data.
 
 The tradeoff is that the token is all-or-nothing: a client trusted with retrieval also gets generation and the mutating tools (`reset`, `remove`, `model_rm`, `settings_set`). That is acceptable for the user's own agents on localhost. Giving retrieval-only access to a less-trusted client would require a scoped token, which lilbee does not have today.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -670,13 +670,15 @@ lilbee serve --port 8080               # fixed port
 lilbee serve --host 0.0.0.0            # bind all interfaces (default: 127.0.0.1)
 ```
 
-The surface covers search (with SSE streaming variants for `ask` and `chat`),
+Every route needs the session token, reads included, `GET /api/health` among
+them; the daemon writes the token to `server.json` (mode `0600`) next to the
+port file, and `lilbee agent-config` hands it to local clients. The surface
+covers search (with SSE streaming variants for `ask` and `chat`),
 document lifecycle, crawling, model management, memory
 (`GET`/`POST`/`PATCH`/`DELETE /api/memories`, when memory is enabled),
 saved conversations (`/api/sessions`: list, read, create, append, rename,
-delete, and the compaction summary; every one of these needs the session
-token, reads included), configuration (including a defaults endpoint
-that powers per-setting reset), and status/health. The
+delete, and the compaction summary), configuration (including a defaults
+endpoint that powers per-setting reset), and status/health. The
 Obsidian plugin uses the `/api/source` endpoint for vault-aware source
 retrieval. Interactive REST API docs live at `/schema/redoc` when the server
 is running, and the full OpenAPI schema is published at the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -674,8 +674,8 @@ The surface covers search (with SSE streaming variants for `ask` and `chat`),
 document lifecycle, crawling, model management, memory
 (`GET`/`POST`/`PATCH`/`DELETE /api/memories`, when memory is enabled),
 saved conversations (`/api/sessions`: list, read, create, append, rename,
-delete, and the compaction summary; reads work with a read-only token,
-writes need a full one), configuration (including a defaults endpoint
+delete, and the compaction summary; every one of these needs the session
+token, reads included), configuration (including a defaults endpoint
 that powers per-setting reset), and status/health. The
 Obsidian plugin uses the `/api/source` endpoint for vault-aware source
 retrieval. Interactive REST API docs live at `/schema/redoc` when the server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ dependencies = [
     "psutil>=5.9",
     "pydantic-settings>=2.14.2",
     "numpy",
+    # The read side is stdlib tomllib; this is its write half.
+    "tomli-w>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "numpy",
     # The read side is stdlib tomllib; this is its write half.
     "tomli-w>=1.0",
+    "cachetools>=7.1.4",
 ]
 
 [project.optional-dependencies]
@@ -119,6 +120,7 @@ dev = [
     "pytest-forked>=1.6.0",
     "pytest-timeout>=2.3",
     "pre-commit>=4.0",
+    "types-cachetools>=7.0.0.20260713",
 ]
 
 [tool.pytest.ini_options]

--- a/src/lilbee/cli/agent_configs/config_file.py
+++ b/src/lilbee/cli/agent_configs/config_file.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import os
-import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import typer
+
+from lilbee.core.security import write_private_text
 
 
 def load_config_dict(
@@ -39,17 +39,11 @@ def load_config_dict(
 
 
 def atomic_write_text(path: Path, text: str) -> None:
-    """Write *text* to *path* atomically (temp file + os.replace), creating parents."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_name: str | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            dir=path.parent, suffix=".tmp", delete=False, mode="w", encoding="utf-8"
-        ) as tmp:
-            tmp_name = tmp.name
-            tmp.write(text)
-        os.replace(tmp_name, path)
-    except BaseException:
-        if tmp_name is not None:
-            Path(tmp_name).unlink(missing_ok=True)
-        raise
+    """Write *text* to *path* atomically (temp file + os.replace), creating parents.
+
+    Agent configs carry the lilbee bearer token, so they get the same
+    owner-only treatment as the other secret files. This already wrote through
+    a temp file, which is created 0600 and keeps that mode across the replace;
+    sharing the one implementation just makes that explicit.
+    """
+    write_private_text(path, text)

--- a/src/lilbee/cli/launchers/hermes.py
+++ b/src/lilbee/cli/launchers/hermes.py
@@ -54,9 +54,9 @@ def _upsert_env_token(path: Path, token: str) -> None:
     line = f"{LILBEE_TOKEN_ENV_VAR}={token}"
     existing = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
     kept = [ln for ln in existing if not ln.startswith(f"{LILBEE_TOKEN_ENV_VAR}=")]
+    # atomic_write_text creates the file 0600 and keeps that mode across the
+    # replace, so the token is never briefly readable and needs no chmod after.
     config_file.atomic_write_text(path, "\n".join([*kept, line]) + "\n")
-    if os.name == "posix":
-        path.chmod(0o600)
 
 
 def warn_hermes_ungrounded() -> None:

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -74,14 +74,38 @@ def free_port() -> int:
         return int(s.getsockname()[1])
 
 
+def _session_token() -> str | None:
+    """The bearer token from server.json, or None if it is not readable yet."""
+    try:
+        data = json.loads(server_json_path().read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    token = data.get("token")
+    return token if isinstance(token, str) and token else None
+
+
 def _probe_health(port: int) -> dict[str, object] | None:
     """GET ``/api/health`` once; return the parsed body on 200, else None.
 
     The single place the probe URL, timeout, error handling, and status check
     live, so the three public probes below stay consistent.
+
+    Health needs the token like every other route: it reports the chat
+    engine's last error, which carries model paths and loader failures. The
+    token is re-read per attempt rather than captured once, because these
+    probes poll a server that is still starting and server.json does not exist
+    until its lifespan has run. No token yet means no server yet, which is the
+    same answer a refused connection gives.
     """
+    token = _session_token()
+    if token is None:
+        return None
     try:
-        resp = httpx.get(f"http://{LOOPBACK}:{port}{_HEALTH_PATH}", timeout=_HEALTH_PROBE_TIMEOUT_S)
+        resp = httpx.get(
+            f"http://{LOOPBACK}:{port}{_HEALTH_PATH}",
+            timeout=_HEALTH_PROBE_TIMEOUT_S,
+            headers={"Authorization": f"Bearer {token}"},
+        )
     except httpx.HTTPError:
         return None
     if resp.status_code != _HTTP_OK:

--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -105,10 +105,8 @@ _ATTACHMENT_EXCLUDE: tuple[str, ...] = (
     r"\?attachment_id=",
 )
 
-# These are regexes matched against the whole URL, not globs, so a bare path
-# prefix also matches longer words: /cart excluded /cartography, /account
-# excluded /accounting, /profile excluded /professional-services. Require the
-# segment to end or be followed by a separator.
+# Regexes against the whole URL, not globs, so a bare prefix also matches
+# longer words: /cart excluded /cartography. Require a segment boundary.
 _PATH_BOUNDARY = r"(?:/|\?|#|$)"
 
 
@@ -146,10 +144,9 @@ _ECOMMERCE_EXCLUDE = (
 )
 
 # Marketing / tracking query parameters (utm_*, fbclid, gclid, etc.).
-# Only vendor campaign tokens belong here: dropping ?utm_source= costs nothing
-# because the canonical URL is in the frontier too, but ?ref= and ?share= are
-# ordinary content links on docs and forum platforms and dropping one can drop
-# the only URL that reaches a page.
+# Vendor campaign tokens only. Dropping ?utm_source= is free (the canonical
+# URL is in the frontier too), but ?ref= and ?share= are ordinary content
+# links on docs and forum platforms.
 _TRACKING_EXCLUDE: tuple[str, ...] = (
     (
         r"[?&]("

--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -145,6 +145,10 @@ _ECOMMERCE_EXCLUDE = (
 )
 
 # Marketing / tracking query parameters (utm_*, fbclid, gclid, etc.).
+# Only vendor campaign tokens belong here: dropping ?utm_source= costs nothing
+# because the canonical URL is in the frontier too, but ?ref= and ?share= are
+# ordinary content links on docs and forum platforms and dropping one can drop
+# the only URL that reaches a page.
 _TRACKING_EXCLUDE: tuple[str, ...] = (
     (
         r"[?&]("
@@ -160,10 +164,9 @@ _TRACKING_EXCLUDE: tuple[str, ...] = (
         r"|igshid"
         r"|pk_campaign|pk_source|pk_medium|pk_[a-z_]+"
         r"|_ga"
-        r"|ref|referrer"
         r"|affiliate|aff_id|aff_ref|aff|partner"
         r"|srsltid"
-        r"|share|replytocom"
+        r"|replytocom"
         r")="
     ),
 )

--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -1,8 +1,9 @@
 """Default values and constants for :mod:`lilbee.config`.
 
-Holds frozen literal data: directory ignore lists, NER label allow-list,
-LanceDB table names, the crawl URL exclusion patterns (grouped per
-category), and the default system / CORS prompts.
+Holds frozen literal data: directory ignore lists, the NER label allow-list,
+LanceDB table names, the default HTTP timeout and context size, the crawl URL
+exclusion patterns (grouped per category), the default RAG and general system
+prompts, and the CORS allow-origin regex.
 """
 
 DEFAULT_IGNORE_DIRS = frozenset(

--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -104,27 +104,42 @@ _ATTACHMENT_EXCLUDE: tuple[str, ...] = (
     r"\?attachment_id=",
 )
 
+# These are regexes matched against the whole URL, not globs, so a bare path
+# prefix also matches longer words: /cart excluded /cartography, /account
+# excluded /accounting, /profile excluded /professional-services. Require the
+# segment to end or be followed by a separator.
+_PATH_BOUNDARY = r"(?:/|\?|#|$)"
+
+
+def _whole_segments(*paths: str) -> tuple[str, ...]:
+    """Anchor each path prefix so it matches a whole segment, not a word."""
+    return tuple(path + _PATH_BOUNDARY for path in paths)
+
+
 # Auth and account flows (generic across CMSes and e-commerce platforms).
-_AUTH_EXCLUDE: tuple[str, ...] = (
+_AUTH_EXCLUDE: tuple[str, ...] = _whole_segments(
     r"/login",
     r"/logout",
     r"/register",
     r"/signup",
     r"/signin",
     r"/account",
-    r"/my-account/",
     r"/profile",
     r"/password-reset",
     r"/forgot-password",
 )
+_AUTH_EXCLUDE = (*_AUTH_EXCLUDE, r"/my-account/")
 
 # E-commerce transactional flows (cart / checkout / compare / etc.).
-_ECOMMERCE_EXCLUDE: tuple[str, ...] = (
+_ECOMMERCE_EXCLUDE: tuple[str, ...] = _whole_segments(
     r"/cart",
     r"/checkout",
     r"/wishlist",
     r"/orders?",
     r"/compare",
+)
+_ECOMMERCE_EXCLUDE = (
+    *_ECOMMERCE_EXCLUDE,
     r"/products\.json",
     r"/collections/.+/products/.+\?page=",
 )

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -757,7 +757,11 @@ class Config(BaseSettings):
             try:
                 return parse_bool(v)
             except ValueError:
-                pass  # fall through to bool() coercion below for unrecognised strings
+                # bool() on a non-empty string is True, so falling through here
+                # turned an unparseable value into "on". Warn and auto-detect,
+                # matching the sibling validators.
+                log.warning("Invalid LILBEE_ENABLE_OCR=%r, using auto", v)
+                return None
         return bool(v)
 
     @field_validator("flash_attention", mode="before")

--- a/src/lilbee/core/config/parsing.py
+++ b/src/lilbee/core/config/parsing.py
@@ -1,11 +1,14 @@
 """Boolean parsing helpers used by :mod:`lilbee.config` validators."""
 
-_BOOL_TRUE = frozenset({"true", "1", "yes"})
-_BOOL_FALSE = frozenset({"false", "0", "no"})
+# Matches what pydantic itself accepts for a bool field. Every other bool on
+# Config is coerced by pydantic, so a narrower vocabulary here would make the
+# same env spelling mean different things on different fields of one object.
+_BOOL_TRUE = frozenset({"true", "t", "yes", "y", "on", "1"})
+_BOOL_FALSE = frozenset({"false", "f", "no", "n", "off", "0"})
 
 
 def parse_bool(raw: str) -> bool:
-    """Parse true/1/yes or false/0/no; raises ValueError on anything else."""
+    """Parse a boolean env string; raises ValueError on anything else."""
     normalized = raw.strip().lower()
     if normalized in _BOOL_TRUE:
         return True

--- a/src/lilbee/core/config/validators.py
+++ b/src/lilbee/core/config/validators.py
@@ -24,5 +24,8 @@ def ConfigField(  # noqa: N802  pydantic Field wrapper; matches Field's PascalCa
     if not public:
         extra["public"] = False
     if extra:
-        kwargs["json_schema_extra"] = extra
+        # Merge rather than assign: a caller passing its own json_schema_extra
+        # had it silently dropped, with lilbee's flags winning.
+        supplied = kwargs.get("json_schema_extra")
+        kwargs["json_schema_extra"] = {**supplied, **extra} if isinstance(supplied, dict) else extra
     return Field(*args, **kwargs)

--- a/src/lilbee/core/results.py
+++ b/src/lilbee/core/results.py
@@ -44,6 +44,15 @@ def _to_excerpt(chunk: SearchChunk) -> Excerpt:
     )
 
 
+def _best_content_type(source_chunks: list[SearchChunk]) -> str:
+    """Content type of the highest-scoring chunk for a source.
+
+    score is optional on the model, so an unscored chunk sorts last rather
+    than raising.
+    """
+    return max(source_chunks, key=lambda c: c.score if c.score is not None else -1.0).content_type
+
+
 def group(chunks: list[SearchChunk]) -> list[DocumentResult]:
     """Group raw LanceDB chunks into document-centric results."""
     from lilbee.app.search import resolve_vault_path
@@ -63,7 +72,10 @@ def group(chunks: list[SearchChunk]) -> list[DocumentResult]:
         results.append(
             DocumentResult(
                 source=source,
-                content_type=source_chunks[0].content_type,
+                # From the best-scoring chunk, not whichever the store returned
+                # first: excerpts are already sorted by relevance and a source
+                # can carry chunks of more than one type.
+                content_type=_best_content_type(source_chunks),
                 excerpts=excerpts,
                 best_relevance=excerpts[0].relevance,
                 vault_path=resolve_vault_path(source),

--- a/src/lilbee/core/security.py
+++ b/src/lilbee/core/security.py
@@ -7,11 +7,36 @@ import os
 import stat
 import sys
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
 
 log = logging.getLogger(__name__)
 
 _OWNER_ONLY_MODE = 0o600
+
+
+@contextmanager
+def file_lock_or_warn(path: Path, timeout_s: float) -> Iterator[None]:
+    """Serialize access to *path* across processes via a sibling ``.lock`` file.
+
+    On timeout the caller proceeds unserialized: losing coordination to a stale
+    lock file is worse than the rare interleave the lock prevents.
+    """
+    flock = FileLock(str(path) + ".lock")
+    try:
+        flock.acquire(timeout=timeout_s)
+    except FileLockTimeout:
+        log.warning("Timed out waiting for the %s lock; proceeding without it.", path.name)
+        yield
+        return
+    try:
+        yield
+    finally:
+        flock.release()
 
 
 class PathTraversalError(ValueError):

--- a/src/lilbee/core/security.py
+++ b/src/lilbee/core/security.py
@@ -31,10 +31,8 @@ def validate_path_within(path: str | Path, root: Path) -> Path:
     Returns the resolved path on success.
     """
     root_resolved = root.resolve()
-    # A relative path resolves against the process CWD, not *root*, so a bare
-    # user-supplied name was judged against wherever the process happened to be
-    # started. Anchor it to root, which is what the docstring describes; a
-    # traversal inside it is still caught by the containment check below.
+    # Relative paths resolve against the CWD, not *root*, so anchor them here;
+    # a traversal inside is still caught by the containment check below.
     candidate = Path(path)
     resolved = (candidate if candidate.is_absolute() else root_resolved / candidate).resolve()
     if not resolved.is_relative_to(root_resolved):
@@ -45,15 +43,13 @@ def validate_path_within(path: str | Path, root: Path) -> Path:
 def write_private_text(path: Path, text: str) -> None:
     """Write *text* to *path* so it is owner-only for its entire existence.
 
-    Writing with the process umask and narrowing to 0600 afterwards leaves a
-    window in which any local user can read the file, which matters because the
-    callers here persist a bearer token and provider API keys. ``mkstemp``
-    creates the temp file 0600 by construction, and ``os.replace`` carries that
-    mode over, so the secret is never observable at wider permissions. The
-    replace is also atomic, so a crash mid-write cannot truncate the original.
+    Writing under the umask and chmod'ing afterwards leaves a window where any
+    local user can read the file, and these callers persist a bearer token and
+    API keys. ``mkstemp`` creates at 0600 and ``os.replace`` keeps that mode,
+    atomically.
 
-    Windows has no POSIX mode bits; there these files rely on the inherited
-    ``%LOCALAPPDATA%`` DACL for owner-only access.
+    Windows has no POSIX mode bits; there these rely on the inherited
+    ``%LOCALAPPDATA%`` DACL.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
@@ -69,17 +65,12 @@ def write_private_text(path: Path, text: str) -> None:
 def harden_private_file(path: Path) -> None:
     """Narrow *path* to owner-only, tolerating a file we do not own.
 
-    :func:`write_private_text` creates these files owner-only, but one can
-    arrive wider: written by a release predating that hardening, restored from
-    a backup, copied between machines. Their contents (a bearer token, provider
-    API keys) are then read indefinitely without the file ever being rewritten,
-    so callers narrow on every load rather than only at creation.
+    A secret file can arrive wider than :func:`write_private_text` leaves it
+    (backup, older release) and is then read indefinitely without a rewrite, so
+    callers narrow on every load. A refused chmod warns rather than raising: a
+    file owned by someone else must not stop the caller from reading it.
 
-    Never fatal: a file owned by another user must not stop the caller from
-    reading it, so a refused chmod warns and returns.
-
-    Windows has no POSIX mode bits; there these files rely on the inherited
-    ``%LOCALAPPDATA%`` DACL for owner-only access.
+    No-op on Windows, which has no POSIX mode bits.
     """
     if sys.platform == "win32":  # pragma: no cover - Windows uses the DACL
         return

--- a/src/lilbee/core/security.py
+++ b/src/lilbee/core/security.py
@@ -17,12 +17,19 @@ class PathTraversalError(ValueError):
 
 
 def validate_path_within(path: str | Path, root: Path) -> Path:
-    """Resolve *path* and verify it stays within *root*.
+    """Resolve *path* under *root* and verify it stays within it.
+
+    A relative *path* is taken as relative to *root*.
     Raises :class:`PathTraversalError` if the resolved path escapes the root.
     Returns the resolved path on success.
     """
-    resolved = Path(path).resolve()
     root_resolved = root.resolve()
+    # A relative path resolves against the process CWD, not *root*, so a bare
+    # user-supplied name was judged against wherever the process happened to be
+    # started. Anchor it to root, which is what the docstring describes; a
+    # traversal inside it is still caught by the containment check below.
+    candidate = Path(path)
+    resolved = (candidate if candidate.is_absolute() else root_resolved / candidate).resolve()
     if not resolved.is_relative_to(root_resolved):
         raise PathTraversalError(f"Path escapes allowed directory: {path}")
     return resolved

--- a/src/lilbee/core/security.py
+++ b/src/lilbee/core/security.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import stat
+import sys
 import tempfile
 from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_OWNER_ONLY_MODE = 0o600
 
 
 class PathTraversalError(ValueError):
@@ -57,3 +64,28 @@ def write_private_text(path: Path, text: str) -> None:
     except BaseException:
         Path(tmp_name).unlink(missing_ok=True)
         raise
+
+
+def harden_private_file(path: Path) -> None:
+    """Narrow *path* to owner-only, tolerating a file we do not own.
+
+    :func:`write_private_text` creates these files owner-only, but one can
+    arrive wider: written by a release predating that hardening, restored from
+    a backup, copied between machines. Their contents (a bearer token, provider
+    API keys) are then read indefinitely without the file ever being rewritten,
+    so callers narrow on every load rather than only at creation.
+
+    Never fatal: a file owned by another user must not stop the caller from
+    reading it, so a refused chmod warns and returns.
+
+    Windows has no POSIX mode bits; there these files rely on the inherited
+    ``%LOCALAPPDATA%`` DACL for owner-only access.
+    """
+    if sys.platform == "win32":  # pragma: no cover - Windows uses the DACL
+        return
+    if stat.S_IMODE(path.stat().st_mode) == _OWNER_ONLY_MODE:
+        return
+    try:
+        path.chmod(_OWNER_ONLY_MODE)
+    except OSError:
+        log.warning("Could not restrict permissions on %s.", path, exc_info=True)

--- a/src/lilbee/core/security.py
+++ b/src/lilbee/core/security.py
@@ -1,7 +1,9 @@
-"""Security helpers: path validation, input sanitization."""
+"""Security helpers: path validation, input sanitization, secret-file writes."""
 
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 
 
@@ -24,3 +26,27 @@ def validate_path_within(path: str | Path, root: Path) -> Path:
     if not resolved.is_relative_to(root_resolved):
         raise PathTraversalError(f"Path escapes allowed directory: {path}")
     return resolved
+
+
+def write_private_text(path: Path, text: str) -> None:
+    """Write *text* to *path* so it is owner-only for its entire existence.
+
+    Writing with the process umask and narrowing to 0600 afterwards leaves a
+    window in which any local user can read the file, which matters because the
+    callers here persist a bearer token and provider API keys. ``mkstemp``
+    creates the temp file 0600 by construction, and ``os.replace`` carries that
+    mode over, so the secret is never observable at wider permissions. The
+    replace is also atomic, so a crash mid-write cannot truncate the original.
+
+    Windows has no POSIX mode bits; there these files rely on the inherited
+    ``%LOCALAPPDATA%`` DACL for owner-only access.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -18,17 +18,37 @@ def _config_path(data_root: Path) -> Path:
     return data_root / "config.toml"
 
 
+# The escapes TOML gives a short name to. Everything else in the C0 range
+# (plus U+007F) has to go out as \uXXXX.
+_TOML_NAMED_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+
+
 def _escape_toml_string(s: str) -> str:
-    """Escape a string for embedding in a TOML double-quoted value."""
-    return (
-        s.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-        .replace("\b", "\\b")
-        .replace("\f", "\\f")
-    )
+    """Escape a string for embedding in a TOML double-quoted value.
+
+    TOML forbids every control character from appearing raw in a basic string,
+    and the reader responds to a parse failure by discarding the whole file, so
+    a single stray ESC or NUL in one setting value would silently wipe every
+    other persisted setting on the next start.
+    """
+    out: list[str] = []
+    for char in s:
+        named = _TOML_NAMED_ESCAPES.get(char)
+        if named is not None:
+            out.append(named)
+        elif char < "\x20" or char == "\x7f":
+            out.append(f"\\u{ord(char):04X}")
+        else:
+            out.append(char)
+    return "".join(out)
 
 
 def load(data_root: Path) -> dict[str, Any]:

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -2,8 +2,6 @@
 
 import logging
 import os
-import stat
-import sys
 import threading
 import tomllib
 from collections.abc import Generator
@@ -17,7 +15,7 @@ from filelock import Timeout as FileLockTimeout
 
 from lilbee.config_meta import MODEL_ROLE_FIELDS, WRITABLE_CONFIG_FIELDS
 from lilbee.core.config import cfg
-from lilbee.core.security import write_private_text
+from lilbee.core.security import harden_private_file, write_private_text
 
 _settings_lock = threading.Lock()
 
@@ -25,8 +23,6 @@ _settings_lock = threading.Lock()
 # data root, so the in-process mutex alone lets two of them interleave a
 # read-modify-write and silently drop each other's keys.
 _CONFIG_LOCK_TIMEOUT_S = 10.0
-
-_OWNER_ONLY_MODE = 0o600
 
 
 def _config_path(data_root: Path) -> Path:
@@ -69,31 +65,9 @@ def load(data_root: Path) -> dict[str, Any]:
     path = _config_path(data_root)
     if not path.exists():
         return {}
-    _harden(path)
+    harden_private_file(path)
     with path.open("rb") as f:
         return dict(tomllib.load(f))
-
-
-def _harden(path: Path) -> None:
-    """Narrow *path* to owner-only, tolerating a file we do not own.
-
-    ``save`` writes this file owner-only, but a config.toml can arrive 0644
-    from a release predating that, from a backup, or from a copy between
-    machines, and the API keys inside it are read indefinitely without ever
-    being rewritten. Same treatment server.json gets on every load, for the
-    same reason: hardening once at creation is wrong for a file whose whole
-    point is long-lived secret storage.
-    """
-    if sys.platform == "win32":  # pragma: no cover - Windows uses the DACL
-        return
-    if stat.S_IMODE(path.stat().st_mode) == _OWNER_ONLY_MODE:
-        return
-    try:
-        path.chmod(_OWNER_ONLY_MODE)
-    except OSError:
-        logging.getLogger(__name__).warning(
-            "Could not restrict permissions on %s.", path, exc_info=True
-        )
 
 
 def save(data_root: Path, settings: dict[str, Any]) -> None:

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+import tomli_w
 from filelock import FileLock
 from filelock import Timeout as FileLockTimeout
 
@@ -54,39 +55,6 @@ def _config_write_lock(data_root: Path) -> Generator[None, None, None]:
             flock.release()
 
 
-# The escapes TOML gives a short name to. Everything else in the C0 range
-# (plus U+007F) has to go out as \uXXXX.
-_TOML_NAMED_ESCAPES = {
-    "\\": "\\\\",
-    '"': '\\"',
-    "\b": "\\b",
-    "\f": "\\f",
-    "\n": "\\n",
-    "\r": "\\r",
-    "\t": "\\t",
-}
-
-
-def _escape_toml_string(s: str) -> str:
-    """Escape a string for embedding in a TOML double-quoted value.
-
-    TOML forbids every control character from appearing raw in a basic string,
-    and the reader responds to a parse failure by discarding the whole file, so
-    a single stray ESC or NUL in one setting value would silently wipe every
-    other persisted setting on the next start.
-    """
-    out: list[str] = []
-    for char in s:
-        named = _TOML_NAMED_ESCAPES.get(char)
-        if named is not None:
-            out.append(named)
-        elif char < "\x20" or char == "\x7f":
-            out.append(f"\\u{ord(char):04X}")
-        else:
-            out.append(char)
-    return "".join(out)
-
-
 def load(data_root: Path) -> dict[str, Any]:
     """Read all settings from config.toml. Returns {} if file is missing.
 
@@ -101,22 +69,25 @@ def load(data_root: Path) -> dict[str, Any]:
         return dict(tomllib.load(f))
 
 
-def _render_toml_value(value: Any) -> str:
-    """Render a scalar as TOML: booleans and numbers bare, everything else quoted."""
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, int | float):
-        return str(value)
-    return f'"{_escape_toml_string(str(value))}"'
-
-
 def save(data_root: Path, settings: dict[str, Any]) -> None:
-    """Write settings dict as simple TOML key-value pairs."""
+    """Write *settings* to config.toml.
+
+    ``tomli_w`` is the write half of the stdlib ``tomllib`` used by ``load``.
+    The emitter this replaced escaped strings by hand and stringified anything
+    that was not a bool or a number, so a list value was persisted as its
+    quoted repr and read back as text. A control character it escaped wrongly
+    was worse still: the reader discards the whole file on a parse error, so
+    one bad value silently wiped every other setting.
+
+    A ``None`` is dropped rather than written. TOML has no null, and the old
+    emitter wrote the literal string "None", which then read back as a set
+    value instead of an absent one.
+    """
     path = _config_path(data_root)
-    lines = [f"{k} = {_render_toml_value(v)}\n" for k, v in sorted(settings.items())]
+    present = {k: v for k, v in sorted(settings.items()) if v is not None}
     # config.toml can hold provider API keys, so it gets the same owner-only
     # treatment as the session token rather than a post-hoc chmod.
-    write_private_text(path, "".join(lines))
+    write_private_text(path, tomli_w.dumps(present))
 
 
 def get(data_root: Path, key: str) -> str | None:

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -4,8 +4,13 @@ import logging
 import os
 import threading
 import tomllib
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
 
 from lilbee.config_meta import MODEL_ROLE_FIELDS, WRITABLE_CONFIG_FIELDS
 from lilbee.core.config import cfg
@@ -13,9 +18,40 @@ from lilbee.core.security import write_private_text
 
 _settings_lock = threading.Lock()
 
+# A server, a CLI invocation, and an MCP process routinely run against the same
+# data root, so the in-process mutex alone lets two of them interleave a
+# read-modify-write and silently drop each other's keys.
+_CONFIG_LOCK_TIMEOUT_S = 10.0
+
 
 def _config_path(data_root: Path) -> Path:
     return data_root / "config.toml"
+
+
+@contextmanager
+def _config_write_lock(data_root: Path) -> Generator[None, None, None]:
+    """Serialize a config read-modify-write across threads and processes.
+
+    A lock timeout falls through to the write rather than failing the caller:
+    losing a settings update to a stale lock file is worse than the interleave
+    the lock exists to prevent, which is already rare.
+    """
+    path = _config_path(data_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flock = FileLock(str(path) + ".lock")
+    with _settings_lock:
+        try:
+            flock.acquire(timeout=_CONFIG_LOCK_TIMEOUT_S)
+        except FileLockTimeout:
+            logging.getLogger(__name__).warning(
+                "Timed out waiting for the %s lock; writing anyway.", path.name
+            )
+            yield
+            return
+        try:
+            yield
+        finally:
+            flock.release()
 
 
 # The escapes TOML gives a short name to. Everything else in the C0 range
@@ -90,8 +126,8 @@ def get(data_root: Path, key: str) -> str | None:
 
 
 def set_value(data_root: Path, key: str, value: Any) -> None:
-    """Read-modify-write a single key in config.toml (thread-safe)."""
-    with _settings_lock:
+    """Read-modify-write a single key in config.toml."""
+    with _config_write_lock(data_root):
         current = load(data_root)
         current[key] = value
         save(data_root, current)
@@ -99,7 +135,7 @@ def set_value(data_root: Path, key: str, value: Any) -> None:
 
 def delete_value(data_root: Path, key: str) -> None:
     """Remove a key from config.toml. No-op if key doesn't exist."""
-    with _settings_lock:
+    with _config_write_lock(data_root):
         current = load(data_root)
         current.pop(key, None)
         save(data_root, current)
@@ -107,7 +143,7 @@ def delete_value(data_root: Path, key: str) -> None:
 
 def update_values(data_root: Path, updates: dict[str, Any]) -> None:
     """Batch update multiple keys in config.toml (single write)."""
-    with _settings_lock:
+    with _config_write_lock(data_root):
         current = load(data_root)
         current.update(updates)
         save(data_root, current)
@@ -115,7 +151,7 @@ def update_values(data_root: Path, updates: dict[str, Any]) -> None:
 
 def delete_values(data_root: Path, keys: list[str]) -> None:
     """Batch delete multiple keys from config.toml (single write)."""
-    with _settings_lock:
+    with _config_write_lock(data_root):
         current = load(data_root)
         for key in keys:
             current.pop(key, None)

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import stat
+import sys
 import threading
 import tomllib
 from collections.abc import Generator
@@ -23,6 +25,8 @@ _settings_lock = threading.Lock()
 # data root, so the in-process mutex alone lets two of them interleave a
 # read-modify-write and silently drop each other's keys.
 _CONFIG_LOCK_TIMEOUT_S = 10.0
+
+_OWNER_ONLY_MODE = 0o600
 
 
 def _config_path(data_root: Path) -> Path:
@@ -65,8 +69,31 @@ def load(data_root: Path) -> dict[str, Any]:
     path = _config_path(data_root)
     if not path.exists():
         return {}
+    _harden(path)
     with path.open("rb") as f:
         return dict(tomllib.load(f))
+
+
+def _harden(path: Path) -> None:
+    """Narrow *path* to owner-only, tolerating a file we do not own.
+
+    ``save`` writes this file owner-only, but a config.toml can arrive 0644
+    from a release predating that, from a backup, or from a copy between
+    machines, and the API keys inside it are read indefinitely without ever
+    being rewritten. Same treatment server.json gets on every load, for the
+    same reason: hardening once at creation is wrong for a file whose whole
+    point is long-lived secret storage.
+    """
+    if sys.platform == "win32":  # pragma: no cover - Windows uses the DACL
+        return
+    if stat.S_IMODE(path.stat().st_mode) == _OWNER_ONLY_MODE:
+        return
+    try:
+        path.chmod(_OWNER_ONLY_MODE)
+    except OSError:
+        logging.getLogger(__name__).warning(
+            "Could not restrict permissions on %s.", path, exc_info=True
+        )
 
 
 def save(data_root: Path, settings: dict[str, Any]) -> None:

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -10,12 +10,10 @@ from pathlib import Path
 from typing import Any
 
 import tomli_w
-from filelock import FileLock
-from filelock import Timeout as FileLockTimeout
 
 from lilbee.config_meta import MODEL_ROLE_FIELDS, WRITABLE_CONFIG_FIELDS
 from lilbee.core.config import cfg
-from lilbee.core.security import harden_private_file, write_private_text
+from lilbee.core.security import file_lock_or_warn, harden_private_file, write_private_text
 
 _settings_lock = threading.Lock()
 
@@ -39,20 +37,8 @@ def _config_write_lock(data_root: Path) -> Generator[None, None, None]:
     """
     path = _config_path(data_root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    flock = FileLock(str(path) + ".lock")
-    with _settings_lock:
-        try:
-            flock.acquire(timeout=_CONFIG_LOCK_TIMEOUT_S)
-        except FileLockTimeout:
-            logging.getLogger(__name__).warning(
-                "Timed out waiting for the %s lock; writing anyway.", path.name
-            )
-            yield
-            return
-        try:
-            yield
-        finally:
-            flock.release()
+    with _settings_lock, file_lock_or_warn(path, _CONFIG_LOCK_TIMEOUT_S):
+        yield
 
 
 def load(data_root: Path) -> dict[str, Any]:

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import sys
 import threading
 import tomllib
 from pathlib import Path
@@ -10,6 +9,7 @@ from typing import Any
 
 from lilbee.config_meta import MODEL_ROLE_FIELDS, WRITABLE_CONFIG_FIELDS
 from lilbee.core.config import cfg
+from lilbee.core.security import write_private_text
 
 _settings_lock = threading.Lock()
 
@@ -57,11 +57,10 @@ def _render_toml_value(value: Any) -> str:
 def save(data_root: Path, settings: dict[str, Any]) -> None:
     """Write settings dict as simple TOML key-value pairs."""
     path = _config_path(data_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
     lines = [f"{k} = {_render_toml_value(v)}\n" for k, v in sorted(settings.items())]
-    path.write_text("".join(lines), encoding="utf-8", newline="\n")
-    if sys.platform != "win32":
-        path.chmod(0o600)  # pragma: no cover - POSIX-only; Windows has no 0600 mode bits
+    # config.toml can hold provider API keys, so it gets the same owner-only
+    # treatment as the session token rather than a post-hoc chmod.
+    write_private_text(path, "".join(lines))
 
 
 def get(data_root: Path, key: str) -> str | None:

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -10,7 +10,11 @@ from pathlib import Path
 #: Directory name for a project-local lilbee knowledge base (sibling of ``.git/``).
 LOCAL_ROOT_DIRNAME = ".lilbee"
 
-_STDERR_LOCK = threading.Lock()
+# Reentrant: a suppressed block can re-enter this, directly or through a
+# native helper that wraps its own stderr, and a plain Lock self-deadlocks
+# there. Nesting restores correctly, the inner exit puts back the outer's
+# devnull and the outer puts back the real stderr.
+_STDERR_LOCK = threading.RLock()
 
 
 @contextmanager

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -10,10 +10,9 @@ from pathlib import Path
 #: Directory name for a project-local lilbee knowledge base (sibling of ``.git/``).
 LOCAL_ROOT_DIRNAME = ".lilbee"
 
-# Reentrant: a suppressed block can re-enter this, directly or through a
-# native helper that wraps its own stderr, and a plain Lock self-deadlocks
-# there. Nesting restores correctly, the inner exit puts back the outer's
-# devnull and the outer puts back the real stderr.
+# Reentrant: a suppressed block can re-enter this (directly or via a native
+# helper wrapping its own stderr) and a plain Lock self-deadlocks. Nesting
+# restores correctly: the inner exit puts back the outer's devnull.
 _STDERR_LOCK = threading.RLock()
 
 

--- a/src/lilbee/core/text.py
+++ b/src/lilbee/core/text.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 _SLUG_CLEAN_RE = re.compile(r"[^a-z0-9-]")
+_SLUG_WHITESPACE_RE = re.compile(r"\s+")
 
 # Characters that signal markdown-structural noise in a concept label.
 # Single source of truth for both ``is_valid_label`` (membership check)
@@ -30,7 +31,12 @@ def make_slug(label: str) -> str:
     only leading and trailing hyphens (e.g. ``--body`` from a stripped
     ``| | Body``) are removed.
     """
-    slug = label.lower().replace(" ", "-").replace("/", "--")
+    # Collapse whitespace runs first: ``--`` is the reserved encoding for
+    # ``/``, so a double space used to produce it and two different entities
+    # would share one page, the later write silently replacing the earlier.
+    # Non-space whitespace was dropped entirely, welding two words together.
+    slug = _SLUG_WHITESPACE_RE.sub(" ", label.lower()).strip()
+    slug = slug.replace("/", "--").replace(" ", "-")
     slug = _SLUG_CLEAN_RE.sub("", slug)
     return slug.strip("-")
 

--- a/src/lilbee/core/text.py
+++ b/src/lilbee/core/text.py
@@ -31,10 +31,8 @@ def make_slug(label: str) -> str:
     only leading and trailing hyphens (e.g. ``--body`` from a stripped
     ``| | Body``) are removed.
     """
-    # Collapse whitespace runs first: ``--`` is the reserved encoding for
-    # ``/``, so a double space used to produce it and two different entities
-    # would share one page, the later write silently replacing the earlier.
-    # Non-space whitespace was dropped entirely, welding two words together.
+    # ``--`` is the reserved encoding for ``/``, so collapse whitespace first:
+    # a double space would produce it and collide two entities onto one page.
     slug = _SLUG_WHITESPACE_RE.sub(" ", label.lower()).strip()
     slug = slug.replace("/", "--").replace(" ", "-")
     slug = _SLUG_CLEAN_RE.sub("", slug)

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -259,14 +259,12 @@ async def bootstrap_chromium(
         _emit_setup_done(on_progress, success=True, error=None)
         return
 
-    # Two callers can get here at once: a second POST /setup/crawler, or a
-    # crawl triggering first-use bootstrap alongside one. Both would unpack a
-    # browser bundle into the same directory and corrupt it. The lock is on
-    # disk, not in memory, because the CLI and MCP processes share this path.
-    # thread_local=False because the acquire runs in a worker thread (so the
-    # wait does not block the event loop) while the release runs on the loop
-    # thread. With the default the release would not count and the lock would
-    # never be freed.
+    # Two callers (a second POST /setup/crawler, or a crawl bootstrapping on
+    # first use) would unpack a browser bundle into the same directory and
+    # corrupt it. On disk, not in memory, because the CLI and MCP are separate
+    # processes sharing this path. thread_local=False because the acquire runs
+    # in a worker thread and the release on the loop thread; with the default
+    # the release would not count and the lock would never be freed.
     lock = FileLock(str(_bootstrap_lock_path()), thread_local=False)
     try:
         await asyncio.to_thread(lock.acquire, timeout=_BOOTSTRAP_LOCK_TIMEOUT_S)

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -9,6 +9,9 @@ import re
 import sys
 from pathlib import Path
 
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
 from lilbee._frozen import is_frozen
 from lilbee.runtime.progress import (
     DetailedProgressCallback,
@@ -28,6 +31,10 @@ class CrawlerBackendError(RuntimeError):
 
 
 _CHROMIUM_COMPONENT = "chromium"
+
+# A Chromium unpack runs into the minutes on a slow link, so a caller queued
+# behind one waits well past any normal request timeout before giving up.
+_BOOTSTRAP_LOCK_TIMEOUT_S = 900.0
 # Rough size estimate for the Chromium download; Playwright bundles vary
 # slightly per platform but this gives the UI a decent denominator before
 # 'Total bytes' parses out of stdout.
@@ -110,6 +117,13 @@ def chromium_installed() -> bool:
     if expected is None:
         return any(p.is_dir() and p.name.startswith("chromium-") for p in root.iterdir())
     return (root / f"{_CHROMIUM_COMPONENT}-{expected}").is_dir()
+
+
+def _bootstrap_lock_path() -> Path:
+    """Lock file serializing Chromium installs into the browsers cache."""
+    root = _browsers_cache_path()
+    root.mkdir(parents=True, exist_ok=True)
+    return root / ".lilbee-bootstrap.lock"
 
 
 def crawler_browsers_path() -> Path:
@@ -245,6 +259,36 @@ async def bootstrap_chromium(
         _emit_setup_done(on_progress, success=True, error=None)
         return
 
+    # Two callers can get here at once: a second POST /setup/crawler, or a
+    # crawl triggering first-use bootstrap alongside one. Both would unpack a
+    # browser bundle into the same directory and corrupt it. The lock is on
+    # disk, not in memory, because the CLI and MCP processes share this path.
+    # thread_local=False because the acquire runs in a worker thread (so the
+    # wait does not block the event loop) while the release runs on the loop
+    # thread. With the default the release would not count and the lock would
+    # never be freed.
+    lock = FileLock(str(_bootstrap_lock_path()), thread_local=False)
+    try:
+        await asyncio.to_thread(lock.acquire, timeout=_BOOTSTRAP_LOCK_TIMEOUT_S)
+    except FileLockTimeout as exc:
+        message = (
+            "Timed out waiting for another Chromium install to finish. "
+            "If no other lilbee process is installing, retry."
+        )
+        _emit_setup_done(on_progress, success=False, error=message)
+        raise CrawlerBrowserError(message) from exc
+    try:
+        # The install we were queued behind may have been the one we needed.
+        if chromium_installed():
+            _emit_setup_done(on_progress, success=True, error=None)
+            return
+        await _install_chromium(on_progress)
+    finally:
+        lock.release()
+
+
+async def _install_chromium(on_progress: DetailedProgressCallback | None) -> None:
+    """Run the install subprocess. Caller holds the bootstrap lock."""
     _emit_setup_start(on_progress)
 
     try:

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -208,8 +208,11 @@ def search(
         )
         return [clean_result(r) for r in results]
     except EmbeddingModelMismatchError as exc:
-        # Structured, like the HTTP 409: an agent can offer to adopt the
-        # index's embedder instead of parsing prose out of a generic error.
+        # Structured so an agent can offer to adopt the index's embedder instead
+        # of parsing prose out of a generic error. Names the embedder, which the
+        # HTTP search route deliberately does not: this tool answers a caller
+        # that already reached the MCP surface, while GET /api/search answers
+        # anyone who can reach the port.
         return {
             "error": str(exc),
             "code": "INDEX_EMBEDDER_MISMATCH",

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -208,11 +208,9 @@ def search(
         )
         return [clean_result(r) for r in results]
     except EmbeddingModelMismatchError as exc:
-        # Structured so an agent can offer to adopt the index's embedder instead
-        # of parsing prose out of a generic error. Names the embedder, which the
-        # HTTP search route deliberately does not: this tool answers a caller
-        # that already reached the MCP surface, while GET /api/search answers
-        # anyone who can reach the port.
+        # Structured so an agent can offer to adopt the index's embedder
+        # rather than parse prose out of a generic error. Names the embedder,
+        # which the HTTP search route keeps out of its generic 503.
         return {
             "error": str(exc),
             "code": "INDEX_EMBEDDER_MISMATCH",

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -85,13 +85,12 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-mcp = FastMCP(
-    "lilbee",
-    instructions="Local search engine over the user's files, code, and crawled pages. "
+_INSTRUCTIONS = (
+    "Local search engine over the user's files, code, and crawled pages. "
     "For any question about the user's own documents or codebase -- a lookup, a "
     "find-in-docs, 'where is X', 'how does Y work here' -- call lilbee_search first "
     "and answer from its cited chunks. Prefer it over web-fetch or file-read tools: "
-    "those cannot see the indexed corpus.",
+    "those cannot see the indexed corpus."
 )
 
 
@@ -138,13 +137,16 @@ def _offload_sync(fn: _F) -> _F:
     return cast("_F", _runner)
 
 
+_REGISTRATIONS: list[tuple[Callable[..., Any], str | None]] = []
+
+
 def _tool(fn: _F) -> _F:
     """Register *fn* as an MCP tool with sync handlers offloaded off the loop.
 
     Returns the original callable so in-process callers (tests, the stdio
     fallback) keep the synchronous API while the schema sees the offloaded form.
     """
-    mcp.tool()(_offload_sync(fn))
+    _REGISTRATIONS.append((_offload_sync(fn), None))
     return fn
 
 
@@ -152,7 +154,7 @@ def _tool_named(name: str) -> Callable[[_F], _F]:
     """Register an MCP tool under an explicit wire *name* (sync handlers offloaded)."""
 
     def deco(fn: _F) -> _F:
-        mcp.tool(name=name)(_offload_sync(fn))
+        _REGISTRATIONS.append((_offload_sync(fn), name))
         return fn
 
     return deco
@@ -432,7 +434,7 @@ def init(path: str = "") -> dict[str, Any]:
     reset_services()
     # The new vault may have a different cfg.wiki; re-tune the search tool's scope
     # hint so it advertises the scopes this corpus actually has.
-    _tune_search_scope_for_corpus()
+    _tune_search_scope_for_corpus(mcp)
 
     return {"command": "init", "path": str(root), "created": created}
 
@@ -1100,7 +1102,7 @@ def _flatten_tool_description(text: str) -> str:
     return "\n".join(line.strip() for line in text.strip().splitlines())
 
 
-def _strip_schema_noise() -> None:
+def _strip_schema_noise(server: FastMCP) -> None:
     """Trim auto-generated noise from every registered tool's schema before
     it ships on the OpenAI tools wire for each chat request.
 
@@ -1120,9 +1122,9 @@ def _strip_schema_noise() -> None:
     payload, which matters most for small-context (16K) chat models where
     the tools surface was previously eating ~60% of the budget.
 
-    Runs once after every ``@_tool`` decoration in this module has fired.
+    Runs once per built server, after every registration has been applied.
     """
-    for info in mcp._tool_manager._tools.values():
+    for info in server._tool_manager._tools.values():
         params = info.parameters
         if isinstance(params, dict):
             params.pop("title", None)
@@ -1138,14 +1140,14 @@ def _strip_schema_noise() -> None:
 _NO_WIKI_SCOPE_HINT = ' No wiki layer here: use scope "raw" or "both".'
 
 
-def _tune_search_scope_for_corpus() -> None:
+def _tune_search_scope_for_corpus(server: FastMCP) -> None:
     """Tell ``search`` which scopes this corpus actually has.
 
     When wiki generation is off (``cfg.wiki`` is False), a model that guesses
     ``scope="wiki"`` only gets a silent fallback to the full pool, so advertise
     raw/both only. Idempotent and reversible so a config reload re-tunes it.
     """
-    info = mcp._tool_manager._tools.get("search")
+    info = server._tool_manager._tools.get("search")
     if info is None or not isinstance(info.description, str):
         return
     has_hint = _NO_WIKI_SCOPE_HINT in info.description
@@ -1342,8 +1344,23 @@ def clear_placement_tool() -> dict[str, Any]:
     return _placement_result(lambda: set_placement(None))
 
 
-_strip_schema_noise()
-_tune_search_scope_for_corpus()
+def build_mcp_server() -> FastMCP:
+    """Build a FastMCP server carrying every tool registered in this module.
+
+    Each transport gets its own instance: FastMCP caches one
+    ``StreamableHTTPSessionManager`` per server and its ``run()`` is single-use,
+    so a shared server cannot back two apps in one process.
+    """
+    server = FastMCP("lilbee", instructions=_INSTRUCTIONS)
+    for fn, name in _REGISTRATIONS:
+        server.add_tool(fn, name=name)
+    _strip_schema_noise(server)
+    _tune_search_scope_for_corpus(server)
+    return server
+
+
+# The stdio server. The HTTP daemon builds its own; see build_mcp_mount.
+mcp = build_mcp_server()
 
 
 def main() -> None:

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -13,6 +13,7 @@ import re
 import threading
 import uuid
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -20,6 +21,7 @@ from weakref import WeakKeyDictionary
 
 import anyio
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import Tool as MCPTool
 
 from lilbee.app.memory import (
     MEMORY_DISABLED_HINT,
@@ -137,7 +139,8 @@ def _offload_sync(fn: _F) -> _F:
     return cast("_F", _runner)
 
 
-_REGISTRATIONS: list[tuple[Callable[..., Any], str | None]] = []
+# (handler, wire name override, gate) applied by build_mcp_server per instance.
+_REGISTRATIONS: list[tuple[Callable[..., Any], str | None, Callable[[], bool] | None]] = []
 
 
 def _tool(fn: _F) -> _F:
@@ -146,7 +149,7 @@ def _tool(fn: _F) -> _F:
     Returns the original callable so in-process callers (tests, the stdio
     fallback) keep the synchronous API while the schema sees the offloaded form.
     """
-    _REGISTRATIONS.append((_offload_sync(fn), None))
+    _REGISTRATIONS.append((_offload_sync(fn), None, None))
     return fn
 
 
@@ -154,27 +157,31 @@ def _tool_named(name: str) -> Callable[[_F], _F]:
     """Register an MCP tool under an explicit wire *name* (sync handlers offloaded)."""
 
     def deco(fn: _F) -> _F:
-        _REGISTRATIONS.append((_offload_sync(fn), name))
+        _REGISTRATIONS.append((_offload_sync(fn), name, None))
         return fn
 
     return deco
 
 
-def _tool_if(condition: bool) -> Callable[[_F], _F]:
-    """Register an MCP tool only when *condition* is true.
+def _tool_if(when: Callable[[], bool]) -> Callable[[_F], _F]:
+    """Register an MCP tool gated on *when*, evaluated at server-build time.
 
     The function stays importable so direct callers (tests, in-process
-    fallback) can still reach it. Whether the tool appears in the MCP
-    schema is fixed at import time; changing the gating config requires
-    a server restart.
+    fallback) can still reach it. A server built after a config change
+    carries the current tool surface; live servers keep theirs.
     """
-    if condition:
-        return _tool
+    if not callable(when):
+        raise TypeError("_tool_if takes a zero-arg callable, evaluated per build")
 
-    def _passthrough(fn: _F) -> _F:
+    def deco(fn: _F) -> _F:
+        _REGISTRATIONS.append((_offload_sync(fn), None, when))
         return fn
 
-    return _passthrough
+    return deco
+
+
+def _wiki_enabled() -> bool:
+    return cfg.wiki
 
 
 def _error(msg: str) -> dict[str, Any]:
@@ -344,7 +351,7 @@ async def add(
     return result
 
 
-@_tool_if(crawler_available())
+@_tool_if(crawler_available)
 async def crawl(
     url: str,
     depth: int | None = None,
@@ -382,7 +389,7 @@ async def crawl(
     return {"status": "started", "task_id": task_id, "url": url}
 
 
-@_tool_if(crawler_available())
+@_tool_if(crawler_available)
 def crawl_status(task_id: str) -> dict[str, Any]:
     """Poll a crawl task by id; returns ``{status, pages, error}``."""
     task = get_task(task_id)
@@ -432,9 +439,6 @@ def init(path: str = "") -> dict[str, Any]:
     os.environ["LILBEE_DATA"] = str(base)
     overlay_persisted_settings(base)
     reset_services()
-    # The new vault may have a different cfg.wiki; re-tune the search tool's scope
-    # hint so it advertises the scopes this corpus actually has.
-    _tune_search_scope_for_corpus(mcp)
 
     return {"command": "init", "path": str(root), "created": created}
 
@@ -472,7 +476,7 @@ def _require_agent_session(session_id: str) -> Session:
     return session
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def sessions_list() -> dict[str, Any]:
     """List the agent's sessions, newest first."""
     if not agent_sessions_enabled():
@@ -481,7 +485,7 @@ def sessions_list() -> dict[str, Any]:
     return {"sessions": [asdict(meta) for meta in metas], "total": len(metas)}
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def session_get(session_id: str) -> dict[str, Any]:
     """Return one agent session: metadata, transcript, summary."""
     if not agent_sessions_enabled():
@@ -508,7 +512,7 @@ def session_get(session_id: str) -> dict[str, Any]:
     }
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def session_create(model_ref: str, scope: str = "both") -> dict[str, Any]:
     """Start a saved chat session; returns its id."""
     if not agent_sessions_enabled():
@@ -519,7 +523,7 @@ def session_create(model_ref: str, scope: str = "both") -> dict[str, Any]:
     return {"id": session_id, "model_ref": model_ref, "scope": scope}
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def session_add_message(
     session_id: str,
     role: MessageRole,
@@ -547,7 +551,7 @@ def session_add_message(
     return {"id": session_id, "added": True}
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def session_set_summary(session_id: str, summary: str) -> dict[str, Any]:
     """Replace an agent session's compaction summary."""
     if not agent_sessions_enabled():
@@ -560,7 +564,7 @@ def session_set_summary(session_id: str, summary: str) -> dict[str, Any]:
     return {"id": session_id, "summary": summary}
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def session_rename(session_id: str, title: str) -> dict[str, Any]:
     """Rename an agent session."""
     if not agent_sessions_enabled():
@@ -573,7 +577,7 @@ def session_rename(session_id: str, title: str) -> dict[str, Any]:
     return {"id": session_id, "title": title}
 
 
-@_tool_if(agent_sessions_enabled())
+@_tool_if(agent_sessions_enabled)
 def session_delete(session_id: str) -> dict[str, Any]:
     """Delete an agent session."""
     if not agent_sessions_enabled():
@@ -649,7 +653,7 @@ def reset(confirm: bool = False) -> dict[str, Any]:
     return result
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_lint(wiki_source: str = "") -> dict[str, Any]:
     """Lint wiki pages; empty ``wiki_source`` lints all."""
     from lilbee.wiki.lint import lint_all, lint_wiki_page
@@ -667,7 +671,7 @@ def wiki_lint(wiki_source: str = "") -> dict[str, Any]:
     }
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_citations(wiki_source: str) -> dict[str, Any]:
     """List citations for a wiki page."""
     records = get_services().store.get_citations_for_wiki(wiki_source)
@@ -679,7 +683,7 @@ def wiki_citations(wiki_source: str) -> dict[str, Any]:
     }
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_status() -> dict[str, Any]:
     """Show wiki layer status: page counts, recent lint issues."""
     from lilbee.wiki.lint import lint_all
@@ -705,7 +709,7 @@ def wiki_status() -> dict[str, Any]:
     }
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_list() -> dict[str, Any]:
     """List wiki pages with metadata."""
     if not cfg.wiki:
@@ -723,7 +727,7 @@ def wiki_list() -> dict[str, Any]:
     }
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_read(slug: str) -> dict[str, Any]:
     """Read a wiki page's content + frontmatter by slug."""
     if not cfg.wiki:
@@ -739,7 +743,7 @@ def wiki_read(slug: str) -> dict[str, Any]:
     return {"command": "wiki_read", **asdict(result)}
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_build() -> dict[str, Any]:
     """Build the concept and entity wiki across all ingested sources."""
     if not cfg.wiki:
@@ -749,7 +753,7 @@ def wiki_build() -> dict[str, Any]:
     return {"command": "wiki_build", **run_full_build(cfg)}
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_update() -> dict[str, Any]:
     """Refresh the concept and entity wiki after an ingest. Currently a full rebuild."""
     if not cfg.wiki:
@@ -759,7 +763,7 @@ def wiki_update() -> dict[str, Any]:
     return {"command": "wiki_update", **run_full_build(cfg)}
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_synthesize() -> dict[str, Any]:
     """Generate synthesis pages for concept clusters with three or more sources."""
     if not cfg.wiki:
@@ -769,7 +773,7 @@ def wiki_synthesize() -> dict[str, Any]:
     return {"command": "wiki_synthesize", **run_full_synthesize(cfg)}
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_prune() -> dict[str, Any]:
     """Prune stale and orphaned wiki pages."""
     from lilbee.wiki.prune import prune_wiki
@@ -1034,7 +1038,7 @@ def model_rm(model: str, source: str = "") -> dict[str, Any]:
         return _error(str(exc))
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_drafts_list() -> dict[str, Any]:
     """List pending wiki drafts (read-only; accept/reject are CLI-only)."""
     from lilbee.wiki.drafts import list_drafts
@@ -1048,7 +1052,7 @@ def wiki_drafts_list() -> dict[str, Any]:
     }
 
 
-@_tool_if(cfg.wiki)
+@_tool_if(_wiki_enabled)
 def wiki_drafts_diff(slug: str) -> dict[str, Any]:
     """Unified diff of a draft against its published counterpart."""
     from lilbee.core.security import PathTraversalError
@@ -1102,9 +1106,8 @@ def _flatten_tool_description(text: str) -> str:
     return "\n".join(line.strip() for line in text.strip().splitlines())
 
 
-def _strip_schema_noise(server: FastMCP) -> None:
-    """Trim auto-generated noise from every registered tool's schema before
-    it ships on the OpenAI tools wire for each chat request.
+def _strip_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Trim auto-generated noise from a tool's input schema, on a copy.
 
     Drops:
     - FastMCP/Pydantic ``title`` keys (per-schema + per-property). Tools the
@@ -1115,46 +1118,45 @@ def _strip_schema_noise(server: FastMCP) -> None:
       every ``dict[str, Any]`` but it's the JSON Schema default behavior.
     - The ``null`` arm of ``anyOf: [{type: X}, {type: null}]`` unions for
       ``T | None`` defaults; the null branch is implicit.
-    - Triple-quoted docstring indentation on the tool description. The model
-      sees a flat sentence instead of multi-line text with 4-space prefixes.
 
-    The net effect is a roughly 25-35% reduction in the serialized tools
-    payload, which matters most for small-context (16K) chat models where
-    the tools surface was previously eating ~60% of the budget.
-
-    Runs once per built server, after every registration has been applied.
+    A roughly 25-35% reduction in the serialized tools payload, which matters
+    most for small-context (16K) chat models where the tools surface was
+    previously eating ~60% of the budget.
     """
-    for info in server._tool_manager._tools.values():
-        params = info.parameters
-        if isinstance(params, dict):
-            params.pop("title", None)
-            properties = params.get("properties")
-            if isinstance(properties, dict):
-                for prop in properties.values():
-                    if isinstance(prop, dict):
-                        _strip_property_noise(prop)
-        if isinstance(info.description, str):
-            info.description = _flatten_tool_description(info.description)
+    schema = deepcopy(schema)
+    schema.pop("title", None)
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        for prop in properties.values():
+            if isinstance(prop, dict):
+                _strip_property_noise(prop)
+    return schema
 
 
 _NO_WIKI_SCOPE_HINT = ' No wiki layer here: use scope "raw" or "both".'
 
 
-def _tune_search_scope_for_corpus(server: FastMCP) -> None:
-    """Tell ``search`` which scopes this corpus actually has.
+class LilbeeMCP(FastMCP):
+    """FastMCP that trims its tools wire and keeps it current with config."""
 
-    When wiki generation is off (``cfg.wiki`` is False), a model that guesses
-    ``scope="wiki"`` only gets a silent fallback to the full pool, so advertise
-    raw/both only. Idempotent and reversible so a config reload re-tunes it.
-    """
-    info = server._tool_manager._tools.get("search")
-    if info is None or not isinstance(info.description, str):
-        return
-    has_hint = _NO_WIKI_SCOPE_HINT in info.description
-    if cfg.wiki and has_hint:
-        info.description = info.description.replace(_NO_WIKI_SCOPE_HINT, "")
-    elif not cfg.wiki and not has_hint:
-        info.description += _NO_WIKI_SCOPE_HINT
+    async def list_tools(self) -> list[MCPTool]:
+        """The registered tools with schema noise stripped and flat descriptions.
+
+        The transforms run on the wire representation per request, never on the
+        stored registrations, so they cannot drift out of sync with config. The
+        ``search`` description advertises only the scopes this corpus has: when
+        wiki generation is off, a model that guesses ``scope="wiki"`` gets a
+        silent fallback to the full pool, so raw/both only.
+        """
+        tools = await super().list_tools()
+        for tool in tools:
+            tool.inputSchema = _strip_schema(tool.inputSchema)
+            if isinstance(tool.description, str):
+                description = _flatten_tool_description(tool.description)
+                if tool.name == "search" and not cfg.wiki:
+                    description += _NO_WIKI_SCOPE_HINT
+                tool.description = description
+        return tools
 
 
 def _client_name(ctx: Context | None) -> str:
@@ -1213,7 +1215,7 @@ def _derive_owner(agent_id: str, ctx: Context | None) -> str:
     return agent_owner(_slug(_anon_owner_id(ctx)))
 
 
-@_tool_if(memory_enabled())
+@_tool_if(memory_enabled)
 def memory_remember(
     text: str,
     kind: MemoryKind = MemoryKind.FACT,
@@ -1230,7 +1232,7 @@ def memory_remember(
     return {"ok": True, "id": memory_id, "owner": owner}
 
 
-@_tool_if(memory_enabled())
+@_tool_if(memory_enabled)
 def memory_recall(
     query: str, limit: int = 0, agent_id: str = "", ctx: Context | None = None
 ) -> dict[str, Any]:
@@ -1246,7 +1248,7 @@ def memory_recall(
     }
 
 
-@_tool_if(memory_enabled())
+@_tool_if(memory_enabled)
 def memory_list(agent_id: str = "", ctx: Context | None = None) -> dict[str, Any]:
     """List every memory in this agent's namespace (any kind, newest first)."""
     if not memory_enabled():
@@ -1260,7 +1262,7 @@ def memory_list(agent_id: str = "", ctx: Context | None = None) -> dict[str, Any
     }
 
 
-@_tool_if(memory_enabled())
+@_tool_if(memory_enabled)
 def memory_forget(memory_id: str, agent_id: str = "", ctx: Context | None = None) -> dict[str, Any]:
     """Delete one of this agent's own memories by id (agent_id scopes the namespace)."""
     if not memory_enabled():
@@ -1344,27 +1346,23 @@ def clear_placement_tool() -> dict[str, Any]:
     return _placement_result(lambda: set_placement(None))
 
 
-def build_mcp_server() -> FastMCP:
-    """Build a FastMCP server carrying every tool registered in this module.
+def build_mcp_server() -> LilbeeMCP:
+    """Build an MCP server carrying every tool registered in this module.
 
-    Each transport gets its own instance: FastMCP caches one
+    Each transport builds its own instance: FastMCP caches one
     ``StreamableHTTPSessionManager`` per server and its ``run()`` is single-use,
-    so a shared server cannot back two apps in one process.
+    so a shared server cannot back two apps in one process. Gates registered
+    via ``_tool_if`` are evaluated here, against current config.
     """
-    server = FastMCP("lilbee", instructions=_INSTRUCTIONS)
-    for fn, name in _REGISTRATIONS:
-        server.add_tool(fn, name=name)
-    _strip_schema_noise(server)
-    _tune_search_scope_for_corpus(server)
+    server = LilbeeMCP("lilbee", instructions=_INSTRUCTIONS)
+    for fn, name, gate in _REGISTRATIONS:
+        if gate is None or gate():
+            server.add_tool(fn, name=name)
     return server
 
 
-# The stdio server. The HTTP daemon builds its own; see build_mcp_mount.
-mcp = build_mcp_server()
-
-
 def main() -> None:
-    """Entry point for the MCP server."""
+    """Entry point for the stdio MCP server."""
     # Preload so the first tool call doesn't pay the cold-start cost
     # of provider/embedder/store init. Failures (missing model, bad
     # config) still surface on the first tool call rather than crashing
@@ -1380,4 +1378,4 @@ def main() -> None:
     if parent_pid is not None:
         watch_parent_thread(parent_pid, lambda: os._exit(0))
 
-    mcp.run()
+    build_mcp_server().run()

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -190,14 +190,19 @@ class ModelManager:
                 f"Add the model in {where}, then pick it here."
             )
         if not allow_unsupported:
-            self._enforce_arch_compat(model)
+            self.enforce_arch_compat(model)
         try:
             return self._pull_native(model, on_bytes=on_bytes)
         finally:
             self._invalidate_installed_cache()
 
-    def _enforce_arch_compat(self, ref: str) -> None:
-        """Raise UnsupportedArchError if *ref*'s architecture isn't in the supported set."""
+    def enforce_arch_compat(self, ref: str) -> None:
+        """Raise UnsupportedArchError if *ref*'s architecture isn't in the supported set.
+
+        Public because the pull preflight on the HTTP surface runs the same
+        check before starting a download, so a caller learns the model is
+        unsupported before any bytes move.
+        """
         from lilbee.app.services import get_services
         from lilbee.catalog.compat import (
             ModelCompat,

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -229,7 +229,16 @@ def gather_known_model_refs() -> set[str]:
 
 
 class KnownModelCache:
-    """TTL-cached union of native + remote + frontier model refs."""
+    """TTL-cached union of native + remote + frontier model refs.
+
+    Not a ``cachetools.TTLCache``: the generation counter is the point. A pull
+    or a remove calls :meth:`invalidate` and must be visible to the very next
+    ``refs()``, but a fan-out already in flight when that happens would
+    otherwise finish and install its pre-pull answer with a full TTL, hiding
+    the new model for the next 30 seconds. Bumping the generation makes that
+    late writer publish its refs without renewing the expiry. The fan-out
+    itself runs off the lock because it makes network calls.
+    """
 
     DEFAULT_TTL_S = 30.0
 

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -231,13 +231,11 @@ def gather_known_model_refs() -> set[str]:
 class KnownModelCache:
     """TTL-cached union of native + remote + frontier model refs.
 
-    Not a ``cachetools.TTLCache``: the generation counter is the point. A pull
-    or a remove calls :meth:`invalidate` and must be visible to the very next
-    ``refs()``, but a fan-out already in flight when that happens would
-    otherwise finish and install its pre-pull answer with a full TTL, hiding
-    the new model for the next 30 seconds. Bumping the generation makes that
-    late writer publish its refs without renewing the expiry. The fan-out
-    itself runs off the lock because it makes network calls.
+    Not a ``cachetools.TTLCache``: the generation counter is the point. A
+    fan-out already in flight when :meth:`invalidate` runs would otherwise
+    install its pre-pull answer with a full TTL, hiding a freshly pulled model
+    for 30s; bumping the generation makes that late writer publish without
+    renewing the expiry. The fan-out runs off the lock because it hits network.
     """
 
     DEFAULT_TTL_S = 30.0

--- a/src/lilbee/modelhub/role_validator.py
+++ b/src/lilbee/modelhub/role_validator.py
@@ -15,7 +15,7 @@ from lilbee.providers.model_ref import PROVIDER_PREFIXES, is_native_gguf_ref
 # leaked env var cannot disable validation in production.
 _SKIP_MODEL_TASK_VALIDATION_ENV = "LILBEE_SKIP_MODEL_TASK_VALIDATION"
 
-_MODEL_FIELD_TO_TASK: dict[str, str] = {
+MODEL_FIELD_TO_TASK: dict[str, str] = {
     "chat_model": "chat",
     "embedding_model": "embedding",
     "vision_model": "vision",
@@ -103,7 +103,7 @@ def validate_model_task_assignment(field_name: str, ref: str, *, allow_bypass: b
     """
     if _skips_catalog_check(ref, allow_bypass=allow_bypass):
         return ref
-    want = ModelTask(_MODEL_FIELD_TO_TASK[field_name])
+    want = ModelTask(MODEL_FIELD_TO_TASK[field_name])
     entry = find_catalog_entry(ref)
     if entry is not None:
         return _canonical_featured_ref(ref, entry, want)

--- a/src/lilbee/providers/fleet/gpu_backends/nvidia.py
+++ b/src/lilbee/providers/fleet/gpu_backends/nvidia.py
@@ -17,7 +17,15 @@ _CACHE_TTL_S = 0.9
 
 
 class SmiCache:
-    """Shares one nvidia-smi probe across concurrent callers within the TTL."""
+    """Shares one nvidia-smi probe across concurrent callers within the TTL.
+
+    Not a ``cachetools.TTLCache``: this holds the lock *across* the probe, so
+    concurrent callers block and share the one result. ``@cached(cache,
+    lock=...)`` releases the lock around the call by design, so three streams
+    ticking at once would spawn three nvidia-smi subprocesses. Measured, not
+    assumed: three concurrent misses call the producer three times.
+    ``test_concurrent_threads_probe_once`` pins the behaviour that matters.
+    """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()

--- a/src/lilbee/providers/fleet/gpu_backends/nvidia.py
+++ b/src/lilbee/providers/fleet/gpu_backends/nvidia.py
@@ -19,12 +19,10 @@ _CACHE_TTL_S = 0.9
 class SmiCache:
     """Shares one nvidia-smi probe across concurrent callers within the TTL.
 
-    Not a ``cachetools.TTLCache``: this holds the lock *across* the probe, so
-    concurrent callers block and share the one result. ``@cached(cache,
-    lock=...)`` releases the lock around the call by design, so three streams
-    ticking at once would spawn three nvidia-smi subprocesses. Measured, not
-    assumed: three concurrent misses call the producer three times.
-    ``test_concurrent_threads_probe_once`` pins the behaviour that matters.
+    Not a ``cachetools.TTLCache``: this holds the lock *across* the probe so
+    concurrent callers share one result. ``@cached(cache, lock=...)`` releases
+    the lock around the call, so three concurrent misses spawn three
+    subprocesses (measured). ``test_concurrent_threads_probe_once`` pins it.
     """
 
     def __init__(self) -> None:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -984,6 +984,11 @@ _DEVICE_PROBE_FAILURE_TTL_S = 60.0
 class _ReadDeviceCache:
     """Short-TTL device-probe cache for the read/view path.
 
+    Not a ``cachetools.TTLCache``: it caches the *failure* as well as the
+    result, under its own longer TTL, and re-raises it to every read in the
+    window. A memoizing cache stores return values only, so a probe that keeps
+    failing would re-spawn the subprocess on every placement read.
+
     Inspecting placement (GET placement/gpus, preview, ``placement show``)
     resolves devices on every call, which spawns a ``llama-server --list-devices``
     subprocess; a brief TTL collapses a burst of reads onto one probe. A probe

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -984,10 +984,9 @@ _DEVICE_PROBE_FAILURE_TTL_S = 60.0
 class _ReadDeviceCache:
     """Short-TTL device-probe cache for the read/view path.
 
-    Not a ``cachetools.TTLCache``: it caches the *failure* as well as the
-    result, under its own longer TTL, and re-raises it to every read in the
-    window. A memoizing cache stores return values only, so a probe that keeps
-    failing would re-spawn the subprocess on every placement read.
+    Not a ``cachetools.TTLCache``: it caches the *failure* too, under its own
+    longer TTL, and re-raises it. A memoizing cache stores return values only,
+    so a failing probe would re-spawn the subprocess on every placement read.
 
     Inspecting placement (GET placement/gpus, preview, ``placement show``)
     resolves devices on every call, which spawns a ``llama-server --list-devices``

--- a/src/lilbee/runtime/ingest_lock.py
+++ b/src/lilbee/runtime/ingest_lock.py
@@ -49,16 +49,25 @@ class IngestLockRegistry:
 
     @staticmethod
     def canonical_source_name(p_str: str) -> str:
-        """Match the basename ``copy_files`` writes under ``cfg.documents_dir``."""
+        """Basename of *p_str*, for callers that flatten into ``documents_dir``.
+
+        ``copy_files`` writes server-side paths by basename, so /api/add locks
+        on that. Uploads keep their relative layout and pass the relative path
+        instead, which is why the caller picks the key rather than this class.
+        """
         return Path(p_str).name
 
-    async def acquire(self, paths: list[str]) -> tuple[list[tuple[str, asyncio.Lock]], list[str]]:
-        """Return ``(acquired, busy)`` partitioning of ``paths`` by lock state."""
+    async def acquire(self, names: list[str]) -> tuple[list[tuple[str, asyncio.Lock]], list[str]]:
+        """Return ``(acquired, busy)`` partitioning of ``names`` by lock state.
+
+        Each name is the source identity as it will exist on disk; the caller
+        derives it, because how a path maps to a stored source differs per
+        ingest surface.
+        """
         acquired: list[tuple[str, asyncio.Lock]] = []
         busy: list[str] = []
         seen: set[str] = set()
-        for p_str in paths:
-            name = self.canonical_source_name(p_str)
+        for name in names:
             if name in seen:
                 continue
             seen.add(name)

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -14,11 +14,13 @@ from litestar.exceptions import NotAuthorizedException
 from litestar.types import ASGIApp, Receive, Scope, Send
 
 from lilbee.core.config import cfg
-from lilbee.core.security import harden_private_file, write_private_text
+from lilbee.core.security import file_lock_or_warn, harden_private_file, write_private_text
 
 log = logging.getLogger(__name__)
 
 _TOKEN_BYTES = 32
+
+_BOOT_LOCK_TIMEOUT_S = 30
 
 # Character floor for a persisted token. secrets.token_urlsafe(n) base64url-encodes
 # n bytes, so the entropy count is not a length: reusing _TOKEN_BYTES here accepted
@@ -79,20 +81,26 @@ class SessionManager:
         self._initialized: bool = False
 
     def load_or_generate(self) -> str:
-        """Return the persisted token if shape-valid; generate a new one otherwise."""
+        """Return the persisted token if shape-valid; generate a new one otherwise.
+
+        Read and write happen under a file lock so concurrent boots converge on
+        one token: without it both see no file, both mint, and the last write
+        rejects every client that read the other's file.
+        """
         path = server_json_path()
-        existing = self._read_persisted_token(path)
-        if existing is not None:
-            # The token is reused indefinitely and the file can arrive
-            # world-readable (backup, older release), so narrow on every load.
-            harden_private_file(path)
-            self.token = existing
+        with file_lock_or_warn(path, _BOOT_LOCK_TIMEOUT_S):
+            existing = self._read_persisted_token(path)
+            if existing is not None:
+                # The token is reused indefinitely and the file can arrive
+                # world-readable (backup, older release), so narrow on every load.
+                harden_private_file(path)
+                self.token = existing
+                self._initialized = True
+                return existing
+            self.token = secrets.token_urlsafe(_TOKEN_BYTES)
+            write_private_text(path, json.dumps({"token": self.token}))
             self._initialized = True
-            return existing
-        self.token = secrets.token_urlsafe(_TOKEN_BYTES)
-        write_private_text(path, json.dumps({"token": self.token}))
-        self._initialized = True
-        return self.token
+            return self.token
 
     def disable(self) -> None:
         """Explicitly turn auth off (test harness / embedded read-only use).

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -39,7 +39,20 @@ _READ_ONLY_HANDLERS: set[Callable[..., Any]] = set()
 
 
 def read_only(fn: F) -> F:
-    """Mark a route handler as read-only (no auth required)."""
+    """Mark a route handler as requiring no auth.
+
+    Must sit *below* the Litestar route decorator so it receives the raw
+    function, which is what ``AuthMiddleware`` looks up via ``handler.fn``.
+    Stacked the other way it registers the handler object instead, the lookup
+    misses, and the route quietly starts requiring a token. Since the same
+    mistake in reverse would quietly open a route, the ordering is enforced
+    rather than left to reviewers.
+    """
+    if hasattr(fn, "fn"):
+        raise TypeError(
+            "@read_only must be applied below the route decorator, so it sees "
+            "the function rather than the route handler."
+        )
     _READ_ONLY_HANDLERS.add(fn)
     return fn
 

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -6,7 +6,6 @@ import hmac
 import json
 import logging
 import secrets
-import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar
@@ -15,7 +14,7 @@ from litestar.exceptions import NotAuthorizedException
 from litestar.types import ASGIApp, Receive, Scope, Send
 
 from lilbee.core.config import cfg
-from lilbee.core.security import write_private_text
+from lilbee.core.security import harden_private_file, write_private_text
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +88,7 @@ class SessionManager:
             # predating this hardening, restored from a backup, copied between
             # machines), and the token inside is reused indefinitely, so narrow
             # the mode on every load rather than only at first creation.
-            self._harden(path)
+            harden_private_file(path)
             self.token = existing
             self._initialized = True
             return existing
@@ -97,17 +96,6 @@ class SessionManager:
         write_private_text(path, json.dumps({"token": self.token}))
         self._initialized = True
         return self.token
-
-    @staticmethod
-    def _harden(path: Path) -> None:
-        """Narrow *path* to owner-only, tolerating a file we do not own."""
-        if sys.platform == "win32":  # pragma: no cover - Windows uses the DACL
-            # Windows relies on the inherited %LOCALAPPDATA% DACL instead.
-            return
-        try:
-            path.chmod(0o600)
-        except OSError:
-            log.warning("Could not restrict permissions on %s.", path, exc_info=True)
 
     def disable(self) -> None:
         """Explicitly turn auth off (test harness / embedded read-only use).

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -15,6 +15,7 @@ from litestar.exceptions import NotAuthorizedException
 from litestar.types import ASGIApp, Receive, Scope, Send
 
 from lilbee.core.config import cfg
+from lilbee.core.security import write_private_text
 
 log = logging.getLogger(__name__)
 
@@ -66,18 +67,29 @@ class SessionManager:
         path = server_json_path()
         existing = self._read_persisted_token(path)
         if existing is not None:
+            # A server.json can arrive with permissive bits (written by a release
+            # predating this hardening, restored from a backup, copied between
+            # machines), and the token inside is reused indefinitely, so narrow
+            # the mode on every load rather than only at first creation.
+            self._harden(path)
             self.token = existing
             self._initialized = True
             return existing
         self.token = secrets.token_urlsafe(_TOKEN_BYTES)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"token": self.token}), encoding="utf-8")
-        if sys.platform != "win32":  # pragma: no cover - Windows uses the DACL
-            # POSIX-only; Windows relies on the inherited %LOCALAPPDATA% DACL
-            # for owner-only access control.
-            path.chmod(0o600)
+        write_private_text(path, json.dumps({"token": self.token}))
         self._initialized = True
         return self.token
+
+    @staticmethod
+    def _harden(path: Path) -> None:
+        """Narrow *path* to owner-only, tolerating a file we do not own."""
+        if sys.platform == "win32":  # pragma: no cover - Windows uses the DACL
+            # Windows relies on the inherited %LOCALAPPDATA% DACL instead.
+            return
+        try:
+            path.chmod(0o600)
+        except OSError:
+            log.warning("Could not restrict permissions on %s.", path, exc_info=True)
 
     def disable(self) -> None:
         """Explicitly turn auth off (test harness / embedded read-only use).

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -28,37 +28,48 @@ _MIN_TOKEN_CHARS = len(secrets.token_urlsafe(_TOKEN_BYTES))
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-# Set of route-handler functions that bypass auth. Populated at import time by
-# the @read_only decorator; checked by AuthMiddleware via membership lookup.
+# Route handlers AuthMiddleware skips. Populated at import time by the
+# @auth_checked_in_handler decorator; checked via membership lookup.
 # Module-level set is intentional: route handlers are defined once at import,
 # the registry has no other lifecycle, and the alternative (mutating an
 # attribute on the function object) lands every check on a # type: ignore
 # because mypy cannot see the dynamic attribute on Callable.
-_READ_ONLY_HANDLERS: set[Callable[..., Any]] = set()
+_SELF_AUTHENTICATING_HANDLERS: set[Callable[..., Any]] = set()
 
 
-def read_only(fn: F) -> F:
-    """Mark a route handler as requiring no auth.
+def auth_checked_in_handler(fn: F) -> F:
+    """Mark a route whose token check runs inside the handler, not in middleware.
+
+    This is not an exemption from auth. It exists for the ``/v1/*`` surface,
+    which has to answer a bad token with the OpenAI error envelope rather than
+    Litestar's 401 shape, so the check has to happen somewhere it can build
+    that body. Every route that carries this must still reject an
+    unauthenticated caller itself; ``test_every_route_is_authenticated`` holds
+    the line.
+
+    It was called ``read_only``, which described a token that has never
+    existed: there is one token, and skipping the middleware meant answering
+    callers who sent none. That name is why a reviewer could approve the
+    decorator on a route serving chat transcripts without noticing what it
+    opened.
 
     Must sit *below* the Litestar route decorator so it receives the raw
     function, which is what ``AuthMiddleware`` looks up via ``handler.fn``.
-    Stacked the other way it registers the handler object instead, the lookup
-    misses, and the route quietly starts requiring a token. Since the same
-    mistake in reverse would quietly open a route, the ordering is enforced
-    rather than left to reviewers.
+    Stacked the other way it registers the handler object instead and the
+    lookup misses, so the ordering is enforced rather than left to reviewers.
     """
     if hasattr(fn, "fn"):
         raise TypeError(
-            "@read_only must be applied below the route decorator, so it sees "
-            "the function rather than the route handler."
+            "@auth_checked_in_handler must be applied below the route decorator, "
+            "so it sees the function rather than the route handler."
         )
-    _READ_ONLY_HANDLERS.add(fn)
+    _SELF_AUTHENTICATING_HANDLERS.add(fn)
     return fn
 
 
-def is_read_only(fn: Callable[..., Any]) -> bool:
-    """True iff *fn* was decorated with :func:`read_only`."""
-    return fn in _READ_ONLY_HANDLERS
+def authenticates_itself(fn: Callable[..., Any]) -> bool:
+    """True iff *fn* was decorated with :func:`auth_checked_in_handler`."""
+    return fn in _SELF_AUTHENTICATING_HANDLERS
 
 
 def server_json_path() -> Path:
@@ -180,7 +191,7 @@ class AuthMiddleware:
             return
 
         handler = scope.get("route_handler")
-        if handler and is_read_only(handler.fn):
+        if handler and authenticates_itself(handler.fn):
             await self.app(scope, receive, send)
             return
 

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -28,35 +28,23 @@ _MIN_TOKEN_CHARS = len(secrets.token_urlsafe(_TOKEN_BYTES))
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-# Route handlers AuthMiddleware skips. Populated at import time by the
-# @auth_checked_in_handler decorator; checked via membership lookup.
-# Module-level set is intentional: route handlers are defined once at import,
-# the registry has no other lifecycle, and the alternative (mutating an
-# attribute on the function object) lands every check on a # type: ignore
-# because mypy cannot see the dynamic attribute on Callable.
+# Route handlers AuthMiddleware skips, registered at import by the decorator
+# below. A module-level set rather than an attribute on the function object,
+# which mypy cannot see and would put a # type: ignore on every check.
 _SELF_AUTHENTICATING_HANDLERS: set[Callable[..., Any]] = set()
 
 
 def auth_checked_in_handler(fn: F) -> F:
     """Mark a route whose token check runs inside the handler, not in middleware.
 
-    This is not an exemption from auth. It exists for the ``/v1/*`` surface,
-    which has to answer a bad token with the OpenAI error envelope rather than
-    Litestar's 401 shape, so the check has to happen somewhere it can build
-    that body. Every route that carries this must still reject an
-    unauthenticated caller itself; ``test_every_route_is_authenticated`` holds
-    the line.
+    Not an exemption: the route must still reject an unauthenticated caller
+    itself. Only ``/v1/*`` uses this, to answer a bad token with the OpenAI
+    error envelope instead of Litestar's 401 shape.
+    ``test_every_route_is_authenticated`` holds the line.
 
-    It was called ``read_only``, which described a token that has never
-    existed: there is one token, and skipping the middleware meant answering
-    callers who sent none. That name is why a reviewer could approve the
-    decorator on a route serving chat transcripts without noticing what it
-    opened.
-
-    Must sit *below* the Litestar route decorator so it receives the raw
-    function, which is what ``AuthMiddleware`` looks up via ``handler.fn``.
-    Stacked the other way it registers the handler object instead and the
-    lookup misses, so the ordering is enforced rather than left to reviewers.
+    Must sit *below* the route decorator so it receives the raw function, which
+    is what ``AuthMiddleware`` looks up via ``handler.fn``; stacked the other
+    way the lookup misses. Enforced below.
     """
     if hasattr(fn, "fn"):
         raise TypeError(
@@ -95,10 +83,8 @@ class SessionManager:
         path = server_json_path()
         existing = self._read_persisted_token(path)
         if existing is not None:
-            # A server.json can arrive with permissive bits (written by a release
-            # predating this hardening, restored from a backup, copied between
-            # machines), and the token inside is reused indefinitely, so narrow
-            # the mode on every load rather than only at first creation.
+            # The token is reused indefinitely and the file can arrive
+            # world-readable (backup, older release), so narrow on every load.
             harden_private_file(path)
             self.token = existing
             self._initialized = True

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -21,6 +21,11 @@ log = logging.getLogger(__name__)
 
 _TOKEN_BYTES = 32
 
+# Character floor for a persisted token. secrets.token_urlsafe(n) base64url-encodes
+# n bytes, so the entropy count is not a length: reusing _TOKEN_BYTES here accepted
+# tokens roughly a quarter weaker than the ones this module mints.
+_MIN_TOKEN_CHARS = len(secrets.token_urlsafe(_TOKEN_BYTES))
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 
@@ -102,10 +107,20 @@ class SessionManager:
 
     @staticmethod
     def _read_persisted_token(path: Path) -> str | None:
-        """Return a previously-persisted token if shape-valid, else None."""
+        """Return a previously-persisted token if shape-valid, else None.
+
+        Total by design: every way the file can be unusable returns None so the
+        caller mints a fresh token. A corrupt server.json must never be the
+        reason the server refuses to boot, since nothing would point the user at
+        the file to delete.
+        """
         try:
             raw = path.read_text(encoding="utf-8")
-        except (FileNotFoundError, OSError):
+        except OSError:
+            return None
+        except UnicodeDecodeError:
+            # Not an OSError: a truncated write or a file clobbered by another
+            # tool leaves bytes that are not valid UTF-8.
             return None
         try:
             data = json.loads(raw)
@@ -114,7 +129,7 @@ class SessionManager:
         if not isinstance(data, dict):
             return None
         token = data.get("token")
-        if not isinstance(token, str) or len(token) < _TOKEN_BYTES:
+        if not isinstance(token, str) or len(token) < _MIN_TOKEN_CHARS:
             return None
         return token
 

--- a/src/lilbee/server/chat_completions_api/errors.py
+++ b/src/lilbee/server/chat_completions_api/errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -11,6 +12,8 @@ from lilbee.server.chat_dispatch.dispatch import (
     ModelDoesNotSupportToolsError,
     ModelNotFoundError,
 )
+
+log = logging.getLogger(__name__)
 
 
 class CompletionsErrorCode(StrEnum):
@@ -24,6 +27,8 @@ class CompletionsErrorCode(StrEnum):
     RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
     INTERNAL_ERROR = "internal_error"
 
+
+_FALLBACK_ERROR_TYPE = "invalid_request_error"
 
 COMPLETIONS_ERROR_TYPES: dict[CompletionsErrorCode, str] = {
     CompletionsErrorCode.INVALID_REQUEST: "invalid_request_error",
@@ -41,7 +46,10 @@ def completions_error_body(code: CompletionsErrorCode, message: str) -> dict[str
     return {
         "error": {
             "message": message,
-            "type": COMPLETIONS_ERROR_TYPES[code],
+            # .get, not a bare subscript: this map is hand-maintained alongside
+            # the enum, so a new variant without an entry would raise while
+            # building the error response, turning a handled 4xx into a 500.
+            "type": COMPLETIONS_ERROR_TYPES.get(code, _FALLBACK_ERROR_TYPE),
             "code": str(code),
         }
     }
@@ -69,6 +77,17 @@ _PROVIDER_KIND_CLASSIFICATIONS: dict[ProviderErrorKind, tuple[int, CompletionsEr
 }
 
 
+# Kinds that describe the backend rather than the caller's request. Their text
+# comes from the fleet boundary and carries internal detail (up to 600 bytes of
+# the upstream body, plus the dead server's captured stderr: loopback ports,
+# engine binary paths, CUDA load failures), so it is logged rather than
+# returned. The client-input kinds above stay pass-through: that text tells the
+# caller what to change about their own request.
+_INFRASTRUCTURE_KINDS = frozenset({ProviderErrorKind.CONNECTION, ProviderErrorKind.SERVER})
+
+_BACKEND_FAILURE_MESSAGE = "The model backend is unavailable. Check the server logs for details."
+
+
 def classify_provider_error(exc: BaseException) -> ClassifiedError | None:
     """Map a typed dispatch/provider failure to ``(status, code, message)``, or None.
 
@@ -84,5 +103,8 @@ def classify_provider_error(exc: BaseException) -> ClassifiedError | None:
         mapped = _PROVIDER_KIND_CLASSIFICATIONS.get(exc.kind)
         if mapped is not None:
             status, code = mapped
+            if exc.kind in _INFRASTRUCTURE_KINDS:
+                log.warning("Chat backend failure (%s)", exc.kind, exc_info=exc)
+                return ClassifiedError(status, code, _BACKEND_FAILURE_MESSAGE)
             return ClassifiedError(status, code, str(exc))
     return None

--- a/src/lilbee/server/chat_completions_api/errors.py
+++ b/src/lilbee/server/chat_completions_api/errors.py
@@ -46,9 +46,8 @@ def completions_error_body(code: CompletionsErrorCode, message: str) -> dict[str
     return {
         "error": {
             "message": message,
-            # .get, not a bare subscript: this map is hand-maintained alongside
-            # the enum, so a new variant without an entry would raise while
-            # building the error response, turning a handled 4xx into a 500.
+            # .get, not a subscript: this map is hand-maintained alongside the
+            # enum, and a missing entry would turn a handled 4xx into a 500.
             "type": COMPLETIONS_ERROR_TYPES.get(code, _FALLBACK_ERROR_TYPE),
             "code": str(code),
         }
@@ -77,12 +76,10 @@ _PROVIDER_KIND_CLASSIFICATIONS: dict[ProviderErrorKind, tuple[int, CompletionsEr
 }
 
 
-# Kinds that describe the backend rather than the caller's request. Their text
-# comes from the fleet boundary and carries internal detail (up to 600 bytes of
-# the upstream body, plus the dead server's captured stderr: loopback ports,
-# engine binary paths, CUDA load failures), so it is logged rather than
-# returned. The client-input kinds above stay pass-through: that text tells the
-# caller what to change about their own request.
+# Kinds describing the backend, not the caller's request. Their text is built
+# at the fleet boundary and carries up to 600 bytes of upstream body plus the
+# dead server's stderr (loopback ports, engine paths), so it is logged rather
+# than returned. The client-input kinds stay pass-through.
 _INFRASTRUCTURE_KINDS = frozenset({ProviderErrorKind.CONNECTION, ProviderErrorKind.SERVER})
 
 _BACKEND_FAILURE_MESSAGE = "The model backend is unavailable. Check the server logs for details."

--- a/src/lilbee/server/chat_completions_api/routes.py
+++ b/src/lilbee/server/chat_completions_api/routes.py
@@ -99,7 +99,22 @@ def _build_models_list_payload() -> ModelsListResponse:
     )
 
 
-@post("/v1/chat/completions", status_code=200)
+async def _auth_before_request(request: Request) -> Response | None:
+    """Reject an unauthenticated caller before Litestar parses the body.
+
+    The endpoint is marked @read_only so AuthMiddleware waves it through and
+    the bearer check lives in the handler. But binding the body as a handler
+    parameter made Litestar parse and pydantic-validate the whole payload
+    first, so an unauthenticated caller got request_max_body_size worth of
+    JSON processed on every request, and a malformed body was answered with a
+    400 naming the failing fields instead of ever reaching the 401. Litestar
+    runs before_request ahead of kwargs resolution and short-circuits on a
+    returned value, so this is the one place the check can sit.
+    """
+    return _auth_failure(request)
+
+
+@post("/v1/chat/completions", status_code=200, before_request=_auth_before_request)
 @read_only
 async def chat_completions_endpoint(
     request: Request, data: CompletionsRequest
@@ -147,15 +162,13 @@ async def chat_completions_endpoint(
 
 
 def _reject_before_dispatch(request: Request, data: CompletionsRequest) -> Response | None:
-    """Auth, multi-choice, and unsupported-param checks before any dispatch work.
+    """Multi-choice and unsupported-param checks before any dispatch work.
 
     Returns a 4xx Response to short-circuit, or None to proceed. Unmapped OpenAI
     params (``response_format``, ``logprobs``, and any other unknown field) are
-    accepted but logged at debug so a client learns they had no effect.
+    accepted but logged at debug so a client learns they had no effect. Auth is
+    not checked here: it runs in the before_request hook, ahead of body parsing.
     """
-    auth_error = _auth_failure(request)
-    if auth_error is not None:
-        return auth_error
     if data.n is not None and data.n > 1:
         return _error_response(400, CompletionsErrorCode.INVALID_REQUEST, _MULTI_CHOICE_MESSAGE)
     if data.model_extra:

--- a/src/lilbee/server/chat_completions_api/routes.py
+++ b/src/lilbee/server/chat_completions_api/routes.py
@@ -19,7 +19,7 @@ from lilbee.app.services import get_services
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config import cfg
 from lilbee.providers.model_ref import default_first, with_configured_remote_chat
-from lilbee.server.auth import read_only, session_manager
+from lilbee.server.auth import auth_checked_in_handler, session_manager
 from lilbee.server.chat_completions_api.errors import (
     CompletionsErrorCode,
     classify_provider_error,
@@ -55,7 +55,7 @@ _MULTI_CHOICE_MESSAGE = "lilbee serves one choice per request; set n to 1 or omi
 
 
 @get("/v1/models")
-@read_only
+@auth_checked_in_handler
 async def list_models_endpoint(request: Request) -> Response:
     """Return installed chat models in the ``/v1/models`` shape, the configured one leading."""
     auth_error = _auth_failure(request)
@@ -102,8 +102,9 @@ def _build_models_list_payload() -> ModelsListResponse:
 async def _auth_before_request(request: Request) -> Response | None:
     """Reject an unauthenticated caller before Litestar parses the body.
 
-    The endpoint is marked @read_only so AuthMiddleware waves it through and
-    the bearer check lives in the handler. But binding the body as a handler
+    The endpoint is marked @auth_checked_in_handler so AuthMiddleware defers to
+    the handler, which answers a bad token with the OpenAI error envelope
+    rather than Litestar's 401 shape. But binding the body as a handler
     parameter made Litestar parse and pydantic-validate the whole payload
     first, so an unauthenticated caller got request_max_body_size worth of
     JSON processed on every request, and a malformed body was answered with a
@@ -115,7 +116,7 @@ async def _auth_before_request(request: Request) -> Response | None:
 
 
 @post("/v1/chat/completions", status_code=200, before_request=_auth_before_request)
-@read_only
+@auth_checked_in_handler
 async def chat_completions_endpoint(
     request: Request, data: CompletionsRequest
 ) -> Response | Stream:

--- a/src/lilbee/server/chat_completions_api/routes.py
+++ b/src/lilbee/server/chat_completions_api/routes.py
@@ -65,7 +65,10 @@ async def list_models_endpoint(request: Request) -> Response:
     # list_installed walks the model filesystem and served_chat_ctx may probe the
     # engine; run both off the event loop like the sibling chat-completions route.
     payload = await asyncio.to_thread(_build_models_list_payload)
-    return Response(payload.model_dump(), media_type="application/json")
+    # exclude_none like the sibling completions responses: context_window is
+    # deliberately None for every model but the active one, and emitting it as
+    # null adds a field OpenAI clients do not expect on a model entry.
+    return Response(payload.model_dump(exclude_none=True), media_type="application/json")
 
 
 def _build_models_list_payload() -> ModelsListResponse:

--- a/src/lilbee/server/chat_completions_api/routes.py
+++ b/src/lilbee/server/chat_completions_api/routes.py
@@ -227,11 +227,15 @@ async def _gated_completions_stream(
     all unwind cleanly; a disconnect before the first iteration is covered
     by the route's after-send release of the same guard.
     """
+    # One id for the whole stream, error frame included: the frame is shaped as a
+    # real chunk so SDK clients parse it, and those accumulate by chunk id, so a
+    # fresh id made the error look like part of a different completion.
+    response_id = _response_id()
     try:
         try:
             events = dispatch_chat_stream(req, canonical_model=model)
             chunks = canonical_stream_to_completions_chunks(
-                events, model=model, response_id=_response_id(), include_usage=include_usage
+                events, model=model, response_id=response_id, include_usage=include_usage
             )
             async for frame in encode_completions_sse(chunks):
                 yield frame
@@ -240,15 +244,26 @@ async def _gated_completions_stream(
             if classified is None:
                 log.exception("chat_completions stream failed")
                 yield _sse_error_frame(
-                    CompletionsErrorCode.INTERNAL_ERROR, _INTERNAL_ERROR_MESSAGE, model=model
+                    CompletionsErrorCode.INTERNAL_ERROR,
+                    _INTERNAL_ERROR_MESSAGE,
+                    model=model,
+                    response_id=response_id,
                 )
             else:
-                yield _sse_error_frame(classified.code, classified.message, model=model)
+                yield _sse_error_frame(
+                    classified.code, classified.message, model=model, response_id=response_id
+                )
     finally:
         await guard.release()
 
 
-def _sse_error_frame(code: CompletionsErrorCode, message: str, *, model: str = "") -> bytes:
+def _sse_error_frame(
+    code: CompletionsErrorCode,
+    message: str,
+    *,
+    model: str = "",
+    response_id: str | None = None,
+) -> bytes:
     """SSE frame carrying a mid-stream error in OpenAI's chunk-shaped wire format.
 
     OpenAI-SDK clients only parse ``chat.completion.chunk``-shaped frames, so the
@@ -259,7 +274,7 @@ def _sse_error_frame(code: CompletionsErrorCode, message: str, *, model: str = "
     """
     body = completions_error_body(code, message)
     chunk: dict[str, object] = {
-        "id": _response_id(),
+        "id": response_id or _response_id(),
         "object": "chat.completion.chunk",
         "created": int(time.time()),
         "model": model,

--- a/src/lilbee/server/chat_completions_api/streaming.py
+++ b/src/lilbee/server/chat_completions_api/streaming.py
@@ -47,17 +47,15 @@ async def encode_completions_sse(
     finally:
         if not pending.done():
             pending.cancel()
-            current = asyncio.current_task()
             try:
                 await pending
             except asyncio.CancelledError:
-                # Awaiting the future we just cancelled raises here, which is
-                # expected. A cancellation aimed at this task is not: this
-                # cleanup runs during aclose(), which the server calls while
-                # unwinding a request that is often itself being cancelled, and
-                # swallowing that let the task resume as if it never was.
-                if current is not None and current.cancelling() > 0:
-                    raise
+                # Expected: this is the future we just cancelled. Caught by
+                # name rather than as BaseException, which also covered
+                # KeyboardInterrupt and SystemExit, so a Ctrl-C landing on this
+                # await was discarded. A cancellation aimed at this task is
+                # already unwinding through the finally and keeps propagating.
+                pass
             except Exception:
                 # The upstream failed as it was torn down. The request is
                 # already unwinding, so record it rather than mask the unwind.

--- a/src/lilbee/server/chat_completions_api/streaming.py
+++ b/src/lilbee/server/chat_completions_api/streaming.py
@@ -50,11 +50,8 @@ async def encode_completions_sse(
             try:
                 await pending
             except asyncio.CancelledError:
-                # Expected: this is the future we just cancelled. Caught by
-                # name rather than as BaseException, which also covered
-                # KeyboardInterrupt and SystemExit, so a Ctrl-C landing on this
-                # await was discarded. A cancellation aimed at this task is
-                # already unwinding through the finally and keeps propagating.
+                # Expected: the future we just cancelled. By name, not
+                # BaseException, which also swallowed a Ctrl-C landing here.
                 pass
             except Exception:
                 # The upstream failed as it was torn down. The request is

--- a/src/lilbee/server/chat_completions_api/streaming.py
+++ b/src/lilbee/server/chat_completions_api/streaming.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
+import logging
 from collections.abc import AsyncIterator
 
 from lilbee.server.chat_completions_api.models import CompletionsStreamChunk
+
+log = logging.getLogger(__name__)
 
 # Cadence for SSE comment frames emitted when no chat token has arrived. Keeps
 # clients (notably opencode) from tripping their idle-stream timeout during
@@ -45,6 +47,19 @@ async def encode_completions_sse(
     finally:
         if not pending.done():
             pending.cancel()
-            with contextlib.suppress(BaseException):
+            current = asyncio.current_task()
+            try:
                 await pending
+            except asyncio.CancelledError:
+                # Awaiting the future we just cancelled raises here, which is
+                # expected. A cancellation aimed at this task is not: this
+                # cleanup runs during aclose(), which the server calls while
+                # unwinding a request that is often itself being cancelled, and
+                # swallowing that let the task resume as if it never was.
+                if current is not None and current.cancelling() > 0:
+                    raise
+            except Exception:
+                # The upstream failed as it was torn down. The request is
+                # already unwinding, so record it rather than mask the unwind.
+                log.debug("upstream chat stream errored during cleanup", exc_info=True)
     yield b"data: [DONE]\n\n"

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -168,7 +168,12 @@ class _StreamMapper:
         if isinstance(event.delta, TextDelta):
             return self._text_delta(self._reasoning.feed(event.delta.text))
         if isinstance(event.delta, ToolUseDelta):
-            tool_index = self._tool_index_for_block[event.index]
+            # A delta for a block we never saw start is a provider quirk, not a
+            # server fault; a bare subscript turned it into a KeyError that
+            # surfaced as a stream-level internal error.
+            tool_index = self._tool_index_for_block.get(event.index)
+            if tool_index is None:
+                return None
             return CompletionsStreamDelta(
                 tool_calls=[_tool_call_args(tool_index, event.delta.partial_json)],
             )

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -320,9 +320,16 @@ def _usage_chunk(model: str, response_id: str, usage: CanonicalUsage) -> Complet
 
 
 def _system_text(msg: CompletionsMessage) -> str:
+    """Flatten a system message to text, rejecting image parts.
+
+    The same image part is a 400 in a user message, so silently dropping it
+    here answered as though the request had been honoured.
+    """
     if isinstance(msg.content, str):
         return msg.content
     if isinstance(msg.content, list):
+        if any(isinstance(part, CompletionsImageContent) for part in msg.content):
+            raise ValueError(_IMAGE_CONTENT_UNSUPPORTED)
         return "".join(
             part.text for part in msg.content if isinstance(part, CompletionsTextContent)
         )

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -65,6 +65,7 @@ _STOP_REASON_TO_FINISH: dict[StopReason, FinishReason] = {
     StopReason.TOOL_USE: FinishReason.TOOL_CALLS,
 }
 
+_TOOL_CALL_ID_REQUIRED = "A tool message requires tool_call_id naming the call it answers."
 _IMAGE_CONTENT_UNSUPPORTED = (
     "Image content is not supported by /v1/chat/completions yet. Send a text-only request."
 )
@@ -362,11 +363,15 @@ def _message_from_request(msg: CompletionsMessage) -> CanonicalMessage:
     if role == "system":
         raise ValueError("system messages should be extracted by the caller")
     if role == "tool":
+        if not msg.tool_call_id:
+            # Substituting "" produced a tool result no tool call can pair with,
+            # which the provider sees as a result for a call it never made.
+            raise ValueError(_TOOL_CALL_ID_REQUIRED)
         return CanonicalMessage(
             role="tool",
             content=[
                 ToolResultBlock(
-                    tool_use_id=msg.tool_call_id or "",
+                    tool_use_id=msg.tool_call_id,
                     content=_tool_result_content(msg.content),
                 )
             ],

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -225,9 +225,18 @@ async def canonical_stream_to_completions_chunks(
     matching OpenAI's ``stream_options.include_usage`` contract.
     """
     mapper = _StreamMapper()
+    # One timestamp for the whole completion. OpenAI holds created constant
+    # across a stream; recomputing it per chunk reported several creation times
+    # for one completion, and clients order or dedupe on it.
+    created = int(time.time())
     async for event in events:
         for chunk in _chunks_for_event(
-            event, mapper, model=model, response_id=response_id, include_usage=include_usage
+            event,
+            mapper,
+            model=model,
+            response_id=response_id,
+            include_usage=include_usage,
+            created=created,
         ):
             yield chunk
 
@@ -239,19 +248,24 @@ def _chunks_for_event(
     model: str,
     response_id: str,
     include_usage: bool,
+    created: int,
 ) -> list[CompletionsStreamChunk]:
     """The OpenAI chunks one canonical event translates to; empty for a no-op event."""
     if isinstance(event, ContentBlockStart):
-        return _maybe_chunk(model, response_id, mapper.block_start(event))
+        return _maybe_chunk(model, response_id, mapper.block_start(event), created=created)
     if isinstance(event, ContentBlockDelta):
-        return _maybe_chunk(model, response_id, mapper.block_delta(event))
+        return _maybe_chunk(model, response_id, mapper.block_delta(event), created=created)
     if isinstance(event, ContentBlockStop):
         # Closing a text block flushes any text the reasoning splitter still
         # buffers (an unclosed <think>, or a tag that never completed).
-        return _maybe_chunk(model, response_id, mapper.block_stop())
+        return _maybe_chunk(model, response_id, mapper.block_stop(), created=created)
     if isinstance(event, MessageDelta):
         return _message_delta_chunks(
-            event, model=model, response_id=response_id, include_usage=include_usage
+            event,
+            model=model,
+            response_id=response_id,
+            include_usage=include_usage,
+            created=created,
         )
     if isinstance(event, MessageStart | MessageStop):
         # OpenAI's wire format has no equivalent: MessageStart carries metadata
@@ -264,12 +278,16 @@ def _chunks_for_event(
 
 
 def _message_delta_chunks(
-    event: MessageDelta, *, model: str, response_id: str, include_usage: bool
+    event: MessageDelta, *, model: str, response_id: str, include_usage: bool, created: int
 ) -> list[CompletionsStreamChunk]:
     """The finish chunk, plus the usage-only chunk when the client asked for it."""
     chunks = [
         _chunk(
-            model, response_id, CompletionsStreamDelta(), finish_reason=_finish_reason_for(event)
+            model,
+            response_id,
+            CompletionsStreamDelta(),
+            finish_reason=_finish_reason_for(event),
+            created=created,
         )
     ]
     if include_usage:
@@ -277,15 +295,15 @@ def _message_delta_chunks(
         # include_usage is set; a client blocking on it must not hang because the
         # provider streamed no usage frame.
         usage = event.usage or CanonicalUsage(input_tokens=0, output_tokens=0)
-        chunks.append(_usage_chunk(model, response_id, usage))
+        chunks.append(_usage_chunk(model, response_id, usage, created=created))
     return chunks
 
 
 def _maybe_chunk(
-    model: str, response_id: str, delta: CompletionsStreamDelta | None
+    model: str, response_id: str, delta: CompletionsStreamDelta | None, *, created: int
 ) -> list[CompletionsStreamChunk]:
     """Wrap a delta in a chunk, or nothing when the event produced no delta."""
-    return [] if delta is None else [_chunk(model, response_id, delta)]
+    return [] if delta is None else [_chunk(model, response_id, delta, created=created)]
 
 
 def _chunk(
@@ -294,21 +312,24 @@ def _chunk(
     delta: CompletionsStreamDelta,
     *,
     finish_reason: FinishReason | None = None,
+    created: int,
 ) -> CompletionsStreamChunk:
     return CompletionsStreamChunk(
         id=response_id,
-        created=int(time.time()),
+        created=created,
         model=model,
         choices=[CompletionsStreamChoice(index=0, delta=delta, finish_reason=finish_reason)],
     )
 
 
-def _usage_chunk(model: str, response_id: str, usage: CanonicalUsage) -> CompletionsStreamChunk:
+def _usage_chunk(
+    model: str, response_id: str, usage: CanonicalUsage, *, created: int
+) -> CompletionsStreamChunk:
     """Final include_usage chunk: empty choices, populated usage totals."""
     total = usage.input_tokens + usage.output_tokens
     return CompletionsStreamChunk(
         id=response_id,
-        created=int(time.time()),
+        created=created,
         model=model,
         choices=[],
         usage=CompletionsUsage(

--- a/src/lilbee/server/chat_dispatch/canonical.py
+++ b/src/lilbee/server/chat_dispatch/canonical.py
@@ -81,11 +81,9 @@ class CanonicalToolChoice:
     tool_name: str | None = None
 
     def __post_init__(self) -> None:
-        # The invariant was held only by the discipline of the single caller
-        # that builds this, while the type advertised it as a property of the
-        # type. A mode="tool" with no name reaches the provider payload as
-        # {"function": {"name": None}}, which the backend sees as a malformed
-        # tool choice rather than a rejected request.
+        # Without this the None reaches the provider as
+        # {"function": {"name": None}}, a malformed tool choice rather than a
+        # rejected request.
         if self.mode == "tool" and not self.tool_name:
             raise ValueError('CanonicalToolChoice(mode="tool") requires a tool_name')
 

--- a/src/lilbee/server/chat_dispatch/canonical.py
+++ b/src/lilbee/server/chat_dispatch/canonical.py
@@ -80,6 +80,15 @@ class CanonicalToolChoice:
     mode: Literal["auto", "any", "none", "tool"]
     tool_name: str | None = None
 
+    def __post_init__(self) -> None:
+        # The invariant was held only by the discipline of the single caller
+        # that builds this, while the type advertised it as a property of the
+        # type. A mode="tool" with no name reaches the provider payload as
+        # {"function": {"name": None}}, which the backend sees as a malformed
+        # tool choice rather than a rejected request.
+        if self.mode == "tool" and not self.tool_name:
+            raise ValueError('CanonicalToolChoice(mode="tool") requires a tool_name')
+
 
 @dataclass(frozen=True)
 class CanonicalChatRequest:

--- a/src/lilbee/server/chat_dispatch/concurrency.py
+++ b/src/lilbee/server/chat_dispatch/concurrency.py
@@ -29,6 +29,16 @@ class ChatGate:
     waiters that are already queued rather than leaving them to time out
     against a backend that now has room.
 
+    Hand-rolled on purpose, and the reason is worth keeping because the obvious
+    replacement almost fits. ``anyio.CapacityLimiter`` has a runtime-settable
+    ``total_tokens`` that would make a capacity increase wake waiters for free,
+    but it binds each token to the borrowing task and raises ``RuntimeError``
+    when another task releases it. Slots here are released from wherever cleanup
+    happens first, including a response's after-send hook, which is not the task
+    that acquired. ``asyncio.Semaphore`` allows the cross-task release but has no
+    live capacity. Neither fits until the streaming cleanup paths are collapsed
+    onto one task.
+
     Slots are *handed to* waiters rather than merely signalled. Waking a waiter
     reserves its slot in the same synchronous step, and a request arriving while
     a waiter is queued joins the back of the queue instead of testing the

--- a/src/lilbee/server/chat_dispatch/concurrency.py
+++ b/src/lilbee/server/chat_dispatch/concurrency.py
@@ -18,17 +18,30 @@ class ChatBusyError(Exception):
 
 
 class ChatGate:
-    """Admit up to the backend's live slot capacity; the rest wait, then 429.
+    """Admit up to the backend's live slot capacity; the rest wait FIFO, then 429.
 
     Capacity is read at admission time, not fixed when the gate is created, so a
     model swap or provider change that changes the slot count takes effect at
     once, and a single in-process model (capacity 1) is never oversubscribed.
     The fleet reports its ``--parallel`` slot count, so its continuous-batching
-    slots are actually used instead of one request at a time.
+    slots are actually used instead of one request at a time. The latest count
+    any caller reports is remembered, so a capacity increase also admits the
+    waiters that are already queued rather than leaving them to time out
+    against a backend that now has room.
+
+    Slots are *handed to* waiters rather than merely signalled. Waking a waiter
+    reserves its slot in the same synchronous step, and a request arriving while
+    a waiter is queued joins the back of the queue instead of testing the
+    counter. Without both, a newcomer could take the slot in the window between
+    the wake-up and the woken waiter resuming, and the waiter would rejoin at
+    the tail: the requests that had waited longest would be overtaken
+    repeatedly and would be the ones to time out.
     """
 
     def __init__(self) -> None:
         self._in_flight = 0
+        # Last slot count reported by a caller; the gate has no other view of it.
+        self._ceiling = 1
         self._waiters: deque[asyncio.Future[None]] = deque()
 
     @property
@@ -38,55 +51,75 @@ class ChatGate:
 
     async def acquire(self, capacity: int, timeout: float) -> None:
         """Reserve a slot, waiting up to *timeout*; raise ChatBusyError if full."""
-        ceiling = max(1, capacity)
         loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
-        while self._in_flight >= ceiling:
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                raise ChatBusyError(_busy_message(timeout))
-            waiter: asyncio.Future[None] = loop.create_future()
-            self._waiters.append(waiter)
-            try:
-                # asyncio.timeout, not wait_for: 3.11's wait_for swallows a task
-                # cancellation that races a completed waiter (fixed in 3.12).
-                async with asyncio.timeout(remaining):
-                    await waiter
-            except TimeoutError as exc:
-                self._renotify_if_woken(waiter)
-                raise ChatBusyError(_busy_message(timeout)) from exc
-            except asyncio.CancelledError:
-                self._renotify_if_woken(waiter)
-                raise
-            finally:
-                if waiter in self._waiters:
-                    self._waiters.remove(waiter)
-        self._in_flight += 1
+        self._observe_capacity(max(1, capacity))
+        # Admit straight away only with room AND nobody ahead in the queue.
+        if not self._waiters and self._in_flight < self._ceiling:
+            self._in_flight += 1
+            return
+        if timeout <= 0:
+            raise ChatBusyError(_busy_message(timeout))
+        waiter: asyncio.Future[None] = loop.create_future()
+        self._waiters.append(waiter)
+        try:
+            # asyncio.timeout, not wait_for: 3.11's wait_for swallows a task
+            # cancellation that races a completed waiter (fixed in 3.12).
+            async with asyncio.timeout(timeout):
+                await waiter
+            # Returning means a slot was reserved for us by whoever woke us;
+            # there is nothing left to claim.
+        except TimeoutError as exc:
+            self._abandon(waiter)
+            raise ChatBusyError(_busy_message(timeout)) from exc
+        except asyncio.CancelledError:
+            self._abandon(waiter)
+            raise
+        finally:
+            if waiter in self._waiters:
+                self._waiters.remove(waiter)
 
     async def release(self) -> None:
-        """Free an acquired slot and wake one waiter.
+        """Free an acquired slot and admit whoever it makes room for.
 
-        Contains no awaits: the decrement and wake-up run synchronously on the
+        Contains no awaits: the decrement and wake-ups run synchronously on the
         event loop, so a cancellation delivered to the caller (for example a
         client disconnect tearing down a streaming response) can never abort
         the release halfway and leak the slot.
         """
         if self._in_flight > 0:
             self._in_flight -= 1
-        self._wake_next()
+        self._admit_waiters()
 
-    def _wake_next(self) -> None:
-        """Wake the oldest still-pending waiter, if any."""
+    def _observe_capacity(self, ceiling: int) -> None:
+        """Record the caller's live slot count and admit anyone it now fits."""
+        self._ceiling = ceiling
+        self._admit_waiters()
+
+    def _admit_waiters(self) -> None:
+        """Hand a reserved slot to each queued waiter that now fits."""
+        while self._in_flight < self._ceiling:
+            waiter = self._pop_live_waiter()
+            if waiter is None:
+                return
+            # Reserve before waking: the slot is the waiter's from this moment,
+            # so nothing entering acquire() in between can take it.
+            self._in_flight += 1
+            waiter.set_result(None)
+
+    def _pop_live_waiter(self) -> asyncio.Future[None] | None:
+        """Remove and return the oldest waiter still able to take a slot."""
         while self._waiters:
             waiter = self._waiters.popleft()
             if not waiter.done():
-                waiter.set_result(None)
-                return
+                return waiter
+        return None
 
-    def _renotify_if_woken(self, waiter: asyncio.Future[None]) -> None:
-        """Pass a wake-up consumed by a bailing-out waiter on to the next one."""
+    def _abandon(self, waiter: asyncio.Future[None]) -> None:
+        """Give back a slot that was reserved for a waiter that then bailed out."""
         if waiter.done() and not waiter.cancelled():
-            self._wake_next()
+            if self._in_flight > 0:
+                self._in_flight -= 1
+            self._admit_waiters()
 
 
 def _busy_message(timeout: float) -> str:

--- a/src/lilbee/server/chat_dispatch/dispatch.py
+++ b/src/lilbee/server/chat_dispatch/dispatch.py
@@ -108,6 +108,20 @@ def _provider_chat_kwargs(req: CanonicalChatRequest, canonical_model: str) -> di
     }
 
 
+def _stop_reason_for(result: ChatResult) -> StopReason:
+    """Closing stop reason for a non-streaming result.
+
+    Tool calls win over the reported finish reason. FinishReason.coerce falls
+    back to STOP for a missing or unknown value, so a provider that returns
+    tool calls without saying so produced tool_use content under end_turn, and
+    a client reading stop_reason decides whether to run the tools. The
+    streaming path already refuses the same downgrade.
+    """
+    if result.tool_calls:
+        return StopReason.TOOL_USE
+    return _FINISH_REASON_TO_STOP.get(result.finish_reason, StopReason.END_TURN)
+
+
 def _content_blocks_from_result(result: ChatResult) -> list[ContentBlock]:
     """Build canonical content blocks from a non-streaming provider result."""
     content: list[ContentBlock] = []
@@ -140,7 +154,7 @@ def dispatch_chat(
         id=_new_message_id(),
         model=canonical_model,
         content=_content_blocks_from_result(result),
-        stop_reason=_FINISH_REASON_TO_STOP.get(result.finish_reason, StopReason.END_TURN),
+        stop_reason=_stop_reason_for(result),
         usage=CanonicalUsage(
             input_tokens=result.usage.prompt_tokens,
             output_tokens=result.usage.completion_tokens,

--- a/src/lilbee/server/chat_dispatch/dispatch.py
+++ b/src/lilbee/server/chat_dispatch/dispatch.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import uuid
-from collections.abc import AsyncIterable, AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Iterator
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -197,21 +197,21 @@ async def dispatch_chat_stream(
 
 
 async def _async_iter_provider_stream(
-    stream: Iterator[ChatStreamItem] | AsyncIterator[ChatStreamItem],
+    stream: Iterator[ChatStreamItem],
 ) -> AsyncIterator[ChatStreamItem]:
     """Iterate a provider chat stream without blocking the event loop.
 
-    An async-native stream is consumed directly, without thread hops. The
-    fleet and SDK providers stream via plain sync generators; iterating one
-    inline on the event loop would block, so each ``next()`` runs in a
-    worker thread via ``asyncio.to_thread``. ``LLMProvider.chat`` cannot
-    narrow this distinction in the Protocol because the SDK backend has no
-    async-native path.
+    ``LLMProvider.chat`` types a streaming result as a ClosableIterator, and
+    every provider in the tree returns a plain sync generator; iterating one
+    inline on the event loop would block, so each ``next()`` runs in a worker
+    thread via ``asyncio.to_thread``.
+
+    There used to be an async-native branch here for a provider shape that
+    does not exist. It was dead and also wrong: the caller's cleanup is
+    ``await asyncio.to_thread(stream.close)``, which an async-native stream
+    would not satisfy. Adding one means changing the Protocol and that
+    cleanup together, not restoring a branch nothing reaches.
     """
-    if isinstance(stream, AsyncIterable):
-        async for frame in stream:
-            yield frame
-        return
     while True:
         frame = await asyncio.to_thread(_next_or_done, stream)
         if frame is _STREAM_DONE:
@@ -245,6 +245,9 @@ class _StreamState:
         self._open: _OpenBlockKind = _OpenBlockKind.NONE
         self._index: int = -1
         self._tool_index: int | None = None
+        # Provider tool index -> the (id, name) its first delta carried.
+        # Continuation deltas typically carry neither.
+        self._tool_identity: dict[int, tuple[str, str]] = {}
         self._stop_reason: StopReason = StopReason.END_TURN
         self._usage: TokenUsage | None = None
 
@@ -300,17 +303,32 @@ class _StreamState:
             self._tool_index = frame.index
             yield ContentBlockStart(
                 index=self._index,
-                block=ToolUseBlock(
-                    id=frame.id or _new_call_id(),
-                    name=frame.name or "",
-                    input={},
-                ),
+                block=ToolUseBlock(**self._tool_block_fields(frame)),
             )
         if frame.arguments_delta is not None:
             yield ContentBlockDelta(
                 index=self._index,
                 delta=ToolUseDelta(partial_json=frame.arguments_delta),
             )
+
+    def _tool_block_fields(self, frame: ToolCallDelta) -> dict[str, Any]:
+        """Identity for the block opening on *frame*, remembered per tool index.
+
+        A text frame between two argument deltas of one call (streamed
+        reasoning surfaced as text, say) closes the open tool block, so the
+        next delta for the same call has to open a second block. Continuation
+        deltas carry no id and no name, so that block used to get a fresh
+        synthetic id and an empty name, splitting one logical call across two
+        blocks the second of which matched no tool. Reusing the identity the
+        call already announced at least leaves both blocks stitchable by id.
+        """
+        known = self._tool_identity.get(frame.index)
+        identity = (
+            frame.id or (known[0] if known else _new_call_id()),
+            frame.name or (known[1] if known else ""),
+        )
+        self._tool_identity[frame.index] = identity
+        return {"id": identity[0], "name": identity[1], "input": {}}
 
     def _close_current(self) -> Iterator[CanonicalStreamEvent]:
         if self._open != _OpenBlockKind.NONE:

--- a/src/lilbee/server/chat_dispatch/tool_args.py
+++ b/src/lilbee/server/chat_dispatch/tool_args.py
@@ -17,6 +17,8 @@ def parse_tool_arguments(raw: str) -> dict[str, Any]:
         return {}
     try:
         parsed = json.loads(raw)
-    except (ValueError, TypeError):
+    except ValueError:
+        # JSONDecodeError only: raw is a str, so json.loads cannot raise
+        # TypeError here, and catching it widened this to hide real bugs.
         return {"_raw": raw}
     return parsed if isinstance(parsed, dict) else {"_raw": raw}

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -40,7 +40,7 @@ from lilbee.server.handlers.ingest import (
     import_stream,
     sync_stream,
     validate_add_paths,
-    validate_uploads,
+    validate_upload_names,
 )
 from lilbee.server.handlers.models import (
     TASK_ENDPOINT_PATH,
@@ -284,6 +284,6 @@ __all__ = [
     "sync_stream",
     "update_config",
     "validate_add_paths",
-    "validate_uploads",
+    "validate_upload_names",
     "warm_stream",
 ]

--- a/src/lilbee/server/handlers/config.py
+++ b/src/lilbee/server/handlers/config.py
@@ -57,6 +57,10 @@ def _compute_config_defaults() -> dict[str, Any]:
     """Materialize Config defaults once per process."""
     defaults: dict[str, Any] = {}
     for name, info in Config.model_fields.items():
+        # The writable conjunct is redundant today, since every public field is
+        # either writable or a model role, and the next clause keeps the roles.
+        # It stays as the guard that keeps a future public-but-not-writable
+        # field out of this payload; dropping it would expose one silently.
         is_writable_public = name in WRITABLE_CONFIG_FIELDS and name in _PUBLIC_CONFIG_FIELDS
         if not is_writable_public and name not in _MODEL_ROLE_FIELDS:
             continue

--- a/src/lilbee/server/handlers/config.py
+++ b/src/lilbee/server/handlers/config.py
@@ -57,10 +57,9 @@ def _compute_config_defaults() -> dict[str, Any]:
     """Materialize Config defaults once per process."""
     defaults: dict[str, Any] = {}
     for name, info in Config.model_fields.items():
-        # The writable conjunct is redundant today, since every public field is
-        # either writable or a model role, and the next clause keeps the roles.
-        # It stays as the guard that keeps a future public-but-not-writable
-        # field out of this payload; dropping it would expose one silently.
+        # The writable conjunct is redundant today (every public field is
+        # writable or a model role) but keeps a future public-but-not-writable
+        # field out of this payload.
         is_writable_public = name in WRITABLE_CONFIG_FIELDS and name in _PUBLIC_CONFIG_FIELDS
         if not is_writable_public and name not in _MODEL_ROLE_FIELDS:
             continue

--- a/src/lilbee/server/handlers/crawl.py
+++ b/src/lilbee/server/handlers/crawl.py
@@ -18,13 +18,16 @@ async def crawl_stream(
     include_subdomains: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Stream crawl progress as SSE events.
+
     Emits crawl_start, crawl_page, crawl_done events, then a final done event
     with the list of files written. On error emits crawl_error.
     Sets a cancel event on client disconnect so the crawl stops between pages.
 
-    On first use, Chromium isn't installed yet. The stream inlines
-    setup_start/progress/done events before the crawl begins so a stream
-    consumer can render a matching 'setup' progress indicator.
+    A browser crawl that finds no Chromium installed inlines
+    setup_start/progress/done events before the crawl begins, so a consumer can
+    render a matching 'setup' progress indicator. These are not part of every
+    stream: an http crawl never launches a browser, and that is the default
+    render mode, so a client must not block waiting for a setup phase.
     """
     sse = SseStream()
 

--- a/src/lilbee/server/handlers/crawl.py
+++ b/src/lilbee/server/handlers/crawl.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from lilbee.core.config.enums import CrawlRenderMode
-from lilbee.server.handlers.sse import SseStream, sse_done, sse_error
+from lilbee.server.handlers.sse import SseStream
 
 
 async def crawl_stream(
@@ -53,10 +53,6 @@ async def crawl_stream(
     task = asyncio.create_task(_run_crawl())
     async for event in sse.drain(task, "Crawl stream"):
         yield event
-    if not sse.cancel.is_set() and task.done() and not task.cancelled():
-        exc = task.exception()
-        if exc is not None:
-            yield sse_error(str(exc))
-            return
-        paths = task.result()
-        yield sse_done({"files_written": [str(p) for p in paths]})
+    frame = sse.terminal_frame(task, lambda paths: {"files_written": [str(p) for p in paths]})
+    if frame is not None:
+        yield frame

--- a/src/lilbee/server/handlers/documents.py
+++ b/src/lilbee/server/handlers/documents.py
@@ -32,10 +32,9 @@ _RAW_INLINE_RENDER_DENY: frozenset[str] = frozenset(
         "application/xhtml+xml",
         "text/css",
         "image/svg+xml",
-        # An xml-stylesheet processing instruction can pull in XSLT that emits
-        # script. Both spellings are listed because which one a ``.xml`` file
-        # resolves to depends on the host mimetypes database, and only the
-        # ``text/`` spelling would otherwise match the category rule below.
+        # An xml-stylesheet PI can pull in XSLT that emits script. Both
+        # spellings, because which one a ``.xml`` file resolves to depends on
+        # the host mimetypes database.
         "text/xml",
         "application/xml",
     }
@@ -103,10 +102,9 @@ async def list_documents(
         total=total,
         limit=limit,
         offset=offset,
-        # Gated on a non-empty page on purpose: a concurrent writer shrinking
-        # SOURCES between count_sources() and get_sources() leaves a stale total,
-        # and without this a client reading has_more would spin past the end.
-        # Stopping early beats looping forever.
+        # Gated on a non-empty page: a concurrent writer shrinking SOURCES
+        # between count and fetch leaves a stale total, and a client reading
+        # has_more would spin past the end.
         has_more=len(page) > 0 and (offset + len(page)) < total,
     )
 

--- a/src/lilbee/server/handlers/documents.py
+++ b/src/lilbee/server/handlers/documents.py
@@ -32,6 +32,12 @@ _RAW_INLINE_RENDER_DENY: frozenset[str] = frozenset(
         "application/xhtml+xml",
         "text/css",
         "image/svg+xml",
+        # An xml-stylesheet processing instruction can pull in XSLT that emits
+        # script. Both spellings are listed because which one a ``.xml`` file
+        # resolves to depends on the host mimetypes database, and only the
+        # ``text/`` spelling would otherwise match the category rule below.
+        "text/xml",
+        "application/xml",
     }
 )
 

--- a/src/lilbee/server/handlers/documents.py
+++ b/src/lilbee/server/handlers/documents.py
@@ -103,6 +103,10 @@ async def list_documents(
         total=total,
         limit=limit,
         offset=offset,
+        # Gated on a non-empty page on purpose: a concurrent writer shrinking
+        # SOURCES between count_sources() and get_sources() leaves a stale total,
+        # and without this a client reading has_more would spin past the end.
+        # Stopping early beats looping forever.
         has_more=len(page) > 0 and (offset + len(page)) < total,
     )
 

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -16,7 +16,7 @@ from lilbee.core.config import cfg
 from lilbee.core.security import validate_path_within
 from lilbee.runtime.ingest_lock import IngestLockRegistry
 from lilbee.runtime.progress import SseEvent
-from lilbee.server.handlers.sse import SseStream, sse_done, sse_error, sse_event
+from lilbee.server.handlers.sse import SseStream, sse_event
 from lilbee.server.models import AddSummary, SyncSummary
 
 if TYPE_CHECKING:
@@ -70,12 +70,9 @@ async def sync_stream(
     )
     async for event in sse.drain(task, "Sync stream"):
         yield event
-    if not sse.cancel.is_set() and task.done() and not task.cancelled():
-        exc = task.exception()
-        if exc is not None:
-            yield sse_error(str(exc))
-            return
-        yield sse_done(task.result().model_dump())
+    frame = sse.terminal_frame(task, lambda result: result.model_dump())
+    if frame is not None:
+        yield frame
 
 
 async def _run_add(
@@ -196,16 +193,13 @@ async def _ingest_stream(
         try:
             async for event in sse.drain(task, label):
                 yield event
-            if not sse.cancel.is_set() and task.done() and not task.cancelled():
-                exc = task.exception()
-                if exc is not None:
-                    yield sse_error(str(exc))
-                    return
-                summary = task.result()
-                # Name the sources this run never attempted, so a client
-                # reading only the terminal event still sees a partial batch.
-                summary.already_ingesting = list(busy)
-                yield sse_done(summary.model_dump())
+            # already_ingesting names the sources this run never attempted, so
+            # a client reading only the terminal event still sees a partial batch.
+            frame = sse.terminal_frame(
+                task, lambda s: s.model_copy(update={"already_ingesting": list(busy)}).model_dump()
+            )
+            if frame is not None:
+                yield frame
         finally:
             if not task.done():
                 task.cancel()
@@ -338,9 +332,6 @@ async def import_stream(data: bytes, fmt: str) -> AsyncGenerator[str, None]:
     task = asyncio.create_task(_run_import_with_sentinel(sse, data, fmt))
     async for event in sse.drain(task, "Import stream"):
         yield event
-    if not sse.cancel.is_set() and task.done() and not task.cancelled():
-        exc = task.exception()
-        if exc is not None:
-            yield sse_error(str(exc))
-            return
-        yield sse_done(task.result().model_dump())
+    frame = sse.terminal_frame(task, lambda result: result.model_dump())
+    if frame is not None:
+        yield frame

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -14,6 +14,7 @@ from lilbee.app.ingest import copy_files
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.security import validate_path_within
+from lilbee.runtime.ingest_lock import IngestLockRegistry
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.sse import SseStream, sse_done, sse_error, sse_event
 from lilbee.server.models import AddSummary, SyncSummary
@@ -173,11 +174,7 @@ async def _ingest_stream(
             return
 
         acquired_names = {name for name, _lock in acquired}
-        locked = [
-            payload
-            for key, payload in items
-            if registry.canonical_source_name(key) in acquired_names
-        ]
+        locked = [payload for key, payload in items if key in acquired_names]
         sse = SseStream()
         task = asyncio.create_task(run(locked, sse))
         try:
@@ -215,7 +212,7 @@ async def add_files_stream(
     request dict is decoded once.
     """
     async for event in _ingest_stream(
-        [(p, p) for p in paths],
+        [(IngestLockRegistry.canonical_source_name(p), p) for p in paths],
         lambda locked, sse: _run_add(locked, force, enable_ocr, ocr_timeout, sse),
         "Add files stream",
     ):

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -255,17 +255,24 @@ def _clean_upload_name(name: str) -> str:
     return relative
 
 
-def validate_uploads(files: list[tuple[str, bytes]]) -> list[tuple[str, bytes]]:
-    """Validate uploaded (filename, content) pairs. Raises ValueError on bad input.
+def validate_upload_names(names: list[str | None]) -> list[str]:
+    """Validate uploaded filenames, returning the cleaned relative paths.
 
-    Filenames keep their relative path, validated to stay inside
-    ``cfg.documents_dir``, so an uploaded source tree preserves its layout
-    instead of colliding on basenames. There is no file-count cap; the
-    resource guard is the app's size-based request_max_body_size.
+    Names only, deliberately: the route validates before reading any part's
+    bytes, so a request that will be rejected never costs a full copy of the
+    payload in the server's own memory. Filenames keep their relative path,
+    validated to stay inside ``cfg.documents_dir``, so an uploaded source tree
+    preserves its layout instead of colliding on basenames. There is no
+    file-count cap; the resource guard is the app's request_max_body_size.
+
+    Raises ValueError on bad input.
     """
-    if not files:
+    if not names:
         raise ValueError("no files uploaded")
-    return [(_clean_upload_name(name), content) for name, content in files]
+    # A multipart part is allowed to carry no filename at all; that is not a
+    # file upload, and the cleaner's message should name it as missing rather
+    # than crash on None.
+    return [_clean_upload_name(name if name is not None else "") for name in names]
 
 
 async def _run_upload(files: list[tuple[str, bytes]], sse: SseStream) -> AddSummary:

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -102,12 +102,9 @@ async def _run_add(
             return AddSummary(copied=copy_result.copied, skipped=copy_result.skipped, errors=errors)
 
         if not copy_result.copied and not copy_result.skipped:
-            # Every requested path was missing, so nothing reached the corpus.
-            # sync() is a whole-vault discovery/hash/embed pass holding the
-            # ingest lock, which on a large vault is minutes of work in
-            # response to a request that changed nothing. A *skipped* file is
-            # not the same case: it is already in the documents dir but may
-            # never have been indexed, so that path still needs the sync.
+            # Nothing reached the corpus, and sync() is a whole-vault pass
+            # holding the ingest lock. A *skipped* file is not this case: it is
+            # already in the documents dir but may never have been indexed.
             return AddSummary(copied=[], skipped=[], errors=errors)
 
         with temporary_ocr_config(enable_ocr, ocr_timeout):
@@ -135,10 +132,9 @@ def validate_add_paths(
     # your-codebase use case (hundreds of small files).
 
     for p_str in paths:
-        # Path(x).name is always a bare final component, so joining it onto the
-        # root cannot escape and the traversal check alone could never fail. The
-        # case it does need to catch is a name that is empty ("/", "a/"), which
-        # would resolve to documents_dir itself as the copy destination.
+        # Path(x).name cannot escape the root, so the traversal check alone
+        # never fires. What it catches is an empty name ("/", "a/"), which
+        # would resolve to documents_dir itself as the destination.
         name = Path(p_str).name
         if not name:
             raise ValueError(f"{p_str!r} does not name a file")

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -129,7 +129,14 @@ def validate_add_paths(
     # your-codebase use case (hundreds of small files).
 
     for p_str in paths:
-        validate_path_within(cfg.documents_dir / Path(p_str).name, cfg.documents_dir)
+        # Path(x).name is always a bare final component, so joining it onto the
+        # root cannot escape and the traversal check alone could never fail. The
+        # case it does need to catch is a name that is empty ("/", "a/"), which
+        # would resolve to documents_dir itself as the copy destination.
+        name = Path(p_str).name
+        if not name:
+            raise ValueError(f"{p_str!r} does not name a file")
+        validate_path_within(cfg.documents_dir / name, cfg.documents_dir)
 
     force = bool(data.get("force", False))
     enable_ocr, ocr_timeout = _parse_ocr_params(data)

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -156,9 +156,11 @@ async def _ingest_stream(
     Shared by /api/add (server paths) and /api/add/upload (uploaded content).
     Each item is ``(lock_key, payload)``: the key is the source identifier used
     for the per-source ingest lock; the payload is what ``run`` receives for the
-    subset whose lock was acquired. Contended sources emit ``already_ingesting``
-    and the stream closes without a ``done`` event, signalling the client to wait
-    rather than retry.
+    subset whose lock was acquired. Contended sources emit ``already_ingesting``.
+    When every source is contended the stream closes with no ``done`` event,
+    signalling the client to wait rather than retry. When only some are, the
+    acquired subset still runs and the ``done`` summary names the contended ones
+    in ``already_ingesting``, so a partial batch never reads as a full success.
     """
     registry = get_services().ingest_lock_registry
     acquired, busy = await registry.acquire([key for key, _payload in items])
@@ -187,6 +189,9 @@ async def _ingest_stream(
                     yield sse_error(str(exc))
                     return
                 summary = task.result()
+                # Name the sources this run never attempted, so a client
+                # reading only the terminal event still sees a partial batch.
+                summary.already_ingesting = list(busy)
                 yield sse_done(summary.model_dump())
         finally:
             if not task.done():

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -104,6 +104,15 @@ async def _run_add(
         if sse.cancel.is_set():
             return AddSummary(copied=copy_result.copied, skipped=copy_result.skipped, errors=errors)
 
+        if not copy_result.copied and not copy_result.skipped:
+            # Every requested path was missing, so nothing reached the corpus.
+            # sync() is a whole-vault discovery/hash/embed pass holding the
+            # ingest lock, which on a large vault is minutes of work in
+            # response to a request that changed nothing. A *skipped* file is
+            # not the same case: it is already in the documents dir but may
+            # never have been indexed, so that path still needs the sync.
+            return AddSummary(copied=[], skipped=[], errors=errors)
+
         with temporary_ocr_config(enable_ocr, ocr_timeout):
             sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -28,7 +28,7 @@ from lilbee.catalog.types import CatalogSize, CatalogSort, KeyStatus, ModelSourc
 from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import classify_all_remote_models, discover_api_models
 from lilbee.modelhub.model_manager.types import RemoteModel
-from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
+from lilbee.modelhub.role_validator import MODEL_FIELD_TO_TASK, validate_model_task_assignment
 from lilbee.providers.local_servers import canonical_local_ref, local_server_for_label
 from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
@@ -237,8 +237,8 @@ def _require_model_available(model: str) -> str:
 
 
 def _build_task_to_field() -> dict[ModelTask, str]:
-    """Invert config's ``_MODEL_FIELD_TO_TASK`` so the two maps stay in sync."""
-    return {ModelTask(task): field for field, task in _MODEL_FIELD_TO_TASK.items()}
+    """Invert ``MODEL_FIELD_TO_TASK`` so the two maps stay in sync."""
+    return {ModelTask(task): field for field, task in MODEL_FIELD_TO_TASK.items()}
 
 
 _TASK_TO_FIELD: dict[ModelTask, str] = _build_task_to_field()
@@ -560,7 +560,7 @@ async def enforce_pull_arch_compat(
         return
     manager = get_services().model_manager
     try:
-        await asyncio.to_thread(manager._enforce_arch_compat, model)
+        await asyncio.to_thread(manager.enforce_arch_compat, model)
     except UnsupportedArchError as exc:
         raise HTTPException(
             status_code=409,

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Literal
 
+from cachetools import TTLCache
 from pydantic import BaseModel
 
 from lilbee.app.services import get_services
@@ -395,36 +395,15 @@ def _hosted_entry(rm: RemoteModel, source: ModelSource) -> CatalogEntryResponse:
 _HOSTED_MODELS_TTL = 60
 
 
-_CacheT = TypeVar("_CacheT")
-
-
-class _TtlCache(Generic[_CacheT]):
-    """Single-entry TTL cache keyed on the config tuple that produced it.
-
-    One class rather than the two near-identical copies this module used to
-    carry: they differed only in the cached type and in whether the freshness
-    check tested the result for truthiness or for None, and the truthiness
-    variant re-fetched every time the answer was legitimately empty.
-    """
-
-    def __init__(self, ttl_seconds: float) -> None:
-        self._ttl = ttl_seconds
-        self._time: float = 0.0
-        self._key: str = ""
-        self._result: _CacheT | None = None
-
-    def get(self, key: str) -> _CacheT | None:
-        if self._result is None or key != self._key:
-            return None
-        return self._result if (time.monotonic() - self._time) < self._ttl else None
-
-    def set(self, key: str, result: _CacheT) -> None:
-        self._time = time.monotonic()
-        self._key = key
-        self._result = result
-
-
-_hosted_cache: _TtlCache[list[CatalogEntryResponse]] = _TtlCache(_HOSTED_MODELS_TTL)
+# Single-entry TTL caches keyed on the config tuple that produced the value.
+# maxsize=1 is the "single entry" part: a lookup under a new key misses and the
+# store evicts the old one, which is the behaviour the two hand-rolled classes
+# here reimplemented. They had already drifted apart, one testing the cached
+# value for truthiness instead of for presence, so a legitimately empty result
+# was never cached and re-fetched on every request.
+_hosted_cache: TTLCache[str, list[CatalogEntryResponse]] = TTLCache(
+    maxsize=1, ttl=_HOSTED_MODELS_TTL
+)
 
 
 def _discover_hosted_sync() -> list[CatalogEntryResponse]:
@@ -463,7 +442,7 @@ async def _collect_hosted_entries(
     rows = _hosted_cache.get(key)
     if rows is None:
         rows = await asyncio.to_thread(_discover_hosted_sync)
-        _hosted_cache.set(key, rows)
+        _hosted_cache[key] = rows
     if task is not None:
         rows = [r for r in rows if r.task == task]
     if search:
@@ -660,20 +639,24 @@ async def models_delete(model: str, *, source: str = "native") -> ModelsDeleteRe
 _EXTERNAL_MODELS_TTL = 60
 
 
-_external_cache: _TtlCache[ExternalModelsResponse] = _TtlCache(_EXTERNAL_MODELS_TTL)
+_external_cache: TTLCache[str, ExternalModelsResponse] = TTLCache(
+    maxsize=1, ttl=_EXTERNAL_MODELS_TTL
+)
 
 
 async def list_external_models() -> ExternalModelsResponse:
     """Query the provider for available models via its list_models() API."""
     key = f"{cfg.ollama_base_url}:{cfg.lm_studio_base_url}:{cfg.llm_api_key or ''}"
+    # ``is not None``, not truthiness: an empty model list is a real answer and
+    # caching it is the point. Testing the value itself re-fetched every time.
     cached = _external_cache.get(key)
-    if cached:
+    if cached is not None:
         return cached
 
     try:
         models = await asyncio.to_thread(get_services().provider.list_models)
         result = ExternalModelsResponse(models=models)
-        _external_cache.set(key, result)
+        _external_cache[key] = result
         return result
     except Exception as exc:
         log.warning("Failed to list external models: %s", exc)

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -258,7 +258,7 @@ def _require_model_for_task(model: str, expected: ModelTask, *, allow_empty: boo
 
 async def set_chat_model(model: str) -> SetModelResponse:
     """Switch active chat model. Validates installation and catalog task."""
-    normalized = _require_model_for_task(model, ModelTask.CHAT)
+    normalized = await asyncio.to_thread(_require_model_for_task, model, ModelTask.CHAT)
     return await _set_model("chat_model", normalized)
 
 
@@ -272,27 +272,33 @@ async def set_embedding_model(model: str) -> SetModelResponse:
     until that happens. The settings boundary pins legacy store meta to
     the OLD ref before the write and computes ``reindex_required`` after.
     """
-    normalized = _require_model_for_task(model, ModelTask.EMBEDDING)
+    normalized = await asyncio.to_thread(_require_model_for_task, model, ModelTask.EMBEDDING)
     result = apply_settings_update({"embedding_model": normalized})
     return SetModelResponse(model=normalized, reindex_required=result.reindex_required)
 
 
 async def set_vision_model(model: str) -> SetModelResponse:
     """Switch vision OCR model. Empty string unsets it (vision OCR disabled)."""
-    normalized = _require_model_for_task(model, ModelTask.VISION, allow_empty=True)
+    normalized = await asyncio.to_thread(
+        _require_model_for_task, model, ModelTask.VISION, allow_empty=True
+    )
     return await _set_model("vision_model", normalized)
 
 
 async def set_reranker_model(model: str) -> SetModelResponse:
     """Switch reranker model. Empty string unsets it (reranking disabled)."""
-    normalized = _require_model_for_task(model, ModelTask.RERANK, allow_empty=True)
+    normalized = await asyncio.to_thread(
+        _require_model_for_task, model, ModelTask.RERANK, allow_empty=True
+    )
     return await _set_model("reranker_model", normalized)
 
 
 async def models_show(model: str) -> ModelsShowResponse:
     """Return model metadata/parameters. Returns empty model if unavailable."""
     provider = get_services().provider
-    result = provider.show_model(model)
+    # show_model dispatches to the SDK backend, which does a network call to the
+    # local server; offload so a hung backend doesn't block the event loop.
+    result = await asyncio.to_thread(provider.show_model, model)
     return ModelsShowResponse(**(result or {}))
 
 
@@ -513,16 +519,24 @@ async def models_catalog(
     )
 
 
-async def models_installed() -> ModelsInstalledResponse:
-    """Return installed models with their granular source and canonical ref."""
+def _installed_entries_sync() -> list[InstalledModelEntry]:
+    """Blocking body of :func:`models_installed`: list installs and their sources."""
     manager = get_services().model_manager
-    models = []
+    entries = []
     for name in manager.list_installed():
         source = manager.get_source(name) or ModelSource.REMOTE
-        models.append(
+        entries.append(
             InstalledModelEntry(name=canonical_local_ref(name, source.value), source=source)
         )
-    return ModelsInstalledResponse(models=models)
+    return entries
+
+
+async def models_installed() -> ModelsInstalledResponse:
+    """Return installed models with their granular source and canonical ref."""
+    # list_installed walks the model filesystem and, on TTL expiry, queries the
+    # configured local servers over HTTP; offload it like list_models does.
+    entries = await asyncio.to_thread(_installed_entries_sync)
+    return ModelsInstalledResponse(models=entries)
 
 
 async def enforce_pull_arch_compat(

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -505,14 +505,16 @@ async def models_catalog(
     ]
     # Hosted rows (frontier + ollama) are selectable and download-free, so
     # they're shown on the first page only (mirrors the featured first-page
-    # convention), skipped for featured-only and installed=False filters, and
-    # counted toward ``total``.
+    # convention) and skipped for featured-only and installed=False filters.
+    # They are an unpaginated overlay, so they stay out of ``total``: adding
+    # them made page 1 report a larger total than page 2 of the same listing,
+    # and total/limit/offset/has_more now all describe the same paginated set.
     hosted_rows: list[CatalogEntryResponse] = []
     if offset == 0 and not featured and installed is not False:
         hosted_rows = await _collect_hosted_entries(task=parsed_task, search=search)
 
     return ModelsCatalogResponse(
-        total=result.total + len(hosted_rows),
+        total=result.total,
         limit=result.limit,
         offset=result.offset,
         has_more=result.has_more,

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -32,6 +32,7 @@ from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_
 from lilbee.providers.local_servers import canonical_local_ref, local_server_for_label
 from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
+from lilbee.runtime.cancellation import TaskCancelledError
 from lilbee.runtime.hardware import (
     FitLevel,
     SizeVariantInfo,
@@ -589,8 +590,12 @@ async def models_pull(
 
     def _pull_blocking() -> None:
         def _on_bytes(downloaded: int, total: int) -> None:
+            # Raise rather than return: the pull runs in a worker thread that
+            # asyncio cannot interrupt, so returning quietly left a multi-GB
+            # download running for a client that had already gone. This is the
+            # abort path the downloader is written for.
             if sse.cancel.is_set():
-                return
+                raise TaskCancelledError
             payload = sse_event(SseEvent.PROGRESS, {"current": downloaded, "total": total})
             sse.loop.call_soon_threadsafe(sse.queue.put_event_nowait, payload, SseEvent.PROGRESS)
 
@@ -601,14 +606,23 @@ async def models_pull(
                 on_bytes=_on_bytes,
                 allow_unsupported=allow_unsupported,
             )
+        except TaskCancelledError:
+            log.info("Model pull for %s aborted: client disconnected", model)
         except Exception as exc:
             sse.loop.call_soon_threadsafe(sse.queue.put_nowait, sse_error(str(exc)))
         finally:
             sse.loop.call_soon_threadsafe(sse.queue.put_nowait, None)
 
     task = asyncio.ensure_future(asyncio.to_thread(_pull_blocking))
-    async for event in sse.drain(task, "Model pull stream"):
-        yield event
+    try:
+        async for event in sse.drain(task, "Model pull stream"):
+            yield event
+    finally:
+        # Closing this generator means the client is gone. Set the flag here
+        # rather than relying on drain's own cleanup, which runs only once that
+        # inner generator is collected: until then the worker thread keeps
+        # downloading for a client that has already disconnected.
+        sse.cancel.set()
 
 
 async def models_delete(model: str, *, source: str = "native") -> ModelsDeleteResponse:

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
@@ -395,28 +395,36 @@ def _hosted_entry(rm: RemoteModel, source: ModelSource) -> CatalogEntryResponse:
 _HOSTED_MODELS_TTL = 60
 
 
-class _HostedModelsCache:
-    """TTL cache for discovered hosted rows (no module-level mutable global)."""
+_CacheT = TypeVar("_CacheT")
 
-    def __init__(self) -> None:
+
+class _TtlCache(Generic[_CacheT]):
+    """Single-entry TTL cache keyed on the config tuple that produced it.
+
+    One class rather than the two near-identical copies this module used to
+    carry: they differed only in the cached type and in whether the freshness
+    check tested the result for truthiness or for None, and the truthiness
+    variant re-fetched every time the answer was legitimately empty.
+    """
+
+    def __init__(self, ttl_seconds: float) -> None:
+        self._ttl = ttl_seconds
         self._time: float = 0.0
         self._key: str = ""
-        self._result: list[CatalogEntryResponse] | None = None
+        self._result: _CacheT | None = None
 
-    def get(self, key: str) -> list[CatalogEntryResponse] | None:
-        now = time.monotonic()
-        fresh = (now - self._time) < _HOSTED_MODELS_TTL
-        if self._result is not None and key == self._key and fresh:
-            return self._result
-        return None
+    def get(self, key: str) -> _CacheT | None:
+        if self._result is None or key != self._key:
+            return None
+        return self._result if (time.monotonic() - self._time) < self._ttl else None
 
-    def set(self, key: str, result: list[CatalogEntryResponse]) -> None:
+    def set(self, key: str, result: _CacheT) -> None:
         self._time = time.monotonic()
         self._key = key
         self._result = result
 
 
-_hosted_cache = _HostedModelsCache()
+_hosted_cache: _TtlCache[list[CatalogEntryResponse]] = _TtlCache(_HOSTED_MODELS_TTL)
 
 
 def _discover_hosted_sync() -> list[CatalogEntryResponse]:
@@ -652,27 +660,7 @@ async def models_delete(model: str, *, source: str = "native") -> ModelsDeleteRe
 _EXTERNAL_MODELS_TTL = 60
 
 
-class _ExternalModelsCache:
-    """TTL cache for external model listings (no module-level mutable global)."""
-
-    def __init__(self) -> None:
-        self._time: float = 0.0
-        self._key: str = ""
-        self._result: ExternalModelsResponse | None = None
-
-    def get(self, key: str) -> ExternalModelsResponse | None:
-        now = time.monotonic()
-        if self._result and key == self._key and (now - self._time) < _EXTERNAL_MODELS_TTL:
-            return self._result
-        return None
-
-    def set(self, key: str, result: ExternalModelsResponse) -> None:
-        self._time = time.monotonic()
-        self._key = key
-        self._result = result
-
-
-_external_cache = _ExternalModelsCache()
+_external_cache: _TtlCache[ExternalModelsResponse] = _TtlCache(_EXTERNAL_MODELS_TTL)
 
 
 async def list_external_models() -> ExternalModelsResponse:

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -395,12 +395,8 @@ def _hosted_entry(rm: RemoteModel, source: ModelSource) -> CatalogEntryResponse:
 _HOSTED_MODELS_TTL = 60
 
 
-# Single-entry TTL caches keyed on the config tuple that produced the value.
-# maxsize=1 is the "single entry" part: a lookup under a new key misses and the
-# store evicts the old one, which is the behaviour the two hand-rolled classes
-# here reimplemented. They had already drifted apart, one testing the cached
-# value for truthiness instead of for presence, so a legitimately empty result
-# was never cached and re-fetched on every request.
+# Single-entry TTL caches keyed on the config tuple that produced the value:
+# maxsize=1 means a lookup under a new key evicts the old one.
 _hosted_cache: TTLCache[str, list[CatalogEntryResponse]] = TTLCache(
     maxsize=1, ttl=_HOSTED_MODELS_TTL
 )
@@ -490,12 +486,10 @@ async def models_catalog(
         _build_catalog_entry(e, available_bytes=available_bytes, families_by_repo=families_by_repo)
         for e in enriched
     ]
-    # Hosted rows (frontier + ollama) are selectable and download-free, so
-    # they're shown on the first page only (mirrors the featured first-page
-    # convention) and skipped for featured-only and installed=False filters.
-    # They are an unpaginated overlay, so they stay out of ``total``: adding
-    # them made page 1 report a larger total than page 2 of the same listing,
-    # and total/limit/offset/has_more now all describe the same paginated set.
+    # Hosted rows (frontier + ollama) are selectable and download-free, shown
+    # on the first page only and skipped for featured-only / installed=False.
+    # They stay out of ``total``: as an unpaginated overlay they made page 1
+    # report a larger total than page 2 of the same listing.
     hosted_rows: list[CatalogEntryResponse] = []
     if offset == 0 and not featured and installed is not False:
         hosted_rows = await _collect_hosted_entries(task=parsed_task, search=search)
@@ -579,10 +573,9 @@ async def models_pull(
 
     def _pull_blocking() -> None:
         def _on_bytes(downloaded: int, total: int) -> None:
-            # Raise rather than return: the pull runs in a worker thread that
-            # asyncio cannot interrupt, so returning quietly left a multi-GB
-            # download running for a client that had already gone. This is the
-            # abort path the downloader is written for.
+            # Raise, not return: the pull runs in a worker thread asyncio
+            # cannot interrupt, so returning left a multi-GB download running
+            # for a client that had gone.
             if sse.cancel.is_set():
                 raise TaskCancelledError
             payload = sse_event(SseEvent.PROGRESS, {"current": downloaded, "total": total})
@@ -607,10 +600,9 @@ async def models_pull(
         async for event in sse.drain(task, "Model pull stream"):
             yield event
     finally:
-        # Closing this generator means the client is gone. Set the flag here
-        # rather than relying on drain's own cleanup, which runs only once that
-        # inner generator is collected: until then the worker thread keeps
-        # downloading for a client that has already disconnected.
+        # Closing this generator means the client is gone. Set it here, not in
+        # drain's cleanup, which runs only once that generator is collected;
+        # until then the worker thread keeps downloading.
         sse.cancel.set()
 
 
@@ -647,8 +639,7 @@ _external_cache: TTLCache[str, ExternalModelsResponse] = TTLCache(
 async def list_external_models() -> ExternalModelsResponse:
     """Query the provider for available models via its list_models() API."""
     key = f"{cfg.ollama_base_url}:{cfg.lm_studio_base_url}:{cfg.llm_api_key or ''}"
-    # ``is not None``, not truthiness: an empty model list is a real answer and
-    # caching it is the point. Testing the value itself re-fetched every time.
+    # ``is not None``, not truthiness: an empty model list is a real answer.
     cached = _external_cache.get(key)
     if cached is not None:
         return cached

--- a/src/lilbee/server/handlers/sessions.py
+++ b/src/lilbee/server/handlers/sessions.py
@@ -6,6 +6,9 @@ container. A missing session id surfaces as a 404.
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
+
 from litestar.exceptions import ClientException, NotFoundException
 from litestar.status_codes import HTTP_409_CONFLICT
 
@@ -47,6 +50,26 @@ def _store() -> SessionStore:
     return get_services().session_store
 
 
+@contextmanager
+def _session_errors() -> Generator[None, None, None]:
+    """Map the store's typed failures onto the statuses the handlers document.
+
+    Wraps the *whole* handler body, not just the mutation. Each of these
+    handlers mutates and then re-reads the session to build its response, and
+    the TUI and HTTP surfaces share one store: a session deleted between the
+    two calls made the trailing read raise an unguarded SessionNotFoundError
+    that escaped as a 500 instead of the promised 404.
+    """
+    try:
+        yield
+    except SessionNotFoundError as exc:
+        raise NotFoundException(detail=str(exc)) from exc
+    except SessionOwnershipError as exc:
+        # 409, not 403: the resource exists and the token is fine; the session
+        # is owned elsewhere, and claiming it is the documented resolution.
+        raise ClientException(detail=str(exc), status_code=HTTP_409_CONFLICT) from exc
+
+
 def _meta_item(meta: SessionMeta) -> SessionMetaItem:
     return SessionMetaItem(
         id=meta.id,
@@ -85,19 +108,18 @@ async def list_sessions() -> SessionListResponse:
 
 async def get_session(session_id: str) -> SessionDetailResponse:
     """Return a session's metadata and transcript, or 404 if unknown."""
-    try:
-        session = _store().get(session_id)
-    except SessionNotFoundError as exc:
-        raise NotFoundException(detail=str(exc)) from exc
-    return _detail(session)
+    with _session_errors():
+        return _detail(_store().get(session_id))
 
 
 async def create_session(data: SessionCreateRequest) -> SessionDetailResponse:
     """Start a new conversation and return it (empty transcript, no summary)."""
-    session_id = _store().create(
-        model_ref=data.model_ref, scope=data.scope, origin=SessionOrigin.HTTP
-    )
-    return _detail(_store().get(session_id))
+    store = _store()
+    with _session_errors():
+        session_id = store.create(
+            model_ref=data.model_ref, scope=data.scope, origin=SessionOrigin.HTTP
+        )
+        return _detail(store.get(session_id))
 
 
 async def add_session_message(
@@ -105,50 +127,39 @@ async def add_session_message(
 ) -> SessionDetailResponse:
     """Append one turn to a conversation and return it, or 404 if unknown."""
     message = SessionMessage(role=data.role, content=data.content, sources=tuple(data.sources))
-    try:
-        _store().add_message(session_id, message, surface=SessionOrigin.HTTP)
-    except SessionNotFoundError as exc:
-        raise NotFoundException(detail=str(exc)) from exc
-    except SessionOwnershipError as exc:
-        # 409, not 403: the resource exists and the token is fine; the session
-        # is owned elsewhere, and claiming it is the documented resolution.
-        raise ClientException(detail=str(exc), status_code=HTTP_409_CONFLICT) from exc
-    return _detail(_store().get(session_id))
+    store = _store()
+    with _session_errors():
+        store.add_message(session_id, message, surface=SessionOrigin.HTTP)
+        return _detail(store.get(session_id))
 
 
 async def claim_session(session_id: str) -> SessionDetailResponse:
     """Claim a conversation for the HTTP surface, or 404 if unknown."""
-    try:
-        _store().transfer(session_id, SessionOrigin.HTTP)
-    except SessionNotFoundError as exc:
-        raise NotFoundException(detail=str(exc)) from exc
-    return _detail(_store().get(session_id))
+    store = _store()
+    with _session_errors():
+        store.transfer(session_id, SessionOrigin.HTTP)
+        return _detail(store.get(session_id))
 
 
 async def set_session_summary(
     session_id: str, data: SessionSummaryRequest
 ) -> SessionDetailResponse:
     """Replace a conversation's compaction summary, or 404 if unknown."""
-    try:
-        _store().set_summary(session_id, data.summary)
-    except SessionNotFoundError as exc:
-        raise NotFoundException(detail=str(exc)) from exc
-    return _detail(_store().get(session_id))
+    store = _store()
+    with _session_errors():
+        store.set_summary(session_id, data.summary)
+        return _detail(store.get(session_id))
 
 
 async def rename_session(session_id: str, title: str) -> SessionRenameResponse:
     """Rename a session, or 404 if unknown."""
-    try:
+    with _session_errors():
         _store().set_title(session_id, title, TitleSource.CUSTOM)
-    except SessionNotFoundError as exc:
-        raise NotFoundException(detail=str(exc)) from exc
     return SessionRenameResponse(id=session_id, title=title)
 
 
 async def delete_session(session_id: str) -> SessionDeleteResponse:
     """Delete a session, or 404 if unknown."""
-    try:
+    with _session_errors():
         _store().delete(session_id)
-    except SessionNotFoundError as exc:
-        raise NotFoundException(detail=str(exc)) from exc
     return SessionDeleteResponse(id=session_id, deleted=True)

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -146,11 +146,18 @@ class SseEventQueue(asyncio.Queue[str | None]):
         return self._queue.popleft().payload
 
     def _evict_oldest_droppable(self) -> bool:
-        """Shed the queue head when it is a progress event; True when a slot freed."""
-        if self._queue and self._queue[0].droppable:
-            self._queue.popleft()
-            self.dropped_events += 1
-            return True
+        """Shed the oldest progress event anywhere in the queue; True when one went.
+
+        Scans rather than checking only the head. A stream that interleaves
+        tokens with progress puts a non-droppable event at the head almost
+        immediately, and head-only eviction then reported "nothing to shed"
+        while the queue still held progress events it was allowed to drop.
+        """
+        for index, event in enumerate(self._queue):
+            if event.droppable:
+                del self._queue[index]
+                self.dropped_events += 1
+                return True
         return False
 
     def put_nowait(self, item: str | None) -> None:

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -142,6 +142,9 @@ class SseEventQueue(asyncio.Queue[str | None]):
         self._max_events = max_events
         self._put_droppable = False
         self.dropped_events = 0
+        # Set once the queue is full of undroppable events, i.e. the consumer
+        # has stopped reading. See put_nowait.
+        self.stalled = False
 
     def _put(self, item: str | None) -> None:
         self._queue.append(_QueuedEvent(item, self._put_droppable))
@@ -166,8 +169,14 @@ class SseEventQueue(asyncio.Queue[str | None]):
 
     def put_nowait(self, item: str | None) -> None:
         """Enqueue an always-delivered event, evicting old progress when full."""
-        if self.qsize() >= self._max_events:
-            self._evict_oldest_droppable()
+        if self.qsize() >= self._max_events and not self._evict_oldest_droppable():
+            # Nothing left that may be shed: the queue is full of events this
+            # class is required to deliver (chat and RAG tokens go through
+            # here), and the consumer has not taken one in _max_events. That
+            # is a stalled or already-gone client, so record it. Growing the
+            # queue for the rest of the generation is the alternative, and it
+            # is unbounded by construction.
+            self.stalled = True
         self._put_droppable = False
         super().put_nowait(item)
 
@@ -207,7 +216,26 @@ class SseStream:
         producer running under ``run_in_executor`` therefore hands the put back
         to the loop instead of mutating the queue directly.
         """
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, item)
+        self.loop.call_soon_threadsafe(self._put_and_check_stall, item)
+
+    def _put_and_check_stall(self, item: str | None) -> None:
+        """Enqueue on the loop thread, cancelling the producer if it has stalled.
+
+        Chat and RAG tokens are in the always-deliver class, so a fast
+        generation streaming to a client that has stopped reading fills the
+        queue with events nothing is permitted to shed and it grows until the
+        generation ends. A consumer that has not taken a single event in a
+        full queue's worth is gone or as good as gone; cancelling is the same
+        signal a detected disconnect sends, just reached a different way.
+        """
+        self.queue.put_nowait(item)
+        if self.queue.stalled and not self.cancel.is_set():
+            log.warning(
+                "SSE consumer stalled with %d undroppable events queued; "
+                "cancelling the producer.",
+                self.queue.qsize(),
+            )
+            self.cancel.set()
 
     def _build_callback(self) -> DetailedProgressCallback:
         """Create a progress callback that serializes events into the queue.

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -98,6 +98,10 @@ def _resolve_generation_options(options: dict[str, Any] | None) -> dict[str, Any
 # stream sheds the oldest progress event rather than buffering millions.
 SSE_QUEUE_MAX_EVENTS = 1000
 
+# Poll ceiling once the producer task has finished, for the case where the
+# queue drains empty without the sentinel ever arriving.
+_FINISHED_PRODUCER_POLL_S = 1.0
+
 # Progress-class event types: high-frequency, safe to coalesce under
 # backpressure. Everything else (done, errors, crawl/setup lifecycle) must land.
 _DROPPABLE_EVENT_TYPES: frozenset[EventType | SseEvent] = frozenset(
@@ -238,6 +242,30 @@ class SseStream:
             if leftover is not None:
                 yield leftover
 
+    @staticmethod
+    def _drain_waiters(
+        getter: asyncio.Future[str | None],
+        task: asyncio.Task[Any] | asyncio.Future[Any],
+    ) -> set[asyncio.Future[Any]]:
+        """Futures the drain loop waits on. A finished task is left out: it
+        would resolve the wait instantly on every pass and spin the loop."""
+        return {getter} if task.done() else {getter, task}
+
+    @staticmethod
+    def _drain_timeout(task: asyncio.Task[Any] | asyncio.Future[Any]) -> float | None:
+        """How long one drain pass may sleep.
+
+        While the producer runs, the only thing the timeout serves is the
+        heartbeat, and the task is in the wait set for everything else, so a
+        disabled heartbeat can wait indefinitely. Once the task has finished it
+        is out of the wait set, so this bounds the one remaining case: a queue
+        that empties without the sentinel ever arriving.
+        """
+        if task.done():
+            return _FINISHED_PRODUCER_POLL_S
+        interval = cfg.sse_heartbeat_interval
+        return interval if interval > 0 else None
+
     async def drain(
         self, task: asyncio.Task[Any] | asyncio.Future[Any], label: str
     ) -> AsyncGenerator[str, None]:
@@ -250,6 +278,12 @@ class SseStream:
         The pending ``queue.get`` survives across poll rounds (``asyncio.wait``,
         not ``wait_for``): cancelling a completed get on the timeout boundary
         would drop the event it already popped from the queue.
+
+        The wait covers *task* as well, so a producer that dies without a
+        sentinel wakes the loop directly. That is what lets the timeout be the
+        seconds-scale heartbeat interval rather than a fixed 0.1s tick: the
+        loop used to wake ten times a second per open stream purely to
+        re-evaluate two conditions that neither need that resolution.
         """
         last_yielded = time.monotonic()
         getter: asyncio.Future[str | None] | None = None
@@ -257,8 +291,12 @@ class SseStream:
             while True:
                 if getter is None:
                     getter = asyncio.ensure_future(self.queue.get())
-                done, _ = await asyncio.wait({getter}, timeout=0.1)
-                if not done:
+                done, _ = await asyncio.wait(
+                    self._drain_waiters(getter, task),
+                    timeout=self._drain_timeout(task),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if getter not in done:
                     now = time.monotonic()
                     heartbeat_interval = cfg.sse_heartbeat_interval
                     if heartbeat_interval > 0 and now - last_yielded >= heartbeat_interval:

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -51,7 +51,12 @@ def sse_error(
     return sse_event(SseEvent.ERROR, payload)
 
 
-_OOM_MARKERS = ("failed to load", "free ram", "try a smaller model", "llama_context")
+# Phrases that describe an allocation failure. "llama_context" alone used to be
+# here, but that is the prefix llama.cpp stamps on every context-subsystem
+# diagnostic, so n_ctx-over-training-context and KV-cache rejections were all
+# reported as "model too large", pointing at a smaller model when the fix is a
+# config change.
+_OOM_MARKERS = ("failed to load", "free ram", "try a smaller model", "failed to allocate")
 _NOT_INSTALLED_MARKERS = ("is not installed", "is not available", "pull it first")
 
 

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -8,7 +8,7 @@ import logging
 import threading
 import time
 from collections import deque
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from typing import Any, NamedTuple
 
 from pydantic import BaseModel
@@ -241,6 +241,27 @@ class SseStream:
             leftover = self.queue.get_nowait()
             if leftover is not None:
                 yield leftover
+
+    def terminal_frame(
+        self,
+        task: asyncio.Task[Any] | asyncio.Future[Any],
+        payload: Callable[[Any], dict[str, Any]],
+    ) -> str | None:
+        """The final SSE frame for a finished producer, or None if there is none.
+
+        Every streaming handler ended with the same five lines: check cancel,
+        check the task finished and was not cancelled, turn an exception into
+        sse_error, otherwise sse_done of the result. The copies had drifted --
+        the crawler-setup one skipped the cancel check and so emitted a done
+        frame to a client that had already disconnected -- which is the reason
+        this lives in one place now.
+        """
+        if self.cancel.is_set() or not task.done() or task.cancelled():
+            return None
+        exc = task.exception()
+        if exc is not None:
+            return sse_error(str(exc))
+        return sse_done(payload(task.result()))
 
     @staticmethod
     def _drain_waiters(

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -231,8 +231,7 @@ class SseStream:
         self.queue.put_nowait(item)
         if self.queue.stalled and not self.cancel.is_set():
             log.warning(
-                "SSE consumer stalled with %d undroppable events queued; "
-                "cancelling the producer.",
+                "SSE consumer stalled with %d undroppable events queued; cancelling the producer.",
                 self.queue.qsize(),
             )
             self.cancel.set()

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -170,12 +170,9 @@ class SseEventQueue(asyncio.Queue[str | None]):
     def put_nowait(self, item: str | None) -> None:
         """Enqueue an always-delivered event, evicting old progress when full."""
         if self.qsize() >= self._max_events and not self._evict_oldest_droppable():
-            # Nothing left that may be shed: the queue is full of events this
-            # class is required to deliver (chat and RAG tokens go through
-            # here), and the consumer has not taken one in _max_events. That
-            # is a stalled or already-gone client, so record it. Growing the
-            # queue for the rest of the generation is the alternative, and it
-            # is unbounded by construction.
+            # Full of undroppable events (chat and RAG tokens come through
+            # here) and the consumer has taken none in _max_events: a stalled
+            # or gone client. The alternative is unbounded growth.
             self.stalled = True
         self._put_droppable = False
         super().put_nowait(item)
@@ -221,12 +218,8 @@ class SseStream:
     def _put_and_check_stall(self, item: str | None) -> None:
         """Enqueue on the loop thread, cancelling the producer if it has stalled.
 
-        Chat and RAG tokens are in the always-deliver class, so a fast
-        generation streaming to a client that has stopped reading fills the
-        queue with events nothing is permitted to shed and it grows until the
-        generation ends. A consumer that has not taken a single event in a
-        full queue's worth is gone or as good as gone; cancelling is the same
-        signal a detected disconnect sends, just reached a different way.
+        A consumer that has taken nothing in a full queue's worth is gone;
+        cancelling is the same signal a detected disconnect sends.
         """
         self.queue.put_nowait(item)
         if self.queue.stalled and not self.cancel.is_set():
@@ -276,12 +269,9 @@ class SseStream:
     ) -> str | None:
         """The final SSE frame for a finished producer, or None if there is none.
 
-        Every streaming handler ended with the same five lines: check cancel,
-        check the task finished and was not cancelled, turn an exception into
-        sse_error, otherwise sse_done of the result. The copies had drifted --
-        the crawler-setup one skipped the cancel check and so emitted a done
-        frame to a client that had already disconnected -- which is the reason
-        this lives in one place now.
+        Shared by all five streaming handlers, which used to carry their own
+        copy of this and had drifted: one skipped the cancel check and emitted
+        a done frame to a client that had already disconnected.
         """
         if self.cancel.is_set() or not task.done() or task.cancelled():
             return None
@@ -295,19 +285,18 @@ class SseStream:
         getter: asyncio.Future[str | None],
         task: asyncio.Task[Any] | asyncio.Future[Any],
     ) -> set[asyncio.Future[Any]]:
-        """Futures the drain loop waits on. A finished task is left out: it
-        would resolve the wait instantly on every pass and spin the loop."""
+        """Futures the drain loop waits on. A finished task is left out or it
+        would resolve the wait instantly every pass and spin the loop."""
         return {getter} if task.done() else {getter, task}
 
     @staticmethod
     def _drain_timeout(task: asyncio.Task[Any] | asyncio.Future[Any]) -> float | None:
         """How long one drain pass may sleep.
 
-        While the producer runs, the only thing the timeout serves is the
-        heartbeat, and the task is in the wait set for everything else, so a
-        disabled heartbeat can wait indefinitely. Once the task has finished it
-        is out of the wait set, so this bounds the one remaining case: a queue
-        that empties without the sentinel ever arriving.
+        While the producer runs the timeout only serves the heartbeat, since
+        the task itself is in the wait set; a disabled heartbeat can wait
+        indefinitely. Once it finishes it leaves the wait set, so this bounds
+        the remaining case: a queue emptying without the sentinel arriving.
         """
         if task.done():
             return _FINISHED_PRODUCER_POLL_S
@@ -323,15 +312,13 @@ class SseStream:
         idle longer than ``cfg.sse_heartbeat_interval`` seconds so
         clients that enforce a stream-idle timeout don't abort.
 
-        The pending ``queue.get`` survives across poll rounds (``asyncio.wait``,
-        not ``wait_for``): cancelling a completed get on the timeout boundary
-        would drop the event it already popped from the queue.
+        The pending ``queue.get`` survives across rounds (``asyncio.wait``, not
+        ``wait_for``): cancelling a completed get on the timeout boundary would
+        drop the event it already popped.
 
-        The wait covers *task* as well, so a producer that dies without a
-        sentinel wakes the loop directly. That is what lets the timeout be the
-        seconds-scale heartbeat interval rather than a fixed 0.1s tick: the
-        loop used to wake ten times a second per open stream purely to
-        re-evaluate two conditions that neither need that resolution.
+        *task* is in the wait set, so a producer dying without a sentinel wakes
+        the loop directly. That is what lets the timeout be the seconds-scale
+        heartbeat interval instead of a 10Hz tick.
         """
         last_yielded = time.monotonic()
         getter: asyncio.Future[str | None] | None = None

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import TYPE_CHECKING, cast
@@ -16,6 +17,8 @@ from lilbee.mcp_server import mcp, set_http_mounted
 if TYPE_CHECKING:
     from litestar import Litestar
     from litestar.handlers import ASGIRouteHandler
+
+log = logging.getLogger(__name__)
 
 MCP_MOUNT_PATH = "/mcp"
 
@@ -45,7 +48,19 @@ def _transport_security() -> TransportSecuritySettings:
         f"{scheme}://{_fmt_host(h)}:*" for h in _LOOPBACK_HOSTS for scheme in ("http", "https")
     ]
     bind = cfg.server_host
-    if bind and bind not in _LOOPBACK_HOSTS and bind not in _WILDCARD_BINDS:
+    if bind in _WILDCARD_BINDS:
+        # The REST API on this port serves LAN clients fine, so without this
+        # the operator sees a half-working server: only /mcp fails, and it
+        # fails with an opaque transport-security rejection rather than
+        # anything naming the bind address as the cause.
+        log.warning(
+            "Bound to %s, which cannot be enumerated for a Host allowlist, so %s "
+            "accepts loopback Host headers only. Bind to a specific address to "
+            "reach the MCP endpoint from other machines.",
+            bind,
+            MCP_MOUNT_PATH,
+        )
+    elif bind and bind not in _LOOPBACK_HOSTS:
         hosts.append(f"{_fmt_host(bind)}:*")
         origins.extend(f"{scheme}://{_fmt_host(bind)}:*" for scheme in ("http", "https"))
     return TransportSecuritySettings(
@@ -67,7 +82,18 @@ def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     # concurrent in-flight handlers on the process-global Services singleton.
     set_http_mounted(True)
     # FastMCP caches the session manager; clear it so each app owns its own,
-    # since run() is single-use per instance.
+    # since run() is single-use per instance. There is no public reset in the
+    # mcp package (the property only lazily constructs and raises if read
+    # early), so this reaches into the private attribute deliberately, under
+    # the mcp>=1.26,<2 pin in pyproject. Checked rather than assumed: a rename
+    # would otherwise surface much later as an opaque run()-already-entered
+    # error from the lifespan, with nothing pointing at the dependency.
+    if not hasattr(mcp, "_session_manager"):
+        raise RuntimeError(
+            "This mcp release no longer caches the session manager on "
+            "FastMCP._session_manager, so a per-app session manager cannot be "
+            "forced. Check the mcp version pin in pyproject.toml."
+        )
     mcp._session_manager = None
     mcp.settings.streamable_http_path = "/"
     mcp.settings.transport_security = _transport_security()

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -71,24 +71,18 @@ def _transport_security() -> TransportSecuritySettings:
 def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     """Return the MCP route handler and the session-manager lifespan.
 
-    A fresh session manager is built per call: ``session_manager.run()`` can
-    only be entered once per instance, and the app factory runs once per
-    process in production but repeatedly across tests.
+    Every call yields a mount whose lifespan can start. FastMCP caches one
+    session manager on the module-level server and
+    ``StreamableHTTPSessionManager.run()`` is single-use, so the cache is
+    cleared here; without it a second app in the same process gets a manager
+    whose lifespan raises. The package exposes no public reset, so this pokes
+    the attribute ``streamable_http_app()`` populates lazily, under the
+    ``mcp>=1.26,<2`` pin.
     """
     # Mark MCP as served over the shared HTTP daemon so single-vault-only tools
     # (init, reset) refuse runtime vault-switch / teardown that would race
     # concurrent in-flight handlers on the process-global Services singleton.
     set_http_mounted(True)
-    # run() is single-use per instance, so each app needs its own manager.
-    # The mcp package has no public reset, hence the private attribute, under
-    # the mcp>=1.26,<2 pin. Checked, not assumed: a rename would otherwise
-    # surface as an opaque run()-already-entered error from the lifespan.
-    if not hasattr(mcp, "_session_manager"):
-        raise RuntimeError(
-            "This mcp release no longer caches the session manager on "
-            "FastMCP._session_manager, so a per-app session manager cannot be "
-            "forced. Check the mcp version pin in pyproject.toml."
-        )
     mcp._session_manager = None
     mcp.settings.streamable_http_path = "/"
     mcp.settings.transport_security = _transport_security()

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -50,9 +50,7 @@ def _transport_security() -> TransportSecuritySettings:
     bind = cfg.server_host
     if bind in _WILDCARD_BINDS:
         # The REST API on this port serves LAN clients fine, so without this
-        # the operator sees a half-working server: only /mcp fails, and it
-        # fails with an opaque transport-security rejection rather than
-        # anything naming the bind address as the cause.
+        # only /mcp fails, with an opaque transport-security rejection.
         log.warning(
             "Bound to %s, which cannot be enumerated for a Host allowlist, so %s "
             "accepts loopback Host headers only. Bind to a specific address to "
@@ -81,13 +79,10 @@ def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     # (init, reset) refuse runtime vault-switch / teardown that would race
     # concurrent in-flight handlers on the process-global Services singleton.
     set_http_mounted(True)
-    # FastMCP caches the session manager; clear it so each app owns its own,
-    # since run() is single-use per instance. There is no public reset in the
-    # mcp package (the property only lazily constructs and raises if read
-    # early), so this reaches into the private attribute deliberately, under
-    # the mcp>=1.26,<2 pin in pyproject. Checked rather than assumed: a rename
-    # would otherwise surface much later as an opaque run()-already-entered
-    # error from the lifespan, with nothing pointing at the dependency.
+    # run() is single-use per instance, so each app needs its own manager.
+    # The mcp package has no public reset, hence the private attribute, under
+    # the mcp>=1.26,<2 pin. Checked, not assumed: a rename would otherwise
+    # surface as an opaque run()-already-entered error from the lifespan.
     if not hasattr(mcp, "_session_manager"):
         raise RuntimeError(
             "This mcp release no longer caches the session manager on "

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -12,7 +12,7 @@ from litestar.types import ASGIApp, Receive, Scope, Send
 from mcp.server.transport_security import TransportSecuritySettings
 
 from lilbee.core.config import cfg
-from lilbee.mcp_server import mcp, set_http_mounted
+from lilbee.mcp_server import build_mcp_server, set_http_mounted
 
 if TYPE_CHECKING:
     from litestar import Litestar
@@ -71,23 +71,19 @@ def _transport_security() -> TransportSecuritySettings:
 def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     """Return the MCP route handler and the session-manager lifespan.
 
-    Every call yields a mount whose lifespan can start. FastMCP caches one
-    session manager on the module-level server and
-    ``StreamableHTTPSessionManager.run()`` is single-use, so the cache is
-    cleared here; without it a second app in the same process gets a manager
-    whose lifespan raises. The package exposes no public reset, so this pokes
-    the attribute ``streamable_http_app()`` populates lazily, under the
-    ``mcp>=1.26,<2`` pin.
+    Builds its own MCP server rather than sharing the stdio one: FastMCP caches
+    a single session manager per server and ``run()`` is single-use, so a shared
+    server's second lifespan would raise.
     """
     # Mark MCP as served over the shared HTTP daemon so single-vault-only tools
     # (init, reset) refuse runtime vault-switch / teardown that would race
     # concurrent in-flight handlers on the process-global Services singleton.
     set_http_mounted(True)
-    mcp._session_manager = None
-    mcp.settings.streamable_http_path = "/"
-    mcp.settings.transport_security = _transport_security()
-    asgi_app = cast("ASGIApp", mcp.streamable_http_app())
-    manager = mcp.session_manager
+    server = build_mcp_server()
+    server.settings.streamable_http_path = "/"
+    server.settings.transport_security = _transport_security()
+    asgi_app = cast("ASGIApp", server.streamable_http_app())
+    manager = server.session_manager
 
     async def _forward(scope: Scope, receive: Receive, send: Send) -> None:
         await asgi_app(scope, receive, send)

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -71,9 +71,9 @@ def _transport_security() -> TransportSecuritySettings:
 def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     """Return the MCP route handler and the session-manager lifespan.
 
-    Builds its own MCP server rather than sharing the stdio one: FastMCP caches
-    a single session manager per server and ``run()`` is single-use, so a shared
-    server's second lifespan would raise.
+    Each mount builds its own MCP server: FastMCP caches a single session
+    manager per server and ``run()`` is single-use, so a shared server's
+    second lifespan would raise.
     """
     # Mark MCP as served over the shared HTTP daemon so single-vault-only tools
     # (init, reset) refuse runtime vault-switch / teardown that would race

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -41,7 +41,7 @@ class AskRequest(BaseModel):
     """Request body for /api/ask."""
 
     question: str
-    top_k: int = Field(default=0, le=100)
+    top_k: int = Field(default=0, ge=0, le=100)
     options: dict[str, Any] | None = None
     chunk_type: ChunkType | None = None
 
@@ -58,7 +58,7 @@ class ChatRequest(BaseModel):
     history: list[ChatMessage] = []
     # None (unspecified) grounds with the configured top_k; an explicit 0 is a
     # pure-LLM call that skips retrieval entirely.
-    top_k: int | None = Field(default=None, le=100)
+    top_k: int | None = Field(default=None, ge=0, le=100)
     options: dict[str, Any] | None = None
     chunk_type: ChunkType | None = None
     summary: str = ""

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -400,6 +400,14 @@ class AddSummary(BaseModel):
     skipped: list[str]
     errors: list[str]
     sync: SyncSummary | None = None
+    already_ingesting: list[str] = []
+    """Sources another ingest held a lock on, so this run never attempted them.
+
+    Distinct from ``skipped``, which means the file was examined and needed no
+    work. These were not looked at and are worth retrying. Carried on the
+    terminal event so a client that missed the earlier ``already_ingesting``
+    frames can still tell the batch was partial.
+    """
 
 
 class WikiCitationRecord(BaseModel):

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -77,13 +77,15 @@ async def add_upload_route(
     e.g. the plugin or CLI in external mode against a remote lilbee / GPU box --
     ingest its own local files by uploading them straight to the server.
     """
-    files: list[tuple[str, bytes]] = []
-    for upload in data:
-        files.append((upload.filename, await upload.read()))
+    # Names first, bytes second. Reading every part into a list before
+    # validating meant a request that was going to be rejected on filename
+    # still cost a full in-memory copy of the payload, per concurrent
+    # uploader, on a box that is also holding model weights.
     try:
-        cleaned = handlers.validate_uploads(files)
+        names = handlers.validate_upload_names([upload.filename for upload in data])
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
+    cleaned = [(name, await upload.read()) for name, upload in zip(names, data, strict=True)]
     return Stream(
         handlers.add_uploads_stream(cleaned),
         media_type="text/event-stream",

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -113,10 +113,15 @@ async def export_route(
     source: str = Parameter(query="source", default=""),
 ) -> Response[bytes]:
     """Download the per-page text dataset as a file (parquet by default)."""
+    import asyncio
+
     from lilbee.app.dataset import DatasetError, export_to_bytes
 
     try:
-        payload = export_to_bytes(fmt, source or None)
+        # export_to_bytes serializes the whole per-page dataset into memory;
+        # offload so a large export doesn't stall every other request, matching
+        # get_source_content's own off-loop read.
+        payload = await asyncio.to_thread(export_to_bytes, fmt, source or None)
     except DatasetError as exc:
         raise ValidationException(str(exc)) from exc
     return Response(

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from litestar import Request, Response, get, post
 from litestar.datastructures import UploadFile
 from litestar.enums import RequestEncodingType
@@ -113,8 +115,6 @@ async def export_route(
     source: str = Parameter(query="source", default=""),
 ) -> Response[bytes]:
     """Download the per-page text dataset as a file (parquet by default)."""
-    import asyncio
-
     from lilbee.app.dataset import DatasetError, export_to_bytes
 
     try:

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -1,7 +1,7 @@
 """Document management route handlers: add, list, remove, sync, export.
 
-Every route here needs the session token, reads included: the listing names
-the user's files and ``/api/export`` serializes the whole corpus.
+Every route needs the token, reads included: the listing names the user's
+files and ``/api/export`` serializes the whole corpus.
 """
 
 from __future__ import annotations
@@ -80,10 +80,8 @@ async def add_upload_route(
     e.g. the plugin or CLI in external mode against a remote lilbee / GPU box --
     ingest its own local files by uploading them straight to the server.
     """
-    # Names first, bytes second. Reading every part into a list before
-    # validating meant a request that was going to be rejected on filename
-    # still cost a full in-memory copy of the payload, per concurrent
-    # uploader, on a box that is also holding model weights.
+    # Names first, bytes second: reading every part before validating cost a
+    # full in-memory copy of a payload that was going to be rejected anyway.
     try:
         names = handlers.validate_upload_names([upload.filename for upload in data])
     except ValueError as exc:

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -95,7 +95,7 @@ async def add_upload_route(
 @read_only
 async def documents_list_route(
     search: str = Parameter(query="search", default=""),
-    limit: int = Parameter(query="limit", default=50, le=1000),
+    limit: int = Parameter(query="limit", default=50, ge=1, le=1000),
     offset: int = Parameter(query="offset", default=0, ge=0),
 ) -> DocumentListResponse:
     """List indexed documents with metadata, paginated and searchable."""

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -1,4 +1,8 @@
-"""Document management route handlers: add, list, remove, sync."""
+"""Document management route handlers: add, list, remove, sync, export.
+
+Every route here needs the session token, reads included: the listing names
+the user's files and ``/api/export`` serializes the whole corpus.
+"""
 
 from __future__ import annotations
 
@@ -13,7 +17,6 @@ from litestar.response import Stream
 from pydantic import BaseModel, Field
 
 from lilbee.server import handlers
-from lilbee.server.auth import read_only
 from lilbee.server.models import (
     AddRequest,
     DocumentListResponse,
@@ -94,7 +97,6 @@ async def add_upload_route(
 
 
 @get("/api/documents")
-@read_only
 async def documents_list_route(
     search: str = Parameter(query="search", default=""),
     limit: int = Parameter(query="limit", default=50, ge=1, le=1000),
@@ -111,7 +113,6 @@ async def documents_remove_route(data: RemoveRequest) -> DocumentRemoveResponse:
 
 
 @get("/api/export")
-@read_only
 async def export_route(
     fmt: str = Parameter(query="format", default=""),
     source: str = Parameter(query="source", default=""),

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -1,11 +1,8 @@
 """General routes: health, status, config, source, warm.
 
-Every route here needs the session token, ``/api/health`` included. Health
-looks like the one endpoint that could stay open, but it reports the chat
-engine's last error string, which carries model paths and loader failures, so
-an unauthenticated liveness probe would hand out the most useful reconnaissance
-on the box. A local probe runs as the user and can read the token out of
-server.json the same way every other local client does.
+Every route needs the token, ``/api/health`` included: it reports the chat
+engine's last error, which carries model paths and loader failures. A local
+probe reads the token from server.json like every other local client.
 """
 
 from __future__ import annotations

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -1,4 +1,12 @@
-"""General routes: health, status, config."""
+"""General routes: health, status, config, source, warm.
+
+Every route here needs the session token, ``/api/health`` included. Health
+looks like the one endpoint that could stay open, but it reports the chat
+engine's last error string, which carries model paths and loader failures, so
+an unauthenticated liveness probe would hand out the most useful reconnaissance
+on the box. A local probe runs as the user and can read the token out of
+server.json the same way every other local client does.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +19,6 @@ from litestar.response import Stream
 from pydantic import ValidationError
 
 from lilbee.server import handlers
-from lilbee.server.auth import read_only
 from lilbee.server.models import (
     ConfigResponse,
     ConfigUpdateResponse,
@@ -22,35 +29,30 @@ from lilbee.server.models import (
 
 
 @get("/api/health")
-@read_only
 async def health_route() -> HealthResponse:
     """Service health check returning server version and uptime status."""
     return await handlers.health()
 
 
 @get("/api/warm/stream")
-@read_only
 async def warm_stream_route() -> Stream:
     """Stream chat-model cold-load progress as SSE for a launcher's warm indicator."""
     return Stream(handlers.warm_stream(), media_type="text/event-stream")
 
 
 @get("/api/status")
-@read_only
 async def status_route() -> StatusResponse:
     """Current configuration, indexed document sources, and chunk counts."""
     return await handlers.status()
 
 
 @get("/api/config")
-@read_only
 async def config_route() -> ConfigResponse:
     """Return all user-facing configuration values."""
     return await handlers.get_config()
 
 
 @get("/api/config/defaults")
-@read_only
 async def config_defaults_route() -> ConfigResponse:
     """Return canonical defaults for every writable, public configuration field."""
     return await handlers.get_config_defaults()
@@ -66,7 +68,6 @@ async def config_update_route(data: dict[str, Any]) -> ConfigUpdateResponse:
 
 
 @get("/api/source")
-@read_only
 async def source_content_route(
     source: str, raw: bool = False
 ) -> SourceContentResponse | Response[bytes]:

--- a/src/lilbee/server/routes/memory.py
+++ b/src/lilbee/server/routes/memory.py
@@ -1,10 +1,7 @@
-"""Memory route handlers: list, remember, update flags, forget.
+"""Memory routes: list, remember, update, forget.
 
-Every route here requires the session token. ``@read_only`` does not mean
-"a weaker token is accepted": ``AuthMiddleware`` short-circuits before any
-token check for handlers in that registry, so a decorated route answers
-callers with no ``Authorization`` header at all. Memories are the human's
-own facts and preferences in plain text, so none of these routes carry it.
+Every route here requires the session token. Memories are the human's own
+notes about themselves, so they are not part of any open-read surface.
 """
 
 from __future__ import annotations

--- a/src/lilbee/server/routes/memory.py
+++ b/src/lilbee/server/routes/memory.py
@@ -1,14 +1,16 @@
 """Memory route handlers: list, remember, update flags, forget.
 
-``GET`` is ``@read_only`` so a read-only session token can list memories;
-the mutating routes are unmarked so read-only tokens cannot write memory.
+Every route here requires the session token. ``@read_only`` does not mean
+"a weaker token is accepted": ``AuthMiddleware`` short-circuits before any
+token check for handlers in that registry, so a decorated route answers
+callers with no ``Authorization`` header at all. Memories are the human's
+own facts and preferences in plain text, so none of these routes carry it.
 """
 
 from __future__ import annotations
 
 from litestar import delete, get, patch, post
 
-from lilbee.server.auth import read_only
 from lilbee.server.handlers.memory import (
     list_local_memories,
     remember_memory,
@@ -26,7 +28,6 @@ from lilbee.server.models import (
 
 
 @get("/api/memories")
-@read_only
 async def memories_list_route() -> MemoryListResponse:
     """List the human's stored memories."""
     return await list_local_memories()

--- a/src/lilbee/server/routes/memory.py
+++ b/src/lilbee/server/routes/memory.py
@@ -1,7 +1,6 @@
 """Memory routes: list, remember, update, forget.
 
-Every route here requires the session token. Memories are the human's own
-notes about themselves, so they are not part of any open-read surface.
+Every route requires the token: memories are the human's notes about themselves.
 """
 
 from __future__ import annotations

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -1,8 +1,7 @@
 """Model management route handlers: catalog, installed, pull, show, delete, set.
 
-Every route here needs the session token. The read routes describe which
-models the user has installed and what their machine can fit, which is
-inventory about the host rather than public catalog data.
+Every route needs the token: the reads describe what the user has installed
+and what their machine fits, which is host inventory.
 """
 
 from __future__ import annotations

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -98,7 +98,7 @@ async def models_catalog_route(
     installed: bool | None = Parameter(query="installed", default=None),
     featured: bool | None = Parameter(query="featured", default=None),
     sort: str = Parameter(query="sort", default="featured"),
-    limit: int = Parameter(query="limit", default=20, le=1000),
+    limit: int = Parameter(query="limit", default=20, ge=1, le=1000),
     offset: int = Parameter(query="offset", default=0, ge=0),
 ) -> ModelsCatalogResponse:
     """Browse the model catalog with optional filters."""

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -1,4 +1,9 @@
-"""Model management route handlers: catalog, installed, pull, show, delete, set."""
+"""Model management route handlers: catalog, installed, pull, show, delete, set.
+
+Every route here needs the session token. The read routes describe which
+models the user has installed and what their machine can fit, which is
+inventory about the host rather than public catalog data.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +16,6 @@ from pydantic import BaseModel
 from lilbee.catalog.types import ModelSource
 from lilbee.modelhub.role_validator import TaskMismatchError
 from lilbee.server import handlers
-from lilbee.server.auth import read_only
 from lilbee.server.handlers import ModelsResponse, format_task_mismatch
 from lilbee.server.models import (
     ExternalModelsResponse,
@@ -40,14 +44,12 @@ class PullRequest(BaseModel):
 
 
 @get("/api/models")
-@read_only
 async def models_list_route() -> ModelsResponse:
     """Available chat, embedding, vision, and reranker models."""
     return await handlers.list_models()
 
 
 @get("/api/models/external")
-@read_only
 async def models_external_route() -> ExternalModelsResponse:
     """Discover models available from the configured external provider."""
     return await handlers.list_external_models()
@@ -90,7 +92,6 @@ async def models_set_reranker_route(data: SetModelRequest) -> SetModelResponse:
 
 
 @get("/api/models/catalog")
-@read_only
 async def models_catalog_route(
     task: str | None = Parameter(query="task", default=None),
     search: str = Parameter(query="search", default=""),
@@ -118,7 +119,6 @@ async def models_catalog_route(
 
 
 @get("/api/models/installed")
-@read_only
 async def models_installed_route() -> ModelsInstalledResponse:
     """List installed models with their source (native or remote)."""
     return await handlers.models_installed()

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -11,6 +11,7 @@ capability the CLI and TUI have.
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 from litestar import delete, get, post, put
@@ -100,8 +101,6 @@ async def gpus_route() -> list[GpuInfoResponse]:
 @get("/api/gpus/stream")
 async def gpu_stats_stream_route() -> Stream:
     """Live per-GPU utilization + free memory as SSE for the placement view."""
-    import asyncio
-
     from lilbee.app.placement import get_placement
 
     try:

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 from litestar import delete, get, post, put
 from litestar.exceptions import HTTPException
@@ -24,10 +25,19 @@ from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
 from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
 
+log = logging.getLogger(__name__)
+
 _HTTP_UNPROCESSABLE = 422
 _HTTP_CONFLICT = 409
 _HTTP_UNAVAILABLE = 503
-_INPUT_ERRORS = (PlacementError, ValueError, OSError)
+# OSError is deliberately absent: on this path it means the device probe could
+# not run (no nvidia-smi on PATH, no permission on the device node, a failed
+# spawn), which is a host fault and not something the caller's spec can fix.
+_INPUT_ERRORS = (PlacementError, ValueError)
+_PROBE_FAILED_DETAIL = (
+    "Could not probe the GPUs. Check that the vendor tool (nvidia-smi or "
+    "rocm-smi) is installed and this process may read the device."
+)
 _MISSING_SPEC_DETAIL = "spec is required to apply placement; send {} to DELETE for auto."
 
 
@@ -58,6 +68,9 @@ async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
         return await handlers.placement_preview(_spec_json(data))
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        log.exception("GPU probe failed")
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=_PROBE_FAILED_DETAIL) from exc
     except _INPUT_ERRORS as exc:
         raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=str(exc)) from exc
 
@@ -74,6 +87,9 @@ async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
         return await handlers.placement_set(spec_json)
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        log.exception("GPU probe failed")
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=_PROBE_FAILED_DETAIL) from exc
     except _INPUT_ERRORS as exc:
         raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=str(exc)) from exc
 

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -1,7 +1,7 @@
 """Placement routes: inspect, preview, and (when enabled) apply GPU placement.
 
 Every route requires auth: even the reads run resolve_placement_plan, which
-spawns subprocess device probes, so none are marked @read_only. Applying or
+spawns subprocess device probes. Every route needs the token. Applying or
 clearing placement restarts the shared fleet's moved roles, which is unsafe
 across concurrent HTTP clients, so PUT/DELETE are refused by default. They are gated on the
 ``allow_http_placement`` flag (LILBEE_ALLOW_HTTP_PLACEMENT), which an operator

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -100,10 +100,15 @@ async def gpus_route() -> list[GpuInfoResponse]:
 @get("/api/gpus/stream")
 async def gpu_stats_stream_route() -> Stream:
     """Live per-GPU utilization + free memory as SSE for the placement view."""
+    import asyncio
+
     from lilbee.app.placement import get_placement
 
     try:
-        devices = get_placement().gpus
+        # get_placement runs resolve_placement_plan, which spawns subprocess
+        # device probes that can wedge for the probe timeout on a broken driver;
+        # offload so the probe never blocks the event loop.
+        view = await asyncio.to_thread(get_placement)
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
-    return Stream(handlers.gpu_stats_stream(devices), media_type="text/event-stream")
+    return Stream(handlers.gpu_stats_stream(view.gpus), media_type="text/event-stream")

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -150,12 +150,14 @@ async def search_route(
         return await handlers.search(q, top_k=top_k, chunk_type=parsed_chunk_type)
     except EmbeddingModelMismatchError as exc:
         # This route is unauthenticated (@read_only), so unlike ask/chat it must
-        # not hand back the persisted/current embedder names an authenticated
-        # client would use to render its adopt prompt. Report only that the
-        # index and the configured embedder disagree.
+        # not name the persisted and configured embedders. ``adoptable`` is kept:
+        # it is a bare yes/no on whether switching embedder alone would fix the
+        # index, which is what a client renders its recovery hint from, and it
+        # identifies nothing.
         raise HTTPException(
             status_code=409,
             detail="The index was built with a different embedding model than the one configured.",
+            extra={"adoptable": exc.dims_match},
         ) from exc
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -1,4 +1,8 @@
-"""Search, ask, ask_stream, chat, and chat_stream route handlers."""
+"""Search, ask, ask_stream, chat, and chat_stream route handlers.
+
+Every route here needs the session token. These return the user's own
+documents, so they are not part of the unauthenticated liveness surface.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +21,6 @@ from lilbee.data.store import EmbeddingModelMismatchError
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.retrieval.query import ChatMessage as ChatMessageDict
 from lilbee.server import handlers
-from lilbee.server.auth import read_only
 from lilbee.server.chat_completions_api.errors import classify_provider_error
 from lilbee.server.chat_dispatch.concurrency import (
     ChatBusyError,
@@ -147,7 +150,6 @@ def _slot_gated_sse(generator: AsyncGenerator[str, None], guard: ChatSlotGuard) 
 
 
 @get("/api/search")
-@read_only
 async def search_route(
     q: str = Parameter(query="q"),
     top_k: int = Parameter(query="top_k", default=5, ge=1, le=100),
@@ -161,11 +163,11 @@ async def search_route(
     try:
         return await handlers.search(q, top_k=top_k, chunk_type=parsed_chunk_type)
     except EmbeddingModelMismatchError as exc:
-        # This route is unauthenticated (@read_only), so unlike ask/chat it must
-        # not name the persisted and configured embedders. ``adoptable`` is kept:
-        # it is a bare yes/no on whether switching embedder alone would fix the
-        # index, which is what a client renders its recovery hint from, and it
-        # identifies nothing.
+        # ``adoptable`` is a bare yes/no on whether switching embedder alone
+        # would fix the index, which is what a client renders its recovery hint
+        # from. The embedder names stay out: this is the generic-503 path, and
+        # naming them here would make the message depend on which of the two
+        # mismatched sides the caller already knows.
         raise HTTPException(
             status_code=409,
             detail="The index was built with a different embedding model than the one configured.",

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -149,11 +149,22 @@ async def search_route(
     try:
         return await handlers.search(q, top_k=top_k, chunk_type=parsed_chunk_type)
     except EmbeddingModelMismatchError as exc:
-        raise _embedding_mismatch_http(exc) from exc
+        # This route is unauthenticated (@read_only), so unlike ask/chat it must
+        # not hand back the persisted/current embedder names an authenticated
+        # client would use to render its adopt prompt. Report only that the
+        # index and the configured embedder disagree.
+        raise HTTPException(
+            status_code=409,
+            detail="The index was built with a different embedding model than the one configured.",
+        ) from exc
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        # str(exc) here routinely carries data-root paths, LanceDB table names,
+        # and model ids, and this route has no token gate. Log the real cause
+        # for the operator; return a generic message on the wire.
+        log.exception("Search failed")
+        raise HTTPException(status_code=503, detail="Search is temporarily unavailable.") from exc
 
 
 @post("/api/ask")

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -138,7 +138,7 @@ def _slot_gated_sse(generator: AsyncGenerator[str, None], guard: ChatSlotGuard) 
 @read_only
 async def search_route(
     q: str = Parameter(query="q"),
-    top_k: int = Parameter(query="top_k", default=5, le=100),
+    top_k: int = Parameter(query="top_k", default=5, ge=1, le=100),
     chunk_type: str | None = Parameter(query="chunk_type", default=None),
 ) -> list[DocumentResult]:
     """Search indexed documents by semantic similarity. No LLM call required."""

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -18,6 +18,7 @@ from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.retrieval.query import ChatMessage as ChatMessageDict
 from lilbee.server import handlers
 from lilbee.server.auth import read_only
+from lilbee.server.chat_completions_api.errors import classify_provider_error
 from lilbee.server.chat_dispatch.concurrency import (
     ChatBusyError,
     ChatSlotGuard,
@@ -120,7 +121,18 @@ async def _gated_stream(
             yield chunk
     except Exception as exc:
         log.exception("streaming chat handler failed")
-        yield sse_error(str(exc))
+        # The typed dispatch failures that reach here (unknown model, no tool
+        # support, context overflow) are exactly the ones the SSE error code
+        # vocabulary was widened to cover, and the non-streaming sibling already
+        # maps them to distinct statuses. Without a code the stream flattened
+        # them into one message, so a client could not tell "pull the model"
+        # from "shorten the prompt". classify_provider_error also redacts the
+        # backend-failure kinds, whose text names loopback ports and engine paths.
+        classified = classify_provider_error(exc)
+        if classified is None:
+            yield sse_error(str(exc))
+        else:
+            yield sse_error(classified.message, code=classified.code)
     finally:
         await guard.release()
 

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -1,7 +1,6 @@
 """Search, ask, ask_stream, chat, and chat_stream route handlers.
 
-Every route here needs the session token. These return the user's own
-documents, so they are not part of the unauthenticated liveness surface.
+Every route needs the token: these return the user's own documents.
 """
 
 from __future__ import annotations
@@ -124,13 +123,10 @@ async def _gated_stream(
             yield chunk
     except Exception as exc:
         log.exception("streaming chat handler failed")
-        # The typed dispatch failures that reach here (unknown model, no tool
-        # support, context overflow) are exactly the ones the SSE error code
-        # vocabulary was widened to cover, and the non-streaming sibling already
-        # maps them to distinct statuses. Without a code the stream flattened
-        # them into one message, so a client could not tell "pull the model"
-        # from "shorten the prompt". classify_provider_error also redacts the
-        # backend-failure kinds, whose text names loopback ports and engine paths.
+        # Same mapper as the non-streaming sibling: without a code the stream
+        # flattened unknown-model, no-tool-support and context-overflow into
+        # one message, so a client could not tell "pull the model" from
+        # "shorten the prompt". It also redacts the backend-failure kinds.
         classified = classify_provider_error(exc)
         if classified is None:
             yield sse_error(str(exc))
@@ -164,10 +160,8 @@ async def search_route(
         return await handlers.search(q, top_k=top_k, chunk_type=parsed_chunk_type)
     except EmbeddingModelMismatchError as exc:
         # ``adoptable`` is a bare yes/no on whether switching embedder alone
-        # would fix the index, which is what a client renders its recovery hint
-        # from. The embedder names stay out: this is the generic-503 path, and
-        # naming them here would make the message depend on which of the two
-        # mismatched sides the caller already knows.
+        # fixes the index, which is what a client renders its hint from. The
+        # embedder names stay out of the generic 503.
         raise HTTPException(
             status_code=409,
             detail="The index was built with a different embedding model than the one configured.",

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -182,9 +182,10 @@ async def ask_route(data: AskRequest) -> AskResponse:
         )
     except EmbeddingModelMismatchError as exc:
         raise _embedding_mismatch_http(exc) from exc
-    except ValueError as exc:
-        raise ValidationException(str(exc)) from exc
     except Exception as exc:
+        # No separate ValueError arm: _raise_chat_http_error is the single
+        # translation point and its first branch is ValueError -> 422, which is
+        # what chat_route relies on. Two copies drift.
         _raise_chat_http_error(exc)
     finally:
         await release_chat_slot()

--- a/src/lilbee/server/routes/sessions.py
+++ b/src/lilbee/server/routes/sessions.py
@@ -1,15 +1,17 @@
 """Session routes: list, get, create, append, summary, rename, delete.
 
-The two ``GET`` routes are ``@read_only`` so a read-only session token can browse
-and resume history; the mutating routes are unmarked so read-only tokens cannot
-create, append, summarize, rename, or delete.
+Every route requires the bearer token, reads included. A conversation
+transcript is at least as personal as the memory store, which is gated for the
+same reason. The two ``GET`` routes used to be marked read-only, with a
+docstring claiming that let "a read-only session token" browse history; there
+is no such token, and the marker means no auth check at all, so both reads
+answered callers that sent no Authorization header.
 """
 
 from __future__ import annotations
 
 from litestar import delete, get, patch, post, put
 
-from lilbee.server.auth import read_only
 from lilbee.server.handlers.sessions import (
     add_session_message,
     claim_session,
@@ -33,14 +35,12 @@ from lilbee.server.models import (
 
 
 @get("/api/sessions")
-@read_only
 async def sessions_list_route() -> SessionListResponse:
     """List saved conversations, newest first."""
     return await list_sessions()
 
 
 @get("/api/sessions/{session_id:str}")
-@read_only
 async def session_get_route(session_id: str) -> SessionDetailResponse:
     """Return a conversation's metadata and full transcript."""
     return await get_session(session_id)

--- a/src/lilbee/server/routes/sessions.py
+++ b/src/lilbee/server/routes/sessions.py
@@ -1,11 +1,7 @@
 """Session routes: list, get, create, append, summary, rename, delete.
 
-Every route requires the bearer token, reads included. A conversation
-transcript is at least as personal as the memory store, which is gated for the
-same reason. The two ``GET`` routes used to be marked read-only, with a
-docstring claiming that let "a read-only session token" browse history; there
-is no such token, and the marker means no auth check at all, so both reads
-answered callers that sent no Authorization header.
+Every route requires the token, reads included: a transcript is at least as
+personal as the memory store next door.
 """
 
 from __future__ import annotations

--- a/src/lilbee/server/routes/setup.py
+++ b/src/lilbee/server/routes/setup.py
@@ -27,12 +27,10 @@ from lilbee.crawler import (
     crawler_available,
     crawler_browsers_path,
 )
-from lilbee.server.auth import read_only
 from lilbee.server.handlers import SseStream
 
 
 @get("/setup/crawler/status")
-@read_only
 async def setup_crawler_status_route() -> dict[str, Any]:
     """Return whether the crawler is fully ready (Python package + Chromium)."""
     package_installed = crawler_available()

--- a/src/lilbee/server/routes/setup.py
+++ b/src/lilbee/server/routes/setup.py
@@ -28,7 +28,7 @@ from lilbee.crawler import (
     crawler_browsers_path,
 )
 from lilbee.server.auth import read_only
-from lilbee.server.handlers import SseStream, sse_done, sse_error
+from lilbee.server.handlers import SseStream
 
 
 @get("/setup/crawler/status")
@@ -58,12 +58,11 @@ async def _bootstrap_crawler_stream() -> AsyncGenerator[str, None]:
     task = asyncio.create_task(_run())
     async for event in sse.drain(task, "Crawler setup stream"):
         yield event
-    if task.done() and not task.cancelled():
-        exc = task.exception()
-        if exc is not None:
-            yield sse_error(str(exc))
-            return
-    yield sse_done({})
+    # This copy used to skip the cancel check and emit a done frame even to a
+    # client that had already disconnected; the shared helper does not.
+    frame = sse.terminal_frame(task, lambda _: {})
+    if frame is not None:
+        yield frame
 
 
 @post("/setup/crawler")

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -1,8 +1,7 @@
 """Wiki layer route handlers: page listing, reading, citations, lint, generation, pruning.
 
-Every route here needs the session token. Wiki pages are generated from the
-user's own corpus, so a page body, a citation list, and even the page titles
-in a listing are their content, not public reference material.
+Every route needs the token: pages are generated from the user's own corpus,
+so even the titles in a listing are their content.
 """
 
 from __future__ import annotations

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -126,9 +126,11 @@ async def wiki_draft_accept_route(slug: str) -> WikiDraftAcceptResponse:
     slug = slug.lstrip("/")
     store = svc_mod.get_services().store
     try:
-        # accept_draft re-chunks and embeds the page; offload so it doesn't block
-        # the event loop (and every other REST/MCP request on it).
-        result = await asyncio.to_thread(accept_draft, slug, _wiki_root(), store)
+        # accept_draft overwrites a published page and refreshes the index, the
+        # same artifacts a build writes, so it shares the build mutex. It also
+        # re-chunks and embeds, so it runs off the event loop.
+        async with _wiki_build_lock():
+            result = await asyncio.to_thread(accept_draft, slug, _wiki_root(), store)
     except FileNotFoundError as exc:
         raise NotFoundException(detail=f"draft not found: {slug}") from exc
     except PathTraversalError as exc:
@@ -213,8 +215,11 @@ async def wiki_lint_route() -> WikiLintResult:
 async def wiki_prune_route() -> WikiPruneResult:
     """Trigger pruning of stale/orphaned wiki pages."""
     _require_wiki()
-    # prune_wiki walks the whole wiki tree and store; offload off the loop.
-    report = await asyncio.to_thread(prune_mod.prune_wiki, svc_mod.get_services().store)
+    # prune archives pages and rewrites the index, so it takes the build mutex
+    # like the other writers. It also walks the whole tree and store, so it runs
+    # off the event loop.
+    async with _wiki_build_lock():
+        report = await asyncio.to_thread(prune_mod.prune_wiki, svc_mod.get_services().store)
     return WikiPruneResult(
         records=[WikiPruneRecordResponse(**r.to_dict()) for r in report.records],
         archived=report.archived_count,

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -44,7 +45,6 @@ from lilbee.wiki.drafts import (
     list_drafts,
     reject_draft,
 )
-from lilbee.wiki.index import update_wiki_index
 from lilbee.wiki.shared import (
     INVALID_DRAFT_SLUG_ERROR,
     WIKI_DISABLED_ERROR,
@@ -73,22 +73,18 @@ def _find_page(slug: str) -> Path | None:
 @read_only
 async def wiki_list_route() -> list[dict[str, Any]]:
     """List all wiki pages across subdirectories.
-    If wiki/index.md exists, regenerate it first to ensure freshness,
-    then build the page list from disk.
+
+    Reads the tree without touching it. This route is unauthenticated, so it
+    used to hand any caller a way to rewrite index.md on repeat and to race the
+    build path over the same file. The listing never depended on that write
+    anyway: it is built by walking pages, and every path that changes the tree
+    (build, update, synthesize, prune, draft-accept) refreshes the index itself.
     """
     _require_wiki()
-    root = _wiki_root()
-    # The index regen walks and rewrites files and list_pages walks the tree;
-    # offload both so the listing doesn't block the event loop.
-    return await asyncio.to_thread(_list_wiki_pages_sync, root)
-
-
-def _list_wiki_pages_sync(root: Path) -> list[dict[str, Any]]:
-    """Blocking body of :func:`wiki_list_route`: refresh index, then walk pages."""
-    index_path = root / "index.md"
-    if index_path.is_file():
-        update_wiki_index()
-    return [p.to_dict() for p in list_pages(root)]
+    # list_pages walks the whole tree; offload so the listing doesn't block
+    # the event loop.
+    pages = await asyncio.to_thread(list_pages, _wiki_root())
+    return [p.to_dict() for p in pages]
 
 
 @get("/api/wiki/drafts")
@@ -287,11 +283,19 @@ async def wiki_synthesize_route() -> WikiSynthesizeResult:
 
 
 @get("/api/wiki/status")
-@read_only
 async def wiki_status_route() -> WikiStatusResult:
-    """Wiki layer status: page counts and recent lint counts."""
+    """Wiki layer status: page counts and recent lint counts.
+
+    Token-gated, unlike the other wiki reads: the lint behind it walks every
+    page and issues a store query each, so leaving it open made it an
+    unauthenticated way to spend the machine's IO budget. It still answers
+    while the wiki is disabled so a client can render the disabled state
+    without a second round trip to /api/config.
+    """
     root = _wiki_root()
-    if not root.exists():
+    if not cfg.wiki or not root.exists():
+        # A disabled wiki can still have a tree left over from an earlier
+        # build; report the disabled state rather than linting it.
         return WikiStatusResult(wiki_enabled=cfg.wiki)
 
     summaries_dir = root / WikiSubdir.SUMMARIES
@@ -299,7 +303,12 @@ async def wiki_status_route() -> WikiStatusResult:
     summaries = list(summaries_dir.rglob("*.md")) if summaries_dir.exists() else []
     drafts = list(drafts_dir.rglob("*.md")) if drafts_dir.exists() else []
 
-    report = await asyncio.to_thread(lint_mod.lint_all, svc_mod.get_services().store)
+    # record_log=False: a status poll is a read, and appending a LINT entry to
+    # log.md on every poll is what that flag exists to avoid. The MCP and CLI
+    # status surfaces already pass it.
+    report = await asyncio.to_thread(
+        partial(lint_mod.lint_all, svc_mod.get_services().store, record_log=False)
+    )
     return WikiStatusResult(
         wiki_enabled=cfg.wiki,
         summaries=len(summaries),

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -1,4 +1,9 @@
-"""Wiki layer route handlers: page listing, reading, citations, lint, generation, pruning."""
+"""Wiki layer route handlers: page listing, reading, citations, lint, generation, pruning.
+
+Every route here needs the session token. Wiki pages are generated from the
+user's own corpus, so a page body, a citation list, and even the page titles
+in a listing are their content, not public reference material.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +19,6 @@ from litestar.params import Parameter
 from lilbee.app import services as svc_mod
 from lilbee.core.config import cfg
 from lilbee.core.security import PathTraversalError
-from lilbee.server.auth import read_only
 from lilbee.server.models import (
     DraftInfoResponse,
     WikiBuildResult,
@@ -70,7 +74,6 @@ def _find_page(slug: str) -> Path | None:
 
 
 @get("/api/wiki")
-@read_only
 async def wiki_list_route() -> list[dict[str, Any]]:
     """List all wiki pages across subdirectories.
 
@@ -88,7 +91,6 @@ async def wiki_list_route() -> list[dict[str, Any]]:
 
 
 @get("/api/wiki/drafts")
-@read_only
 async def wiki_drafts_route() -> list[DraftInfoResponse]:
     """List pending wiki drafts with drift, faithfulness, and pending-marker info."""
     _require_wiki()
@@ -96,7 +98,6 @@ async def wiki_drafts_route() -> list[DraftInfoResponse]:
 
 
 @get("/api/wiki/drafts/diff/{slug:path}")
-@read_only
 async def wiki_draft_diff_route(slug: str) -> WikiDraftDiffResponse:
     """Return the unified diff of a draft against its published counterpart.
 
@@ -153,7 +154,6 @@ async def wiki_draft_reject_route(slug: str) -> WikiDraftRejectResponse:
 
 
 @get("/api/wiki/citations")
-@read_only
 async def wiki_citations_reverse_route(
     source: str = Parameter(query="source", default=""),
 ) -> list[WikiCitationRecord]:
@@ -167,7 +167,6 @@ async def wiki_citations_reverse_route(
 
 
 @get("/api/wiki/{slug:path}")
-@read_only
 async def wiki_read_route(slug: str) -> WikiPageDetail | WikiCitationsResult:
     """Read a specific wiki page as markdown, or its citations."""
     _require_wiki()

--- a/tests/cli/test_config_file.py
+++ b/tests/cli/test_config_file.py
@@ -60,7 +60,7 @@ def test_atomic_write_leaves_no_litter_on_failure(tmp_path, monkeypatch):
     def _boom(*_a, **_k):
         raise OSError("rename failed")
 
-    monkeypatch.setattr(config_file.os, "replace", _boom)
+    monkeypatch.setattr("lilbee.core.security.os.replace", _boom)
     with pytest.raises(OSError):
         config_file.atomic_write_text(path, "new")
     assert path.read_text() == "original"

--- a/tests/cli/test_launch_hermes.py
+++ b/tests/cli/test_launch_hermes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -215,15 +217,24 @@ def test_launch_hermes_env_upsert_preserves_other_lines(tmp_path):
     assert "LILBEE_TOKEN=stale" not in env_text
 
 
-def test_upsert_env_token_chmods_env_on_posix(tmp_path, monkeypatch):
-    """The token .env is chmod 0600 on posix. Force os.name so the chmod line is
-    covered on Windows runners too, where os.name is 'nt' and the branch is skipped."""
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")
+def test_upsert_env_token_writes_the_env_owner_only(tmp_path):
+    """The .env carries the bearer token, so it must be 0600 the whole time.
+
+    Asserts the resulting mode rather than that a chmod was called: the write
+    creates the file owner-only and keeps that mode across the atomic replace,
+    so there is no chmod to observe and no window where it is world-readable.
+    """
+    import stat
+
     from lilbee.cli.launchers import hermes
 
-    monkeypatch.setattr(hermes.os, "name", "posix")
-    chmodded: list[int] = []
-    monkeypatch.setattr(Path, "chmod", lambda self, mode: chmodded.append(mode))
-    env = tmp_path / ".env"
-    hermes._upsert_env_token(env, "tok-xyz")
-    assert 0o600 in chmodded
+    previous = os.umask(0)
+    try:
+        env = tmp_path / ".env"
+        hermes._upsert_env_token(env, "tok-xyz")
+    finally:
+        os.umask(previous)
+
     assert "LILBEE_TOKEN=tok-xyz" in env.read_text()
+    assert stat.S_IMODE(env.stat().st_mode) == 0o600

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -181,7 +181,8 @@ def test_health_ok_returns_true_on_200(monkeypatch):
 
     resp = MagicMock()
     resp.status_code = 200
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.health_ok(8765) is True
 
 
@@ -191,7 +192,8 @@ def test_health_ok_returns_false_on_non_200(monkeypatch):
 
     resp = MagicMock()
     resp.status_code = 503
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.health_ok(8765) is False
 
 
@@ -202,7 +204,8 @@ def test_chat_ready_true_when_health_reports_warm(monkeypatch):
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {"chat_ready": True}
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.chat_ready(8765) is True
 
 
@@ -213,7 +216,8 @@ def test_chat_ready_false_when_health_reports_cold(monkeypatch):
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {"chat_ready": False}
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.chat_ready(8765) is False
 
 
@@ -291,7 +295,8 @@ def test_served_chat_ctx_reads_health_window(monkeypatch):
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {"chat_ready": True, "chat_ctx": 40960}
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.served_chat_ctx(8765) == 40960
 
 
@@ -302,7 +307,8 @@ def test_served_chat_ctx_none_when_window_absent(monkeypatch):
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {"chat_ready": True}
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.served_chat_ctx(8765) is None
 
 
@@ -695,7 +701,8 @@ def test_wait_for_health_returns_true_on_200(monkeypatch):
 
     resp = MagicMock()
     resp.status_code = 200
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     assert launch_mod.wait_for_health(8765, timeout_s=1.0) is True
 
 
@@ -717,7 +724,8 @@ def test_wait_for_health_returns_false_on_non_200(monkeypatch):
 
     resp = MagicMock()
     resp.status_code = 503
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
     monkeypatch.setattr(launch_mod.time, "sleep", lambda _seconds: None)
     assert launch_mod.wait_for_health(8765, timeout_s=0.05) is False
 

--- a/tests/cli/test_launch_server_ctx.py
+++ b/tests/cli/test_launch_server_ctx.py
@@ -15,7 +15,10 @@ def _health(monkeypatch, body: dict) -> None:
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = body
-    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+    # /api/health needs the token like every other route, and the probe reads
+    # it from server.json, which does not exist under test.
+    monkeypatch.setattr(launch_mod, "_session_token", lambda: "t")
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, **_kw: resp)
 
 
 @pytest.mark.no_warm_default

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -130,6 +130,37 @@ def test_log_unlink_permission_error_falls_through_to_append(
 class TestHealthProbes:
     """chat_ready / served_chat_ctx / wait_for_chat_warm read /api/health."""
 
+    @pytest.fixture(autouse=True)
+    def _token(self, monkeypatch):
+        """/api/health needs the token like every other route; these probes read
+        it from server.json, which does not exist under test."""
+        monkeypatch.setattr(server_mod, "_session_token", lambda: "t")
+
+    def test_no_probe_is_attempted_before_the_token_exists(self, monkeypatch) -> None:
+        """server.json is written by the app lifespan, so a probe racing startup
+        finds no token. That is the same answer a refused connection gives, and
+        it must not fire a request that would only come back 401."""
+        monkeypatch.setattr(server_mod, "_session_token", lambda: None)
+
+        def _fail(*_a, **_k):
+            raise AssertionError("probed without a token")
+
+        monkeypatch.setattr(server_mod.httpx, "get", _fail)
+        assert server_mod.health_ok(8080) is False
+        assert server_mod.chat_ready(8080) is False
+        assert server_mod.served_chat_ctx(8080) is None
+
+    def test_the_probe_sends_the_bearer_token(self, monkeypatch) -> None:
+        seen: dict[str, object] = {}
+
+        def _capture(url, **kwargs):
+            seen.update(kwargs)
+            return httpx.Response(200, json={"status": "ok"})
+
+        monkeypatch.setattr(server_mod.httpx, "get", _capture)
+        assert server_mod.health_ok(8080) is True
+        assert seen["headers"] == {"Authorization": "Bearer t"}
+
     def test_chat_ready_false_on_non_ok_status(self, monkeypatch) -> None:
         monkeypatch.setattr(
             server_mod.httpx, "get", lambda *_a, **_k: httpx.Response(503, text="loading")

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -137,9 +137,8 @@ class TestHealthProbes:
         monkeypatch.setattr(server_mod, "_session_token", lambda: "t")
 
     def test_no_probe_is_attempted_before_the_token_exists(self, monkeypatch) -> None:
-        """server.json is written by the app lifespan, so a probe racing startup
-        finds no token. That is the same answer a refused connection gives, and
-        it must not fire a request that would only come back 401."""
+        """A probe racing startup finds no server.json, which means no server
+        yet; firing a request that can only 401 is pointless."""
         monkeypatch.setattr(server_mod, "_session_token", lambda: None)
 
         def _fail(*_a, **_k):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,18 @@ def _ignore_user_global_config(monkeypatch):
     monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_playwright_browsers_path(tmp_path_factory, monkeypatch):
+    """Keep the browser cache out of the developer's real Playwright directory.
+
+    Tests that fake ``chromium_installed() -> False`` drive the install path,
+    which creates and locks the browsers directory. Without this they would
+    reach ``~/Library/Caches/ms-playwright`` on the machine running them.
+    ``_browsers_cache_path`` honors this env var ahead of the platform default.
+    """
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path_factory.mktemp("ms-playwright")))
+
+
 @pytest.fixture
 def overlay_reads_config_toml(monkeypatch):
     """Opt a test back into the config.toml overlay path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,8 +214,19 @@ def _ignore_user_global_config(monkeypatch):
     monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
 
 
+@pytest.fixture(scope="session")
+def _playwright_browsers_root(tmp_path_factory):
+    """One throwaway browser cache for the whole session.
+
+    Session-scoped on purpose: a per-test directory would mean one mkdir per
+    test, and a temp root holding thousands of sibling directories is slow
+    enough to push the timing-sensitive TUI tests into their timeout.
+    """
+    return tmp_path_factory.mktemp("ms-playwright")
+
+
 @pytest.fixture(autouse=True)
-def _isolate_playwright_browsers_path(tmp_path_factory, monkeypatch):
+def _isolate_playwright_browsers_path(_playwright_browsers_root, monkeypatch):
     """Keep the browser cache out of the developer's real Playwright directory.
 
     Tests that fake ``chromium_installed() -> False`` drive the install path,
@@ -223,7 +234,7 @@ def _isolate_playwright_browsers_path(tmp_path_factory, monkeypatch):
     reach ``~/Library/Caches/ms-playwright`` on the machine running them.
     ``_browsers_cache_path`` honors this env var ahead of the platform default.
     """
-    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path_factory.mktemp("ms-playwright")))
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(_playwright_browsers_root))
 
 
 @pytest.fixture

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -127,3 +127,46 @@ class TestPersistedSettingsPermissions:
         settings.save(tmp_path, {"api_key": "sk-secret"})
         path = tmp_path / "config.toml"
         assert _mode(path) == 0o600
+
+
+class TestPersistedTokenIsTotal:
+    """Every corruption mode must mint a fresh token, never take the server down."""
+
+    @pytest.fixture()
+    def fresh_manager(self):
+        from lilbee.server.auth import SessionManager, server_json_path
+
+        path = server_json_path()
+        path.unlink(missing_ok=True)
+        yield SessionManager()
+        path.unlink(missing_ok=True)
+
+    def test_non_utf8_server_json_regenerates_instead_of_crashing(self, fresh_manager):
+        """UnicodeDecodeError subclasses ValueError, not OSError, so it escaped
+        both except clauses and killed the app lifespan on a truncated write."""
+        from lilbee.server.auth import server_json_path
+
+        path = server_json_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"token": "\xff\xfe not utf-8"}')
+
+        token = fresh_manager.load_or_generate()
+
+        assert isinstance(token, str)
+        assert json.loads(path.read_text(encoding="utf-8"))["token"] == token
+
+    def test_a_token_shorter_than_the_generator_mints_is_rejected(self, fresh_manager):
+        """The length floor is a character count, so it must match the encoded
+        length, not the raw entropy byte count it used to be compared against."""
+        from lilbee.server.auth import server_json_path
+
+        path = server_json_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # 32 chars: passed the old byte-count floor, but well short of the ~43
+        # characters secrets.token_urlsafe(32) actually produces.
+        path.write_text(json.dumps({"token": "a" * 32}), encoding="utf-8")
+
+        token = fresh_manager.load_or_generate()
+
+        assert token != "a" * 32
+        assert len(token) > 32

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -11,11 +11,9 @@ import pytest
 
 from lilbee.core.security import write_private_text
 
-# Scoped per class, not module-wide: it used to blanket the file, which also
-# skipped the token-corruption and path-anchoring tests on Windows. Those
-# assert nothing about mode bits, and Windows is exactly where a truncated or
-# clobbered server.json is most likely, so the regeneration path went untested
-# on the platform that needs it most.
+# Scoped per test, not module-wide: a blanket skip also hid the
+# token-corruption and path-anchoring tests, which assert no mode bits, from
+# Windows -- where a clobbered server.json is most likely.
 posix_only = pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")
 
 
@@ -237,9 +235,9 @@ class TestPersistedSettingsAreHardenedOnLoad:
 
 
 class TestHardeningOnWindows:
-    """The POSIX body has to be exercised on Windows too, or it is only ever
-    measured on the platforms where it runs. Patching ``sys.platform`` is the
-    same technique ``tests/test_system.py`` uses for its platform branches."""
+    """Drives both platform branches everywhere by patching ``sys.platform``,
+    as ``tests/test_system.py`` does, so the POSIX body is covered on Windows
+    too."""
 
     def test_the_windows_branch_leaves_the_file_alone(self, tmp_path, monkeypatch):
         """Windows has no POSIX mode bits; the file rides the inherited DACL."""

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -79,9 +79,10 @@ class TestSessionTokenPermissions:
         Pins that the descriptor is created restricted rather than widened by
         the umask and narrowed a moment later, which is the TOCTOU window.
         """
+        from lilbee.core import security
         from lilbee.server import auth
 
-        monkeypatch.setattr(auth.Path, "chmod", lambda *_a, **_k: None)
+        monkeypatch.setattr(security.Path, "chmod", lambda *_a, **_k: None)
         token = fresh_manager.load_or_generate()
         path = auth.server_json_path()
         assert json.loads(path.read_text(encoding="utf-8"))["token"] == token
@@ -91,14 +92,19 @@ class TestSessionTokenPermissions:
         self, fresh_manager, monkeypatch, caplog
     ):
         """A server.json owned by another user must not take the server down."""
+        from lilbee.core import security
         from lilbee.server import auth
 
         first = fresh_manager.load_or_generate()
+        # Widen it first: hardening skips the chmod when the mode is already
+        # right, so without this the refusal below is never reached and the
+        # test passes without exercising anything.
+        auth.server_json_path().chmod(0o644)
 
         def refuse(*_args, **_kwargs):
             raise PermissionError("not owner")
 
-        monkeypatch.setattr(auth.Path, "chmod", refuse)
+        monkeypatch.setattr(security.Path, "chmod", refuse)
         fresh_manager.token = None
         with caplog.at_level("WARNING"):
             assert fresh_manager.load_or_generate() == first
@@ -123,9 +129,9 @@ class TestPersistedSettingsPermissions:
     """config.toml can hold provider API keys and gets the same treatment."""
 
     def test_saved_config_is_never_world_readable(self, tmp_path, permissive_umask, monkeypatch):
-        from lilbee.core import settings
+        from lilbee.core import security, settings
 
-        monkeypatch.setattr(settings.Path, "chmod", lambda *_a, **_k: None)
+        monkeypatch.setattr(security.Path, "chmod", lambda *_a, **_k: None)
         settings.save(tmp_path, {"api_key": "sk-secret"})
         path = tmp_path / "config.toml"
         assert _mode(path) == 0o600
@@ -206,7 +212,7 @@ class TestPersistedSettingsAreHardenedOnLoad:
     def test_an_unchmoddable_config_warns_instead_of_failing_the_read(
         self, tmp_path, monkeypatch, caplog
     ):
-        from lilbee.core import settings
+        from lilbee.core import security, settings
 
         settings.set_value(tmp_path, "api_key", "sk-secret")
         (tmp_path / "config.toml").chmod(0o644)
@@ -214,7 +220,7 @@ class TestPersistedSettingsAreHardenedOnLoad:
         def refuse(*_args, **_kwargs):
             raise PermissionError("not owner")
 
-        monkeypatch.setattr(settings.Path, "chmod", refuse)
+        monkeypatch.setattr(security.Path, "chmod", refuse)
         with caplog.at_level("WARNING"):
             assert settings.load(tmp_path) == {"api_key": "sk-secret"}
         assert "Could not restrict permissions" in caplog.text

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -22,6 +22,17 @@ def permissive_umask():
     os.umask(previous)
 
 
+@pytest.fixture()
+def fresh_manager():
+    """Yield a new SessionManager with no server.json on either side of the test."""
+    from lilbee.server.auth import SessionManager, server_json_path
+
+    path = server_json_path()
+    path.unlink(missing_ok=True)
+    yield SessionManager()
+    path.unlink(missing_ok=True)
+
+
 def _mode(path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
 
@@ -59,15 +70,6 @@ class TestWritePrivateText:
 
 class TestSessionTokenPermissions:
     """server.json holds the bearer token: it must never be readable by other users."""
-
-    @pytest.fixture()
-    def fresh_manager(self):
-        from lilbee.server.auth import SessionManager, server_json_path
-
-        path = server_json_path()
-        path.unlink(missing_ok=True)
-        yield SessionManager()
-        path.unlink(missing_ok=True)
 
     def test_generated_token_file_is_never_world_readable(
         self, fresh_manager, permissive_umask, monkeypatch
@@ -131,15 +133,6 @@ class TestPersistedSettingsPermissions:
 
 class TestPersistedTokenIsTotal:
     """Every corruption mode must mint a fresh token, never take the server down."""
-
-    @pytest.fixture()
-    def fresh_manager(self):
-        from lilbee.server.auth import SessionManager, server_json_path
-
-        path = server_json_path()
-        path.unlink(missing_ok=True)
-        yield SessionManager()
-        path.unlink(missing_ok=True)
 
     def test_non_utf8_server_json_regenerates_instead_of_crashing(self, fresh_manager):
         """UnicodeDecodeError subclasses ValueError, not OSError, so it escaped

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -1,0 +1,129 @@
+"""Secret files must be owner-only from the moment they exist, not chmod'd afterwards."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+from lilbee.core.security import write_private_text
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")
+
+
+@pytest.fixture()
+def permissive_umask():
+    """Run the body under umask 0 so any non-atomic write lands world-readable."""
+    previous = os.umask(0)
+    yield
+    os.umask(previous)
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+class TestWritePrivateText:
+    def test_creates_file_owner_only_under_permissive_umask(self, tmp_path, permissive_umask):
+        target = tmp_path / "secret.txt"
+        write_private_text(target, "s3cret")
+        assert target.read_text(encoding="utf-8") == "s3cret"
+        assert _mode(target) == 0o600
+
+    def test_creates_missing_parents(self, tmp_path):
+        target = tmp_path / "nested" / "deeper" / "secret.txt"
+        write_private_text(target, "s3cret")
+        assert target.read_text(encoding="utf-8") == "s3cret"
+
+    def test_replaces_existing_file_and_narrows_its_mode(self, tmp_path, permissive_umask):
+        target = tmp_path / "secret.txt"
+        target.write_text("old", encoding="utf-8")
+        target.chmod(0o644)
+        write_private_text(target, "new")
+        assert target.read_text(encoding="utf-8") == "new"
+        assert _mode(target) == 0o600
+
+    def test_leaves_no_temp_file_behind_when_the_write_fails(self, tmp_path, monkeypatch):
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        target = tmp_path / "secret.txt"
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(RuntimeError):
+            write_private_text(target, "s3cret")
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestSessionTokenPermissions:
+    """server.json holds the bearer token: it must never be readable by other users."""
+
+    @pytest.fixture()
+    def fresh_manager(self):
+        from lilbee.server.auth import SessionManager, server_json_path
+
+        path = server_json_path()
+        path.unlink(missing_ok=True)
+        yield SessionManager()
+        path.unlink(missing_ok=True)
+
+    def test_generated_token_file_is_never_world_readable(
+        self, fresh_manager, permissive_umask, monkeypatch
+    ):
+        """With the after-the-fact chmod neutered, the file must still be 0600.
+
+        Pins that the descriptor is created restricted rather than widened by
+        the umask and narrowed a moment later, which is the TOCTOU window.
+        """
+        from lilbee.server import auth
+
+        monkeypatch.setattr(auth.Path, "chmod", lambda *_a, **_k: None)
+        token = fresh_manager.load_or_generate()
+        path = auth.server_json_path()
+        assert json.loads(path.read_text(encoding="utf-8"))["token"] == token
+        assert _mode(path) == 0o600
+
+    def test_unchmoddable_token_file_warns_instead_of_failing_startup(
+        self, fresh_manager, monkeypatch, caplog
+    ):
+        """A server.json owned by another user must not take the server down."""
+        from lilbee.server import auth
+
+        first = fresh_manager.load_or_generate()
+
+        def refuse(*_args, **_kwargs):
+            raise PermissionError("not owner")
+
+        monkeypatch.setattr(auth.Path, "chmod", refuse)
+        fresh_manager.token = None
+        with caplog.at_level("WARNING"):
+            assert fresh_manager.load_or_generate() == first
+        assert "Could not restrict permissions" in caplog.text
+
+    def test_reused_token_file_is_hardened_on_load(self, fresh_manager):
+        """A server.json that arrived world-readable gets narrowed, not left as-is."""
+        from lilbee.server.auth import server_json_path
+
+        first = fresh_manager.load_or_generate()
+        path = server_json_path()
+        path.chmod(0o644)
+
+        fresh_manager.token = None
+        second = fresh_manager.load_or_generate()
+
+        assert second == first
+        assert _mode(path) == 0o600
+
+
+class TestPersistedSettingsPermissions:
+    """config.toml can hold provider API keys and gets the same treatment."""
+
+    def test_saved_config_is_never_world_readable(self, tmp_path, permissive_umask, monkeypatch):
+        from lilbee.core import settings
+
+        monkeypatch.setattr(settings.Path, "chmod", lambda *_a, **_k: None)
+        settings.save(tmp_path, {"api_key": "sk-secret"})
+        path = tmp_path / "config.toml"
+        assert _mode(path) == 0o600

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -186,3 +186,35 @@ class TestValidatePathWithinAnchorsToRoot:
 
         target = tmp_path / "a.txt"
         assert validate_path_within(str(target), tmp_path) == target.resolve()
+
+
+class TestPersistedSettingsAreHardenedOnLoad:
+    """config.toml holds provider API keys and is read indefinitely without
+    ever being rewritten, so a file that arrived world-readable must be
+    narrowed on load, not only when something happens to save it."""
+
+    def test_a_world_readable_config_is_narrowed_on_read(self, tmp_path):
+        from lilbee.core import settings
+
+        settings.set_value(tmp_path, "api_key", "sk-secret")
+        path = tmp_path / "config.toml"
+        path.chmod(0o644)
+
+        assert settings.load(tmp_path) == {"api_key": "sk-secret"}
+        assert _mode(path) == 0o600
+
+    def test_an_unchmoddable_config_warns_instead_of_failing_the_read(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from lilbee.core import settings
+
+        settings.set_value(tmp_path, "api_key", "sk-secret")
+        (tmp_path / "config.toml").chmod(0o644)
+
+        def refuse(*_args, **_kwargs):
+            raise PermissionError("not owner")
+
+        monkeypatch.setattr(settings.Path, "chmod", refuse)
+        with caplog.at_level("WARNING"):
+            assert settings.load(tmp_path) == {"api_key": "sk-secret"}
+        assert "Could not restrict permissions" in caplog.text

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -163,3 +163,26 @@ class TestPersistedTokenIsTotal:
 
         assert token != "a" * 32
         assert len(token) > 32
+
+
+class TestValidatePathWithinAnchorsToRoot:
+    """A relative path resolved against the process CWD, not the root it is
+    being checked into, so a bare name was judged against wherever the process
+    happened to be started."""
+
+    def test_a_relative_path_resolves_under_root(self, tmp_path):
+        from lilbee.core.security import validate_path_within
+
+        assert validate_path_within("notes.txt", tmp_path) == (tmp_path / "notes.txt").resolve()
+
+    def test_a_relative_traversal_is_still_blocked(self, tmp_path):
+        from lilbee.core.security import PathTraversalError, validate_path_within
+
+        with pytest.raises(PathTraversalError):
+            validate_path_within("../escape.txt", tmp_path)
+
+    def test_an_absolute_path_is_unchanged(self, tmp_path):
+        from lilbee.core.security import validate_path_within
+
+        target = tmp_path / "a.txt"
+        assert validate_path_within(str(target), tmp_path) == target.resolve()

--- a/tests/core/test_write_private_text.py
+++ b/tests/core/test_write_private_text.py
@@ -11,7 +11,12 @@ import pytest
 
 from lilbee.core.security import write_private_text
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")
+# Scoped per class, not module-wide: it used to blanket the file, which also
+# skipped the token-corruption and path-anchoring tests on Windows. Those
+# assert nothing about mode bits, and Windows is exactly where a truncated or
+# clobbered server.json is most likely, so the regeneration path went untested
+# on the platform that needs it most.
+posix_only = pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")
 
 
 @pytest.fixture()
@@ -38,6 +43,7 @@ def _mode(path) -> int:
 
 
 class TestWritePrivateText:
+    @posix_only
     def test_creates_file_owner_only_under_permissive_umask(self, tmp_path, permissive_umask):
         target = tmp_path / "secret.txt"
         write_private_text(target, "s3cret")
@@ -49,6 +55,7 @@ class TestWritePrivateText:
         write_private_text(target, "s3cret")
         assert target.read_text(encoding="utf-8") == "s3cret"
 
+    @posix_only
     def test_replaces_existing_file_and_narrows_its_mode(self, tmp_path, permissive_umask):
         target = tmp_path / "secret.txt"
         target.write_text("old", encoding="utf-8")
@@ -68,6 +75,7 @@ class TestWritePrivateText:
         assert list(tmp_path.iterdir()) == []
 
 
+@posix_only
 class TestSessionTokenPermissions:
     """server.json holds the bearer token: it must never be readable by other users."""
 
@@ -125,6 +133,7 @@ class TestSessionTokenPermissions:
         assert _mode(path) == 0o600
 
 
+@posix_only
 class TestPersistedSettingsPermissions:
     """config.toml can hold provider API keys and gets the same treatment."""
 
@@ -194,6 +203,7 @@ class TestValidatePathWithinAnchorsToRoot:
         assert validate_path_within(str(target), tmp_path) == target.resolve()
 
 
+@posix_only
 class TestPersistedSettingsAreHardenedOnLoad:
     """config.toml holds provider API keys and is read indefinitely without
     ever being rewritten, so a file that arrived world-readable must be
@@ -224,3 +234,56 @@ class TestPersistedSettingsAreHardenedOnLoad:
         with caplog.at_level("WARNING"):
             assert settings.load(tmp_path) == {"api_key": "sk-secret"}
         assert "Could not restrict permissions" in caplog.text
+
+
+class TestHardeningOnWindows:
+    """The POSIX body has to be exercised on Windows too, or it is only ever
+    measured on the platforms where it runs. Patching ``sys.platform`` is the
+    same technique ``tests/test_system.py`` uses for its platform branches."""
+
+    def test_the_windows_branch_leaves_the_file_alone(self, tmp_path, monkeypatch):
+        """Windows has no POSIX mode bits; the file rides the inherited DACL."""
+        from lilbee.core import security
+
+        target = tmp_path / "secret.txt"
+        target.write_text("s", encoding="utf-8")
+        monkeypatch.setattr(security.sys, "platform", "win32")
+
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("chmod attempted on Windows")
+
+        monkeypatch.setattr(security.Path, "chmod", _fail)
+        security.harden_private_file(target)
+
+    def test_a_refused_chmod_warns_instead_of_raising(self, tmp_path, monkeypatch, caplog):
+        """A file owned by another user must not stop the caller from reading it."""
+        from lilbee.core import security
+
+        target = tmp_path / "secret.txt"
+        target.write_text("s", encoding="utf-8")
+        monkeypatch.setattr(security.sys, "platform", "linux")
+        # Report a mode that needs narrowing, so the chmod is actually reached
+        # on a platform whose real mode bits may already satisfy the check.
+        monkeypatch.setattr(security.stat, "S_IMODE", lambda _mode: 0o644)
+
+        def refuse(*_args, **_kwargs):
+            raise PermissionError("not owner")
+
+        monkeypatch.setattr(security.Path, "chmod", refuse)
+        with caplog.at_level("WARNING"):
+            security.harden_private_file(target)
+        assert "Could not restrict permissions" in caplog.text
+
+    def test_an_already_narrow_file_is_not_chmodded_again(self, tmp_path, monkeypatch):
+        from lilbee.core import security
+
+        target = tmp_path / "secret.txt"
+        target.write_text("s", encoding="utf-8")
+        monkeypatch.setattr(security.sys, "platform", "linux")
+        monkeypatch.setattr(security.stat, "S_IMODE", lambda _mode: 0o600)
+
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("chmod on an already-owner-only file")
+
+        monkeypatch.setattr(security.Path, "chmod", _fail)
+        security.harden_private_file(target)

--- a/tests/crawler/test_bootstrap_serialization.py
+++ b/tests/crawler/test_bootstrap_serialization.py
@@ -1,0 +1,73 @@
+"""Concurrent Chromium bootstraps must not unpack into the same directory at once."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lilbee.crawler import bootstrap
+
+
+@pytest.fixture(autouse=True)
+def browsers_root(tmp_path, monkeypatch):
+    """Point the browser cache (and so the lock file) at a temp dir."""
+    monkeypatch.setattr(bootstrap, "_browsers_cache_path", lambda: tmp_path)
+    return tmp_path
+
+
+async def test_a_second_bootstrap_waits_and_then_skips_the_install(monkeypatch):
+    """The loser of the race must not run a second install.
+
+    Two callers reach here whenever a POST /setup/crawler races another one or
+    the first-use bootstrap a crawl triggers. Without the lock both spawn
+    ``playwright install chromium`` into one directory and corrupt it.
+    """
+    installs = 0
+    first_inside = asyncio.Event()
+    release_first = asyncio.Event()
+    installed = False
+
+    def _installed() -> bool:
+        return installed
+
+    async def _fake_install(_on_progress) -> None:
+        nonlocal installs, installed
+        installs += 1
+        first_inside.set()
+        await release_first.wait()
+        installed = True
+
+    monkeypatch.setattr(bootstrap, "chromium_installed", _installed)
+    monkeypatch.setattr(bootstrap, "_install_chromium", _fake_install)
+
+    first = asyncio.create_task(bootstrap.bootstrap_chromium())
+    await asyncio.wait_for(first_inside.wait(), timeout=5)
+
+    second = asyncio.create_task(bootstrap.bootstrap_chromium())
+    await asyncio.sleep(0.05)
+    assert not second.done(), "second caller must block on the lock, not install"
+
+    release_first.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=5)
+
+    assert installs == 1
+
+
+async def test_a_lock_timeout_reports_the_wait_instead_of_installing(monkeypatch):
+    """Rather than unpack alongside another install, say what is happening."""
+    monkeypatch.setattr(bootstrap, "chromium_installed", lambda: False)
+    monkeypatch.setattr(bootstrap, "_BOOTSTRAP_LOCK_TIMEOUT_S", 0.05)
+
+    async def _unexpected(_on_progress) -> None:
+        raise AssertionError("must not install while another holds the lock")
+
+    monkeypatch.setattr(bootstrap, "_install_chromium", _unexpected)
+
+    held = bootstrap.FileLock(str(bootstrap._bootstrap_lock_path()))
+    held.acquire()
+    try:
+        with pytest.raises(bootstrap.CrawlerBrowserError, match="Timed out"):
+            await bootstrap.bootstrap_chromium()
+    finally:
+        held.release()

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -199,7 +199,7 @@ def test_clear_placement_tool_provider_error(monkeypatch):
 @pytest.mark.asyncio
 async def test_placement_tools_wire_names():
     """Placement tools must be registered under clean wire names (no _tool suffix)."""
-    tools = await mcp_server.mcp.list_tools()
+    tools = await mcp_server.build_mcp_server().list_tools()
     names = {t.name for t in tools}
     assert "get_placement" in names
     assert "preview_placement" in names

--- a/tests/server/chat_completions_api/test_errors.py
+++ b/tests/server/chat_completions_api/test_errors.py
@@ -59,10 +59,14 @@ class TestCompletionsErrorCodeEnum:
             assert code in COMPLETIONS_ERROR_TYPES, code
 
 
-class TestInvalidCodeRejected:
-    def test_bare_string_not_in_enum_raises_key_error(self) -> None:
-        with pytest.raises(KeyError):
-            completions_error_body("zzz_unknown", "wat")  # type: ignore[arg-type]
+class TestUnmappedCodeDegrades:
+    def test_a_code_with_no_type_mapping_still_builds_a_body(self) -> None:
+        """A bare subscript here turned a handled 4xx into a 500 while building
+        the error body. test_every_code_has_a_type_mapping is the real guard
+        that the map stays complete; this one keeps the failure mode graceful."""
+        body = completions_error_body("zzz_unknown", "wat")  # type: ignore[arg-type]
+        assert body["error"]["message"] == "wat"
+        assert body["error"]["type"] == "invalid_request_error"
 
 
 class TestClassifyProviderError:
@@ -100,18 +104,33 @@ class TestClassifyProviderError:
             (ProviderErrorKind.BAD_REQUEST, 400, CompletionsErrorCode.INVALID_REQUEST),
             (ProviderErrorKind.AUTH, 401, CompletionsErrorCode.INVALID_API_KEY),
             (ProviderErrorKind.RATE_LIMIT, 429, CompletionsErrorCode.RATE_LIMIT_EXCEEDED),
-            (ProviderErrorKind.CONNECTION, 503, CompletionsErrorCode.INTERNAL_ERROR),
-            (ProviderErrorKind.SERVER, 502, CompletionsErrorCode.INTERNAL_ERROR),
         ],
     )
-    def test_classified_provider_kinds_keep_status_code_and_message(
-        self, kind, status, code
-    ) -> None:
+    def test_client_input_kinds_keep_status_code_and_message(self, kind, status, code) -> None:
+        """These describe the caller's own request, so the text helps them."""
         result = classify_provider_error(ProviderError("the original message", kind=kind))
         assert result is not None
         assert result.http_status == status
         assert result.code == code
         assert result.message == "the original message"
+
+    @pytest.mark.parametrize(
+        ("kind", "status"),
+        [(ProviderErrorKind.CONNECTION, 503), (ProviderErrorKind.SERVER, 502)],
+    )
+    def test_backend_failure_text_is_not_returned_to_the_caller(self, kind, status, caplog) -> None:
+        """A backend failure carries up to 600 characters of the upstream body
+        plus the dead server's captured stderr: loopback ports, engine binary
+        paths, CUDA load failures. None of that belongs in a client response."""
+        leak = "HTTP 502: bind 127.0.0.1:8137 failed, /opt/engine/llama-server died"
+        with caplog.at_level("WARNING"):
+            result = classify_provider_error(ProviderError(leak, kind=kind))
+        assert result is not None
+        assert result.http_status == status
+        assert result.code == CompletionsErrorCode.INTERNAL_ERROR
+        assert "127.0.0.1" not in result.message
+        assert "/opt/engine" not in result.message
+        assert leak in caplog.text
 
     def test_unknown_provider_kind_returns_none(self) -> None:
         assert classify_provider_error(ProviderError("x", kind=ProviderErrorKind.UNKNOWN)) is None

--- a/tests/server/chat_completions_api/test_errors.py
+++ b/tests/server/chat_completions_api/test_errors.py
@@ -61,9 +61,8 @@ class TestCompletionsErrorCodeEnum:
 
 class TestUnmappedCodeDegrades:
     def test_a_code_with_no_type_mapping_still_builds_a_body(self) -> None:
-        """A bare subscript here turned a handled 4xx into a 500 while building
-        the error body. test_every_code_has_a_type_mapping is the real guard
-        that the map stays complete; this one keeps the failure mode graceful."""
+        """A bare subscript turned a handled 4xx into a 500 while building the
+        error body. test_every_code_has_a_type_mapping guards completeness."""
         body = completions_error_body("zzz_unknown", "wat")  # type: ignore[arg-type]
         assert body["error"]["message"] == "wat"
         assert body["error"]["type"] == "invalid_request_error"
@@ -119,9 +118,8 @@ class TestClassifyProviderError:
         [(ProviderErrorKind.CONNECTION, 503), (ProviderErrorKind.SERVER, 502)],
     )
     def test_backend_failure_text_is_not_returned_to_the_caller(self, kind, status, caplog) -> None:
-        """A backend failure carries up to 600 characters of the upstream body
-        plus the dead server's captured stderr: loopback ports, engine binary
-        paths, CUDA load failures. None of that belongs in a client response."""
+        """Backend failure text carries the upstream body and the dead
+        server's stderr: loopback ports, engine paths, CUDA failures."""
         leak = "HTTP 502: bind 127.0.0.1:8137 failed, /opt/engine/llama-server died"
         with caplog.at_level("WARNING"):
             result = classify_provider_error(ProviderError(leak, kind=kind))

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -757,9 +757,7 @@ class TestNonStreamingCompletion:
         assert body["error"]["message"] == "the provider said no, here is what to do about it"
         assert chat_gate().in_flight == 0
 
-    @pytest.mark.parametrize(
-        ("kind", "status"), [("connection", 503), ("server", 502)]
-    )
+    @pytest.mark.parametrize(("kind", "status"), [("connection", 503), ("server", 502)])
     async def test_backend_failure_returns_a_generic_envelope(
         self, services_with_chat_model, _auth_token, kind, status
     ):

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -352,6 +352,41 @@ class TestListModelsEndpoint:
         assert resp.json()["data"][0]["created"] == 0
 
 
+class TestAuthRunsBeforeTheBodyIsParsed:
+    """The endpoint is @read_only, so the middleware waves it through and the
+    bearer check happens in the handler. With the body bound as a handler
+    parameter, Litestar parsed and validated it first, so an unauthenticated
+    caller got the whole payload processed and a malformed one was answered
+    with a 400 naming the failing fields, never reaching the 401."""
+
+    async def test_a_malformed_body_without_a_token_is_401_not_400(
+        self, services_with_chat_model, _auth_token
+    ):
+        async with AsyncTestClient(_build_app()) as client:
+            resp = await client.post("/v1/chat/completions", json={"messages": "not a list"})
+        assert resp.status_code == 401
+
+    async def test_an_unparseable_body_without_a_token_is_401(
+        self, services_with_chat_model, _auth_token
+    ):
+        async with AsyncTestClient(_build_app()) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                content=b"{not json",
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 401
+
+    async def test_a_malformed_body_with_a_token_is_still_400(
+        self, services_with_chat_model, _auth_token
+    ):
+        async with AsyncTestClient(_build_app()) as client:
+            resp = await client.post(
+                "/v1/chat/completions", headers=_h(), json={"messages": "not a list"}
+            )
+        assert resp.status_code == 400
+
+
 class TestNonStreamingCompletion:
     async def test_text_only_response(self, services_with_chat_model, _auth_token):
         async with AsyncTestClient(_build_app()) as client:

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -1648,3 +1648,52 @@ class TestIgnoredParamsLogged:
             )
         assert resp.status_code == 200
         spy.assert_not_called()
+
+
+class TestStreamErrorFrameKeepsTheStreamId:
+    """SDK accumulators key on chunk id.
+
+    The error frame is deliberately shaped as a real chat.completion.chunk so
+    OpenAI clients parse it, but it minted a fresh chatcmpl id, so it read as a
+    chunk of some other completion and the error could be dropped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_error_reuses_the_id_of_the_preceding_chunks(
+        self, monkeypatch
+    ) -> None:
+        import json
+
+        from lilbee.server.chat_completions_api.routes import _gated_completions_stream
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalChatRequest,
+            CanonicalMessage,
+            ContentBlockDelta,
+            TextDelta,
+        )
+
+        async def _one_chunk_then_boom(req: object, *, canonical_model: str | None = None) -> Any:
+            yield ContentBlockDelta(index=0, delta=TextDelta(text="partial"))
+            raise RuntimeError("upstream died mid-stream")
+
+        monkeypatch.setattr(
+            "lilbee.server.chat_completions_api.routes.dispatch_chat_stream", _one_chunk_then_boom
+        )
+        req = CanonicalChatRequest(
+            model="vendor/model",
+            messages=(CanonicalMessage(role="user", content="hi"),),
+            stream=True,
+        )
+        frames = [
+            frame
+            async for frame in _gated_completions_stream(req, ChatSlotGuard(), model=req.model)
+        ]
+
+        ids = []
+        for line in b"".join(frames).decode().splitlines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            ids.append(json.loads(line[len("data: ") :])["id"])
+
+        assert len(ids) >= 2, f"expected content and error frames, got {ids}"
+        assert len(set(ids)) == 1, f"error frame changed the completion id: {ids}"

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 from unittest.mock import MagicMock
@@ -116,18 +116,23 @@ def _clear_chat_lock():
 
 
 class FakeProviderStream:
-    """Async iterator that mimics the provider streaming protocol."""
+    """``ClosableIterator`` mimicking the provider streaming protocol.
+
+    This was an async iterator, which no provider in the tree returns; the
+    streaming tests therefore drove a dispatch branch that only existed for
+    that shape, and never the sync path production uses.
+    """
 
     def __init__(self, frames: list[Any]) -> None:
         self._frames = list(frames)
         self.closed = False
 
-    def __aiter__(self) -> AsyncIterator[Any]:
+    def __iter__(self) -> Iterator[Any]:
         return self
 
-    async def __anext__(self) -> Any:
+    def __next__(self) -> Any:
         if not self._frames:
-            raise StopAsyncIteration
+            raise StopIteration
         return self._frames.pop(0)
 
     def close(self) -> None:

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -204,7 +204,9 @@ class TestListModelsEndpoint:
             resp = await client.get("/v1/models", headers=_h())
         by_id = {m["id"]: m for m in resp.json()["data"]}
         assert by_id[INSTALLED_REF]["context_window"] == 40960
-        assert by_id["z/Other/o.gguf"]["context_window"] is None
+        # Omitted rather than null: the field is dumped with exclude_none, so a
+        # model with no served window simply carries no context_window key.
+        assert "context_window" not in by_id["z/Other/o.gguf"]
 
     async def test_remote_configured_chat_model_is_listed_first(
         self, services_with_chat_model, _auth_token, monkeypatch
@@ -728,8 +730,6 @@ class TestNonStreamingCompletion:
             ("auth", 401, "invalid_api_key"),
             ("rate_limit", 429, "rate_limit_exceeded"),
             ("bad_request", 400, "invalid_request"),
-            ("connection", 503, "internal_error"),
-            ("server", 502, "internal_error"),
         ],
     )
     async def test_classified_provider_error_returns_mapped_envelope(
@@ -755,6 +755,35 @@ class TestNonStreamingCompletion:
         body = resp.json()
         assert body["error"]["code"] == code
         assert body["error"]["message"] == "the provider said no, here is what to do about it"
+        assert chat_gate().in_flight == 0
+
+    @pytest.mark.parametrize(
+        ("kind", "status"), [("connection", 503), ("server", 502)]
+    )
+    async def test_backend_failure_returns_a_generic_envelope(
+        self, services_with_chat_model, _auth_token, kind, status
+    ):
+        """Unlike a request-shaped failure, a backend failure's text carries the
+        fleet's internal detail, so the caller gets the generic message and the
+        slot is still released."""
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        services_with_chat_model.provider.chat.side_effect = ProviderError(
+            "bind 127.0.0.1:8137 failed", kind=ProviderErrorKind(kind)
+        )
+        async with AsyncTestClient(_build_app()) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                headers=_h(),
+                json={
+                    "model": INSTALLED_REF,
+                    "messages": [{"role": "user", "content": "x"}],
+                },
+            )
+        assert resp.status_code == status
+        body = resp.json()
+        assert body["error"]["code"] == "internal_error"
+        assert "127.0.0.1" not in body["error"]["message"]
         assert chat_gate().in_flight == 0
 
     async def test_installed_but_not_configured_model_returns_actionable_400(

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -358,11 +358,9 @@ class TestListModelsEndpoint:
 
 
 class TestAuthRunsBeforeTheBodyIsParsed:
-    """The endpoint is @read_only, so the middleware waves it through and the
-    bearer check happens in the handler. With the body bound as a handler
-    parameter, Litestar parsed and validated it first, so an unauthenticated
-    caller got the whole payload processed and a malformed one was answered
-    with a 400 naming the failing fields, never reaching the 401."""
+    """The check runs in the handler, and Litestar parses the body before
+    calling it, so a malformed body used to 400 with field names instead of
+    reaching the 401."""
 
     async def test_a_malformed_body_without_a_token_is_401_not_400(
         self, services_with_chat_model, _auth_token

--- a/tests/server/chat_completions_api/test_streaming.py
+++ b/tests/server/chat_completions_api/test_streaming.py
@@ -207,3 +207,24 @@ class TestCleanupSuppression:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert task.cancelled()
+
+    async def test_upstream_failure_during_cleanup_does_not_mask_the_unwind(self) -> None:
+        """An upstream that errors as it is torn down is recorded, not raised."""
+        import asyncio
+
+        started = asyncio.Event()
+
+        async def _fails_on_cancel() -> AsyncIterator[CompletionsStreamChunk]:
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise RuntimeError("upstream died during teardown") from None
+            yield _chunk(delta=CompletionsStreamDelta(content="unreachable"))
+
+        encoder = encode_completions_sse(_fails_on_cancel())
+        assert await encoder.__anext__() == _KEEPALIVE_FRAME
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        # aclose() completes rather than surfacing the upstream's error.
+        await encoder.aclose()

--- a/tests/server/chat_completions_api/test_streaming.py
+++ b/tests/server/chat_completions_api/test_streaming.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator
 
+import pytest
+
 from lilbee.server.chat_completions_api.models import (
     CompletionsStreamChoice,
     CompletionsStreamChunk,
@@ -176,3 +178,32 @@ class TestEncodeCompletionsSse:
         assert text.count(keepalive) >= 2
         assert "finally" in text
         assert text.endswith("data: [DONE]\n\n")
+
+
+class TestCleanupSuppression:
+    """The cleanup cancels its in-flight future and awaits it. Suppressing
+    BaseException there also discarded KeyboardInterrupt and SystemExit."""
+
+    async def test_consumer_cancellation_still_propagates(self) -> None:
+        """Regression guard: cancelling the consumer must cancel the task."""
+        import asyncio
+
+        started = asyncio.Event()
+
+        async def _never_yields() -> AsyncIterator[CompletionsStreamChunk]:
+            started.set()
+            await asyncio.Event().wait()
+            yield _chunk(delta=CompletionsStreamDelta(content="unreachable"))
+
+        async def _consume() -> None:
+            async for _frame in encode_completions_sse(_never_yields()):
+                pass
+
+        task = asyncio.create_task(_consume())
+        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()

--- a/tests/server/chat_completions_api/test_translate.py
+++ b/tests/server/chat_completions_api/test_translate.py
@@ -1033,6 +1033,22 @@ class TestCanonicalStreamToCompletionsChunks:
         )
         assert chunks == []
 
+    async def test_a_tool_delta_for_a_block_that_never_started_is_skipped(self) -> None:
+        """The block index map is populated only by ContentBlockStart for a
+        ToolUseBlock, and the lookup was a bare subscript, so a provider that
+        emitted a delta for a block it never opened raised KeyError inside the
+        stream generator and surfaced as a stream-level internal error."""
+        events: list[CanonicalStreamEvent] = [
+            MessageStart(id="msg_x", model="m"),
+            ContentBlockDelta(index=7, delta=ToolUseDelta(partial_json='{"q":1}')),
+        ]
+        chunks = await _drain(
+            canonical_stream_to_completions_chunks(
+                _async_iter(events), model="m", response_id="msg_x"
+            )
+        )
+        assert all(c.choices[0].delta.tool_calls is None for c in chunks if c.choices)
+
     async def test_tool_call_stream_emits_function_chunks(self) -> None:
         events: list[CanonicalStreamEvent] = [
             MessageStart(id="msg_x", model="m"),

--- a/tests/server/chat_completions_api/test_translate.py
+++ b/tests/server/chat_completions_api/test_translate.py
@@ -166,6 +166,30 @@ class TestCompletionsToCanonicalRequest:
                 }
             )
 
+    def test_image_content_in_system_message_is_rejected(self) -> None:
+        # The same part is a 400 in a user message. The system path filtered it
+        # out instead, so an identical payload was rejected in one role and
+        # silently honoured minus the image in the other.
+        with pytest.raises(ValueError, match="Image content is not supported"):
+            _translate(
+                {
+                    "model": "m",
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": [
+                                {"type": "text", "text": "you are terse"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": "data:image/png;base64,aGVsbG8="},
+                                },
+                            ],
+                        },
+                        {"role": "user", "content": "hi"},
+                    ],
+                }
+            )
+
     def test_assistant_message_with_tool_calls(self) -> None:
         req = _translate(
             {

--- a/tests/server/chat_completions_api/test_translate.py
+++ b/tests/server/chat_completions_api/test_translate.py
@@ -1151,3 +1151,40 @@ def test_message_from_request_rejects_system_role_defensively() -> None:
     system_msg = CompletionsMessage(role="system", content="be terse")
     with pytest.raises(ValueError, match="system messages"):
         _message_from_request(system_msg)
+
+
+class TestStreamCreatedIsConstant:
+    async def test_every_chunk_of_one_completion_shares_created(self) -> None:
+        """OpenAI holds created constant across a stream; it was recomputed per
+        chunk, so one completion reported several creation times."""
+        import time
+        from unittest import mock
+
+        from lilbee.server.chat_completions_api.translate import (
+            canonical_stream_to_completions_chunks,
+        )
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalUsage,
+            ContentBlockDelta,
+            MessageDelta,
+            TextDelta,
+        )
+
+        async def _events():
+            yield ContentBlockDelta(index=0, delta=TextDelta(text="a"))
+            yield ContentBlockDelta(index=0, delta=TextDelta(text="b"))
+            yield MessageDelta(
+                stop_reason=None, usage=CanonicalUsage(input_tokens=1, output_tokens=1)
+            )
+
+        ticking = iter([1000.0, 1001.0, 1002.0, 1003.0, 1004.0, 1005.0])
+        with mock.patch.object(time, "time", lambda: next(ticking)):
+            chunks = [
+                c
+                async for c in canonical_stream_to_completions_chunks(
+                    _events(), model="m", response_id="chatcmpl-x", include_usage=True
+                )
+            ]
+
+        assert len(chunks) >= 3
+        assert len({c.created for c in chunks}) == 1

--- a/tests/server/chat_completions_api/test_translate.py
+++ b/tests/server/chat_completions_api/test_translate.py
@@ -190,6 +190,20 @@ class TestCompletionsToCanonicalRequest:
                 }
             )
 
+    def test_tool_message_without_tool_call_id_is_rejected(self) -> None:
+        # An empty id produced a tool result no tool call can pair with, so the
+        # provider saw a result for a call it never made.
+        with pytest.raises(ValueError, match="tool_call_id"):
+            _translate(
+                {
+                    "model": "m",
+                    "messages": [
+                        {"role": "user", "content": "hi"},
+                        {"role": "tool", "content": "42"},
+                    ],
+                }
+            )
+
     def test_assistant_message_with_tool_calls(self) -> None:
         req = _translate(
             {

--- a/tests/server/chat_dispatch/test_canonical.py
+++ b/tests/server/chat_dispatch/test_canonical.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lilbee.server.chat_dispatch.canonical import (
     CanonicalChatRequest,
     CanonicalMessage,
@@ -115,11 +117,18 @@ def test_stop_reason_is_string_enum() -> None:
 
 
 def test_canonical_tool_choice_modes() -> None:
-    for mode in ("auto", "any", "none", "tool"):
+    for mode in ("auto", "any", "none"):
         choice = CanonicalToolChoice(mode=mode)  # type: ignore[arg-type]
         assert choice.mode == mode
     forced = CanonicalToolChoice(mode="tool", tool_name="search")
     assert forced.tool_name == "search"
+
+
+def test_forced_tool_choice_requires_a_name() -> None:
+    """Without the name this reached the provider as {"function": {"name": None}},
+    a malformed tool choice the backend rejects instead of the boundary."""
+    with pytest.raises(ValueError, match="requires a tool_name"):
+        CanonicalToolChoice(mode="tool")
 
 
 def test_canonical_message_holds_tool_result_blocks() -> None:

--- a/tests/server/chat_dispatch/test_concurrency.py
+++ b/tests/server/chat_dispatch/test_concurrency.py
@@ -171,3 +171,73 @@ async def test_release_skips_already_cancelled_waiters() -> None:
     await asyncio.wait_for(second, timeout=1)
     assert chat_gate().in_flight == 1
     await release_chat_slot()
+
+
+async def test_a_newcomer_does_not_barge_past_a_queued_waiter() -> None:
+    """FIFO: a request arriving while someone is queued waits behind them.
+
+    Without this, release() wakes a waiter but does not hand it the slot, so any
+    request entering acquire() in between takes the slot synchronously and the
+    woken waiter re-queues at the tail. Under load the oldest requests are
+    overtaken repeatedly and are the ones that time out into a 429.
+    """
+    await acquire_chat_slot_or_busy(1, timeout=0.5)  # fill the only slot
+    order: list[str] = []
+
+    async def _contend(name: str) -> None:
+        await acquire_chat_slot_or_busy(1, timeout=5)
+        order.append(name)
+
+    first = asyncio.create_task(_contend("first"))
+    await asyncio.sleep(0)  # first is queued
+    second = asyncio.create_task(_contend("second"))
+    await asyncio.sleep(0)  # second must queue behind, not take the free slot
+
+    await release_chat_slot()
+    await asyncio.wait_for(first, timeout=1)
+    assert order == ["first"]
+    assert second.done() is False
+
+    await release_chat_slot()
+    await asyncio.wait_for(second, timeout=1)
+    assert order == ["first", "second"]
+    await release_chat_slot()
+
+
+async def test_the_woken_waiter_keeps_the_slot_against_a_racing_newcomer() -> None:
+    """The freed slot is handed to the waiter, not left up for grabs."""
+    await acquire_chat_slot_or_busy(1, timeout=0.5)
+    waiter = asyncio.create_task(acquire_chat_slot_or_busy(1, timeout=5))
+    await asyncio.sleep(0)  # queued
+
+    await release_chat_slot()  # hands the slot to the queued waiter
+    # A newcomer running before the woken waiter resumes must not steal it.
+    with pytest.raises(ChatBusyError):
+        await acquire_chat_slot_or_busy(1, timeout=0)
+
+    await asyncio.wait_for(waiter, timeout=1)
+    assert chat_gate().in_flight == 1
+    await release_chat_slot()
+
+
+async def test_a_capacity_increase_wakes_already_queued_waiters() -> None:
+    """A slot count that grows must admit the waiters it just made room for.
+
+    Capacity is read at admission time, so the gate learns the new count from
+    the next caller; the waiters parked under the old count have to be woken
+    then, not left to time out into a 429 against an idle backend.
+    """
+    await acquire_chat_slot_or_busy(1, timeout=0.5)  # capacity 1, slot taken
+    parked = [asyncio.create_task(acquire_chat_slot_or_busy(1, timeout=5)) for _ in range(3)]
+    await asyncio.sleep(0)
+    assert all(not t.done() for t in parked)
+
+    # The backend is reconfigured to 4 slots; the next caller reports it.
+    late = asyncio.create_task(acquire_chat_slot_or_busy(4, timeout=5))
+    await asyncio.wait_for(asyncio.gather(*parked), timeout=1)
+    assert chat_gate().in_flight == 4
+
+    for _ in range(4):
+        await release_chat_slot()
+    await asyncio.wait_for(late, timeout=1)
+    await release_chat_slot()

--- a/tests/server/chat_dispatch/test_dispatch.py
+++ b/tests/server/chat_dispatch/test_dispatch.py
@@ -445,18 +445,23 @@ class TestDispatchChat:
 
 
 class _FakeStream:
-    """Test-only async iterator that mimics ``ClosableIterator[ChatStreamItem]``."""
+    """Test-only ``ClosableIterator[ChatStreamItem]``.
+
+    This used to be an *async* iterator, despite the docstring, so every
+    streaming test drove the async-native branch of the dispatch iterator
+    rather than the sync path every real provider returns.
+    """
 
     def __init__(self, frames):
         self._frames = list(frames)
         self.closed = False
 
-    def __aiter__(self):
+    def __iter__(self):
         return self
 
-    async def __anext__(self):
+    def __next__(self):
         if not self._frames:
-            raise StopAsyncIteration
+            raise StopIteration
         return self._frames.pop(0)
 
     def close(self) -> None:
@@ -762,6 +767,35 @@ class TestDispatchChatStream:
         assert all(isinstance(s.block, ToolUseBlock) for s in starts)
         # Two content blocks opened, two closed.
         assert len(stops) == 2
+
+    async def test_text_between_argument_deltas_keeps_one_call_identity(
+        self, services_with_model
+    ) -> None:
+        """A text frame closes the open tool block, so the next delta for the
+        same call has to open a second one. Continuation deltas carry no id and
+        no name, so that block used to get a fresh synthetic id and an empty
+        name: one logical call split into two blocks, the second matching no
+        tool. Both blocks must at least carry the identity the call announced."""
+        services_with_model.provider.supports_tools.return_value = True
+        frames = [
+            ToolCallDelta(index=0, id="c1", name="search", arguments_delta='{"q":'),
+            "thinking out loud",
+            ToolCallDelta(index=0, id=None, name=None, arguments_delta='"x"}'),
+        ]
+        services_with_model.provider.chat.return_value = _FakeStream(frames)
+        events = await self._drain(
+            dispatch_chat_stream(
+                _req(tools=[CanonicalTool(name="search", description="", input_schema={})])
+            )
+        )
+        tool_starts = [
+            e
+            for e in events
+            if isinstance(e, ContentBlockStart) and isinstance(e.block, ToolUseBlock)
+        ]
+        assert len(tool_starts) == 2
+        assert {s.block.id for s in tool_starts} == {"c1"}
+        assert {s.block.name for s in tool_starts} == {"search"}
 
 
 class _SyncFakeStream:

--- a/tests/server/chat_dispatch/test_dispatch.py
+++ b/tests/server/chat_dispatch/test_dispatch.py
@@ -772,10 +772,9 @@ class TestDispatchChatStream:
         self, services_with_model
     ) -> None:
         """A text frame closes the open tool block, so the next delta for the
-        same call has to open a second one. Continuation deltas carry no id and
-        no name, so that block used to get a fresh synthetic id and an empty
-        name: one logical call split into two blocks, the second matching no
-        tool. Both blocks must at least carry the identity the call announced."""
+        same call opens a second one. Continuation deltas carry no id or name,
+        so it used to get a synthetic id and an empty name, splitting one call
+        across two blocks."""
         services_with_model.provider.supports_tools.return_value = True
         frames = [
             ToolCallDelta(index=0, id="c1", name="search", arguments_delta='{"q":'),

--- a/tests/server/chat_dispatch/test_dispatch.py
+++ b/tests/server/chat_dispatch/test_dispatch.py
@@ -104,6 +104,27 @@ class TestDispatchChat:
         assert resp.stop_reason == StopReason.END_TURN
         assert resp.id.startswith("msg_")
 
+    def test_tool_calls_force_tool_use_even_when_the_provider_says_stop(
+        self, services_with_model
+    ) -> None:
+        """A provider that returns tool calls without saying so still means tool_use.
+
+        FinishReason.coerce falls back to STOP for a missing or unknown value,
+        so the response carried tool_use content under end_turn and a client
+        reading stop_reason would not run the tools. The streaming path already
+        refuses the same downgrade.
+        """
+        from lilbee.providers.base import ToolCall
+
+        services_with_model.provider.chat.return_value = ChatResult(
+            text="",
+            tool_calls=(ToolCall(id="call_1", name="search", arguments='{"q": "x"}'),),
+            finish_reason=FinishReason.STOP,
+        )
+        resp = dispatch_chat(_req())
+        assert resp.stop_reason == StopReason.TOOL_USE
+        assert any(getattr(block, "name", None) == "search" for block in resp.content)
+
     def test_empty_text_returns_empty_content(self, services_with_model) -> None:
         services_with_model.provider.chat.return_value = ChatResult(
             text="", tool_calls=(), finish_reason=FinishReason.STOP

--- a/tests/server/test_every_route_is_authenticated.py
+++ b/tests/server/test_every_route_is_authenticated.py
@@ -1,16 +1,8 @@
 """No HTTP route answers a caller who sent no token.
 
-The old ``@read_only`` marker read like "a read-only token is accepted". There
-is no such token: the marker made AuthMiddleware skip the check entirely, so
-every route carrying it answered callers with no Authorization header at all.
-That is how routes serving chat transcripts, wiki pages built from the user's
-corpus, the document listing, and ``GET /api/export`` (which serializes the
-whole corpus) ended up open, on a daemon documented as binding loopback "to
-keep out other local users".
-
-This test is the line. A new route is authenticated by default because
-middleware covers everything; the only way to opt out is the registry below,
-and anything in it has to prove it does its own check.
+Middleware covers everything, so a new route is authenticated by default. The
+only way out is the registry below, and anything in it must prove it checks
+the token itself.
 """
 
 from __future__ import annotations

--- a/tests/server/test_every_route_is_authenticated.py
+++ b/tests/server/test_every_route_is_authenticated.py
@@ -1,0 +1,100 @@
+"""No HTTP route answers a caller who sent no token.
+
+The old ``@read_only`` marker read like "a read-only token is accepted". There
+is no such token: the marker made AuthMiddleware skip the check entirely, so
+every route carrying it answered callers with no Authorization header at all.
+That is how routes serving chat transcripts, wiki pages built from the user's
+corpus, the document listing, and ``GET /api/export`` (which serializes the
+whole corpus) ended up open, on a daemon documented as binding loopback "to
+keep out other local users".
+
+This test is the line. A new route is authenticated by default because
+middleware covers everything; the only way to opt out is the registry below,
+and anything in it has to prove it does its own check.
+"""
+
+from __future__ import annotations
+
+import pytest
+from litestar.testing import TestClient
+
+from lilbee.app import services as svc_mod
+from lilbee.core.config import cfg
+from lilbee.server.app import create_app
+from lilbee.server.auth import session_manager
+from tests.conftest import make_mock_services
+
+# Routes whose token check runs inside the handler instead of in middleware.
+# Both belong to the OpenAI-compatible surface, which must answer a bad token
+# with the OpenAI error envelope rather than Litestar's 401 shape. They are
+# still authenticated: the assertions below prove it by calling them.
+SELF_AUTHENTICATING = {"/v1/models", "/v1/chat/completions"}
+
+
+@pytest.fixture()
+def client(tmp_path):
+    snapshot = cfg.model_copy()
+    cfg.data_root = tmp_path
+    cfg.data_dir = tmp_path / "data"
+    cfg.wiki = True
+    svc_mod.set_services(make_mock_services())
+    session_manager.token = "a-real-token"
+    session_manager._initialized = True
+    with TestClient(app=create_app()) as c:
+        yield c
+    session_manager.token = None
+    svc_mod.set_services(None)
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+def _get_routes(app) -> list[tuple[str, str]]:
+    """Every (method, path) the app serves, excluding schema and the MCP mount."""
+    found = []
+    for route in app.routes:
+        path = route.path
+        if path.startswith(("/schema", "/mcp")):
+            continue
+        for method in getattr(route, "methods", set()):
+            if method in ("HEAD", "OPTIONS"):
+                continue
+            found.append((method, path))
+    return sorted(set(found))
+
+
+def _concrete(path: str) -> str:
+    """Fill path params with a value that will 404, not 401, if auth passes."""
+    out = []
+    for part in path.split("/"):
+        out.append("x" if part.startswith("{") else part)
+    return "/".join(out)
+
+
+class TestNoRouteAnswersWithoutAToken:
+    def test_the_app_serves_the_routes_this_test_thinks_it_does(self, client):
+        """Guard against the sweep silently covering nothing."""
+        routes = _get_routes(client.app)
+        assert len(routes) > 30
+        paths = {p for _, p in routes}
+        for expected in ("/api/health", "/api/export", "/api/search", "/api/wiki"):
+            assert expected in paths, expected
+
+    def test_no_route_answers_an_unauthenticated_caller(self, client):
+        """A 401 is the only acceptable answer to a request with no token."""
+        answered = []
+        for method, path in _get_routes(client.app):
+            if path in SELF_AUTHENTICATING:
+                continue
+            resp = client.request(method, _concrete(path), json={})
+            if resp.status_code != 401:
+                answered.append(f"{method} {path} -> {resp.status_code}")
+        assert not answered, "routes answered without a token:\n" + "\n".join(answered)
+
+    @pytest.mark.parametrize("path", sorted(SELF_AUTHENTICATING))
+    def test_the_self_authenticating_routes_still_reject(self, client, path):
+        """These skip middleware, so they carry the whole burden themselves."""
+        method = "GET" if path == "/v1/models" else "POST"
+        resp = client.request(method, path, json={"model": "m", "messages": []})
+        assert resp.status_code == 401
+        # And in the OpenAI envelope, which is the reason they opt out at all.
+        assert resp.json()["error"]["code"] == "invalid_api_key"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -635,6 +635,11 @@ class TestAddIngestMutex:
         summary = [d for t, d in events if t == "done" and "copied" in d][-1]
         assert "free.txt" in summary["copied"]
         assert "held.txt" not in summary["copied"]
+        # The done event is the only frame a client is guaranteed to still have,
+        # so it has to say the batch was partial. Without this a caller reads
+        # done as "all ingested" and never retries the contended file.
+        assert summary["already_ingesting"] == ["held.txt"]
+        assert "held.txt" not in summary["skipped"]
 
     async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
         """Disjoint sources do not contend: both requests complete with done."""

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -573,17 +573,25 @@ class TestAddIngestMutex:
         registry.release(held)
         assert registry._locks == {}
 
-    async def test_acquire_add_locks_dedups_repeated_paths(self, isolated_env):
-        """Duplicate paths in one request collapse to a single acquired lock."""
+    async def test_acquire_dedups_repeated_names(self, isolated_env):
+        """The registry locks each distinct name once."""
         from lilbee.app.services import get_services
 
         registry = get_services().ingest_lock_registry
-        acquired, busy = await registry.acquire(["/x/doc.txt", "/y/doc.txt"])
+        acquired, busy = await registry.acquire(["doc.txt", "doc.txt"])
         try:
             assert busy == []
             assert [name for name, _ in acquired] == ["doc.txt"]
         finally:
             registry.release(acquired)
+
+    def test_add_locks_server_paths_by_basename(self):
+        """/api/add flattens into documents_dir, so two paths sharing a
+        basename are one source and must share one lock."""
+        from lilbee.runtime.ingest_lock import IngestLockRegistry
+
+        assert IngestLockRegistry.canonical_source_name("/x/doc.txt") == "doc.txt"
+        assert IngestLockRegistry.canonical_source_name("/y/doc.txt") == "doc.txt"
 
     async def test_second_concurrent_add_emits_already_ingesting(self, isolated_env, tmp_path):
         """Second /api/add for a held source yields already_ingesting, no done."""
@@ -640,6 +648,24 @@ class TestAddIngestMutex:
         # done as "all ingested" and never retries the contended file.
         assert summary["already_ingesting"] == ["held.txt"]
         assert "held.txt" not in summary["skipped"]
+
+    async def test_distinct_relative_paths_get_distinct_locks(self, isolated_env):
+        """Two uploads that land at different paths must not share one lock.
+
+        The registry reduced every key to its basename. That is right for
+        /api/add, where copy_files flattens into documents_dir, but uploads
+        keep their relative layout, so src/util.py and tests/util.py are
+        different files that were being serialized against each other.
+        """
+        from lilbee.app.services import get_services
+
+        registry = get_services().ingest_lock_registry
+        acquired, busy = await registry.acquire(["src/util.py", "tests/util.py"])
+        try:
+            assert busy == []
+            assert sorted(name for name, _lock in acquired) == ["src/util.py", "tests/util.py"]
+        finally:
+            registry.release(acquired)
 
     async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
         """Disjoint sources do not contend: both requests complete with done."""

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -180,23 +180,26 @@ class TestAddEndpoint:
         assert resp.status_code == 201
 
     def test_validate_uploads_rejects_bad_input(self, mock_extract_file, isolated_env):
-        """validate_uploads guards empty/malformed names and keeps relative paths."""
-        from lilbee.server.handlers.ingest import validate_uploads
+        """validate_upload_names guards empty/malformed names and keeps relative paths."""
+        from lilbee.server.handlers.ingest import validate_upload_names
 
         with pytest.raises(ValueError, match="no files"):
-            validate_uploads([])
+            validate_upload_names([])
         with pytest.raises(ValueError, match="invalid upload filename"):
-            validate_uploads([("", b"x")])
+            validate_upload_names([""])
         with pytest.raises(ValueError, match="must be relative"):
-            validate_uploads([("/etc/passwd", b"x")])
+            validate_upload_names(["/etc/passwd"])
         with pytest.raises(ValueError, match="must be relative"):
-            validate_uploads([("C:\\dir\\file.txt", b"x")])
+            validate_upload_names(["C:\\dir\\file.txt"])
         with pytest.raises(ValueError, match="may not contain"):
-            validate_uploads([("../../a/b.txt", b"x")])
+            validate_upload_names(["../../a/b.txt"])
         # Relative paths survive so an uploaded tree keeps its layout.
-        assert validate_uploads([("src/pkg/__init__.py", b"x")]) == [("src/pkg/__init__.py", b"x")]
+        assert validate_upload_names(["src/pkg/__init__.py"]) == ["src/pkg/__init__.py"]
         # Backslash separators and ./ prefixes normalize to POSIX relative form.
-        assert validate_uploads([("./src\\a.py", b"x")]) == [("src/a.py", b"x")]
+        assert validate_upload_names(["./src\\a.py"]) == ["src/a.py"]
+        # A multipart part may carry no filename at all.
+        with pytest.raises(ValueError, match="invalid upload filename"):
+            validate_upload_names([None])
 
     async def test_add_nonexistent_file_in_errors(self, mock_extract_file, isolated_env, tmp_path):
         """Nonexistent paths appear in the summary errors list."""

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -797,3 +797,20 @@ class TestAddIngestHardening:
         # The stale chunks are removed in the same batched write that re-adds them.
         assert "orphan.txt" in self._cleanup_sources(store)
         store.write_chunks_batch.assert_called()
+
+
+class TestValidateAddPathsRejectsNamelessPaths:
+    def test_a_path_with_no_final_component_is_rejected(self):
+        """Path(x).name never contains separators, so the traversal check alone
+        could not fail. What it must catch is an empty name, which would make
+        documents_dir itself the copy destination."""
+        from lilbee.server.handlers.ingest import validate_add_paths
+
+        with pytest.raises(ValueError, match="does not name a file"):
+            validate_add_paths({"paths": ["/"]})
+
+    def test_a_normal_path_still_passes(self):
+        from lilbee.server.handlers.ingest import validate_add_paths
+
+        paths, _force, _ocr, _timeout = validate_add_paths({"paths": ["/tmp/report.pdf"]})
+        assert paths == ["/tmp/report.pdf"]

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -235,3 +235,19 @@ async def test_search_tool_uses_the_shared_services_singleton(
         set_services(None)
     services.searcher.search.assert_called_once()
     assert services.searcher.search.call_args.args[0] == "hello"
+
+
+def test_a_dependency_without_the_private_session_manager_fails_at_build(monkeypatch) -> None:
+    """The mount clears FastMCP's private _session_manager because the package
+    exposes no public reset. If a release renames it, the failure must name the
+    dependency here rather than surfacing later as run()-already-entered."""
+    import pytest
+
+    from lilbee.server import mcp_mount
+
+    class _NoSessionManager:
+        settings = None
+
+    monkeypatch.setattr(mcp_mount, "mcp", _NoSessionManager())
+    with pytest.raises(RuntimeError, match="mcp version pin"):
+        build_mcp_mount()

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -67,6 +67,21 @@ def test_transport_security_loopback_only_for_wildcard_bind(monkeypatch, wildcar
     assert "127.0.0.1:*" in security.allowed_hosts
 
 
+@pytest.mark.parametrize("wildcard", ["0.0.0.0", "::"])
+def test_a_wildcard_bind_warns_that_mcp_stays_loopback_only(monkeypatch, caplog, wildcard) -> None:
+    """The REST API on the same port serves LAN clients fine, so an operator
+    who deliberately exposed the daemon otherwise gets a silently half-working
+    server: only /mcp fails, with an opaque transport-security rejection."""
+    from lilbee.core.config import cfg
+    from lilbee.server.mcp_mount import _transport_security
+
+    monkeypatch.setattr(cfg, "server_host", wildcard)
+    with caplog.at_level("WARNING"):
+        _transport_security()
+    assert "/mcp" in caplog.text
+    assert wildcard in caplog.text
+
+
 def test_handler_mounts_at_mcp_path() -> None:
     handler, _ = build_mcp_mount()
     assert MCP_MOUNT_PATH in handler.paths

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -10,10 +10,12 @@ import pytest
 from litestar import Litestar
 from litestar.middleware.base import DefineMiddleware
 from litestar.testing import AsyncTestClient
+from mcp.server.fastmcp import FastMCP
 
 from lilbee.app.services import set_services
-from lilbee.mcp_server import mcp
+from lilbee.mcp_server import build_mcp_server, mcp
 from lilbee.server import auth as auth_mod
+from lilbee.server import mcp_mount
 from lilbee.server.auth import AuthMiddleware
 from lilbee.server.mcp_mount import MCP_MOUNT_PATH, build_mcp_mount
 
@@ -22,13 +24,37 @@ _HTTP_UNAUTHORIZED = 401
 _ACCEPT = "application/json, text/event-stream"
 
 
-def test_configures_localhost_transport_security() -> None:
+def _mounted_server(monkeypatch) -> FastMCP:
+    """Build a mount and hand back the server it mounted."""
+    built: list[FastMCP] = []
+    real = mcp_mount.build_mcp_server
+
+    def _spy() -> FastMCP:
+        server = real()
+        built.append(server)
+        return server
+
+    monkeypatch.setattr(mcp_mount, "build_mcp_server", _spy)
     build_mcp_mount()
-    assert mcp.settings.streamable_http_path == "/"
-    security = mcp.settings.transport_security
+    return built[0]
+
+
+def test_configures_localhost_transport_security(monkeypatch) -> None:
+    server = _mounted_server(monkeypatch)
+    assert server.settings.streamable_http_path == "/"
+    security = server.settings.transport_security
     assert security is not None
     assert security.enable_dns_rebinding_protection
     assert "127.0.0.1:*" in security.allowed_hosts
+
+
+def test_mount_does_not_reconfigure_the_stdio_server() -> None:
+    """The HTTP mount owns its server. Reconfiguring or resetting the stdio one
+    behind its back is what forced the old private session-manager reset."""
+    pristine = build_mcp_server()
+    build_mcp_mount()
+    assert mcp.settings.streamable_http_path == pristine.settings.streamable_http_path
+    assert mcp.settings.transport_security == pristine.settings.transport_security
 
 
 def test_transport_security_includes_configured_bind_host(monkeypatch) -> None:
@@ -87,13 +113,22 @@ def test_handler_mounts_at_mcp_path() -> None:
     assert MCP_MOUNT_PATH in handler.paths
 
 
-def test_fresh_session_manager_per_build() -> None:
+def test_fresh_session_manager_per_build(monkeypatch) -> None:
     """run() is single-use per manager, so a second app in the same process
     needs its own or its lifespan raises."""
-    build_mcp_mount()
-    first = mcp.session_manager
-    build_mcp_mount()
-    assert mcp.session_manager is not first
+    first = _mounted_server(monkeypatch)
+    second = _mounted_server(monkeypatch)
+    assert first.session_manager is not second.session_manager
+
+
+async def test_two_mounts_in_one_process_both_start() -> None:
+    """Several apps per process is the normal test-suite shape, and the CLI can
+    rebuild one. Both lifespans must enter."""
+    _, first = build_mcp_mount()
+    _, second = build_mcp_mount()
+    app = MagicMock(spec=Litestar)
+    async with first(app), second(app):
+        pass
 
 
 @pytest.fixture

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -111,6 +111,14 @@ def test_fresh_session_manager_per_build(monkeypatch) -> None:
     assert first.session_manager is not second.session_manager
 
 
+def test_mount_is_stateful(monkeypatch) -> None:
+    # Stateful sessions carry clientInfo across requests, which memory owner
+    # derivation reads. Stateless serving is a future scale-out deployment
+    # mode, not a flag on this one.
+    server = _mounted_server(monkeypatch)
+    assert server.settings.stateless_http is False
+
+
 async def test_two_mounts_in_one_process_both_start() -> None:
     """Several apps per process is the normal test-suite shape, and the CLI can
     rebuild one. Both lifespans must enter."""

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -13,7 +13,6 @@ from litestar.testing import AsyncTestClient
 from mcp.server.fastmcp import FastMCP
 
 from lilbee.app.services import set_services
-from lilbee.mcp_server import build_mcp_server, mcp
 from lilbee.server import auth as auth_mod
 from lilbee.server import mcp_mount
 from lilbee.server.auth import AuthMiddleware
@@ -46,15 +45,6 @@ def test_configures_localhost_transport_security(monkeypatch) -> None:
     assert security is not None
     assert security.enable_dns_rebinding_protection
     assert "127.0.0.1:*" in security.allowed_hosts
-
-
-def test_mount_does_not_reconfigure_the_stdio_server() -> None:
-    """The HTTP mount owns its server. Reconfiguring or resetting the stdio one
-    behind its back is what forced the old private session-manager reset."""
-    pristine = build_mcp_server()
-    build_mcp_mount()
-    assert mcp.settings.streamable_http_path == pristine.settings.streamable_http_path
-    assert mcp.settings.transport_security == pristine.settings.transport_security
 
 
 def test_transport_security_includes_configured_bind_host(monkeypatch) -> None:

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -88,11 +88,12 @@ def test_handler_mounts_at_mcp_path() -> None:
 
 
 def test_fresh_session_manager_per_build() -> None:
+    """run() is single-use per manager, so a second app in the same process
+    needs its own or its lifespan raises."""
     build_mcp_mount()
     first = mcp.session_manager
     build_mcp_mount()
-    second = mcp.session_manager
-    assert first is not second
+    assert mcp.session_manager is not first
 
 
 @pytest.fixture
@@ -235,19 +236,3 @@ async def test_search_tool_uses_the_shared_services_singleton(
         set_services(None)
     services.searcher.search.assert_called_once()
     assert services.searcher.search.call_args.args[0] == "hello"
-
-
-def test_a_dependency_without_the_private_session_manager_fails_at_build(monkeypatch) -> None:
-    """The mount clears FastMCP's private _session_manager because the package
-    exposes no public reset. If a release renames it, the failure must name the
-    dependency here rather than surfacing later as run()-already-entered."""
-    import pytest
-
-    from lilbee.server import mcp_mount
-
-    class _NoSessionManager:
-        settings = None
-
-    monkeypatch.setattr(mcp_mount, "mcp", _NoSessionManager())
-    with pytest.raises(RuntimeError, match="mcp version pin"):
-        build_mcp_mount()

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -294,3 +294,32 @@ def test_gpu_stats_stream_streams_events(monkeypatch):
         r = client.get("/api/gpus/stream")
         assert r.status_code == 200
         assert "text/event-stream" in r.headers["content-type"]
+
+
+def test_gpu_stats_stream_probes_off_the_event_loop(monkeypatch):
+    """get_placement spawns subprocess device probes; a wedged driver must not
+    stall every other request, so the probe runs in a worker thread."""
+    import threading
+
+    import lilbee.app.placement as placement_mod
+    from lilbee.app.placement import PlacementView
+
+    view = PlacementView(gpus=(), roles=(), unplaceable=(), manual=False, spec_json=None)
+    probe_tid: list[int] = []
+    loop_tid: list[int] = []
+
+    def _probe():
+        probe_tid.append(threading.get_ident())
+        return view
+
+    async def _fake_stream(devices):
+        # The generator runs on the event loop, so this is the loop's thread.
+        loop_tid.append(threading.get_ident())
+        yield "event: gpu_stats\ndata: {}\n\n"
+
+    monkeypatch.setattr(placement_mod, "get_placement", _probe)
+    monkeypatch.setattr(handlers, "gpu_stats_stream", _fake_stream)
+    with create_test_client([gpu_stats_stream_route]) as client:
+        r = client.get("/api/gpus/stream")
+        assert r.status_code == 200
+    assert probe_tid and loop_tid and probe_tid[0] != loop_tid[0]

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -58,11 +58,11 @@ def test_delete_refused_on_daemon():
 
 def test_placement_routes_require_auth():
     """No placement route is read-only: they all run subprocess device probes."""
-    from lilbee.server.auth import is_read_only
+    from lilbee.server.auth import authenticates_itself
 
-    assert not is_read_only(placement_preview_route.fn)
-    assert not is_read_only(placement_route.fn)
-    assert not is_read_only(gpus_route.fn)
+    assert not authenticates_itself(placement_preview_route.fn)
+    assert not authenticates_itself(placement_route.fn)
+    assert not authenticates_itself(gpus_route.fn)
 
 
 def test_preview_provider_error_returns_503(monkeypatch):

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -341,3 +341,17 @@ def test_probe_oserror_is_service_unavailable_not_unprocessable(monkeypatch):
         r = client.post("/api/placement/preview", json={"spec": None})
     assert r.status_code == 503
     assert "nvidia-smi" in r.text or "probe" in r.text.lower()
+
+
+def test_put_probe_oserror_is_service_unavailable_when_enabled(monkeypatch):
+    """The apply route maps a failed probe the same way preview does."""
+    _enable_http_placement(monkeypatch)
+
+    async def _boom(_spec):
+        raise PermissionError(13, "Permission denied", "/dev/nvidia0")
+
+    monkeypatch.setattr(handlers, "placement_set", _boom)
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+    assert r.status_code == 503
+    assert "probe" in r.text.lower() or "nvidia-smi" in r.text

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -323,3 +323,21 @@ def test_gpu_stats_stream_probes_off_the_event_loop(monkeypatch):
         r = client.get("/api/gpus/stream")
         assert r.status_code == 200
     assert probe_tid and loop_tid and probe_tid[0] != loop_tid[0]
+
+
+def test_probe_oserror_is_service_unavailable_not_unprocessable(monkeypatch):
+    """A missing vendor tool is a host fault, not a bad spec.
+
+    FileNotFoundError (no nvidia-smi on PATH) and PermissionError (device node)
+    were bundled with PlacementError into a 422, which sends the caller looking
+    for a mistake in JSON that is fine.
+    """
+
+    async def _boom(_spec):
+        raise FileNotFoundError(2, "No such file or directory", "nvidia-smi")
+
+    monkeypatch.setattr(handlers, "placement_preview", _boom)
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": None})
+    assert r.status_code == 503
+    assert "nvidia-smi" in r.text or "probe" in r.text.lower()

--- a/tests/server/test_stream_error_codes.py
+++ b/tests/server/test_stream_error_codes.py
@@ -1,8 +1,7 @@
-"""The RAG chat stream must carry the same typed error codes as its non-stream sibling.
+"""The RAG chat stream carries the same typed error codes as its non-stream sibling.
 
-The non-streaming /api/chat maps a dispatch failure to a distinct status, but
-the streaming path flattened every failure into one code-less message, so a
-client could not tell "pull the model" from "shorten the prompt".
+The streaming path used to flatten every failure into one code-less message,
+so a client could not tell "pull the model" from "shorten the prompt".
 """
 
 from __future__ import annotations
@@ -55,8 +54,8 @@ class TestStreamErrorCodes:
         assert (await _collect(exc))["code"] == code
 
     async def test_a_backend_failure_stays_generic(self) -> None:
-        """Same redaction as the completions surface: the fleet's message names
-        loopback ports and engine paths, so it is logged rather than streamed."""
+        """Same redaction as the completions surface: the fleet's message
+        names loopback ports and engine paths."""
         payload = await _collect(
             ProviderError("bind 127.0.0.1:8137 failed", kind=ProviderErrorKind.CONNECTION)
         )
@@ -68,10 +67,8 @@ class TestStreamErrorCodes:
 
 
 class TestStalledConsumerStopsTheProducer:
-    """Chat and RAG tokens are in the always-deliver class, so a generation
-    streaming to a client that has stopped reading filled the queue with
-    events nothing was permitted to shed, and it grew until the generation
-    ended."""
+    """Chat and RAG tokens cannot be shed, so a generation streaming to a
+    client that stopped reading grew the queue until it finished."""
 
     async def test_a_full_undroppable_queue_cancels_the_producer(self) -> None:
         from lilbee.server.handlers.sse import SseStream
@@ -96,9 +93,8 @@ class TestStalledConsumerStopsTheProducer:
 
 
 class TestTerminalFrameIsSharedByEveryStream:
-    """Five streaming handlers ended with the same five lines, and the copies
-    had drifted: the crawler-setup one skipped the cancel check, so it emitted
-    a done frame to a client that had already disconnected."""
+    """One helper for all five streaming handlers, which had drifted: one
+    skipped the cancel check and emitted done to a disconnected client."""
 
     async def _finished(self, result=None, exc=None):
         async def _run():

--- a/tests/server/test_stream_error_codes.py
+++ b/tests/server/test_stream_error_codes.py
@@ -1,0 +1,66 @@
+"""The RAG chat stream must carry the same typed error codes as its non-stream sibling.
+
+The non-streaming /api/chat maps a dispatch failure to a distinct status, but
+the streaming path flattened every failure into one code-less message, so a
+client could not tell "pull the model" from "shorten the prompt".
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lilbee.providers.base import ProviderError, ProviderErrorKind
+from lilbee.server.chat_dispatch.concurrency import ChatSlotGuard
+from lilbee.server.chat_dispatch.dispatch import (
+    ModelDoesNotSupportToolsError,
+    ModelNotFoundError,
+)
+from lilbee.server.routes.search import _gated_stream
+
+
+def _payload(frame: str) -> dict:
+    """Parse the data: line out of an SSE frame."""
+    for line in frame.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line.removeprefix("data: "))
+    raise AssertionError(f"no data line in {frame!r}")
+
+
+async def _collect(exc: BaseException) -> dict:
+    async def _boom():
+        raise exc
+        yield  # pragma: no cover -- makes this an async generator
+
+    frames = [frame async for frame in _gated_stream(_boom(), ChatSlotGuard())]
+    assert len(frames) == 1
+    return _payload(frames[0])
+
+
+class TestStreamErrorCodes:
+    @pytest.mark.parametrize(
+        ("exc", "code"),
+        [
+            (ModelNotFoundError("nope"), "model_not_found"),
+            (ModelDoesNotSupportToolsError("nope"), "model_does_not_support_tools"),
+            (
+                ProviderError("too long", kind=ProviderErrorKind.CONTEXT_OVERFLOW),
+                "context_length_exceeded",
+            ),
+        ],
+    )
+    async def test_a_typed_dispatch_failure_carries_its_code(self, exc, code) -> None:
+        assert (await _collect(exc))["code"] == code
+
+    async def test_a_backend_failure_stays_generic(self) -> None:
+        """Same redaction as the completions surface: the fleet's message names
+        loopback ports and engine paths, so it is logged rather than streamed."""
+        payload = await _collect(
+            ProviderError("bind 127.0.0.1:8137 failed", kind=ProviderErrorKind.CONNECTION)
+        )
+        assert "127.0.0.1" not in payload["message"]
+
+    async def test_an_unclassified_failure_stays_code_less(self) -> None:
+        payload = await _collect(RuntimeError("something else"))
+        assert "code" not in payload

--- a/tests/server/test_stream_error_codes.py
+++ b/tests/server/test_stream_error_codes.py
@@ -7,6 +7,7 @@ client could not tell "pull the model" from "shorten the prompt".
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -64,3 +65,31 @@ class TestStreamErrorCodes:
     async def test_an_unclassified_failure_stays_code_less(self) -> None:
         payload = await _collect(RuntimeError("something else"))
         assert "code" not in payload
+
+
+class TestStalledConsumerStopsTheProducer:
+    """Chat and RAG tokens are in the always-deliver class, so a generation
+    streaming to a client that has stopped reading filled the queue with
+    events nothing was permitted to shed, and it grew until the generation
+    ended."""
+
+    async def test_a_full_undroppable_queue_cancels_the_producer(self) -> None:
+        from lilbee.server.handlers.sse import SseStream
+
+        sse = SseStream()
+        for index in range(sse.queue._max_events + 1):
+            sse.put_threadsafe(f"token {index}")
+        # put_threadsafe hands the work to the loop; let it run.
+        await asyncio.sleep(0)
+        assert sse.cancel.is_set()
+        assert sse.queue.qsize() <= sse.queue._max_events + 1
+
+    async def test_a_reading_consumer_is_never_treated_as_stalled(self) -> None:
+        from lilbee.server.handlers.sse import SseStream
+
+        sse = SseStream()
+        for index in range(sse.queue._max_events * 2):
+            sse.put_threadsafe(f"token {index}")
+            await asyncio.sleep(0)
+            sse.queue.get_nowait()
+        assert not sse.cancel.is_set()

--- a/tests/server/test_stream_error_codes.py
+++ b/tests/server/test_stream_error_codes.py
@@ -93,3 +93,57 @@ class TestStalledConsumerStopsTheProducer:
             await asyncio.sleep(0)
             sse.queue.get_nowait()
         assert not sse.cancel.is_set()
+
+
+class TestTerminalFrameIsSharedByEveryStream:
+    """Five streaming handlers ended with the same five lines, and the copies
+    had drifted: the crawler-setup one skipped the cancel check, so it emitted
+    a done frame to a client that had already disconnected."""
+
+    async def _finished(self, result=None, exc=None):
+        async def _run():
+            if exc is not None:
+                raise exc
+            return result
+
+        task = asyncio.ensure_future(_run())
+        await asyncio.sleep(0)
+        return task
+
+    async def test_a_cancelled_stream_emits_nothing(self) -> None:
+        from lilbee.server.handlers.sse import SseStream
+
+        sse = SseStream()
+        task = await self._finished(result={"ok": True})
+        sse.cancel.set()
+        assert sse.terminal_frame(task, lambda r: r) is None
+
+    async def test_a_completed_producer_emits_its_done_payload(self) -> None:
+        from lilbee.server.handlers.sse import SseStream
+
+        sse = SseStream()
+        task = await self._finished(result={"files_written": ["a.md"]})
+        frame = sse.terminal_frame(task, lambda r: r)
+        assert frame is not None
+        assert "event: done" in frame
+        assert "a.md" in frame
+
+    async def test_a_failed_producer_emits_an_error(self) -> None:
+        from lilbee.server.handlers.sse import SseStream
+
+        sse = SseStream()
+        task = await self._finished(exc=RuntimeError("network unreachable"))
+        frame = sse.terminal_frame(task, lambda r: r)
+        assert frame is not None
+        assert "event: error" in frame
+        assert "network unreachable" in frame
+
+    async def test_an_unfinished_producer_emits_nothing(self) -> None:
+        from lilbee.server.handlers.sse import SseStream
+
+        sse = SseStream()
+        pending = asyncio.ensure_future(asyncio.sleep(60))
+        try:
+            assert sse.terminal_frame(pending, lambda r: r) is None
+        finally:
+            pending.cancel()

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -406,7 +406,13 @@ class TestWikiEnabled:
 
         Asserts that ``run_full_build`` is invoked from a non-loop thread
         (so an LLM-blocking build won't freeze the event loop) and that
-        two concurrent POSTs run sequentially.
+        two concurrent builds run sequentially.
+
+        Drives the handlers directly rather than through AsyncTestClient: that
+        client serializes gathered requests itself, so the spans never overlap
+        whether or not the lock exists, and deleting the lock from the handler
+        left this test green. See the prune-vs-build sibling, which had the
+        same flaw.
         """
         import asyncio
         import threading
@@ -428,29 +434,30 @@ class TestWikiEnabled:
         skew_s = 0.01
 
         def fake_build(*args, **kwargs):
-            invocations.append((threading.get_ident(), time.monotonic(), 0.0))
+            # One append after the sleep, with start held locally: the earlier
+            # version appended a placeholder first and then rewrote
+            # invocations[-1], so with two threads actually overlapping the
+            # second one rewrote the first one's entry and the spans came out
+            # looking serialized either way.
+            start = time.monotonic()
             time.sleep(sleep_s)
-            invocations[-1] = (invocations[-1][0], invocations[-1][1], time.monotonic())
+            invocations.append((threading.get_ident(), start, time.monotonic()))
             return {"paths": [], "entities": 0, "count": 0}
 
         monkeypatch.setattr("lilbee.server.wiki.run_full_build", fake_build)
 
-        async with AsyncTestClient(_create_app()) as client:
-            r1, r2 = await asyncio.gather(
-                client.post("/api/wiki/build", headers=_h()),
-                client.post("/api/wiki/build", headers=_h()),
-            )
         try:
-            assert r1.status_code == 201
-            assert r2.status_code == 201
+            await asyncio.gather(
+                _wiki_mod.wiki_build_route.fn(),
+                _wiki_mod.wiki_build_route.fn(),
+            )
             assert len(invocations) == 2
             # Worker thread is not the event-loop thread.
             for tid, _start, _end in invocations:
                 assert tid != loop_thread_id
             # Lock serialized: second invocation starts at or after first ends.
-            first_end = invocations[0][2]
-            second_start = invocations[1][1]
-            assert second_start >= first_end - skew_s
+            first, second = sorted(invocations, key=lambda i: i[1])
+            assert second[1] >= first[2] - skew_s, f"builds overlapped: {invocations}"
         finally:
             _wiki_mod._reset_wiki_build_lock()
 

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -402,17 +402,11 @@ class TestWikiEnabled:
         assert body["paths"] == ["wiki/concepts/x.md"]
 
     async def test_build_runs_in_worker_thread_and_serializes(self, monkeypatch):
-        """Concurrent build calls don't run in parallel: the lock serializes them.
+        """Concurrent builds serialize on the lock, off the event loop.
 
-        Asserts that ``run_full_build`` is invoked from a non-loop thread
-        (so an LLM-blocking build won't freeze the event loop) and that
-        two concurrent builds run sequentially.
-
-        Drives the handlers directly rather than through AsyncTestClient: that
-        client serializes gathered requests itself, so the spans never overlap
-        whether or not the lock exists, and deleting the lock from the handler
-        left this test green. See the prune-vs-build sibling, which had the
-        same flaw.
+        Drives the handlers directly: AsyncTestClient serializes gathered
+        requests itself, so through it the spans never overlap whether or not
+        the lock exists, and this test stayed green without it.
         """
         import asyncio
         import threading

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -879,8 +879,9 @@ class TestWikiReadPathsDoNotWrite:
         cfg.wiki = True
 
     async def test_listing_pages_does_not_rewrite_the_index(self, isolated_env: Path):
-        """GET /api/wiki is unauthenticated; regenerating index.md there let any
-        caller drive repeated writes and race the build path over the same file."""
+        """A read must not write. GET /api/wiki regenerated index.md, so a
+        listing raced the build path over the same file; at the time the route
+        was also unauthenticated, which let any caller drive those writes."""
         wiki_root = isolated_env / "wiki"
         _make_wiki_page(wiki_root, "summaries", "test-doc")
         index_path = wiki_root / "index.md"
@@ -888,7 +889,7 @@ class TestWikiReadPathsDoNotWrite:
         before = index_path.stat().st_mtime_ns
 
         async with AsyncTestClient(_create_app()) as client:
-            resp = await client.get("/api/wiki")
+            resp = await client.get("/api/wiki", headers=_h())
 
         assert resp.status_code == 200
         assert [p["slug"] for p in resp.json()] == ["summaries/test-doc"]

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -192,19 +192,6 @@ class TestWikiEnabled:
         assert "summaries/doc-a" in slugs
         assert "synthesis/typing" in slugs
 
-    async def test_list_regenerates_index(self, isolated_env: Path):
-        """When wiki/index.md exists, listing regenerates it."""
-        wiki_root = isolated_env / "wiki"
-        _make_wiki_page(wiki_root, "summaries", "test-doc")
-        # Create an index.md so the regeneration path triggers
-        (wiki_root / "index.md").write_text("# Wiki Index\n", encoding="utf-8")
-        async with AsyncTestClient(_create_app()) as client:
-            resp = await client.get("/api/wiki", headers=_h())
-        assert resp.status_code == 200
-        # index.md should be refreshed with actual entries
-        index_text = (wiki_root / "index.md").read_text(encoding="utf-8")
-        assert "test-doc" in index_text
-
     async def test_list_string_sources(self, isolated_env: Path):
         """Pages with sources as a comma-separated string still count correctly."""
         wiki_root = isolated_env / "wiki"
@@ -391,7 +378,7 @@ class TestWikiEnabled:
         loop_tid = threading.get_ident()
         seen: list[int] = []
 
-        def fake_lint(store, config=None):
+        def fake_lint(store, config=None, record_log=True):
             seen.append(threading.get_ident())
             return lint_mod.LintReport()
 
@@ -875,3 +862,63 @@ class TestPydanticModels:
         assert c.excerpt == ""
         assert c.wiki_chunk_index == 0
         assert c.created_at == ""
+
+
+class TestWikiReadPathsDoNotWrite:
+    """A route reachable without a token must not mutate the wiki tree."""
+
+    @pytest.fixture(autouse=True)
+    def enable_wiki(self):
+        cfg.wiki = True
+
+    async def test_listing_pages_does_not_rewrite_the_index(self, isolated_env: Path):
+        """GET /api/wiki is unauthenticated; regenerating index.md there let any
+        caller drive repeated writes and race the build path over the same file."""
+        wiki_root = isolated_env / "wiki"
+        _make_wiki_page(wiki_root, "summaries", "test-doc")
+        index_path = wiki_root / "index.md"
+        index_path.write_text("stale index\n", encoding="utf-8")
+        before = index_path.stat().st_mtime_ns
+
+        async with AsyncTestClient(_create_app()) as client:
+            resp = await client.get("/api/wiki")
+
+        assert resp.status_code == 200
+        assert [p["slug"] for p in resp.json()] == ["summaries/test-doc"]
+        assert index_path.read_text(encoding="utf-8") == "stale index\n"
+        assert index_path.stat().st_mtime_ns == before
+
+    async def test_status_requires_a_token(self):
+        """The full-corpus lint behind status must not be an anonymous amplifier."""
+        async with AsyncTestClient(_create_app()) as client:
+            resp = await client.get("/api/wiki/status")
+        assert resp.status_code == 401
+
+    async def test_status_does_not_append_to_the_wiki_log(self, isolated_env: Path):
+        """lint_all grew record_log=False for exactly this read-only caller."""
+        from unittest import mock
+
+        wiki_root = isolated_env / "wiki"
+        _make_wiki_page(wiki_root, "summaries", "s1")
+        with mock.patch("lilbee.server.wiki.lint_mod.lint_all") as lint_all:
+            lint_all.return_value = mock.MagicMock(error_count=0, warning_count=0)
+            async with AsyncTestClient(_create_app()) as client:
+                resp = await client.get("/api/wiki/status", headers=_h())
+        assert resp.status_code == 200
+        assert lint_all.call_args.kwargs["record_log"] is False
+
+
+class TestWikiDisabledStatusIsCheap:
+    async def test_status_skips_the_lint_when_the_wiki_is_disabled(self, isolated_env: Path):
+        """A leftover wiki dir from a previous build used to make the disabled
+        status poll run the whole lint anyway."""
+        from unittest import mock
+
+        cfg.wiki = False
+        _make_wiki_page(isolated_env / "wiki", "summaries", "leftover")
+        with mock.patch("lilbee.server.wiki.lint_mod.lint_all") as lint_all:
+            async with AsyncTestClient(_create_app()) as client:
+                resp = await client.get("/api/wiki/status", headers=_h())
+        assert resp.status_code == 200
+        assert resp.json()["wiki_enabled"] is False
+        lint_all.assert_not_called()

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -922,3 +922,60 @@ class TestWikiDisabledStatusIsCheap:
         assert resp.status_code == 200
         assert resp.json()["wiki_enabled"] is False
         lint_all.assert_not_called()
+
+
+class TestEveryWikiWriterSharesTheBuildMutex:
+    """The mutex exists because concurrent writers corrupt the tree and index.
+
+    Build, update and synthesize took it; prune and draft-accept did not, even
+    though prune archives pages and both refresh index.md, which is the file the
+    lock's own comment names.
+
+    Drives the handlers directly rather than through AsyncTestClient, which
+    serializes requests and so cannot tell a held lock from an absent one.
+    """
+
+    @pytest.fixture(autouse=True)
+    def enable_wiki(self):
+        cfg.wiki = True
+
+    async def test_prune_serializes_against_a_build(self, monkeypatch, isolated_env: Path):
+        import asyncio
+        import time
+        from unittest import mock
+
+        from lilbee.server import wiki as _wiki_mod
+
+        _wiki_mod._reset_wiki_build_lock()
+        spans: list[tuple[str, float, float]] = []
+        hold_s = 0.1
+        skew_s = 0.01
+
+        def _record(label, result):
+            def _run(*_args, **_kwargs):
+                start = time.monotonic()
+                time.sleep(hold_s)
+                spans.append((label, start, time.monotonic()))
+                return result
+
+            return _run
+
+        monkeypatch.setattr(
+            "lilbee.server.wiki.run_full_build",
+            _record("build", {"paths": [], "entities": 0, "count": 0}),
+        )
+        monkeypatch.setattr(
+            "lilbee.server.wiki.prune_mod.prune_wiki",
+            _record("prune", mock.MagicMock(records=[], archived_count=0, flagged_count=0)),
+        )
+
+        try:
+            await asyncio.gather(
+                _wiki_mod.wiki_build_route.fn(),
+                _wiki_mod.wiki_prune_route.fn(),
+            )
+            assert len(spans) == 2
+            first, second = sorted(spans, key=lambda s: s[1])
+            assert second[1] >= first[2] - skew_s, f"prune and build overlapped: {spans}"
+        finally:
+            _wiki_mod._reset_wiki_build_lock()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1816,3 +1816,45 @@ class TestBoolVocabularyMatchesPydantic:
         from lilbee.core.config.model import Config
 
         assert Config(enable_ocr="maybe").enable_ocr is None
+
+
+class TestCrawlExclusionsMatchWholeSegments:
+    """The exclusion patterns are regexes against the whole URL, not globs.
+
+    Bare path prefixes therefore matched longer words and silently dropped
+    legitimate content pages from a crawl.
+    """
+
+    @staticmethod
+    def _excluded(url: str) -> bool:
+        import re
+
+        from lilbee.core.config.defaults import _AUTH_EXCLUDE, _ECOMMERCE_EXCLUDE
+
+        return any(re.search(p, url) for p in _AUTH_EXCLUDE + _ECOMMERCE_EXCLUDE)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/cartography/maps",
+            "https://example.com/accounting/gaap",
+            "https://example.com/professional-services",
+            "https://example.com/registers-of-companies",
+        ],
+    )
+    def test_content_pages_are_not_excluded(self, url):
+        assert not self._excluded(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/cart",
+            "https://example.com/cart/",
+            "https://example.com/cart?step=1",
+            "https://example.com/checkout/step1",
+            "https://example.com/login",
+            "https://example.com/my-account/orders",
+        ],
+    )
+    def test_transactional_and_auth_urls_are_still_excluded(self, url):
+        assert self._excluded(url)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1846,6 +1846,25 @@ class TestCrawlExclusionsMatchWholeSegments:
         assert not self._excluded(url)
 
     @pytest.mark.parametrize(
+        ("url", "excluded"),
+        [
+            ("https://x.dev/docs?ref=sidebar", False),
+            ("https://x.dev/p?share=twitter", False),
+            ("https://x.dev/p?utm_source=newsletter", True),
+            ("https://x.dev/p?fbclid=abc", True),
+            ("https://x.dev/p?replytocom=5", True),
+        ],
+    )
+    def test_only_campaign_tokens_are_treated_as_tracking(self, url, excluded):
+        """?ref= and ?share= are ordinary content links on docs and forum
+        platforms; dropping one can drop the only URL that reaches a page."""
+        import re
+
+        from lilbee.core.config.defaults import _TRACKING_EXCLUDE
+
+        assert any(re.search(p, url) for p in _TRACKING_EXCLUDE) is excluded
+
+    @pytest.mark.parametrize(
         "url",
         [
             "https://example.com/cart",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -497,11 +497,16 @@ class TestEnableOcrConfig:
             c = Config()
             assert c.enable_ocr is True
 
-    def test_garbage_value_coerces_via_bool(self) -> None:
-        """Unrecognized string falls through parse_bool and coerces via ``bool()``."""
+    def test_garbage_value_falls_back_to_auto(self) -> None:
+        """An unparseable value must not turn OCR on.
+
+        This used to fall through to ``bool()``, and ``bool("maybe")`` is True,
+        so a typo silently enabled an expensive pass. The sibling bool
+        validators warn and take their default; this one now does too.
+        """
         with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "maybe"}):
             c = Config()
-            assert c.enable_ocr is True  # bool("maybe") is True
+            assert c.enable_ocr is None
 
     def test_whitespace_only_means_auto(self) -> None:
         """Whitespace-only strings hit the auto/none branch and return None."""
@@ -1768,3 +1773,46 @@ class TestActiveConfigScope:
         with config_scope(scoped):
             assert active_config() is scoped
         assert active_config() is cfg
+
+
+class TestBoolVocabularyMatchesPydantic:
+    """parse_bool must accept what pydantic accepts for the same settings object.
+
+    Every other bool field on Config is coerced by pydantic, which takes
+    on/off/y/n/t/f as well. The narrower hand-rolled vocabulary made the same
+    env spelling mean different things on different fields, and on enable_ocr
+    it inverted: the ValueError fell through to bool("off"), which is True.
+    """
+
+    @pytest.mark.parametrize("raw", ["on", "y", "t", "true", "1", "yes", "ON", " on "])
+    def test_truthy_spellings(self, raw):
+        from lilbee.core.config.parsing import parse_bool
+
+        assert parse_bool(raw) is True
+
+    @pytest.mark.parametrize("raw", ["off", "n", "f", "false", "0", "no", "OFF", " off "])
+    def test_falsy_spellings(self, raw):
+        from lilbee.core.config.parsing import parse_bool
+
+        assert parse_bool(raw) is False
+
+    def test_unknown_spelling_still_raises(self):
+        from lilbee.core.config.parsing import parse_bool
+
+        with pytest.raises(ValueError, match="Invalid boolean"):
+            parse_bool("maybe")
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"), [("off", False), ("on", True), ("n", False), ("y", True)]
+    )
+    def test_enable_ocr_agrees_with_pydantic(self, raw, expected):
+        """enable_ocr routed through parse_bool; 'off' used to come back True."""
+        from lilbee.core.config.model import Config
+
+        assert Config(enable_ocr=raw).enable_ocr is expected
+
+    def test_enable_ocr_unknown_value_falls_back_to_auto(self):
+        """An unparseable value must not silently become True via bool()."""
+        from lilbee.core.config.model import Config
+
+        assert Config(enable_ocr="maybe").enable_ocr is None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -473,13 +473,27 @@ class TestInit:
         assert cfg.documents_dir == root / "documents"
         assert cfg.data_root == tmp_path
 
-    def test_init_retunes_search_scope_for_new_vault(self, tmp_path):
-        """Switching vaults re-tunes the search-tool scope hint for the new corpus."""
+    async def test_init_switches_search_scope_hint_to_the_new_vault(
+        self, tmp_path, monkeypatch, overlay_reads_config_toml
+    ):
+        """After a vault switch, a live server advertises the new corpus's scopes.
+
+        The hint is computed per list_tools call from current config, so the
+        overlay ``init`` applies is on the wire without a re-tune step.
+        """
+        from lilbee.mcp_server import build_mcp_server
+
+        monkeypatch.setattr(cfg, "wiki", False)
+        server = build_mcp_server()
+
         target = tmp_path / "proj"
         target.mkdir()
-        with mock.patch("lilbee.mcp_server._tune_search_scope_for_corpus") as mock_tune:
-            init(str(target))
-        mock_tune.assert_called_once()
+        (target / "config.toml").write_text("wiki = true\n")
+        init(str(target))
+
+        assert cfg.wiki is True
+        search = next(t for t in await server.list_tools() if t.name == "search")
+        assert "No wiki layer here" not in (search.description or "")
 
     def test_bare_name_tag_rejected_after_init(self, tmp_path):
         """The cfg validator rejects bare ``name:tag`` shapes."""
@@ -712,17 +726,17 @@ class TestAdd:
 
 
 class TestMain:
-    @mock.patch("lilbee.mcp_server.mcp")
-    def test_main_calls_run(self, mock_mcp):
+    @mock.patch("lilbee.mcp_server.build_mcp_server")
+    def test_main_calls_run(self, mock_build):
         main()
-        mock_mcp.run.assert_called_once()
+        mock_build.return_value.run.assert_called_once()
 
-    @mock.patch("lilbee.mcp_server.mcp")
+    @mock.patch("lilbee.mcp_server.build_mcp_server")
     @mock.patch("lilbee.mcp_server.get_services", side_effect=RuntimeError("boom"))
-    def test_main_preload_failure_does_not_block_server(self, mock_get_services, mock_mcp):
-        """A crash in the pre-warm path falls through to mcp.run() instead of aborting."""
+    def test_main_preload_failure_does_not_block_server(self, mock_get_services, mock_build):
+        """A crash in the pre-warm path falls through to run() instead of aborting."""
         main()
-        mock_mcp.run.assert_called_once()
+        mock_build.return_value.run.assert_called_once()
 
 
 class TestAddWithUrls:
@@ -1737,33 +1751,21 @@ class TestToolsSchemaSize:
     reviewers can scrutinise.
     """
 
-    def test_tool_if_gates_registration(self) -> None:
-        """``_tool_if(True)`` puts the function on every built server;
-        ``_tool_if(False)`` is a pass-through so it stays importable but off the
-        MCP wire. Trims the registry after so no sentinel leaks into later builds.
-        """
-        from lilbee.mcp_server import _REGISTRATIONS, _tool_if, build_mcp_server
+    def test_tool_if_rejects_a_pre_evaluated_condition(self) -> None:
+        """``_tool_if(cfg.flag)`` freezes the gate at import; the decorator
+        demands a callable so the mistake fails at decoration, not as a stale
+        tool surface after a config change."""
+        from lilbee.mcp_server import _tool_if
 
-        sentinel_name = "_schema_size_test_sentinel"
-
-        def _schema_size_test_sentinel() -> None: ...
-
-        gated_off = _tool_if(False)(_schema_size_test_sentinel)
-        assert gated_off is _schema_size_test_sentinel
-        assert sentinel_name not in build_mcp_server()._tool_manager._tools
-
-        registered = len(_REGISTRATIONS)
-        gated_on = _tool_if(True)(_schema_size_test_sentinel)
-        try:
-            assert callable(gated_on)
-            assert sentinel_name in build_mcp_server()._tool_manager._tools
-        finally:
-            del _REGISTRATIONS[registered:]
+        with pytest.raises(TypeError, match="zero-arg callable"):
+            _tool_if(True)  # type: ignore[arg-type]
 
     async def test_wiki_tools_not_registered_when_wiki_disabled(self) -> None:
         """``cfg.wiki=False`` (the default) keeps wiki MCP tools off the wire."""
         from lilbee.core.config import cfg as _cfg
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         assert _cfg.wiki is False
         tools = await _mcp.list_tools()
@@ -1777,7 +1779,9 @@ class TestToolsSchemaSize:
         lands here first, named, instead of surfacing as a byte overflow in
         whichever job happens to register the most tools.
         """
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         registered = {t.name for t in tools if not t.name.startswith(_AMBIENT_TOOL_PREFIXES)}
@@ -1792,12 +1796,14 @@ class TestToolsSchemaSize:
     async def test_default_tools_schema_under_budget(self) -> None:
         """The pinned default surface must stay under the cap so small-context
         (16K) chat models keep room for the user's actual content.
-        ``_strip_schema_noise`` removes title / default / null-arm-anyOf /
+        The ``LilbeeMCP`` wire transform removes title / default / null-arm-anyOf /
         additionalProperties=true noise.
         """
         import json as _json
 
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         payload = [
@@ -1818,10 +1824,12 @@ class TestToolsSchemaSize:
         )
 
     async def test_no_title_noise_in_input_schema(self) -> None:
-        """``_strip_schema_noise`` keeps FastMCP-auto-generated title fields
+        """The wire transform keeps FastMCP-auto-generated title fields
         off the wire. Adding a tool whose schema contains a title fails here.
         """
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         for t in tools:
@@ -1833,11 +1841,13 @@ class TestToolsSchemaSize:
                     )
 
     async def test_descriptions_have_no_indented_body_lines(self) -> None:
-        """_strip_schema_noise flattens docstring indentation before it ships. A
+        """The wire transform flattens docstring indentation before it ships. A
         triple-quoted docstring indents every continuation line; textwrap.dedent
         alone left those 4-space prefixes in place because the summary line's zero
         indent makes the common prefix empty."""
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         for t in tools:
@@ -1859,7 +1869,9 @@ class TestToolsSchemaSize:
         """The model picks tools from name + description; ``default`` values
         on properties are server-side trivia that cost tokens at every dispatch.
         """
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         for t in tools:
@@ -1874,7 +1886,9 @@ class TestToolsSchemaSize:
         """``T | None`` should serialize as ``{type: T}``, not a two-arm
         ``anyOf`` with a null branch the model gains nothing from.
         """
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         for t in tools:
@@ -1894,7 +1908,9 @@ class TestToolsSchemaSize:
         """``additionalProperties: true`` is JSON Schema's default; serializing
         it explicitly is bytes for nothing.
         """
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import build_mcp_server
+
+        _mcp = build_mcp_server()
 
         tools = await _mcp.list_tools()
         for t in tools:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1737,14 +1737,12 @@ class TestToolsSchemaSize:
     reviewers can scrutinise.
     """
 
-    def test_tool_if_true_returns_mcp_tool_decorator(self) -> None:
-        """``_tool_if(True)`` returns a real decorator; ``_tool_if(False)``
-        returns a pass-through so the function stays importable but isn't on
-        the MCP wire. Cleans up after itself so the test doesn't pollute the
-        shared FastMCP server with a sentinel tool.
+    def test_tool_if_gates_registration(self) -> None:
+        """``_tool_if(True)`` puts the function on every built server;
+        ``_tool_if(False)`` is a pass-through so it stays importable but off the
+        MCP wire. Trims the registry after so no sentinel leaks into later builds.
         """
-        from lilbee.mcp_server import _tool_if
-        from lilbee.mcp_server import mcp as _mcp
+        from lilbee.mcp_server import _REGISTRATIONS, _tool_if, build_mcp_server
 
         sentinel_name = "_schema_size_test_sentinel"
 
@@ -1752,14 +1750,15 @@ class TestToolsSchemaSize:
 
         gated_off = _tool_if(False)(_schema_size_test_sentinel)
         assert gated_off is _schema_size_test_sentinel
-        assert sentinel_name not in _mcp._tool_manager._tools
+        assert sentinel_name not in build_mcp_server()._tool_manager._tools
 
+        registered = len(_REGISTRATIONS)
         gated_on = _tool_if(True)(_schema_size_test_sentinel)
         try:
             assert callable(gated_on)
-            assert sentinel_name in _mcp._tool_manager._tools
+            assert sentinel_name in build_mcp_server()._tool_manager._tools
         finally:
-            _mcp._tool_manager._tools.pop(sentinel_name, None)
+            del _REGISTRATIONS[registered:]
 
     async def test_wiki_tools_not_registered_when_wiki_disabled(self) -> None:
         """``cfg.wiki=False`` (the default) keeps wiki MCP tools off the wire."""

--- a/tests/test_mcp_offload.py
+++ b/tests/test_mcp_offload.py
@@ -74,10 +74,12 @@ def test_tool_if_true_registers_and_returns_original() -> None:
     returned = decorator(sample_unique_tool_name)
 
     assert returned is sample_unique_tool_name
+    assert "sample_unique_tool_name" in m.build_mcp_server()._tool_manager._tools
 
 
 @pytest.fixture(autouse=True)
 def _drop_test_tool() -> None:
-    """Remove any tool the registration tests add so the schema stays stable."""
+    """Drop registrations the tests add so later-built servers keep a stable schema."""
+    registered = len(m._REGISTRATIONS)
     yield
-    m.mcp._tool_manager._tools.pop("sample_unique_tool_name", None)
+    del m._REGISTRATIONS[registered:]

--- a/tests/test_mcp_offload.py
+++ b/tests/test_mcp_offload.py
@@ -49,24 +49,29 @@ def test_registered_tool_keeps_sync_callable_for_in_process_use() -> None:
 
 
 async def test_registered_tool_schema_preserves_parameters() -> None:
-    tools = {tool.name: tool for tool in await m.mcp.list_tools()}
+    tools = {tool.name: tool for tool in await m.build_mcp_server().list_tools()}
 
     properties = tools["search"].inputSchema["properties"]
 
     assert {"query", "top_k", "scope"} <= set(properties)
 
 
-def test_tool_if_false_leaves_function_unregistered_but_callable() -> None:
-    decorator = m._tool_if(False)
+async def _wire_names() -> set[str]:
+    return {t.name for t in await m.build_mcp_server().list_tools()}
 
-    def handler() -> int:
+
+async def test_tool_if_false_gate_leaves_function_off_the_wire_but_callable() -> None:
+    decorator = m._tool_if(lambda: False)
+
+    def sample_unique_tool_name() -> int:
         return 7
 
-    assert decorator(handler) is handler
+    assert decorator(sample_unique_tool_name) is sample_unique_tool_name
+    assert "sample_unique_tool_name" not in await _wire_names()
 
 
-def test_tool_if_true_registers_and_returns_original() -> None:
-    decorator = m._tool_if(True)
+async def test_tool_if_true_gate_registers_and_returns_original() -> None:
+    decorator = m._tool_if(lambda: True)
 
     def sample_unique_tool_name(value: int) -> int:
         return value
@@ -74,7 +79,22 @@ def test_tool_if_true_registers_and_returns_original() -> None:
     returned = decorator(sample_unique_tool_name)
 
     assert returned is sample_unique_tool_name
-    assert "sample_unique_tool_name" in m.build_mcp_server()._tool_manager._tools
+    assert "sample_unique_tool_name" in await _wire_names()
+
+
+async def test_tool_if_gate_is_evaluated_per_build() -> None:
+    # The gate reflects config at server-build time, not import time, so a
+    # server built after a settings change carries the current tool surface.
+    enabled = False
+
+    def gated_probe_tool() -> int:
+        return 7
+
+    m._tool_if(lambda: enabled)(gated_probe_tool)
+
+    assert "gated_probe_tool" not in await _wire_names()
+    enabled = True
+    assert "gated_probe_tool" in await _wire_names()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_mcp_search_guidance.py
+++ b/tests/test_mcp_search_guidance.py
@@ -43,7 +43,7 @@ def test_scope_hint_warns_when_corpus_has_no_wiki(monkeypatch) -> None:
     original = info.description
     monkeypatch.setattr(mcp_server.cfg, "wiki", False)
     try:
-        _tune_search_scope_for_corpus()
+        _tune_search_scope_for_corpus(mcp)
         assert isinstance(info.description, str)
         assert "No wiki layer here" in info.description
     finally:
@@ -55,7 +55,7 @@ def test_scope_hint_absent_when_wiki_enabled(monkeypatch) -> None:
     original = info.description
     monkeypatch.setattr(mcp_server.cfg, "wiki", True)
     try:
-        _tune_search_scope_for_corpus()
+        _tune_search_scope_for_corpus(mcp)
         assert "No wiki layer here" not in (info.description or "")
     finally:
         info.description = original
@@ -68,11 +68,11 @@ def test_scope_hint_is_stripped_when_wiki_turns_on(monkeypatch) -> None:
     original = info.description
     try:
         monkeypatch.setattr(mcp_server.cfg, "wiki", False)
-        _tune_search_scope_for_corpus()
+        _tune_search_scope_for_corpus(mcp)
         assert "No wiki layer here" in info.description
 
         monkeypatch.setattr(mcp_server.cfg, "wiki", True)
-        _tune_search_scope_for_corpus()
+        _tune_search_scope_for_corpus(mcp)
         assert "No wiki layer here" not in info.description
     finally:
         info.description = original
@@ -84,6 +84,6 @@ def test_tune_is_noop_when_search_tool_absent() -> None:
     tools = mcp._tool_manager._tools
     saved = tools.pop("search")
     try:
-        _tune_search_scope_for_corpus()  # must not raise; returns early
+        _tune_search_scope_for_corpus(mcp)  # must not raise; returns early
     finally:
         tools["search"] = saved

--- a/tests/test_mcp_search_guidance.py
+++ b/tests/test_mcp_search_guidance.py
@@ -3,14 +3,16 @@ from guessing a wiki scope on corpora that have no wiki."""
 
 from __future__ import annotations
 
+import asyncio
+
 import lilbee.mcp_server as mcp_server
-from lilbee.mcp_server import _tune_search_scope_for_corpus, mcp
+from lilbee.mcp_server import build_mcp_server
 
 
-def _search_description() -> str:
-    """The search tool description with whitespace collapsed, since the docstring
-    wraps across indented lines on the wire."""
-    desc = mcp._tool_manager._tools["search"].description
+def _search_description(server) -> str:
+    """The search tool description as shipped on the wire, whitespace collapsed."""
+    tools = asyncio.run(server.list_tools())
+    desc = next(t.description for t in tools if t.name == "search")
     assert isinstance(desc, str)
     return " ".join(desc.split())
 
@@ -19,18 +21,18 @@ def test_server_instructions_direct_models_to_lilbee_search() -> None:
     # Built-in web/file tools out-compete lilbee_search unless the always-loaded
     # context tells the model to prefer retrieval; the FastMCP instructions are
     # that context.
-    instructions = mcp.instructions or ""
+    instructions = build_mcp_server().instructions or ""
     assert "lilbee_search" in instructions
     assert "Prefer it over" in instructions
 
 
 def test_search_description_prefers_retrieval_over_builtin_tools() -> None:
-    desc = _search_description()
+    desc = _search_description(build_mcp_server())
     assert "prefer it over web-fetch or file-read" in desc
 
 
 def test_search_description_guides_scope_selection() -> None:
-    desc = _search_description()
+    desc = _search_description(build_mcp_server())
     # The default is recommended and wiki is gated on actually having a wiki.
     assert '"both"' in desc
     assert "wiki" in desc.lower()
@@ -39,51 +41,20 @@ def test_search_description_guides_scope_selection() -> None:
 def test_scope_hint_warns_when_corpus_has_no_wiki(monkeypatch) -> None:
     # When wiki generation is off, advertise only raw/both so the model stops
     # guessing scope="wiki" (which would silently fall back to the full pool).
-    info = mcp._tool_manager._tools["search"]
-    original = info.description
     monkeypatch.setattr(mcp_server.cfg, "wiki", False)
-    try:
-        _tune_search_scope_for_corpus(mcp)
-        assert isinstance(info.description, str)
-        assert "No wiki layer here" in info.description
-    finally:
-        info.description = original
+    assert "No wiki layer here" in _search_description(build_mcp_server())
 
 
 def test_scope_hint_absent_when_wiki_enabled(monkeypatch) -> None:
-    info = mcp._tool_manager._tools["search"]
-    original = info.description
     monkeypatch.setattr(mcp_server.cfg, "wiki", True)
-    try:
-        _tune_search_scope_for_corpus(mcp)
-        assert "No wiki layer here" not in (info.description or "")
-    finally:
-        info.description = original
+    assert "No wiki layer here" not in _search_description(build_mcp_server())
 
 
-def test_scope_hint_is_stripped_when_wiki_turns_on(monkeypatch) -> None:
-    # A config reload that enables wiki must remove a previously-added hint so
-    # the model is told the wiki scope is now available (the reversible branch).
-    info = mcp._tool_manager._tools["search"]
-    original = info.description
-    try:
-        monkeypatch.setattr(mcp_server.cfg, "wiki", False)
-        _tune_search_scope_for_corpus(mcp)
-        assert "No wiki layer here" in info.description
-
-        monkeypatch.setattr(mcp_server.cfg, "wiki", True)
-        _tune_search_scope_for_corpus(mcp)
-        assert "No wiki layer here" not in info.description
-    finally:
-        info.description = original
-
-
-def test_tune_is_noop_when_search_tool_absent() -> None:
-    # If the search tool isn't registered, tuning returns early instead of
-    # dereferencing a missing tool.
-    tools = mcp._tool_manager._tools
-    saved = tools.pop("search")
-    try:
-        _tune_search_scope_for_corpus(mcp)  # must not raise; returns early
-    finally:
-        tools["search"] = saved
+def test_scope_hint_tracks_config_on_a_live_server(monkeypatch) -> None:
+    # The hint is computed per list_tools call, so a config change (vault
+    # switch, settings reload) is reflected without any re-tune step.
+    server = build_mcp_server()
+    monkeypatch.setattr(mcp_server.cfg, "wiki", False)
+    assert "No wiki layer here" in _search_description(server)
+    monkeypatch.setattr(mcp_server.cfg, "wiki", True)
+    assert "No wiki layer here" not in _search_description(server)

--- a/tests/test_mcp_sessions.py
+++ b/tests/test_mcp_sessions.py
@@ -234,20 +234,30 @@ def test_disabled_session_tools_write_nothing(store):
     assert [meta.id for meta in store.list(origins=(SessionOrigin.MCP,))] == [session_id]
 
 
-async def test_session_tools_are_off_the_wire_by_default():
+async def test_session_tools_are_off_the_wire_by_default(monkeypatch):
     """A default install offers no session tools over MCP.
 
-    Registration is import-time, so the tools were gated out when this process
-    imported ``mcp_server`` under the real default. ``isolated_env`` flips the
-    flag at runtime for the rest of this file, which cannot re-register them,
-    so the wire still reflects the default here.
+    Tool gates are evaluated when the server is built, so this builds one
+    under the default flag regardless of what earlier tests set.
     """
     from lilbee.core.config import Config
-    from lilbee.mcp_server import mcp as _mcp
+    from lilbee.mcp_server import build_mcp_server
 
     assert Config.model_fields["mcp_sessions_enabled"].default is False
     assert Config.model_fields["sessions_enabled"].default is True, (
         "the human surfaces stay on by default; only the agent half is opt-in"
     )
+    monkeypatch.setattr(cfg, "mcp_sessions_enabled", False)
+    _mcp = build_mcp_server()
     on_the_wire = sorted(t.name for t in await _mcp.list_tools() if t.name.startswith("session"))
     assert on_the_wire == [], f"session tools reached the default wire: {on_the_wire}"
+
+
+async def test_session_tools_reach_the_wire_when_enabled(monkeypatch):
+    """A server built with the flag on carries the session tools."""
+    from lilbee.mcp_server import build_mcp_server
+
+    monkeypatch.setattr(cfg, "mcp_sessions_enabled", True)
+    _mcp = build_mcp_server()
+    on_the_wire = {t.name for t in await _mcp.list_tools()}
+    assert "session_create" in on_the_wire

--- a/tests/test_model_manager_compat.py
+++ b/tests/test_model_manager_compat.py
@@ -14,7 +14,7 @@ from lilbee.modelhub.model_manager import ModelManager
 
 
 def _stub_services(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch get_services() so _enforce_arch_compat doesn't need a real container."""
+    """Patch get_services() so enforce_arch_compat doesn't need a real container."""
     import lilbee.app.services as services_mod
 
     stub = mock.MagicMock()

--- a/tests/test_parent_monitor.py
+++ b/tests/test_parent_monitor.py
@@ -262,7 +262,7 @@ class TestMcpMainIntegration:
         monkeypatch.setenv(PARENT_PID_ENV, "888888")
         with (
             mock.patch.object(mcp_mod, "get_services"),
-            mock.patch.object(mcp_mod.mcp, "run"),
+            mock.patch.object(mcp_mod, "build_mcp_server"),
             mock.patch("lilbee.parent_monitor.watch_parent_thread") as watcher,
         ):
             mcp_mod.main()
@@ -274,7 +274,7 @@ class TestMcpMainIntegration:
         monkeypatch.delenv(PARENT_PID_ENV, raising=False)
         with (
             mock.patch.object(mcp_mod, "get_services"),
-            mock.patch.object(mcp_mod.mcp, "run"),
+            mock.patch.object(mcp_mod, "build_mcp_server"),
             mock.patch("lilbee.parent_monitor.watch_parent_thread") as watcher,
         ):
             mcp_mod.main()
@@ -286,7 +286,7 @@ class TestMcpMainIntegration:
         monkeypatch.delenv(PARENT_PID_ENV, raising=False)
         with (
             mock.patch.object(mcp_mod, "get_services", side_effect=RuntimeError("no provider")),
-            mock.patch.object(mcp_mod.mcp, "run"),
+            mock.patch.object(mcp_mod, "build_mcp_server"),
             caplog.at_level("DEBUG", logger="lilbee.mcp_server"),
         ):
             mcp_mod.main()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4041,9 +4041,9 @@ class TestListExternalModels:
         """Reset the external models cache before each test."""
         from lilbee.server.handlers import models as h
 
-        h._external_cache = h._ExternalModelsCache()
+        h._external_cache = h._TtlCache(h._EXTERNAL_MODELS_TTL)
         yield
-        h._external_cache = h._ExternalModelsCache()
+        h._external_cache = h._TtlCache(h._EXTERNAL_MODELS_TTL)
 
     @patch("lilbee.server.handlers.models.get_services")
     async def test_returns_provider_models(self, mock_svc):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4617,6 +4617,20 @@ class TestSourceContentRoute:
         assert resp.headers["content-type"].startswith("application/octet-stream")
         assert "attachment" in resp.headers["content-disposition"]
 
+    @pytest.mark.parametrize("content_type", ["text/xml", "application/xml"])
+    def test_xml_is_never_rendered_inline(self, content_type):
+        """XML can carry an xml-stylesheet PI whose XSLT emits script.
+
+        Asserted on the predicate rather than through a ``.xml`` file because
+        the extension's Content-Type comes from the host mimetypes database:
+        it resolves to ``application/xml`` here, which already degrades, but a
+        host whose database says ``text/xml`` would have matched the ``text/``
+        category and rendered. The verdict must not depend on the host.
+        """
+        from lilbee.server.handlers.documents import _is_safe_for_inline_render
+
+        assert _is_safe_for_inline_render(content_type) is False
+
     async def test_raw_svg_source_forces_octet_stream_attachment(self, isolated_env):
         """SVG can carry script; not in the allowlist → forced to octet-stream."""
         from litestar.testing import AsyncTestClient

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2095,8 +2095,7 @@ class TestHostedCatalogEntries:
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        h._hosted_cache.set("", [])  # prime then clear to defeat any prior TTL entry
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(
             h,
             "discover_api_models",
@@ -2146,7 +2145,7 @@ class TestHostedCatalogEntries:
         from lilbee.catalog.types import ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(h, "discover_api_models", lambda: {})
         monkeypatch.setattr(
             h,
@@ -2169,7 +2168,7 @@ class TestHostedCatalogEntries:
         from lilbee.catalog.types import ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         calls = {"n": 0}
 
         def _discover():
@@ -2255,7 +2254,7 @@ class TestModelsCatalog:
         """
         import lilbee.server.handlers.models as h
 
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(h, "discover_api_models", lambda: {})
         monkeypatch.setattr(h, "classify_all_remote_models", lambda *a, **k: [])
 
@@ -2280,7 +2279,7 @@ class TestModelsCatalog:
 
         mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
         mock_svc.registry.list_installed.return_value = []
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(
             h,
             "discover_api_models",
@@ -2316,7 +2315,7 @@ class TestModelsCatalog:
 
         mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
         mock_svc.registry.list_installed.return_value = []
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(
             h,
             "discover_api_models",
@@ -2344,7 +2343,7 @@ class TestModelsCatalog:
 
         mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=20, models=[])
         mock_svc.registry.list_installed.return_value = []
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(
             h,
             "discover_api_models",
@@ -2374,7 +2373,7 @@ class TestModelsCatalog:
 
         mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
         mock_svc.registry.list_installed.return_value = []
-        h._hosted_cache._result = None
+        h._hosted_cache.clear()
         monkeypatch.setattr(
             h,
             "discover_api_models",
@@ -4041,9 +4040,9 @@ class TestListExternalModels:
         """Reset the external models cache before each test."""
         from lilbee.server.handlers import models as h
 
-        h._external_cache = h._TtlCache(h._EXTERNAL_MODELS_TTL)
+        h._external_cache.clear()
         yield
-        h._external_cache = h._TtlCache(h._EXTERNAL_MODELS_TTL)
+        h._external_cache.clear()
 
     @patch("lilbee.server.handlers.models.get_services")
     async def test_returns_provider_models(self, mock_svc):
@@ -4068,17 +4067,29 @@ class TestListExternalModels:
         assert result1.models == ["model-a"]
         mock_svc.return_value.provider.list_models.assert_called_once()
 
-    @patch("lilbee.server.handlers.models.time")
     @patch("lilbee.server.handlers.models.get_services")
-    async def test_cache_expires(self, mock_svc, mock_time):
-        mock_svc.return_value.provider.list_models.return_value = ["model-a"]
-        mock_time.monotonic.return_value = 0.0
-        await handlers.list_external_models()
+    async def test_cache_expires(self, mock_svc):
+        """Drives the cache's own clock rather than patching the module's, which
+        the store no longer reads: cachetools takes its timer at construction."""
+        from cachetools import TTLCache
 
-        mock_time.monotonic.return_value = 61.0
-        await handlers.list_external_models()
+        from lilbee.server.handlers import models as h
 
-        assert mock_svc.return_value.provider.list_models.call_count == 2
+        now = {"t": 0.0}
+        original = h._external_cache
+        h._external_cache = TTLCache(maxsize=1, ttl=h._EXTERNAL_MODELS_TTL, timer=lambda: now["t"])
+        try:
+            mock_svc.return_value.provider.list_models.return_value = ["model-a"]
+            await handlers.list_external_models()
+            now["t"] = h._EXTERNAL_MODELS_TTL - 1
+            await handlers.list_external_models()
+            assert mock_svc.return_value.provider.list_models.call_count == 1, "still fresh"
+
+            now["t"] = h._EXTERNAL_MODELS_TTL + 1
+            await handlers.list_external_models()
+            assert mock_svc.return_value.provider.list_models.call_count == 2
+        finally:
+            h._external_cache = original
 
     @patch("lilbee.server.handlers.models.get_services")
     async def test_cache_invalidates_on_config_change(self, mock_svc):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2834,6 +2834,23 @@ class TestModelsInstalled:
         assert result.models[0].source == "lm_studio"
 
 
+def _thread_recorder(result):
+    """Stand in for a blocking call, recording which thread each call ran on.
+
+    Returns ``(threads, stub)``. Takes any signature so it can replace whichever
+    blocking function the test is offloading.
+    """
+    import threading
+
+    threads: list[int] = []
+
+    def stub(*_args, **_kwargs):
+        threads.append(threading.get_ident())
+        return result
+
+    return threads, stub
+
+
 class TestModelHandlersRunBlockingWorkOffLoop:
     """Backend model discovery/show do blocking HTTP; they must not run inline.
 
@@ -2845,48 +2862,39 @@ class TestModelHandlersRunBlockingWorkOffLoop:
         import threading
 
         loop_tid = threading.get_ident()
-        seen: list[int] = []
+        threads, stub = _thread_recorder([_CHAT_REF])
+        mock_svc.provider.list_models.side_effect = stub
 
-        def record(*_a, **_k):
-            seen.append(threading.get_ident())
-            return [_CHAT_REF]
-
-        mock_svc.provider.list_models.side_effect = record
         await handlers.set_chat_model(_CHAT_REF)
-        assert seen and all(tid != loop_tid for tid in seen)
+
+        assert threads and all(tid != loop_tid for tid in threads)
 
     async def test_models_show_runs_off_the_loop(self, mock_svc):
         import threading
 
         loop_tid = threading.get_ident()
-        seen: list[int] = []
+        threads, stub = _thread_recorder({})
+        mock_svc.provider.show_model.side_effect = stub
 
-        def record(_model):
-            seen.append(threading.get_ident())
-            return {}
-
-        mock_svc.provider.show_model.side_effect = record
         await handlers.models_show("ollama/qwen3:0.6b")
-        assert seen and seen[0] != loop_tid
+
+        assert threads and threads[0] != loop_tid
 
     async def test_models_installed_runs_off_the_loop(self):
         import threading
 
         loop_tid = threading.get_ident()
-        seen: list[int] = []
-
-        def record():
-            seen.append(threading.get_ident())
-            return []
-
+        threads, stub = _thread_recorder([])
         mock_manager = MagicMock()
-        mock_manager.list_installed.side_effect = record
+        mock_manager.list_installed.side_effect = stub
+
         with patch(
             "lilbee.server.handlers.models.get_services",
             return_value=MagicMock(model_manager=mock_manager),
         ):
             await handlers.models_installed()
-        assert seen and seen[0] != loop_tid
+
+        assert threads and threads[0] != loop_tid
 
 
 class TestModelsPull:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -3816,6 +3816,24 @@ class TestClassifyLoadError:
         assert code == SseErrorCode.MODEL_TOO_LARGE
         assert user_message == "Model too large for available RAM"
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "llama_context: n_ctx_per_seq (8192) > n_ctx_train (4096)",
+            "llama_context: KV cache type not supported",
+            "llama_context: invalid sequence configuration",
+        ],
+    )
+    def test_context_diagnostics_are_not_reported_as_out_of_memory(self, message):
+        """llama_context prefixes a whole family of context diagnostics.
+
+        Matching the bare prefix told users to pick a smaller model when the
+        real fix is a config change, and hid the message that said so.
+        """
+        code, text = handlers.classify_load_error(message)
+        assert code is None
+        assert "too large" not in text.lower()
+
     def test_llama_context_signature_is_classified(self):
         code, _ = handlers.classify_load_error("llama_context: failed to allocate")
         assert code == SseErrorCode.MODEL_TOO_LARGE

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2834,6 +2834,61 @@ class TestModelsInstalled:
         assert result.models[0].source == "lm_studio"
 
 
+class TestModelHandlersRunBlockingWorkOffLoop:
+    """Backend model discovery/show do blocking HTTP; they must not run inline.
+
+    A slow or unreachable Ollama/LM Studio endpoint would otherwise stall every
+    other request on the single event loop for the HTTP timeout.
+    """
+
+    async def test_set_model_runs_list_models_off_the_loop(self, tmp_path, mock_svc):
+        import threading
+
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def record(*_a, **_k):
+            seen.append(threading.get_ident())
+            return [_CHAT_REF]
+
+        mock_svc.provider.list_models.side_effect = record
+        await handlers.set_chat_model(_CHAT_REF)
+        assert seen and all(tid != loop_tid for tid in seen)
+
+    async def test_models_show_runs_off_the_loop(self, mock_svc):
+        import threading
+
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def record(_model):
+            seen.append(threading.get_ident())
+            return {}
+
+        mock_svc.provider.show_model.side_effect = record
+        await handlers.models_show("ollama/qwen3:0.6b")
+        assert seen and seen[0] != loop_tid
+
+    async def test_models_installed_runs_off_the_loop(self):
+        import threading
+
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def record():
+            seen.append(threading.get_ident())
+            return []
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.side_effect = record
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            await handlers.models_installed()
+        assert seen and seen[0] != loop_tid
+
+
 class TestModelsPull:
     async def test_yields_progress_events_native(self):
         mock_manager = MagicMock()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4957,6 +4957,22 @@ class TestSseQueueEviction:
         drained = [queue.get_nowait() for _ in range(queue.qsize())]
         assert drained == ["token-1", "progress-2", "token-2"]
 
+    def test_incoming_progress_is_dropped_when_nothing_is_shedable(self):
+        """With the queue full of tokens there is no progress to shed, so the
+        arriving progress event is the one that goes."""
+        from lilbee.runtime.progress import EventType
+
+        queue = self._queue(max_events=2)
+        queue.put_nowait("token-1")
+        queue.put_nowait("token-2")
+
+        queue.put_event_nowait("progress-1", EventType.EMBED)
+
+        assert queue.qsize() == 2
+        assert queue.dropped_events == 1
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained == ["token-1", "token-2"]
+
     def test_always_delivered_events_are_never_shed(self):
         """done/error/sentinel must land even when nothing is droppable."""
         queue = self._queue(max_events=2)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2929,18 +2929,30 @@ class TestModelsPull:
         assert any("error" in e and "fail" in e for e in non_empty)
 
     async def test_cancel_stops_pull(self, caplog):
-        """Closing the pull generator mid-stream sets cancel and logs."""
+        """A disconnect aborts the download, it does not just silence progress.
+
+        The pull runs in a worker thread that asyncio cannot interrupt, so the
+        progress callback is the only way in. It used to return quietly on
+        cancel, leaving a multi-GB download running for a client that had gone.
+        """
         import threading
 
+        from lilbee.runtime.cancellation import TaskCancelledError
+
         barrier = threading.Event()
+        finished_whole_download = threading.Event()
+        aborted: list[bool] = []
         mock_manager = MagicMock()
 
         def blocking_pull(model, source, *, on_bytes=None, allow_unsupported=False):
-            if on_bytes:
-                on_bytes(100, 1000)
+            on_bytes(100, 1000)
             barrier.wait(timeout=2)
-            if on_bytes:
+            try:
                 on_bytes(1000, 1000)
+            except TaskCancelledError:
+                aborted.append(True)
+                raise
+            finished_whole_download.set()
 
         mock_manager.pull.side_effect = blocking_pull
         caplog.set_level(logging.INFO, logger="lilbee.server.handlers")
@@ -2954,9 +2966,13 @@ class TestModelsPull:
                     await gen.aclose()
                     barrier.set()
                     break
-            await asyncio.sleep(0.05)
+            for _ in range(200):
+                if aborted or finished_whole_download.is_set():
+                    break
+                await asyncio.sleep(0.01)
 
-        assert any("Model pull stream cancelled by client" in r.message for r in caplog.records)
+        assert aborted == [True], "the progress callback must abort the pull, not return"
+        assert not finished_whole_download.is_set(), "the download ran to completion after cancel"
 
 
 class TestModelsDelete:
@@ -4312,18 +4328,27 @@ class TestAddHandlerCancel:
 
 
 class TestModelPullProgressCancel:
-    async def test_cancel_during_pull_skips_later_progress(self):
-        """When cancel is set before pull starts, all progress calls return early."""
+    async def test_cancel_during_pull_aborts_and_emits_no_progress(self):
+        """Cancel set before the pull starts aborts it at the first callback.
+
+        The callback used to return quietly, which emitted nothing but let the
+        download run on. It now raises, so the worker stops as well.
+        """
         import threading
+
+        from lilbee.runtime.cancellation import TaskCancelledError
 
         mock_manager = MagicMock()
         progress_called = threading.Event()
+        aborted = threading.Event()
 
         def fake_pull(model, source, *, on_bytes=None, allow_unsupported=False):
-            if on_bytes:
-                # All progress calls should see cancel already set
+            progress_called.set()
+            try:
                 on_bytes(500, 1000)
-                progress_called.set()
+            except TaskCancelledError:
+                aborted.set()
+                raise
 
         mock_manager.pull.side_effect = fake_pull
 
@@ -4348,7 +4373,8 @@ class TestModelPullProgressCancel:
             # Wait for the pull thread to complete
             await asyncio.sleep(0.2)
 
-        assert progress_called.is_set()  # Pull did call on_bytes
+        assert progress_called.is_set(), "the pull should have started"
+        assert aborted.is_set(), "the callback must abort the pull, not return"
         assert not any("current" in e for e in events if e)
 
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4925,3 +4925,45 @@ class TestPlacementHandlers:
         event_names = [line.split(":", 1)[1].strip() for line in event_lines]
         assert SseEvent.GPU_STATS in event_names
         assert SseEvent.HEARTBEAT in event_names
+
+
+class TestSseQueueEviction:
+    """The cap only holds if eviction can find the progress events it may shed."""
+
+    def _queue(self, max_events: int = 4):
+        from lilbee.server.handlers.sse import SseEventQueue
+
+        return SseEventQueue(max_events=max_events)
+
+    def test_progress_behind_a_token_is_still_evictable(self):
+        """Head-only eviction gave up whenever a token reached the front.
+
+        A real stream interleaves the two, so the head is non-droppable almost
+        immediately and the queue grew past its cap while still holding
+        progress events it was allowed to drop.
+        """
+        from lilbee.runtime.progress import EventType
+
+        queue = self._queue(max_events=3)
+        queue.put_nowait("token-1")
+        queue.put_event_nowait("progress-1", EventType.EMBED)
+        queue.put_event_nowait("progress-2", EventType.EMBED)
+
+        queue.put_nowait("token-2")
+
+        assert queue.qsize() == 3
+        assert queue.dropped_events == 1
+        # The shed one is the oldest progress, not the token at the head.
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained == ["token-1", "progress-2", "token-2"]
+
+    def test_always_delivered_events_are_never_shed(self):
+        """done/error/sentinel must land even when nothing is droppable."""
+        queue = self._queue(max_events=2)
+        queue.put_nowait("token-1")
+        queue.put_nowait("token-2")
+        queue.put_nowait("done")
+
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained == ["token-1", "token-2", "done"]
+        assert queue.dropped_events == 0

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2300,7 +2300,10 @@ class TestModelsCatalog:
         frontier = [m for m in resp.models if m.source == ModelSource.FRONTIER]
         assert frontier and frontier[0].display_name == "gemini-2.0-flash"
         assert frontier[0].key_status == "ready"
-        assert resp.total == 1  # 0 native + 1 hosted
+        # total describes the paginated native listing only. Counting the
+        # first-page-only hosted overlay into it made page 1 report a larger
+        # total than page 2 of the same listing.
+        assert resp.total == 0
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_hosted_skipped_when_featured_filter(

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -2041,3 +2041,36 @@ class TestPaginationAndTopKLowerBounds:
     def test_chat_rejects_negative_top_k(self, client):
         resp = client.post("/api/chat", json={"question": "q", "history": [], "top_k": -1})
         assert resp.status_code == 400
+
+
+class TestReadOnlyDecoratorOrdering:
+    """The registry keys on the raw function, so stacking order is load-bearing.
+
+    Applied above the route decorator it registers the handler object instead;
+    the middleware's handler.fn lookup then misses. Reversed, the same class of
+    mistake silently opens a route, so the ordering is enforced.
+    """
+
+    def test_applying_it_above_the_route_decorator_is_rejected(self):
+        from litestar import get
+
+        from lilbee.server.auth import read_only
+
+        with pytest.raises(TypeError, match="below the route decorator"):
+
+            @read_only
+            @get("/api/example")
+            async def _wrong_order() -> dict[str, str]:
+                return {}
+
+    def test_applying_it_below_the_route_decorator_registers(self):
+        from litestar import get
+
+        from lilbee.server.auth import is_read_only, read_only
+
+        @get("/api/example-ok")
+        @read_only
+        async def _right_order() -> dict[str, str]:
+            return {}
+
+        assert is_read_only(_right_order.fn)

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -155,22 +155,6 @@ class TestSearchDoesNotLeakInternals:
         # The operator still needs the real cause; it goes to the log, not the wire.
         assert "no such table" in caplog.text
 
-    def test_embedding_mismatch_hides_the_model_identifiers(self, client):
-        from lilbee.data.store.types import EmbeddingModelMismatchError
-
-        exc = EmbeddingModelMismatchError(
-            persisted_model="nomic-embed-text-v1.5",
-            persisted_dim=768,
-            current_model="bge-m3",
-            current_dim=1024,
-        )
-        with mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock, side_effect=exc):
-            resp = client.get("/api/search", params={"q": "x"})
-        assert resp.status_code == 409
-        body = resp.text
-        assert "nomic-embed-text-v1.5" not in body
-        assert "bge-m3" not in body
-
 
 class TestAskRoute:
     @mock.patch(
@@ -651,10 +635,12 @@ class TestStreamSingleFlightGate:
 class TestEmbeddingMismatchSurfacing:
     """A downloaded index built with a different embedder surfaces as an actionable
     error, not a generic 503/stream failure. The store raises
-    EmbeddingModelMismatchError; non-stream routes translate it to a 409 whose
-    ``extra`` carries the index's embedder so the client can offer to adopt it,
-    and the streaming path emits an SSE error carrying the INDEX_EMBEDDER_MISMATCH
-    code plus that embedder in ``detail``."""
+    EmbeddingModelMismatchError; the token-gated non-stream routes translate it to
+    a 409 whose ``extra`` carries the index's embedder so the client can offer to
+    adopt it, and the streaming path emits an SSE error carrying the
+    INDEX_EMBEDDER_MISMATCH code plus that embedder in ``detail``. The
+    unauthenticated search route reports the same 409 with the embedder refs
+    redacted."""
 
     PERSISTED = "orgA/repoA/modelA.gguf"
 
@@ -669,13 +655,20 @@ class TestEmbeddingMismatchSurfacing:
         )
 
     @mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock)
-    def test_search_route_returns_structured_409(self, mock_search, client):
+    def test_search_route_returns_409_without_naming_the_embedders(self, mock_search, client):
+        """Search is the one unauthenticated route here, so it redacts.
+
+        The adoptable flag stays, since a client renders its recovery hint from
+        it and a bare yes/no identifies nothing; the embedder refs do not, since
+        anyone who can reach the port would otherwise learn which models the
+        machine runs.
+        """
         mock_search.side_effect = self._mismatch()
         resp = client.get("/api/search", params={"q": "x"})
         assert resp.status_code == 409
         body = resp.json()
-        assert self.PERSISTED in body["detail"]
-        assert body["extra"]["persisted_model"] == self.PERSISTED
+        assert self.PERSISTED not in resp.text
+        assert "persisted_model" not in body.get("extra", {})
         assert body["extra"]["adoptable"] is True
 
     @mock.patch("lilbee.server.handlers.ask", new_callable=AsyncMock)

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -138,6 +138,40 @@ class TestSearchRoute:
         assert resp.status_code == 400
 
 
+class TestSearchDoesNotLeakInternals:
+    """/api/search is reachable without a token, so its errors stay generic."""
+
+    def test_unexpected_failure_hides_the_exception_text(self, client, caplog):
+        boom = RuntimeError("no such table '/home/tobias/data/lancedb/chunks'")
+        with (
+            mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock, side_effect=boom),
+            caplog.at_level("ERROR"),
+        ):
+            resp = client.get("/api/search", params={"q": "x"})
+        assert resp.status_code == 503
+        body = resp.text
+        assert "/home/tobias" not in body
+        assert "lancedb" not in body
+        # The operator still needs the real cause; it goes to the log, not the wire.
+        assert "no such table" in caplog.text
+
+    def test_embedding_mismatch_hides_the_model_identifiers(self, client):
+        from lilbee.data.store.types import EmbeddingModelMismatchError
+
+        exc = EmbeddingModelMismatchError(
+            persisted_model="nomic-embed-text-v1.5",
+            persisted_dim=768,
+            current_model="bge-m3",
+            current_dim=1024,
+        )
+        with mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock, side_effect=exc):
+            resp = client.get("/api/search", params={"q": "x"})
+        assert resp.status_code == 409
+        body = resp.text
+        assert "nomic-embed-text-v1.5" not in body
+        assert "bge-m3" not in body
+
+
 class TestAskRoute:
     @mock.patch(
         "lilbee.server.handlers.ask",

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -2000,3 +2000,44 @@ class TestPlacementSetRoute:
         """DELETE placement is refused on the shared HTTP daemon."""
         resp = client.delete("/api/placement")
         assert resp.status_code == 409
+
+
+class TestPaginationAndTopKLowerBounds:
+    """Upper bounds without lower bounds let 0 and negatives through.
+
+    LanceDB's plain-query ``limit`` treats anything <= 0 as no limit, so
+    ``?limit=0`` returned the whole table, which is what pagination exists to
+    prevent. A negative ``top_k`` reached the store and surfaced as a 503,
+    blaming the server for a bad request.
+    """
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_documents_limit_rejects_non_positive(self, client, value):
+        resp = client.get("/api/documents", params={"limit": value})
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_catalog_limit_rejects_non_positive(self, client, value):
+        resp = client.get("/api/models/catalog", params={"limit": value})
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_search_top_k_rejects_non_positive(self, client, value):
+        resp = client.get("/api/search", params={"q": "x", "top_k": value})
+        assert resp.status_code == 400
+
+    def test_ask_rejects_negative_top_k_but_keeps_zero(self, client):
+        """Zero is a documented pure-LLM call, so only negatives are invalid."""
+        assert client.post("/api/ask", json={"question": "q", "top_k": -1}).status_code == 400
+
+        with mock.patch(
+            "lilbee.server.handlers.ask",
+            new_callable=AsyncMock,
+            return_value={"answer": "a", "sources": []},
+        ):
+            resp = client.post("/api/ask", json={"question": "q", "top_k": 0})
+        assert resp.status_code == 201
+
+    def test_chat_rejects_negative_top_k(self, client):
+        resp = client.post("/api/chat", json={"question": "q", "history": [], "top_k": -1})
+        assert resp.status_code == 400

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1439,10 +1439,7 @@ class TestSetupCrawlerRoutes:
         assert resp.json()["installed"] is False
 
     def test_status_route_is_gated_by_the_middleware(self):
-        """It used to skip auth for parity with the other status GETs, back when
-        those skipped it too. It reports whether Chromium is installed, which is
-        inventory about the host, and nothing on this server answers without a
-        token now."""
+        """Reports whether Chromium is installed, which is host inventory."""
         from lilbee.server.auth import authenticates_itself
         from lilbee.server.routes.setup import setup_crawler_status_route
 
@@ -1902,8 +1899,7 @@ class TestExportRoute:
         assert resp.headers["content-disposition"] == 'attachment; filename="pages.jsonl"'
 
     def test_a_caller_without_the_token_gets_nothing(self, dataset_store):
-        """This asserted a 200. /api/export serializes the entire corpus, so it
-        was the widest of the routes that answered an unauthenticated caller."""
+        """/api/export serializes the entire corpus; this asserted a 200."""
         import lilbee.server.auth as auth_mod
         from lilbee.server.app import create_app
 

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1438,12 +1438,15 @@ class TestSetupCrawlerRoutes:
         assert resp.status_code == 200
         assert resp.json()["installed"] is False
 
-    def test_status_route_is_read_only(self):
-        """Parity with the other status GETs: no auth token required to poll."""
-        from lilbee.server.auth import is_read_only
+    def test_status_route_is_gated_by_the_middleware(self):
+        """It used to skip auth for parity with the other status GETs, back when
+        those skipped it too. It reports whether Chromium is installed, which is
+        inventory about the host, and nothing on this server answers without a
+        token now."""
+        from lilbee.server.auth import authenticates_itself
         from lilbee.server.routes.setup import setup_crawler_status_route
 
-        assert is_read_only(setup_crawler_status_route.fn)
+        assert not authenticates_itself(setup_crawler_status_route.fn)
 
     def test_post_setup_crawler_streams_setup_events(self, client):
         """Stub bootstrap_chromium to emit a setup_done event via on_progress."""
@@ -1760,7 +1763,7 @@ class TestAuthMiddleware:
             auth_mod.session_manager.token = old
 
     @pytest.mark.asyncio
-    async def test_read_only_handler_passes_through(self, middleware):
+    async def test_a_self_authenticating_handler_passes_through(self, middleware):
         import lilbee.server.auth as auth_mod
 
         old = auth_mod.session_manager.token
@@ -1768,7 +1771,7 @@ class TestAuthMiddleware:
         try:
             handler = mock.MagicMock()
 
-            @auth_mod.read_only
+            @auth_mod.auth_checked_in_handler
             def _ro_route() -> None: ...
 
             handler.fn = _ro_route
@@ -1898,7 +1901,9 @@ class TestExportRoute:
         assert row["source"] == "doc.pdf"
         assert resp.headers["content-disposition"] == 'attachment; filename="pages.jsonl"'
 
-    def test_read_only_without_token(self, dataset_store):
+    def test_a_caller_without_the_token_gets_nothing(self, dataset_store):
+        """This asserted a 200. /api/export serializes the entire corpus, so it
+        was the widest of the routes that answered an unauthenticated caller."""
         import lilbee.server.auth as auth_mod
         from lilbee.server.app import create_app
 
@@ -1907,7 +1912,7 @@ class TestExportRoute:
             resp = TestClient(create_app()).get("/api/export")
         finally:
             auth_mod.session_manager.token = None
-        assert resp.status_code == 200
+        assert resp.status_code == 401
 
     def test_unknown_source_is_400(self, dataset_store, client):
         resp = client.get("/api/export", params={"source": "missing.pdf"})
@@ -1936,9 +1941,18 @@ class TestExportRoute:
             return real(fmt, source)
 
         loop_tid = threading.get_ident()
+        import lilbee.server.auth as auth_mod
+
         with mock.patch.object(dataset_mod, "export_to_bytes", record):
             async with AsyncTestClient(create_app()) as client:
-                resp = await client.get("/api/export", params={"format": "jsonl"})
+                # The app lifespan mints the token, so read it after startup
+                # rather than planting one that startup would overwrite.
+                token = auth_mod.session_manager.token
+                resp = await client.get(
+                    "/api/export",
+                    params={"format": "jsonl"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
         assert resp.status_code == 200
         assert seen and seen[0] != loop_tid
 
@@ -2056,11 +2070,11 @@ class TestReadOnlyDecoratorOrdering:
     def test_applying_it_above_the_route_decorator_is_rejected(self):
         from litestar import get
 
-        from lilbee.server.auth import read_only
+        from lilbee.server.auth import auth_checked_in_handler
 
         with pytest.raises(TypeError, match="below the route decorator"):
 
-            @read_only
+            @auth_checked_in_handler
             @get("/api/example")
             async def _wrong_order() -> dict[str, str]:
                 return {}
@@ -2068,11 +2082,11 @@ class TestReadOnlyDecoratorOrdering:
     def test_applying_it_below_the_route_decorator_registers(self):
         from litestar import get
 
-        from lilbee.server.auth import is_read_only, read_only
+        from lilbee.server.auth import auth_checked_in_handler, authenticates_itself
 
         @get("/api/example-ok")
-        @read_only
+        @auth_checked_in_handler
         async def _right_order() -> dict[str, str]:
             return {}
 
-        assert is_read_only(_right_order.fn)
+        assert authenticates_itself(_right_order.fn)

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -736,7 +736,7 @@ class TestModelsPullArchPrecheck:
         from lilbee.catalog.compat import UnsupportedArchError
 
         manager = mock.MagicMock()
-        manager._enforce_arch_compat.side_effect = UnsupportedArchError("acme/foo-GGUF", "kimi_k2")
+        manager.enforce_arch_compat.side_effect = UnsupportedArchError("acme/foo-GGUF", "kimi_k2")
         with mock.patch(
             "lilbee.server.handlers.models.get_services",
             return_value=mock.MagicMock(model_manager=manager),

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1558,7 +1558,46 @@ class TestSessionManagerPersistence:
         fresh_manager.token = None
         second = fresh_manager.load_or_generate()
         assert second == first
-        assert fresh_manager.token == first
+
+    def test_concurrent_boots_converge_on_one_token(self, fresh_manager):
+        """Two workers booting together must end up with the same token.
+
+        Without serialization both see no file and mint their own; the last
+        write wins and the loser rejects every client that read the file.
+        """
+        import threading
+        import time
+
+        from lilbee.server import auth as auth_mod
+        from lilbee.server.auth import SessionManager
+
+        first_inside_generate = threading.Event()
+        resume_first = threading.Event()
+        real_generate = auth_mod.secrets.token_urlsafe
+        gated = {"done": False}
+
+        def slow_first_generate(n: int) -> str:
+            if not gated["done"]:
+                gated["done"] = True
+                first_inside_generate.set()
+                resume_first.wait(timeout=5)
+            return real_generate(n)
+
+        second = SessionManager()
+        with mock.patch.object(auth_mod.secrets, "token_urlsafe", slow_first_generate):
+            t1 = threading.Thread(target=fresh_manager.load_or_generate)
+            t1.start()
+            assert first_inside_generate.wait(timeout=5)
+            # First manager is past its read, paused before its write.
+            t2 = threading.Thread(target=second.load_or_generate)
+            t2.start()
+            time.sleep(0.1)
+            resume_first.set()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+        assert fresh_manager.token is not None
+        assert second.token == fresh_manager.token
 
     def test_regenerates_when_file_is_empty(self, fresh_manager):
         from lilbee.server.auth import server_json_path

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1632,7 +1632,9 @@ class TestSessionManagerPersistence:
 
     def test_load_or_generate_on_win32_skips_chmod(self, fresh_manager, monkeypatch) -> None:
         """On Windows the chmod branch is skipped; file must still be created and readable."""
-        monkeypatch.setattr("lilbee.server.auth.sys.platform", "win32")
+        # The platform check lives in core.security now, with auth and settings
+        # both calling through it.
+        monkeypatch.setattr("lilbee.core.security.sys.platform", "win32")
         token = fresh_manager.load_or_generate()
         assert isinstance(token, str)
         assert len(token) >= 32

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1923,6 +1923,30 @@ class TestExportRoute:
         resp = client.get("/api/export", params={"format": "csv"})
         assert resp.status_code == 400
 
+    async def test_serialization_runs_off_the_event_loop(self, dataset_store):
+        """export_to_bytes serializes the whole dataset in memory; a large export
+        must not stall every other request, so it runs in a worker thread."""
+        import threading
+
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.app import dataset as dataset_mod
+        from lilbee.server.app import create_app
+
+        real = dataset_mod.export_to_bytes
+        seen: list[int] = []
+
+        def record(fmt, source=None):
+            seen.append(threading.get_ident())
+            return real(fmt, source)
+
+        loop_tid = threading.get_ident()
+        with mock.patch.object(dataset_mod, "export_to_bytes", record):
+            async with AsyncTestClient(create_app()) as client:
+                resp = await client.get("/api/export", params={"format": "jsonl"})
+        assert resp.status_code == 200
+        assert seen and seen[0] != loop_tid
+
 
 class TestImportRoute:
     def test_round_trip_streams_progress_and_done(self, dataset_store, client):

--- a/tests/test_server_memory.py
+++ b/tests/test_server_memory.py
@@ -135,3 +135,38 @@ class TestRemove:
         cfg.memory_enabled = False
         assert client.delete("/api/memories/abc123").status_code == 404
         store.delete_memory.assert_not_called()
+
+
+class TestMemoryRoutesRequireAuth:
+    """Memory is the personal-data surface: no route here may bypass the token.
+
+    ``@read_only`` is not "a weaker token is accepted" -- ``AuthMiddleware``
+    short-circuits before any token check for handlers in that registry, so a
+    decorated route serves callers with no Authorization header at all.
+    """
+
+    def test_no_memory_route_bypasses_auth(self):
+        from lilbee.server.auth import is_read_only
+        from lilbee.server.routes.memory import (
+            memories_list_route,
+            memories_remember_route,
+            memories_remove_route,
+            memories_update_route,
+        )
+
+        for route in (
+            memories_list_route,
+            memories_remember_route,
+            memories_update_route,
+            memories_remove_route,
+        ):
+            assert not is_read_only(route.fn), f"{route.fn.__name__} bypasses authentication"
+
+    async def test_listing_memories_without_a_token_is_rejected(self):
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        async with AsyncTestClient(create_app()) as unauthenticated:
+            resp = await unauthenticated.get("/api/memories")
+        assert resp.status_code == 401

--- a/tests/test_server_memory.py
+++ b/tests/test_server_memory.py
@@ -146,7 +146,7 @@ class TestMemoryRoutesRequireAuth:
     """
 
     def test_no_memory_route_bypasses_auth(self):
-        from lilbee.server.auth import is_read_only
+        from lilbee.server.auth import authenticates_itself
         from lilbee.server.routes.memory import (
             memories_list_route,
             memories_remember_route,
@@ -160,7 +160,9 @@ class TestMemoryRoutesRequireAuth:
             memories_update_route,
             memories_remove_route,
         ):
-            assert not is_read_only(route.fn), f"{route.fn.__name__} bypasses authentication"
+            assert not authenticates_itself(route.fn), (
+                f"{route.fn.__name__} bypasses authentication"
+            )
 
     async def test_listing_memories_without_a_token_is_rejected(self):
         from litestar.testing import AsyncTestClient

--- a/tests/test_server_models_pull_compat.py
+++ b/tests/test_server_models_pull_compat.py
@@ -12,14 +12,14 @@ from lilbee.server import handlers
 
 
 @pytest.mark.asyncio
-async def test_enforce_arch_compat_raises_409() -> None:
+async def testenforce_arch_compat_raises_409() -> None:
     """The route-level precheck converts an unsupported arch to HTTPException 409.
 
     It must live outside the models_pull async generator: a raise there fires only
     on first iteration, after the 200 SSE headers flush, and can't set the status.
     """
     mock_manager = MagicMock()
-    mock_manager._enforce_arch_compat.side_effect = UnsupportedArchError("acme/foo-GGUF", "kimi_k2")
+    mock_manager.enforce_arch_compat.side_effect = UnsupportedArchError("acme/foo-GGUF", "kimi_k2")
 
     with (
         patch(
@@ -40,7 +40,7 @@ async def test_enforce_arch_compat_raises_409() -> None:
 
 
 @pytest.mark.asyncio
-async def test_enforce_arch_compat_skips_remote_and_override() -> None:
+async def testenforce_arch_compat_skips_remote_and_override() -> None:
     """Remote source and allow_unsupported both bypass the native arch precheck."""
     mock_manager = MagicMock()
     with patch(
@@ -49,7 +49,7 @@ async def test_enforce_arch_compat_skips_remote_and_override() -> None:
     ):
         await handlers.enforce_pull_arch_compat("ollama:llama3", source="remote")
         await handlers.enforce_pull_arch_compat("acme/foo", source="native", allow_unsupported=True)
-    mock_manager._enforce_arch_compat.assert_not_called()
+    mock_manager.enforce_arch_compat.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -57,7 +57,7 @@ async def test_models_pull_generator_does_not_precheck() -> None:
     """The generator no longer prechecks (the route does); a raise here would be too
     late. manager.pull still enforces compatibility during the pull itself."""
     mock_manager = MagicMock()
-    mock_manager._enforce_arch_compat.side_effect = UnsupportedArchError("acme/foo-GGUF", "kimi_k2")
+    mock_manager.enforce_arch_compat.side_effect = UnsupportedArchError("acme/foo-GGUF", "kimi_k2")
     mock_manager.pull.return_value = None
 
     with patch(
@@ -66,7 +66,7 @@ async def test_models_pull_generator_does_not_precheck() -> None:
     ):
         events = [e async for e in handlers.models_pull("acme/foo-GGUF", source="native")]
 
-    mock_manager._enforce_arch_compat.assert_not_called()
+    mock_manager.enforce_arch_compat.assert_not_called()
     mock_manager.pull.assert_called_once()
     assert events is not None
 
@@ -92,7 +92,7 @@ async def test_pull_native_with_allow_unsupported_skips_precheck() -> None:
             )
         ]
 
-    mock_manager._enforce_arch_compat.assert_not_called()
+    mock_manager.enforce_arch_compat.assert_not_called()
     mock_manager.pull.assert_called_once()
     call_kwargs = mock_manager.pull.call_args.kwargs
     assert call_kwargs["allow_unsupported"] is True
@@ -116,4 +116,4 @@ async def test_pull_remote_skips_arch_precheck() -> None:
         async for _ in handlers.models_pull("ollama:llama3", source="remote"):
             pass
 
-    mock_manager._enforce_arch_compat.assert_not_called()
+    mock_manager.enforce_arch_compat.assert_not_called()

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -174,9 +174,8 @@ class TestDelete:
 
 
 def test_every_session_route_requires_the_token():
-    """Reads included. This used to pin the two GETs as unauthenticated, which
-    served full chat transcripts to any caller that could reach the port; the
-    memory store next door is gated for the same reason."""
+    """Reads included: the two GETs used to serve full chat transcripts to any
+    caller that could reach the port."""
     assert not authenticates_itself(sessions_list_route.fn)
     assert not authenticates_itself(session_get_route.fn)
     assert not authenticates_itself(session_rename_route.fn)
@@ -284,10 +283,9 @@ class TestSessionsDisabled:
 
 
 class TestSessionVanishesMidRequest:
-    """Every mutating handler mutates and then re-reads the session to build
-    its response. The TUI and HTTP surfaces share one store, so a session
-    deleted between those two calls made the trailing read raise an unguarded
-    SessionNotFoundError that escaped as a 500 rather than the promised 404."""
+    """Handlers mutate then re-read to build the response, and the TUI and
+    HTTP surfaces share one store, so a delete landing between the two used to
+    escape as a 500."""
 
     def test_a_delete_between_the_mutation_and_the_read_is_a_404(self, client, store):
         session_id = store.create(model_ref=None, scope=None, origin=SessionOrigin.HTTP)

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -7,7 +7,7 @@ from litestar.testing import TestClient
 
 from lilbee.app import services as svc_mod
 from lilbee.core.config import cfg
-from lilbee.server.auth import is_read_only
+from lilbee.server.auth import authenticates_itself
 from lilbee.server.routes.sessions import (
     session_add_message_route,
     session_claim_route,
@@ -177,16 +177,16 @@ def test_every_session_route_requires_the_token():
     """Reads included. This used to pin the two GETs as unauthenticated, which
     served full chat transcripts to any caller that could reach the port; the
     memory store next door is gated for the same reason."""
-    assert not is_read_only(sessions_list_route.fn)
-    assert not is_read_only(session_get_route.fn)
-    assert not is_read_only(session_rename_route.fn)
-    assert not is_read_only(session_delete_route.fn)
+    assert not authenticates_itself(sessions_list_route.fn)
+    assert not authenticates_itself(session_get_route.fn)
+    assert not authenticates_itself(session_rename_route.fn)
+    assert not authenticates_itself(session_delete_route.fn)
     # A read-only token must not be able to create, append, or summarize.
-    assert not is_read_only(session_create_route.fn)
-    assert not is_read_only(session_add_message_route.fn)
-    assert not is_read_only(session_set_summary_route.fn)
+    assert not authenticates_itself(session_create_route.fn)
+    assert not authenticates_itself(session_add_message_route.fn)
+    assert not authenticates_itself(session_set_summary_route.fn)
     # The takeover operation above all: a read-only token must never claim.
-    assert not is_read_only(session_claim_route.fn)
+    assert not authenticates_itself(session_claim_route.fn)
 
 
 class TestOwnership:

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -173,9 +173,12 @@ class TestDelete:
         assert client.delete("/api/sessions/nope").status_code == 404
 
 
-def test_reads_are_read_only_and_writes_are_not():
-    assert is_read_only(sessions_list_route.fn)
-    assert is_read_only(session_get_route.fn)
+def test_every_session_route_requires_the_token():
+    """Reads included. This used to pin the two GETs as unauthenticated, which
+    served full chat transcripts to any caller that could reach the port; the
+    memory store next door is gated for the same reason."""
+    assert not is_read_only(sessions_list_route.fn)
+    assert not is_read_only(session_get_route.fn)
     assert not is_read_only(session_rename_route.fn)
     assert not is_read_only(session_delete_route.fn)
     # A read-only token must not be able to create, append, or summarize.

--- a/tests/test_server_sessions.py
+++ b/tests/test_server_sessions.py
@@ -278,3 +278,25 @@ class TestSessionsDisabled:
         client.delete(f"/api/sessions/{session_id}")
         cfg.sessions_enabled = True
         assert len(store.get(session_id).messages) == before
+
+
+class TestSessionVanishesMidRequest:
+    """Every mutating handler mutates and then re-reads the session to build
+    its response. The TUI and HTTP surfaces share one store, so a session
+    deleted between those two calls made the trailing read raise an unguarded
+    SessionNotFoundError that escaped as a 500 rather than the promised 404."""
+
+    def test_a_delete_between_the_mutation_and_the_read_is_a_404(self, client, store):
+        session_id = store.create(model_ref=None, scope=None, origin=SessionOrigin.HTTP)
+        real_add = store.add_message
+
+        def add_then_vanish(*args, **kwargs):
+            real_add(*args, **kwargs)
+            store.delete(session_id)
+
+        store.add_message = add_then_vanish
+        resp = client.post(
+            f"/api/sessions/{session_id}/messages",
+            json={"role": "user", "content": "hi"},
+        )
+        assert resp.status_code == 404

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -490,9 +490,9 @@ class TestUtf8RoundTrip:
         decoded = raw.decode("utf-8")
         assert "key" in decoded
 
-    def test_win32_platform_sim_does_not_break_save(self, tmp_path, monkeypatch) -> None:
-        """Simulate Windows platform: write_text with encoding= must still work."""
-        monkeypatch.setattr("lilbee.core.settings.sys.platform", "win32")
+    def test_overwriting_an_existing_file_round_trips_unicode(self, tmp_path) -> None:
+        """The atomic replace must not lose the UTF-8 encoding on a rewrite."""
+        settings.save(tmp_path, {"key": "value"})
         settings.save(tmp_path, {"key": "value", "unicode": "é"})
         result = settings.load(tmp_path)
         assert result["unicode"] == "é"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -189,18 +189,27 @@ class TestTomlEscaping:
         settings.set_value(tmp_path, "reranker_prompt", "rank\x1bthese")
         assert settings.load(tmp_path) == {"model": "qwen3:8b", "reranker_prompt": "rank\x1bthese"}
 
-    def test_escape_toml_string_function(self):
-        from lilbee.core.settings import _escape_toml_string
+    @pytest.mark.parametrize(
+        "value",
+        ['say "hi"', r"C:\path", "a\nb", "a\tb", "normal", "", "a\x1bb", "a\x00b", "a\x7fb"],
+    )
+    def test_a_value_survives_the_round_trip_verbatim(self, tmp_path, value):
+        """Escaping is only correct if the reader gives the string back unchanged."""
+        settings.set_value(tmp_path, "reranker_prompt", value)
+        assert settings.load(tmp_path)["reranker_prompt"] == value
 
-        assert _escape_toml_string('say "hi"') == r"say \"hi\""
-        assert _escape_toml_string(r"C:\path") == r"C:\\path"
-        assert _escape_toml_string("a\nb") == r"a\nb"
-        assert _escape_toml_string("a\tb") == r"a\tb"
-        assert _escape_toml_string("normal") == "normal"
-        assert _escape_toml_string("") == ""
-        assert _escape_toml_string("a\x1bb") == r"a\u001Bb"
-        assert _escape_toml_string("a\x00b") == r"a\u0000b"
-        assert _escape_toml_string("a\x7fb") == r"a\u007Fb"
+    def test_a_list_value_round_trips_as_a_list(self, tmp_path):
+        """The hand-rolled emitter stringified anything non-scalar, so a list
+        was persisted as the quoted repr "['a', 'b']" and read back as text."""
+        settings.set_value(tmp_path, "exclude", ["a", "b"])
+        assert settings.load(tmp_path)["exclude"] == ["a", "b"]
+
+    def test_a_none_value_is_dropped_rather_than_written_as_text(self, tmp_path):
+        """It used to land as the string "None", which then read back as a
+        truthy setting rather than an absent one."""
+        settings.set_value(tmp_path, "model", "qwen3:8b")
+        settings.set_value(tmp_path, "reranker_prompt", None)
+        assert settings.load(tmp_path) == {"model": "qwen3:8b"}
 
 
 class TestRerankerConfig:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -521,3 +521,58 @@ class TestUtf8RoundTrip:
         settings.save(tmp_path, {"key": "value", "unicode": "é"})
         result = settings.load(tmp_path)
         assert result["unicode"] == "é"
+
+
+class TestConcurrentConfigWrites:
+    """A server, a CLI run, and an MCP process share one data root."""
+
+    def test_a_second_process_does_not_drop_the_first_processes_key(self, tmp_path):
+        """Cross-process read-modify-write must serialize, not interleave.
+
+        A threading.Lock only covers one interpreter, so two processes could
+        both load the same snapshot and each save it back without the other's
+        key. This drives real subprocesses, which a thread test cannot.
+        """
+        import subprocess
+        import sys
+        import textwrap
+
+        # Each process holds the read-modify-write open for a beat. Under the
+        # lock they queue up and every key survives; without it they all load
+        # the same snapshot and the last writer wins.
+        script = textwrap.dedent(
+            f"""
+            import sys, time
+            from pathlib import Path
+            from lilbee.core import settings
+
+            real_save = settings.save
+            def slow_save(root, values):
+                time.sleep(0.3)
+                real_save(root, values)
+            settings.save = slow_save
+
+            settings.set_value(Path({str(tmp_path)!r}), sys.argv[1], sys.argv[1])
+            """
+        )
+        procs = [subprocess.Popen([sys.executable, "-c", script, f"key{i}"]) for i in range(4)]
+        for proc in procs:
+            assert proc.wait(timeout=120) == 0
+
+        result = settings.load(tmp_path)
+        assert sorted(result) == [f"key{i}" for i in range(4)]
+
+    def test_a_stale_lock_does_not_block_the_write(self, tmp_path, monkeypatch, caplog):
+        """Losing an update to an abandoned lock file is worse than the race."""
+        from lilbee.core import settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "_CONFIG_LOCK_TIMEOUT_S", 0.01)
+        held = settings_mod.FileLock(str(tmp_path / "config.toml") + ".lock")
+        held.acquire()
+        try:
+            with caplog.at_level("WARNING"):
+                settings.set_value(tmp_path, "key", "value")
+        finally:
+            held.release()
+        assert settings.get(tmp_path, "key") == "value"
+        assert "Timed out waiting" in caplog.text

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -573,10 +573,12 @@ class TestConcurrentConfigWrites:
 
     def test_a_stale_lock_does_not_block_the_write(self, tmp_path, monkeypatch, caplog):
         """Losing an update to an abandoned lock file is worse than the race."""
+        from filelock import FileLock
+
         from lilbee.core import settings as settings_mod
 
         monkeypatch.setattr(settings_mod, "_CONFIG_LOCK_TIMEOUT_S", 0.01)
-        held = settings_mod.FileLock(str(tmp_path / "config.toml") + ".lock")
+        held = FileLock(str(tmp_path / "config.toml") + ".lock")
         held.acquire()
         try:
             with caplog.at_level("WARNING"):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -167,6 +167,28 @@ class TestTomlEscaping:
         settings.set_value(tmp_path, "key", "")
         assert settings.get(tmp_path, "key") == ""
 
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        [
+            ("escape", "before\x1bafter"),
+            ("nul", "before\x00after"),
+            ("vertical_tab", "before\x0bafter"),
+            ("bell", "before\x07after"),
+            ("delete", "before\x7fafter"),
+            ("every_c0", "".join(chr(c) for c in range(0x20))),
+        ],
+    )
+    def test_control_characters_round_trip(self, tmp_path, label, value):
+        """TOML forbids raw control characters; writing one used to break the whole file."""
+        settings.set_value(tmp_path, label, value)
+        assert settings.get(tmp_path, label) == value
+
+    def test_one_control_character_does_not_discard_the_rest_of_the_config(self, tmp_path):
+        """A parse failure makes the reader drop every setting, not just the bad key."""
+        settings.set_value(tmp_path, "model", "qwen3:8b")
+        settings.set_value(tmp_path, "reranker_prompt", "rank\x1bthese")
+        assert settings.load(tmp_path) == {"model": "qwen3:8b", "reranker_prompt": "rank\x1bthese"}
+
     def test_escape_toml_string_function(self):
         from lilbee.core.settings import _escape_toml_string
 
@@ -176,6 +198,9 @@ class TestTomlEscaping:
         assert _escape_toml_string("a\tb") == r"a\tb"
         assert _escape_toml_string("normal") == "normal"
         assert _escape_toml_string("") == ""
+        assert _escape_toml_string("a\x1bb") == r"a\u001Bb"
+        assert _escape_toml_string("a\x00b") == r"a\u0000b"
+        assert _escape_toml_string("a\x7fb") == r"a\u007Fb"
 
 
 class TestRerankerConfig:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -244,3 +244,12 @@ class TestStderrSuppressed:
             original_stat.st_dev,
             original_stat.st_ino,
         )
+
+
+def test_stderr_suppressed_can_nest():
+    """A suppressed block can re-enter this, directly or via a native helper
+    that wraps its own stderr. A plain Lock self-deadlocked there."""
+    from lilbee.core.system import stderr_suppressed
+
+    with stderr_suppressed(), stderr_suppressed():
+        pass

--- a/tests/test_wiki_shared.py
+++ b/tests/test_wiki_shared.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lilbee.core.text import clean_label_for_display, is_valid_label, make_slug
 from lilbee.wiki.shared import (
     SUBDIR_TO_TYPE,
@@ -181,3 +183,29 @@ class TestCleanLabelForDisplay:
 
     def test_leaves_ordinary_label_unchanged(self):
         assert clean_label_for_display("brake pads") == "brake pads"
+
+
+class TestSlugWhitespaceHandling:
+    """The docstring promises whitespace maps to single hyphens."""
+
+    def test_a_double_space_does_not_collide_with_a_slash(self):
+        """`--` is the reserved encoding for `/`, so a run of spaces producing
+        it made two different entities share one wiki page, and whichever was
+        written second silently overwrote the first."""
+        from lilbee.core.text import make_slug
+
+        assert make_slug("Chevrolet  Caprice") != make_slug("Chevrolet/Caprice")
+        assert make_slug("Chevrolet  Caprice") == "chevrolet-caprice"
+        assert make_slug("Chevrolet/Caprice") == "chevrolet--caprice"
+
+    @pytest.mark.parametrize("label", ["Chevrolet\tCaprice", "Chevrolet\nCaprice"])
+    def test_other_whitespace_becomes_a_hyphen_not_nothing(self, label):
+        """Tabs and newlines were deleted, welding two words into one token."""
+        from lilbee.core.text import make_slug
+
+        assert make_slug(label) == "chevrolet-caprice"
+
+    def test_leading_and_trailing_whitespace_is_trimmed(self):
+        from lilbee.core.text import make_slug
+
+        assert make_slug("  Caprice  ") == "caprice"

--- a/uv.lock
+++ b/uv.lock
@@ -1648,6 +1648,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "textual" },
     { name = "tiktoken" },
+    { name = "tomli-w" },
     { name = "tree-sitter-language-pack" },
     { name = "typer" },
     { name = "typing-extensions" },
@@ -1722,6 +1723,7 @@ requires-dist = [
     { name = "spacy", marker = "extra == 'graph'", specifier = ">=3.8" },
     { name = "textual", specifier = ">=0.75" },
     { name = "tiktoken" },
+    { name = "tomli-w", specifier = ">=1.0" },
     { name = "tree-sitter-language-pack", specifier = ">=1.8.0,<2.0" },
     { name = "typer", specifier = ">=0.12" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
@@ -4181,6 +4183,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504 },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561 },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -327,6 +327,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761 },
+]
+
+[[package]]
 name = "catalogue"
 version = "2.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1631,6 +1640,7 @@ name = "lilbee"
 version = "0.6.90b420.dev724"
 source = { editable = "." }
 dependencies = [
+    { name = "cachetools" },
     { name = "diskcache" },
     { name = "filelock" },
     { name = "gguf" },
@@ -1693,11 +1703,13 @@ dev = [
     { name = "pytest-xdist" },
     { name = "reportlab" },
     { name = "ruff" },
+    { name = "types-cachetools" },
     { name = "types-pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "cachetools", specifier = ">=7.1.4" },
     { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.9.0" },
     { name = "diskcache", specifier = ">=5.6.1" },
     { name = "filelock" },
@@ -1746,6 +1758,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "reportlab" },
     { name = "ruff", specifier = ">=0.15.4" },
+    { name = "types-cachetools", specifier = ">=7.0.0.20260713" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
@@ -4245,6 +4258,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085 },
+]
+
+[[package]]
+name = "types-cachetools"
+version = "7.0.0.20260713"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/66d7efdb36ecf6826aca5415e59fe2df96e97d24157147e53acfbe8dda11/types_cachetools-7.0.0.20260713.tar.gz", hash = "sha256:f1acf079e9c66a81e096a897ef0b261a82117cf856834e37b4bd0c9a116a076a", size = 10199 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/c7/d3525c9dbdc1be7786bad46655ef051b6e7993f656d304719ec40079c91c/types_cachetools-7.0.0.20260713-py3-none-any.whl", hash = "sha256:6db9bcc7a3840d39e91c04117d85a9d0937eacc9d14d12a873e2b01a2d24a71d", size = 9615 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

19 HTTP routes answered callers who sent no token: `GET /api/export` (serializes the whole corpus), the document listing, `/api/search`, `/api/source`, `/api/status`, `/api/config`, the model inventory, and five wiki routes. The marker that opened them was called `read_only`, which reads as "a read-only token is accepted". No such token exists.

The session token was written under the process umask and chmod'd afterwards, so any local user could read it in that window. The TOML escaper missed control characters, and the reader drops the whole file on a parse error, so one bad value wiped every other setting.

GPU probes, model discovery, and dataset exports ran inline in async handlers and blocked the event loop. The chat gate woke every waiter to race, so a later arrival could take the slot.

Plus 70 smaller findings from the same review: a `KeyError` mid-stream on an orphaned tool delta, a 500 where a 404 was documented, catalog page 1 reporting a different total than page 2.

## Solution

**Auth.** Every route requires the token, `/api/health` included — it reports the engine's last error, which carries model paths. `read_only` is now `auth_checked_in_handler`; its only users are `/v1/models` and `/v1/chat/completions`, which check the same token in-handler to return the OpenAI error envelope. A new test walks the live route table and asserts 401 without a token.

**Secrets.** One helper writes owner-only and replaces atomically. Token and `config.toml` are re-narrowed on load. `tomli-w` replaces the hand-rolled TOML emitter.

**Concurrency.** Blocking work moved off the event loop. The gate hands a slot to the next waiter instead of waking all of them. The SSE drain waits on its producer rather than polling at 10Hz.

## Worth knowing

Deleting a dead async-stream branch exposed that both streaming test doubles were async iterators, so the whole streaming suite had been exercising a path no provider returns. The wiki lock test could not fail, for two independent reasons. Six tests pinned the defect instead of the fix and were rewritten.


## MCP server ownership

`build_mcp_mount()` cleared a private SDK attribute (`mcp._session_manager`) on every call to make the shared module-global server reusable. Each transport now builds its own server through the public SDK surface: tool decorators record into a registry that `build_mcp_server()` replays via `add_tool`, a `FastMCP` subclass overrides public `list_tools()` for schema stripping and the wiki scope hint (computed from live config, so the `init()` re-tune step is gone), and tool gates are callables evaluated at build time instead of import time. The tools wire is byte-identical.

Also fixes a token boot race: two servers starting together could both mint a token and the last write won; `load_or_generate` now runs under a file lock shared with the config writer.
