### PR TITLE
Close the XML inline-render, bootstrap race, validation and error-reporting findings

### DIFF
--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -757,7 +757,11 @@ class Config(BaseSettings):
             try:
                 return parse_bool(v)
             except ValueError:
-                pass  # fall through to bool() coercion below for unrecognised strings
+                # bool() on a non-empty string is True, so falling through here
+                # turned an unparseable value into "on". Warn and auto-detect,
+                # matching the sibling validators.
+                log.warning("Invalid LILBEE_ENABLE_OCR=%r, using auto", v)
+                return None
         return bool(v)
 
     @field_validator("flash_attention", mode="before")

--- a/src/lilbee/core/config/parsing.py
+++ b/src/lilbee/core/config/parsing.py
@@ -1,11 +1,14 @@
 """Boolean parsing helpers used by :mod:`lilbee.config` validators."""
 
-_BOOL_TRUE = frozenset({"true", "1", "yes"})
-_BOOL_FALSE = frozenset({"false", "0", "no"})
+# Matches what pydantic itself accepts for a bool field. Every other bool on
+# Config is coerced by pydantic, so a narrower vocabulary here would make the
+# same env spelling mean different things on different fields of one object.
+_BOOL_TRUE = frozenset({"true", "t", "yes", "y", "on", "1"})
+_BOOL_FALSE = frozenset({"false", "f", "no", "n", "off", "0"})
 
 
 def parse_bool(raw: str) -> bool:
-    """Parse true/1/yes or false/0/no; raises ValueError on anything else."""
+    """Parse a boolean env string; raises ValueError on anything else."""
     normalized = raw.strip().lower()
     if normalized in _BOOL_TRUE:
         return True

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -9,6 +9,9 @@ import re
 import sys
 from pathlib import Path
 
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
 from lilbee._frozen import is_frozen
 from lilbee.runtime.progress import (
     DetailedProgressCallback,
@@ -28,6 +31,10 @@ class CrawlerBackendError(RuntimeError):
 
 
 _CHROMIUM_COMPONENT = "chromium"
+
+# A Chromium unpack runs into the minutes on a slow link, so a caller queued
+# behind one waits well past any normal request timeout before giving up.
+_BOOTSTRAP_LOCK_TIMEOUT_S = 900.0
 # Rough size estimate for the Chromium download; Playwright bundles vary
 # slightly per platform but this gives the UI a decent denominator before
 # 'Total bytes' parses out of stdout.
@@ -110,6 +117,13 @@ def chromium_installed() -> bool:
     if expected is None:
         return any(p.is_dir() and p.name.startswith("chromium-") for p in root.iterdir())
     return (root / f"{_CHROMIUM_COMPONENT}-{expected}").is_dir()
+
+
+def _bootstrap_lock_path() -> Path:
+    """Lock file serializing Chromium installs into the browsers cache."""
+    root = _browsers_cache_path()
+    root.mkdir(parents=True, exist_ok=True)
+    return root / ".lilbee-bootstrap.lock"
 
 
 def crawler_browsers_path() -> Path:
@@ -245,6 +259,36 @@ async def bootstrap_chromium(
         _emit_setup_done(on_progress, success=True, error=None)
         return
 
+    # Two callers can get here at once: a second POST /setup/crawler, or a
+    # crawl triggering first-use bootstrap alongside one. Both would unpack a
+    # browser bundle into the same directory and corrupt it. The lock is on
+    # disk, not in memory, because the CLI and MCP processes share this path.
+    # thread_local=False because the acquire runs in a worker thread (so the
+    # wait does not block the event loop) while the release runs on the loop
+    # thread. With the default the release would not count and the lock would
+    # never be freed.
+    lock = FileLock(str(_bootstrap_lock_path()), thread_local=False)
+    try:
+        await asyncio.to_thread(lock.acquire, timeout=_BOOTSTRAP_LOCK_TIMEOUT_S)
+    except FileLockTimeout as exc:
+        message = (
+            "Timed out waiting for another Chromium install to finish. "
+            "If no other lilbee process is installing, retry."
+        )
+        _emit_setup_done(on_progress, success=False, error=message)
+        raise CrawlerBrowserError(message) from exc
+    try:
+        # The install we were queued behind may have been the one we needed.
+        if chromium_installed():
+            _emit_setup_done(on_progress, success=True, error=None)
+            return
+        await _install_chromium(on_progress)
+    finally:
+        lock.release()
+
+
+async def _install_chromium(on_progress: DetailedProgressCallback | None) -> None:
+    """Run the install subprocess. Caller holds the bootstrap lock."""
     _emit_setup_start(on_progress)
 
     try:

--- a/src/lilbee/server/handlers/documents.py
+++ b/src/lilbee/server/handlers/documents.py
@@ -32,6 +32,12 @@ _RAW_INLINE_RENDER_DENY: frozenset[str] = frozenset(
         "application/xhtml+xml",
         "text/css",
         "image/svg+xml",
+        # An xml-stylesheet processing instruction can pull in XSLT that emits
+        # script. Both spellings are listed because which one a ``.xml`` file
+        # resolves to depends on the host mimetypes database, and only the
+        # ``text/`` spelling would otherwise match the category rule below.
+        "text/xml",
+        "application/xml",
     }
 )
 

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -156,9 +156,11 @@ async def _ingest_stream(
     Shared by /api/add (server paths) and /api/add/upload (uploaded content).
     Each item is ``(lock_key, payload)``: the key is the source identifier used
     for the per-source ingest lock; the payload is what ``run`` receives for the
-    subset whose lock was acquired. Contended sources emit ``already_ingesting``
-    and the stream closes without a ``done`` event, signalling the client to wait
-    rather than retry.
+    subset whose lock was acquired. Contended sources emit ``already_ingesting``.
+    When every source is contended the stream closes with no ``done`` event,
+    signalling the client to wait rather than retry. When only some are, the
+    acquired subset still runs and the ``done`` summary names the contended ones
+    in ``already_ingesting``, so a partial batch never reads as a full success.
     """
     registry = get_services().ingest_lock_registry
     acquired, busy = await registry.acquire([key for key, _payload in items])
@@ -187,6 +189,9 @@ async def _ingest_stream(
                     yield sse_error(str(exc))
                     return
                 summary = task.result()
+                # Name the sources this run never attempted, so a client
+                # reading only the terminal event still sees a partial batch.
+                summary.already_ingesting = list(busy)
                 yield sse_done(summary.model_dump())
         finally:
             if not task.done():

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -146,11 +146,18 @@ class SseEventQueue(asyncio.Queue[str | None]):
         return self._queue.popleft().payload
 
     def _evict_oldest_droppable(self) -> bool:
-        """Shed the queue head when it is a progress event; True when a slot freed."""
-        if self._queue and self._queue[0].droppable:
-            self._queue.popleft()
-            self.dropped_events += 1
-            return True
+        """Shed the oldest progress event anywhere in the queue; True when one went.
+
+        Scans rather than checking only the head. A stream that interleaves
+        tokens with progress puts a non-droppable event at the head almost
+        immediately, and head-only eviction then reported "nothing to shed"
+        while the queue still held progress events it was allowed to drop.
+        """
+        for index, event in enumerate(self._queue):
+            if event.droppable:
+                del self._queue[index]
+                self.dropped_events += 1
+                return True
         return False
 
     def put_nowait(self, item: str | None) -> None:

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -51,7 +51,12 @@ def sse_error(
     return sse_event(SseEvent.ERROR, payload)
 
 
-_OOM_MARKERS = ("failed to load", "free ram", "try a smaller model", "llama_context")
+# Phrases that describe an allocation failure. "llama_context" alone used to be
+# here, but that is the prefix llama.cpp stamps on every context-subsystem
+# diagnostic, so n_ctx-over-training-context and KV-cache rejections were all
+# reported as "model too large", pointing at a smaller model when the fix is a
+# config change.
+_OOM_MARKERS = ("failed to load", "free ram", "try a smaller model", "failed to allocate")
 _NOT_INSTALLED_MARKERS = ("is not installed", "is not available", "pull it first")
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -41,7 +41,7 @@ class AskRequest(BaseModel):
     """Request body for /api/ask."""
 
     question: str
-    top_k: int = Field(default=0, le=100)
+    top_k: int = Field(default=0, ge=0, le=100)
     options: dict[str, Any] | None = None
     chunk_type: ChunkType | None = None
 
@@ -58,7 +58,7 @@ class ChatRequest(BaseModel):
     history: list[ChatMessage] = []
     # None (unspecified) grounds with the configured top_k; an explicit 0 is a
     # pure-LLM call that skips retrieval entirely.
-    top_k: int | None = Field(default=None, le=100)
+    top_k: int | None = Field(default=None, ge=0, le=100)
     options: dict[str, Any] | None = None
     chunk_type: ChunkType | None = None
     summary: str = ""

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -400,6 +400,14 @@ class AddSummary(BaseModel):
     skipped: list[str]
     errors: list[str]
     sync: SyncSummary | None = None
+    already_ingesting: list[str] = []
+    """Sources another ingest held a lock on, so this run never attempted them.
+
+    Distinct from ``skipped``, which means the file was examined and needed no
+    work. These were not looked at and are worth retrying. Carried on the
+    terminal event so a client that missed the earlier ``already_ingesting``
+    frames can still tell the batch was partial.
+    """
 
 
 class WikiCitationRecord(BaseModel):

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -95,7 +95,7 @@ async def add_upload_route(
 @read_only
 async def documents_list_route(
     search: str = Parameter(query="search", default=""),
-    limit: int = Parameter(query="limit", default=50, le=1000),
+    limit: int = Parameter(query="limit", default=50, ge=1, le=1000),
     offset: int = Parameter(query="offset", default=0, ge=0),
 ) -> DocumentListResponse:
     """List indexed documents with metadata, paginated and searchable."""

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -98,7 +98,7 @@ async def models_catalog_route(
     installed: bool | None = Parameter(query="installed", default=None),
     featured: bool | None = Parameter(query="featured", default=None),
     sort: str = Parameter(query="sort", default="featured"),
-    limit: int = Parameter(query="limit", default=20, le=1000),
+    limit: int = Parameter(query="limit", default=20, ge=1, le=1000),
     offset: int = Parameter(query="offset", default=0, ge=0),
 ) -> ModelsCatalogResponse:
     """Browse the model catalog with optional filters."""

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 from litestar import delete, get, post, put
 from litestar.exceptions import HTTPException
@@ -24,10 +25,19 @@ from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
 from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
 
+log = logging.getLogger(__name__)
+
 _HTTP_UNPROCESSABLE = 422
 _HTTP_CONFLICT = 409
 _HTTP_UNAVAILABLE = 503
-_INPUT_ERRORS = (PlacementError, ValueError, OSError)
+# OSError is deliberately absent: on this path it means the device probe could
+# not run (no nvidia-smi on PATH, no permission on the device node, a failed
+# spawn), which is a host fault and not something the caller's spec can fix.
+_INPUT_ERRORS = (PlacementError, ValueError)
+_PROBE_FAILED_DETAIL = (
+    "Could not probe the GPUs. Check that the vendor tool (nvidia-smi or "
+    "rocm-smi) is installed and this process may read the device."
+)
 _MISSING_SPEC_DETAIL = "spec is required to apply placement; send {} to DELETE for auto."
 
 
@@ -58,6 +68,9 @@ async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
         return await handlers.placement_preview(_spec_json(data))
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        log.exception("GPU probe failed")
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=_PROBE_FAILED_DETAIL) from exc
     except _INPUT_ERRORS as exc:
         raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=str(exc)) from exc
 
@@ -74,6 +87,9 @@ async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
         return await handlers.placement_set(spec_json)
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        log.exception("GPU probe failed")
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=_PROBE_FAILED_DETAIL) from exc
     except _INPUT_ERRORS as exc:
         raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=str(exc)) from exc
 

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -138,7 +138,7 @@ def _slot_gated_sse(generator: AsyncGenerator[str, None], guard: ChatSlotGuard) 
 @read_only
 async def search_route(
     q: str = Parameter(query="q"),
-    top_k: int = Parameter(query="top_k", default=5, le=100),
+    top_k: int = Parameter(query="top_k", default=5, ge=1, le=100),
     chunk_type: str | None = Parameter(query="chunk_type", default=None),
 ) -> list[DocumentResult]:
     """Search indexed documents by semantic similarity. No LLM call required."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,18 @@ def _ignore_user_global_config(monkeypatch):
     monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_playwright_browsers_path(tmp_path_factory, monkeypatch):
+    """Keep the browser cache out of the developer's real Playwright directory.
+
+    Tests that fake ``chromium_installed() -> False`` drive the install path,
+    which creates and locks the browsers directory. Without this they would
+    reach ``~/Library/Caches/ms-playwright`` on the machine running them.
+    ``_browsers_cache_path`` honors this env var ahead of the platform default.
+    """
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path_factory.mktemp("ms-playwright")))
+
+
 @pytest.fixture
 def overlay_reads_config_toml(monkeypatch):
     """Opt a test back into the config.toml overlay path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,8 +214,19 @@ def _ignore_user_global_config(monkeypatch):
     monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
 
 
+@pytest.fixture(scope="session")
+def _playwright_browsers_root(tmp_path_factory):
+    """One throwaway browser cache for the whole session.
+
+    Session-scoped on purpose: a per-test directory would mean one mkdir per
+    test, and a temp root holding thousands of sibling directories is slow
+    enough to push the timing-sensitive TUI tests into their timeout.
+    """
+    return tmp_path_factory.mktemp("ms-playwright")
+
+
 @pytest.fixture(autouse=True)
-def _isolate_playwright_browsers_path(tmp_path_factory, monkeypatch):
+def _isolate_playwright_browsers_path(_playwright_browsers_root, monkeypatch):
     """Keep the browser cache out of the developer's real Playwright directory.
 
     Tests that fake ``chromium_installed() -> False`` drive the install path,
@@ -223,7 +234,7 @@ def _isolate_playwright_browsers_path(tmp_path_factory, monkeypatch):
     reach ``~/Library/Caches/ms-playwright`` on the machine running them.
     ``_browsers_cache_path`` honors this env var ahead of the platform default.
     """
-    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(tmp_path_factory.mktemp("ms-playwright")))
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(_playwright_browsers_root))
 
 
 @pytest.fixture

--- a/tests/crawler/test_bootstrap_serialization.py
+++ b/tests/crawler/test_bootstrap_serialization.py
@@ -1,0 +1,73 @@
+"""Concurrent Chromium bootstraps must not unpack into the same directory at once."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lilbee.crawler import bootstrap
+
+
+@pytest.fixture(autouse=True)
+def browsers_root(tmp_path, monkeypatch):
+    """Point the browser cache (and so the lock file) at a temp dir."""
+    monkeypatch.setattr(bootstrap, "_browsers_cache_path", lambda: tmp_path)
+    return tmp_path
+
+
+async def test_a_second_bootstrap_waits_and_then_skips_the_install(monkeypatch):
+    """The loser of the race must not run a second install.
+
+    Two callers reach here whenever a POST /setup/crawler races another one or
+    the first-use bootstrap a crawl triggers. Without the lock both spawn
+    ``playwright install chromium`` into one directory and corrupt it.
+    """
+    installs = 0
+    first_inside = asyncio.Event()
+    release_first = asyncio.Event()
+    installed = False
+
+    def _installed() -> bool:
+        return installed
+
+    async def _fake_install(_on_progress) -> None:
+        nonlocal installs, installed
+        installs += 1
+        first_inside.set()
+        await release_first.wait()
+        installed = True
+
+    monkeypatch.setattr(bootstrap, "chromium_installed", _installed)
+    monkeypatch.setattr(bootstrap, "_install_chromium", _fake_install)
+
+    first = asyncio.create_task(bootstrap.bootstrap_chromium())
+    await asyncio.wait_for(first_inside.wait(), timeout=5)
+
+    second = asyncio.create_task(bootstrap.bootstrap_chromium())
+    await asyncio.sleep(0.05)
+    assert not second.done(), "second caller must block on the lock, not install"
+
+    release_first.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=5)
+
+    assert installs == 1
+
+
+async def test_a_lock_timeout_reports_the_wait_instead_of_installing(monkeypatch):
+    """Rather than unpack alongside another install, say what is happening."""
+    monkeypatch.setattr(bootstrap, "chromium_installed", lambda: False)
+    monkeypatch.setattr(bootstrap, "_BOOTSTRAP_LOCK_TIMEOUT_S", 0.05)
+
+    async def _unexpected(_on_progress) -> None:
+        raise AssertionError("must not install while another holds the lock")
+
+    monkeypatch.setattr(bootstrap, "_install_chromium", _unexpected)
+
+    held = bootstrap.FileLock(str(bootstrap._bootstrap_lock_path()))
+    held.acquire()
+    try:
+        with pytest.raises(bootstrap.CrawlerBrowserError, match="Timed out"):
+            await bootstrap.bootstrap_chromium()
+    finally:
+        held.release()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -635,6 +635,11 @@ class TestAddIngestMutex:
         summary = [d for t, d in events if t == "done" and "copied" in d][-1]
         assert "free.txt" in summary["copied"]
         assert "held.txt" not in summary["copied"]
+        # The done event is the only frame a client is guaranteed to still have,
+        # so it has to say the batch was partial. Without this a caller reads
+        # done as "all ingested" and never retries the contended file.
+        assert summary["already_ingesting"] == ["held.txt"]
+        assert "held.txt" not in summary["skipped"]
 
     async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
         """Disjoint sources do not contend: both requests complete with done."""

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -341,3 +341,17 @@ def test_probe_oserror_is_service_unavailable_not_unprocessable(monkeypatch):
         r = client.post("/api/placement/preview", json={"spec": None})
     assert r.status_code == 503
     assert "nvidia-smi" in r.text or "probe" in r.text.lower()
+
+
+def test_put_probe_oserror_is_service_unavailable_when_enabled(monkeypatch):
+    """The apply route maps a failed probe the same way preview does."""
+    _enable_http_placement(monkeypatch)
+
+    async def _boom(_spec):
+        raise PermissionError(13, "Permission denied", "/dev/nvidia0")
+
+    monkeypatch.setattr(handlers, "placement_set", _boom)
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+    assert r.status_code == 503
+    assert "probe" in r.text.lower() or "nvidia-smi" in r.text

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -323,3 +323,21 @@ def test_gpu_stats_stream_probes_off_the_event_loop(monkeypatch):
         r = client.get("/api/gpus/stream")
         assert r.status_code == 200
     assert probe_tid and loop_tid and probe_tid[0] != loop_tid[0]
+
+
+def test_probe_oserror_is_service_unavailable_not_unprocessable(monkeypatch):
+    """A missing vendor tool is a host fault, not a bad spec.
+
+    FileNotFoundError (no nvidia-smi on PATH) and PermissionError (device node)
+    were bundled with PlacementError into a 422, which sends the caller looking
+    for a mistake in JSON that is fine.
+    """
+
+    async def _boom(_spec):
+        raise FileNotFoundError(2, "No such file or directory", "nvidia-smi")
+
+    monkeypatch.setattr(handlers, "placement_preview", _boom)
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": None})
+    assert r.status_code == 503
+    assert "nvidia-smi" in r.text or "probe" in r.text.lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -497,11 +497,16 @@ class TestEnableOcrConfig:
             c = Config()
             assert c.enable_ocr is True
 
-    def test_garbage_value_coerces_via_bool(self) -> None:
-        """Unrecognized string falls through parse_bool and coerces via ``bool()``."""
+    def test_garbage_value_falls_back_to_auto(self) -> None:
+        """An unparseable value must not turn OCR on.
+
+        This used to fall through to ``bool()``, and ``bool("maybe")`` is True,
+        so a typo silently enabled an expensive pass. The sibling bool
+        validators warn and take their default; this one now does too.
+        """
         with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "maybe"}):
             c = Config()
-            assert c.enable_ocr is True  # bool("maybe") is True
+            assert c.enable_ocr is None
 
     def test_whitespace_only_means_auto(self) -> None:
         """Whitespace-only strings hit the auto/none branch and return None."""
@@ -1768,3 +1773,46 @@ class TestActiveConfigScope:
         with config_scope(scoped):
             assert active_config() is scoped
         assert active_config() is cfg
+
+
+class TestBoolVocabularyMatchesPydantic:
+    """parse_bool must accept what pydantic accepts for the same settings object.
+
+    Every other bool field on Config is coerced by pydantic, which takes
+    on/off/y/n/t/f as well. The narrower hand-rolled vocabulary made the same
+    env spelling mean different things on different fields, and on enable_ocr
+    it inverted: the ValueError fell through to bool("off"), which is True.
+    """
+
+    @pytest.mark.parametrize("raw", ["on", "y", "t", "true", "1", "yes", "ON", " on "])
+    def test_truthy_spellings(self, raw):
+        from lilbee.core.config.parsing import parse_bool
+
+        assert parse_bool(raw) is True
+
+    @pytest.mark.parametrize("raw", ["off", "n", "f", "false", "0", "no", "OFF", " off "])
+    def test_falsy_spellings(self, raw):
+        from lilbee.core.config.parsing import parse_bool
+
+        assert parse_bool(raw) is False
+
+    def test_unknown_spelling_still_raises(self):
+        from lilbee.core.config.parsing import parse_bool
+
+        with pytest.raises(ValueError, match="Invalid boolean"):
+            parse_bool("maybe")
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"), [("off", False), ("on", True), ("n", False), ("y", True)]
+    )
+    def test_enable_ocr_agrees_with_pydantic(self, raw, expected):
+        """enable_ocr routed through parse_bool; 'off' used to come back True."""
+        from lilbee.core.config.model import Config
+
+        assert Config(enable_ocr=raw).enable_ocr is expected
+
+    def test_enable_ocr_unknown_value_falls_back_to_auto(self):
+        """An unparseable value must not silently become True via bool()."""
+        from lilbee.core.config.model import Config
+
+        assert Config(enable_ocr="maybe").enable_ocr is None

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4617,6 +4617,20 @@ class TestSourceContentRoute:
         assert resp.headers["content-type"].startswith("application/octet-stream")
         assert "attachment" in resp.headers["content-disposition"]
 
+    @pytest.mark.parametrize("content_type", ["text/xml", "application/xml"])
+    def test_xml_is_never_rendered_inline(self, content_type):
+        """XML can carry an xml-stylesheet PI whose XSLT emits script.
+
+        Asserted on the predicate rather than through a ``.xml`` file because
+        the extension's Content-Type comes from the host mimetypes database:
+        it resolves to ``application/xml`` here, which already degrades, but a
+        host whose database says ``text/xml`` would have matched the ``text/``
+        category and rendered. The verdict must not depend on the host.
+        """
+        from lilbee.server.handlers.documents import _is_safe_for_inline_render
+
+        assert _is_safe_for_inline_render(content_type) is False
+
     async def test_raw_svg_source_forces_octet_stream_attachment(self, isolated_env):
         """SVG can carry script; not in the allowlist → forced to octet-stream."""
         from litestar.testing import AsyncTestClient

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -3816,6 +3816,24 @@ class TestClassifyLoadError:
         assert code == SseErrorCode.MODEL_TOO_LARGE
         assert user_message == "Model too large for available RAM"
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "llama_context: n_ctx_per_seq (8192) > n_ctx_train (4096)",
+            "llama_context: KV cache type not supported",
+            "llama_context: invalid sequence configuration",
+        ],
+    )
+    def test_context_diagnostics_are_not_reported_as_out_of_memory(self, message):
+        """llama_context prefixes a whole family of context diagnostics.
+
+        Matching the bare prefix told users to pick a smaller model when the
+        real fix is a config change, and hid the message that said so.
+        """
+        code, text = handlers.classify_load_error(message)
+        assert code is None
+        assert "too large" not in text.lower()
+
     def test_llama_context_signature_is_classified(self):
         code, _ = handlers.classify_load_error("llama_context: failed to allocate")
         assert code == SseErrorCode.MODEL_TOO_LARGE

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4957,6 +4957,22 @@ class TestSseQueueEviction:
         drained = [queue.get_nowait() for _ in range(queue.qsize())]
         assert drained == ["token-1", "progress-2", "token-2"]
 
+    def test_incoming_progress_is_dropped_when_nothing_is_shedable(self):
+        """With the queue full of tokens there is no progress to shed, so the
+        arriving progress event is the one that goes."""
+        from lilbee.runtime.progress import EventType
+
+        queue = self._queue(max_events=2)
+        queue.put_nowait("token-1")
+        queue.put_nowait("token-2")
+
+        queue.put_event_nowait("progress-1", EventType.EMBED)
+
+        assert queue.qsize() == 2
+        assert queue.dropped_events == 1
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained == ["token-1", "token-2"]
+
     def test_always_delivered_events_are_never_shed(self):
         """done/error/sentinel must land even when nothing is droppable."""
         queue = self._queue(max_events=2)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4925,3 +4925,45 @@ class TestPlacementHandlers:
         event_names = [line.split(":", 1)[1].strip() for line in event_lines]
         assert SseEvent.GPU_STATS in event_names
         assert SseEvent.HEARTBEAT in event_names
+
+
+class TestSseQueueEviction:
+    """The cap only holds if eviction can find the progress events it may shed."""
+
+    def _queue(self, max_events: int = 4):
+        from lilbee.server.handlers.sse import SseEventQueue
+
+        return SseEventQueue(max_events=max_events)
+
+    def test_progress_behind_a_token_is_still_evictable(self):
+        """Head-only eviction gave up whenever a token reached the front.
+
+        A real stream interleaves the two, so the head is non-droppable almost
+        immediately and the queue grew past its cap while still holding
+        progress events it was allowed to drop.
+        """
+        from lilbee.runtime.progress import EventType
+
+        queue = self._queue(max_events=3)
+        queue.put_nowait("token-1")
+        queue.put_event_nowait("progress-1", EventType.EMBED)
+        queue.put_event_nowait("progress-2", EventType.EMBED)
+
+        queue.put_nowait("token-2")
+
+        assert queue.qsize() == 3
+        assert queue.dropped_events == 1
+        # The shed one is the oldest progress, not the token at the head.
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained == ["token-1", "progress-2", "token-2"]
+
+    def test_always_delivered_events_are_never_shed(self):
+        """done/error/sentinel must land even when nothing is droppable."""
+        queue = self._queue(max_events=2)
+        queue.put_nowait("token-1")
+        queue.put_nowait("token-2")
+        queue.put_nowait("done")
+
+        drained = [queue.get_nowait() for _ in range(queue.qsize())]
+        assert drained == ["token-1", "token-2", "done"]
+        assert queue.dropped_events == 0

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -2000,3 +2000,44 @@ class TestPlacementSetRoute:
         """DELETE placement is refused on the shared HTTP daemon."""
         resp = client.delete("/api/placement")
         assert resp.status_code == 409
+
+
+class TestPaginationAndTopKLowerBounds:
+    """Upper bounds without lower bounds let 0 and negatives through.
+
+    LanceDB's plain-query ``limit`` treats anything <= 0 as no limit, so
+    ``?limit=0`` returned the whole table, which is what pagination exists to
+    prevent. A negative ``top_k`` reached the store and surfaced as a 503,
+    blaming the server for a bad request.
+    """
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_documents_limit_rejects_non_positive(self, client, value):
+        resp = client.get("/api/documents", params={"limit": value})
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_catalog_limit_rejects_non_positive(self, client, value):
+        resp = client.get("/api/models/catalog", params={"limit": value})
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_search_top_k_rejects_non_positive(self, client, value):
+        resp = client.get("/api/search", params={"q": "x", "top_k": value})
+        assert resp.status_code == 400
+
+    def test_ask_rejects_negative_top_k_but_keeps_zero(self, client):
+        """Zero is a documented pure-LLM call, so only negatives are invalid."""
+        assert client.post("/api/ask", json={"question": "q", "top_k": -1}).status_code == 400
+
+        with mock.patch(
+            "lilbee.server.handlers.ask",
+            new_callable=AsyncMock,
+            return_value={"answer": "a", "sources": []},
+        ):
+            resp = client.post("/api/ask", json={"question": "q", "top_k": 0})
+        assert resp.status_code == 201
+
+    def test_chat_rejects_negative_top_k(self, client):
+        resp = client.post("/api/chat", json={"question": "q", "history": [], "top_k": -1})
+        assert resp.status_code == 400


### PR DESCRIPTION
Stacked on #570. Review that first; this targets it, so the diff here is only the follow-up commits.

## Problem

An XML document can carry an xml-stylesheet processing instruction whose XSLT emits script. Whether a `.xml` file reached the inline-render check as `text/xml` or `application/xml` depended on the host mimetypes database, and only the `text/` spelling matched the category rule.

Two concurrent Chromium bootstraps unpacked a browser bundle into the same directory. `chromium_installed()` is the only short-circuit and stays False for both callers until one finishes, so a second `POST /setup/crawler`, or a crawl triggering first-use bootstrap alongside one, corrupted the install.

`limit` and `top_k` had upper bounds with no lower bounds. LanceDB treats a plain-query limit of `<= 0` as no limit, so `GET /api/documents?limit=0` returned the entire sources table. A negative `top_k` reached the store and came back as a 503.

A partial ingest emitted a normal `done` event listing only the sources it managed to lock. A client reading `done` as success considered the whole batch ingested; the busy files were never copied.

`parse_bool` accepted a narrower vocabulary than pydantic, which coerces every other bool on the same `Config`. On `enable_ocr` the mismatch inverted the value: the ValueError fell through to `bool(v)`, and `bool("off")` is True, so `LILBEE_ENABLE_OCR=off` turned OCR on.

Placement mapped `OSError` to 422 alongside `PlacementError`, so a missing `nvidia-smi` or an unreadable device node told the caller their spec was unprocessable.

`classify_load_error` treated the bare `llama_context` substring as out-of-memory, but that is the prefix llama.cpp puts on every context-subsystem diagnostic. An n_ctx-over-training-context or KV-cache rejection was reported as "Model too large for available RAM".

SSE eviction inspected only the queue head, so it reported nothing-to-shed as soon as a token reached the front, even while droppable progress events sat behind it.

## Solution

`text/xml` and `application/xml` are denied inline. Kept the explicit deny list rather than switching to a strict allowlist, because `image/*` by category is a deliberate decision pinned by an existing test.

`bootstrap_chromium` takes a cross-process file lock and re-checks `chromium_installed()` after acquiring, so the loser skips the install. The guard sits in the bootstrap rather than the route so the first-use path is covered too. The lock is not thread-local: the acquire is offloaded to a worker thread to keep the event loop free, and a thread-local lock would never count the release from the loop thread.

`limit` and the search `top_k` require `>= 1`. The ask and chat bodies require `>= 0`, because an explicit `top_k` of 0 is a documented pure-LLM call that skips retrieval.

The ingest `done` summary carries `already_ingesting` naming the sources this run never attempted. Separate from `skipped`, which means examined and unchanged.

`parse_bool` matches pydantic's vocabulary, and an unparseable `enable_ocr` warns and auto-detects like the sibling validators.

Placement returns 503 for a failed probe, with the vendor tool named and the real error logged.

`classify_load_error` matches on the allocation-failure wording.

SSE eviction scans for the oldest droppable event. A pure token stream to a stalled client is still unbounded, since tokens are in the always-deliver class; bounding that means dropping answer text or applying backpressure to the generation thread, so it is filed rather than decided here.

One test-only change: the browser-cache isolation fixture is session-scoped. Per-test it created a temp directory for every test in the suite, and that churn pushed timing-sensitive TUI tests into their 60s timeout.
