### PR TITLE
Fix the server startup embedding check reporting success when the model is missing

### DIFF
--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -113,15 +113,18 @@ async def _lifespan(app: Litestar) -> AsyncIterator[None]:
     inject_provider_keys()
 
     try:
-        get_services()  # pre-load all services (provider, embedder, etc.)
+        services = get_services()  # pre-load all services (provider, embedder, etc.)
         log.info("LLM provider pre-loaded")
     except Exception:
         log.warning("Failed to pre-load LLM provider", exc_info=True)
-    try:
-        get_services().embedder.validate_model()
-        log.info("Embedding model validated")
-    except Exception:
-        log.warning("Failed to validate embedding model", exc_info=True)
+    else:
+        if services.embedder.validate_model():
+            log.info("Embedding model validated")
+        else:
+            log.warning(
+                "Embedding model %s is unavailable; search and chat will run without embeddings",
+                cfg.embedding_model,
+            )
     try:
         yield
     finally:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -1480,15 +1481,18 @@ class TestLifespan:
             pass
 
     @mock.patch("lilbee.server.app.get_services")
-    async def test_validate_model_failure_does_not_block(self, mock_get_svc):
+    async def test_unavailable_embedding_model_warns_and_does_not_block(self, mock_get_svc, caplog):
         mock_svc = mock.MagicMock()
-        mock_svc.embedder.validate_model.side_effect = RuntimeError("no model")
+        mock_svc.embedder.validate_model.return_value = False
         mock_get_svc.return_value = mock_svc
         from lilbee.server.app import _lifespan
 
-        async with _lifespan(mock.MagicMock()):
-            pass
+        with caplog.at_level(logging.WARNING, logger="lilbee.server.app"):
+            async with _lifespan(mock.MagicMock()):
+                pass
         mock_get_svc.assert_called()
+        assert "Embedding model validated" not in caplog.text
+        assert "embedding" in caplog.text.lower()
 
     @mock.patch("lilbee.server.app.peek_services")
     @mock.patch("lilbee.server.app.get_services")


### PR DESCRIPTION
## Problem

The server lifespan wrapped the embedding check in a try/except and logged "Embedding model validated" regardless of the result. `validate_model()` is a bool predicate that cannot raise, and must not: search and chat are built to degrade when no embedder is available. The except was dead code and the success line was false whenever the model was missing.

Its test stubbed a `RuntimeError` that the real method cannot produce, so it passed without exercising anything.

## Solution

Branch on the returned bool, naming the unavailable model in the warning, and reuse the services handle already built for the provider pre-load instead of calling `get_services()` a second time. The test now covers the false-return path and asserts the warning.