### PR TITLE
Give HyDE its own token budget, use the public spaCy loader, delete unused compaction code

### DIFF
--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -143,11 +143,11 @@ async def _build_entity_records(records: list[ChunkRecord], source_name: str) ->
     nlp = None
     if any(t.kind is ExtractorKind.SPACY for t in schema.types):
         from lilbee.retrieval.concepts import concepts_available
-        from lilbee.retrieval.concepts.nlp import _ensure_spacy_model
+        from lilbee.retrieval.concepts.nlp import load_spacy_pipeline
 
         if concepts_available():
             try:
-                nlp = _ensure_spacy_model()
+                nlp = load_spacy_pipeline()
             except ImportError:
                 log.warning("spaCy model unavailable; spacy-kind entity types skipped")
     provider = None

--- a/src/lilbee/retrieval/entities/lifecycle.py
+++ b/src/lilbee/retrieval/entities/lifecycle.py
@@ -197,10 +197,10 @@ def _full_pass(store: Store, schema: EntitySchema, cancel: threading.Event | Non
         from lilbee.retrieval.concepts import concepts_available
 
         if concepts_available():
-            from lilbee.retrieval.concepts.nlp import _ensure_spacy_model
+            from lilbee.retrieval.concepts.nlp import load_spacy_pipeline
 
             try:
-                nlp = _ensure_spacy_model()
+                nlp = load_spacy_pipeline()
             except ImportError:
                 log.warning("spaCy model unavailable; skipping spaCy entity types")
     provider = None

--- a/src/lilbee/retrieval/query/compaction.py
+++ b/src/lilbee/retrieval/query/compaction.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 
 from lilbee.retrieval.query.history_window import (
     chars_for_tokens,
-    estimate_text_tokens,
     estimate_tokens,
     windowed_history,
 )
@@ -28,7 +27,7 @@ COMPACT_PROMPT = (
     "Condense the conversation below into brief factual notes that let an "
     "assistant carry it on. Keep names, numbers, decisions, and anything left "
     "unresolved; drop pleasantries. Under {words} words. Return ONLY the notes.\n\n"
-    "{previous}Conversation:\n{transcript}"
+    "Conversation:\n{transcript}"
 )
 
 # Ceiling on a summary's tokens; ctx/8 governs below it. A tighter ceiling
@@ -204,9 +203,7 @@ def summary_cap(ctx_target: int) -> int:
     return max(_SUMMARY_MIN_TOKENS, min(COMPACT_MAX_TOKENS, ctx_target // _SUMMARY_CTX_FRACTION))
 
 
-def batch_overflow(
-    dropped: list[ChatMessage], previous_summary: str, *, ctx_target: int
-) -> list[list[ChatMessage]]:
+def batch_overflow(dropped: list[ChatMessage], *, ctx_target: int) -> list[list[ChatMessage]]:
     """Split *dropped* into batches whose summarize prompt each fit *ctx_target*.
 
     Compaction usually nibbles a pair at a time, but switching models does not:
@@ -226,12 +223,7 @@ def batch_overflow(
     room = max(
         _MIN_BATCH_TOKENS,
         int(
-            (
-                ctx_target
-                - summary_cap(ctx_target)
-                - estimate_text_tokens(previous_summary)
-                - _PROMPT_OVERHEAD_TOKENS
-            )
+            (ctx_target - summary_cap(ctx_target) - _PROMPT_OVERHEAD_TOKENS)
             * _ESTIMATE_SAFETY_FRACTION
         ),
     )
@@ -256,9 +248,7 @@ def batch_overflow(
     return batches
 
 
-def plan_compaction(
-    dropped: list[ChatMessage], previous_summary: str, *, ctx_target: int
-) -> CompactionPlan:
+def plan_compaction(dropped: list[ChatMessage], *, ctx_target: int) -> CompactionPlan:
     """Decide what one compaction condenses, keeping its cost bounded.
 
     Beyond MAX_COMPACT_CALLS batches the oldest turns are stranded rather than
@@ -267,7 +257,7 @@ def plan_compaction(
     trade. The most recent slice is the part still worth remembering, and the
     caller reports the stranded count instead of pretending it survived.
     """
-    batches = batch_overflow(dropped, previous_summary, ctx_target=ctx_target)
+    batches = batch_overflow(dropped, ctx_target=ctx_target)
     if len(batches) <= MAX_COMPACT_CALLS:
         return CompactionPlan(batches=batches, stranded=0)
     return CompactionPlan(

--- a/src/lilbee/retrieval/query/expansion.py
+++ b/src/lilbee/retrieval/query/expansion.py
@@ -1,4 +1,4 @@
-"""Constants for LLM-driven query expansion and history condensation."""
+"""Constants for LLM-driven query expansion, HyDE, and history condensation."""
 
 from __future__ import annotations
 
@@ -9,6 +9,11 @@ EXPANSION_PROMPT = (
 )
 
 EXPANSION_MAX_TOKENS = 200
+
+# HyDE writes one hypothetical answer passage to embed, which is a different
+# shape of output from a list of query variants. Same number today, but tuning
+# either one must not move the other.
+HYDE_MAX_TOKENS = 200
 
 CONDENSE_PROMPT = (
     "Rewrite the follow-up question as one standalone search query, resolving "

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -52,6 +52,7 @@ from lilbee.retrieval.query.expansion import (
     CONDENSE_PROMPT,
     EXPANSION_MAX_TOKENS,
     EXPANSION_PROMPT,
+    HYDE_MAX_TOKENS,
 )
 from lilbee.retrieval.query.formatting import (
     CONTEXT_TEMPLATE,
@@ -431,7 +432,7 @@ class Searcher:
             response = self._provider.chat(
                 [{"role": "user", "content": self._config.hyde_prompt.format(question=question)}],
                 stream=False,
-                options={"num_predict": EXPANSION_MAX_TOKENS},
+                options={"num_predict": HYDE_MAX_TOKENS},
             )
             # Reasoning models front-load deliberation; embedding it instead
             # of the passage would search for the model's thought process.
@@ -700,14 +701,14 @@ class Searcher:
         ``on_batch`` hears ``(batch, total)`` before each model call, for progress UI.
         """
         ctx_target = self._config.chat_n_ctx_target
-        plan = plan_compaction(messages, previous_summary, ctx_target=ctx_target)
+        plan = plan_compaction(messages, ctx_target=ctx_target)
         notes: list[str] = []
         condensed = 0
         stranded = plan.stranded
         for index, batch in enumerate(plan.batches):
             if on_batch is not None:
                 on_batch(index + 1, len(plan.batches))
-            note = self._summarize_batch(batch, "")
+            note = self._summarize_batch(batch)
             if note:
                 notes.append(note)
                 condensed += len(batch)
@@ -718,26 +719,29 @@ class Searcher:
         merged = merge_notes(previous_summary, notes)
         cap = summary_cap(ctx_target)
         if estimate_text_tokens(merged) > cap:
-            merged = self._summarize_batch([{"role": "user", "content": merged}], "") or merged
+            merged = self._summarize_batch([{"role": "user", "content": merged}]) or merged
         return CompactionResult(
             summary=merged or previous_summary, condensed=condensed, stranded=stranded
         )
 
-    def _summarize_batch(self, batch: list[ChatMessage], previous_summary: str) -> str:
-        """Fold one batch of dropped turns into *previous_summary*.
+    def _summarize_batch(self, batch: list[ChatMessage]) -> str:
+        """Fold one batch of dropped turns into notes.
+
+        Each batch is summarized on its own, with no carried-forward notes in
+        the prompt: summarize_history merges the per-batch notes instead, which
+        keeps summary depth at one rather than re-summarizing the summary once
+        per batch.
 
         An overflowing batch splits in half and each half folds on its own:
         batch sizing is estimate-based, and the cost of an estimate miss here
         is stranded turns, not a slow call. Depth is log2 of the batch.
 
-        Returns *previous_summary* unchanged on any other failure: older notes
-        beat dropping the turns on the floor.
+        Returns "" on any other failure, so the caller counts the batch as
+        stranded rather than reporting turns it has no notes for.
         """
         transcript = "\n".join(f"{m['role']}: {m['content']}" for m in batch)
-        previous = f"Earlier notes:\n{previous_summary}\n\n" if previous_summary.strip() else ""
         prompt = COMPACT_PROMPT.format(
             words=summary_word_budget(self._config.chat_n_ctx_target),
-            previous=previous,
             transcript=transcript,
         )
         try:
@@ -764,23 +768,23 @@ class Searcher:
             reasoning = split_reasoning(response.text).reasoning.strip()
             if reasoning:
                 return reasoning
-            log.warning("History compaction returned nothing; keeping the previous summary")
+            log.warning("History compaction returned nothing for this batch")
         except ProviderError as exc:
             # A single message too big for the window cannot split; it falls
             # through to the warning below.
             if exc.kind is ProviderErrorKind.CONTEXT_OVERFLOW and len(batch) > 1:
                 mid = len(batch) // 2
-                first = self._summarize_batch(batch[:mid], previous_summary)
-                second = self._summarize_batch(batch[mid:], "")
+                first = self._summarize_batch(batch[:mid])
+                second = self._summarize_batch(batch[mid:])
                 merged = "\n".join(part for part in (first, second) if part.strip())
                 if merged.strip():
                     return merged
-            log.warning("History compaction failed; keeping the previous summary", exc_info=True)
+            log.warning("History compaction failed for this batch", exc_info=True)
         except Exception:
             # warning, not debug: the user is told turns were dropped, so the
             # reason must be in the log by default.
-            log.warning("History compaction failed; keeping the previous summary", exc_info=True)
-        return previous_summary
+            log.warning("History compaction failed for this batch", exc_info=True)
+        return ""
 
     def _known_item_results(self, question: str) -> list[SearchChunk]:
         """Resolve a document named in *question* to its own chunks.

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -89,7 +89,7 @@ def test_batches_each_fit_the_current_model_window() -> None:
     """
     dropped = _msgs(200)  # ~20k tokens, i.e. a large conversation
     ctx = 2048
-    batches = batch_overflow(dropped, "", ctx_target=ctx)
+    batches = batch_overflow(dropped, ctx_target=ctx)
     assert len(batches) > 1, "a 20k backlog must not be summarized in one 2k call"
     # `estimate < ctx` is the invariant that shipped a live failure: a batch
     # estimated at 1728 tokens reached a 2048-token server as ~2666 real tokens
@@ -108,25 +108,17 @@ def test_batches_each_fit_the_current_model_window() -> None:
     assert sum(len(b) for b in batches) == len(dropped)
 
 
-def test_batches_leave_room_for_the_previous_summary() -> None:
-    """The previous notes ride in every batch prompt, so they must be budgeted."""
-    dropped = _msgs(60)
-    lean = batch_overflow(dropped, "", ctx_target=4096)
-    fat = batch_overflow(dropped, "s" * 6000, ctx_target=4096)
-    assert len(fat) >= len(lean), "a long previous summary must shrink the batches"
-
-
 def test_a_single_oversized_turn_is_clipped_rather_than_sent_to_fail() -> None:
     """One turn bigger than the window would fail every call and lose the lot."""
     huge = [{"role": "user", "content": "y" * 200_000}]
-    batches = batch_overflow(huge, "", ctx_target=2048)
+    batches = batch_overflow(huge, ctx_target=2048)
     assert len(batches) == 1
     assert estimate_tokens(batches[0][0]) < 2048
     assert batches[0][0]["content"].endswith("[…clipped]")
 
 
 def test_no_overflow_yields_no_batches() -> None:
-    assert batch_overflow([], "", ctx_target=2048) == []
+    assert batch_overflow([], ctx_target=2048) == []
 
 
 def test_an_oversized_turn_flushes_the_batch_being_built() -> None:
@@ -137,7 +129,7 @@ def test_an_oversized_turn_flushes_the_batch_being_built() -> None:
         {"role": "user", "content": "y" * 200_000},  # bigger than any batch
         {"role": "assistant", "content": "small three"},
     ]
-    batches = batch_overflow(dropped, "", ctx_target=2048)
+    batches = batch_overflow(dropped, ctx_target=2048)
     # the two small turns batch together, the giant one stands alone (clipped)
     assert [len(b) for b in batches] == [2, 1, 1]
     assert batches[0][0]["content"] == "small one"

--- a/tests/test_entities_ingest.py
+++ b/tests/test_entities_ingest.py
@@ -112,7 +112,7 @@ class TestExtractorToolWiring:
         fake_nlp = mock.MagicMock(return_value=mock.MagicMock(ents=[]))
         with (
             mock.patch("lilbee.retrieval.concepts.concepts_available", return_value=True),
-            mock.patch("lilbee.retrieval.concepts.nlp._ensure_spacy_model", return_value=fake_nlp),
+            mock.patch("lilbee.retrieval.concepts.nlp.load_spacy_pipeline", return_value=fake_nlp),
         ):
             rows = asyncio.run(_build_entity_records(_records(), "a.txt"))
         assert rows is not None
@@ -124,7 +124,7 @@ class TestExtractorToolWiring:
         with (
             mock.patch("lilbee.retrieval.concepts.concepts_available", return_value=True),
             mock.patch(
-                "lilbee.retrieval.concepts.nlp._ensure_spacy_model",
+                "lilbee.retrieval.concepts.nlp.load_spacy_pipeline",
                 side_effect=ImportError("no model"),
             ),
             caplog.at_level("WARNING"),

--- a/tests/test_entities_lifecycle.py
+++ b/tests/test_entities_lifecycle.py
@@ -210,7 +210,7 @@ class TestEnsureEntities:
         fake_nlp = mock.MagicMock(return_value=mock.MagicMock(ents=[]))
         with (
             mock.patch("lilbee.retrieval.concepts.concepts_available", return_value=True),
-            mock.patch("lilbee.retrieval.concepts.nlp._ensure_spacy_model", return_value=fake_nlp),
+            mock.patch("lilbee.retrieval.concepts.nlp.load_spacy_pipeline", return_value=fake_nlp),
         ):
             ensure_entities()
         fake_nlp.assert_called()
@@ -234,7 +234,7 @@ class TestEnsureEntities:
         with (
             mock.patch("lilbee.retrieval.concepts.concepts_available", return_value=True),
             mock.patch(
-                "lilbee.retrieval.concepts.nlp._ensure_spacy_model",
+                "lilbee.retrieval.concepts.nlp.load_spacy_pipeline",
                 side_effect=ImportError("no model"),
             ),
             caplog.at_level("WARNING"),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1707,6 +1707,17 @@ class TestHydeSearch:
         get_services().searcher._hyde_search("explain X", top_k=5)
         mock_svc.embedder.embed_query.assert_called_once_with("hypothetical passage")
 
+    def test_spends_its_own_token_budget(self, mock_svc):
+        """A generated answer passage and a list of query variants are not the
+        same length of output, so they must not share one cap: retuning either
+        one through a shared constant silently retunes the other."""
+        from lilbee.retrieval.query.expansion import HYDE_MAX_TOKENS
+
+        mock_svc.provider.chat.return_value = _text_result("hypothetical passage")
+        mock_svc.store.search.return_value = []
+        get_services().searcher._hyde_search("explain X", top_k=5)
+        assert mock_svc.provider.chat.call_args.kwargs["options"]["num_predict"] == HYDE_MAX_TOKENS
+
     def test_returns_empty_on_error(self, mock_svc):
         mock_svc.provider.chat.side_effect = RuntimeError("fail")
         assert get_services().searcher._hyde_search("test", top_k=5) == []

--- a/tests/test_summarize_history.py
+++ b/tests/test_summarize_history.py
@@ -197,7 +197,7 @@ def test_merged_notes_over_the_cap_get_one_compression_pass() -> None:
     long_note = "note " * 300  # ~375 tokens, well over summary_cap(2048)
     provider = _provider(long_note)
     cfg.chat_n_ctx_target = 2048
-    plan = plan_compaction(_msgs(60), "", ctx_target=2048)
+    plan = plan_compaction(_msgs(60), ctx_target=2048)
     result = _searcher(provider).summarize_history(_msgs(60))
     assert provider.chat.call_count == len(plan.batches) + 1, "one merge pass on top of the batches"
     assert result.summary


### PR DESCRIPTION
## Problem

Three retrieval seams pointing at the wrong thing.

- The ingest pipeline and entity backfill both reached across packages for `concepts.nlp`'s private `_ensure_spacy_model`, though a public `load_spacy_pipeline` exists for it.
- HyDE's `num_predict` cap was `EXPANSION_MAX_TOKENS`, the same constant capping query-variant expansion. Retuning one silently retuned the other, and they want different output lengths.
- `COMPACT_PROMPT` had a `{previous}` slot and `batch_overflow` reserved window space for it, but every caller passes an empty string. The scaffolding never rendered; the reservation just made batches smaller than needed.

## Solution

- Both cross-package call sites use `load_spacy_pipeline`. `concepts/graph.py` keeps the private call since it is in the same package.
- HyDE gets its own `HYDE_MAX_TOKENS`.
- Dropped the `{previous}` slot, the reservation, and the `previous_summary` parameter threaded through `plan_compaction`, `batch_overflow`, and `_summarize_batch`. `summarize_history` still takes and merges a running summary, which is the part actually used.
