### PR TITLE
Lock the wiki writers that were missing it, key ingest locks on the real source

### DIFF
--- a/src/lilbee/runtime/ingest_lock.py
+++ b/src/lilbee/runtime/ingest_lock.py
@@ -49,16 +49,25 @@ class IngestLockRegistry:
 
     @staticmethod
     def canonical_source_name(p_str: str) -> str:
-        """Match the basename ``copy_files`` writes under ``cfg.documents_dir``."""
+        """Basename of *p_str*, for callers that flatten into ``documents_dir``.
+
+        ``copy_files`` writes server-side paths by basename, so /api/add locks
+        on that. Uploads keep their relative layout and pass the relative path
+        instead, which is why the caller picks the key rather than this class.
+        """
         return Path(p_str).name
 
-    async def acquire(self, paths: list[str]) -> tuple[list[tuple[str, asyncio.Lock]], list[str]]:
-        """Return ``(acquired, busy)`` partitioning of ``paths`` by lock state."""
+    async def acquire(self, names: list[str]) -> tuple[list[tuple[str, asyncio.Lock]], list[str]]:
+        """Return ``(acquired, busy)`` partitioning of ``names`` by lock state.
+
+        Each name is the source identity as it will exist on disk; the caller
+        derives it, because how a path maps to a stored source differs per
+        ingest surface.
+        """
         acquired: list[tuple[str, asyncio.Lock]] = []
         busy: list[str] = []
         seen: set[str] = set()
-        for p_str in paths:
-            name = self.canonical_source_name(p_str)
+        for name in names:
             if name in seen:
                 continue
             seen.add(name)

--- a/src/lilbee/server/chat_completions_api/streaming.py
+++ b/src/lilbee/server/chat_completions_api/streaming.py
@@ -47,17 +47,15 @@ async def encode_completions_sse(
     finally:
         if not pending.done():
             pending.cancel()
-            current = asyncio.current_task()
             try:
                 await pending
             except asyncio.CancelledError:
-                # Awaiting the future we just cancelled raises here, which is
-                # expected. A cancellation aimed at this task is not: this
-                # cleanup runs during aclose(), which the server calls while
-                # unwinding a request that is often itself being cancelled, and
-                # swallowing that let the task resume as if it never was.
-                if current is not None and current.cancelling() > 0:
-                    raise
+                # Expected: this is the future we just cancelled. Caught by
+                # name rather than as BaseException, which also covered
+                # KeyboardInterrupt and SystemExit, so a Ctrl-C landing on this
+                # await was discarded. A cancellation aimed at this task is
+                # already unwinding through the finally and keeps propagating.
+                pass
             except Exception:
                 # The upstream failed as it was torn down. The request is
                 # already unwinding, so record it rather than mask the unwind.

--- a/src/lilbee/server/chat_completions_api/streaming.py
+++ b/src/lilbee/server/chat_completions_api/streaming.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
+import logging
 from collections.abc import AsyncIterator
 
 from lilbee.server.chat_completions_api.models import CompletionsStreamChunk
+
+log = logging.getLogger(__name__)
 
 # Cadence for SSE comment frames emitted when no chat token has arrived. Keeps
 # clients (notably opencode) from tripping their idle-stream timeout during
@@ -45,6 +47,19 @@ async def encode_completions_sse(
     finally:
         if not pending.done():
             pending.cancel()
-            with contextlib.suppress(BaseException):
+            current = asyncio.current_task()
+            try:
                 await pending
+            except asyncio.CancelledError:
+                # Awaiting the future we just cancelled raises here, which is
+                # expected. A cancellation aimed at this task is not: this
+                # cleanup runs during aclose(), which the server calls while
+                # unwinding a request that is often itself being cancelled, and
+                # swallowing that let the task resume as if it never was.
+                if current is not None and current.cancelling() > 0:
+                    raise
+            except Exception:
+                # The upstream failed as it was torn down. The request is
+                # already unwinding, so record it rather than mask the unwind.
+                log.debug("upstream chat stream errored during cleanup", exc_info=True)
     yield b"data: [DONE]\n\n"

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -14,6 +14,7 @@ from lilbee.app.ingest import copy_files
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.security import validate_path_within
+from lilbee.runtime.ingest_lock import IngestLockRegistry
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.sse import SseStream, sse_done, sse_error, sse_event
 from lilbee.server.models import AddSummary, SyncSummary
@@ -173,11 +174,7 @@ async def _ingest_stream(
             return
 
         acquired_names = {name for name, _lock in acquired}
-        locked = [
-            payload
-            for key, payload in items
-            if registry.canonical_source_name(key) in acquired_names
-        ]
+        locked = [payload for key, payload in items if key in acquired_names]
         sse = SseStream()
         task = asyncio.create_task(run(locked, sse))
         try:
@@ -215,7 +212,7 @@ async def add_files_stream(
     request dict is decoded once.
     """
     async for event in _ingest_stream(
-        [(p, p) for p in paths],
+        [(IngestLockRegistry.canonical_source_name(p), p) for p in paths],
         lambda locked, sse: _run_add(locked, force, enable_ocr, ocr_timeout, sse),
         "Add files stream",
     ):

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -126,9 +126,11 @@ async def wiki_draft_accept_route(slug: str) -> WikiDraftAcceptResponse:
     slug = slug.lstrip("/")
     store = svc_mod.get_services().store
     try:
-        # accept_draft re-chunks and embeds the page; offload so it doesn't block
-        # the event loop (and every other REST/MCP request on it).
-        result = await asyncio.to_thread(accept_draft, slug, _wiki_root(), store)
+        # accept_draft overwrites a published page and refreshes the index, the
+        # same artifacts a build writes, so it shares the build mutex. It also
+        # re-chunks and embeds, so it runs off the event loop.
+        async with _wiki_build_lock():
+            result = await asyncio.to_thread(accept_draft, slug, _wiki_root(), store)
     except FileNotFoundError as exc:
         raise NotFoundException(detail=f"draft not found: {slug}") from exc
     except PathTraversalError as exc:
@@ -213,8 +215,11 @@ async def wiki_lint_route() -> WikiLintResult:
 async def wiki_prune_route() -> WikiPruneResult:
     """Trigger pruning of stale/orphaned wiki pages."""
     _require_wiki()
-    # prune_wiki walks the whole wiki tree and store; offload off the loop.
-    report = await asyncio.to_thread(prune_mod.prune_wiki, svc_mod.get_services().store)
+    # prune archives pages and rewrites the index, so it takes the build mutex
+    # like the other writers. It also walks the whole tree and store, so it runs
+    # off the event loop.
+    async with _wiki_build_lock():
+        report = await asyncio.to_thread(prune_mod.prune_wiki, svc_mod.get_services().store)
     return WikiPruneResult(
         records=[WikiPruneRecordResponse(**r.to_dict()) for r in report.records],
         archived=report.archived_count,

--- a/tests/server/chat_completions_api/test_streaming.py
+++ b/tests/server/chat_completions_api/test_streaming.py
@@ -207,3 +207,24 @@ class TestCleanupSuppression:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert task.cancelled()
+
+    async def test_upstream_failure_during_cleanup_does_not_mask_the_unwind(self) -> None:
+        """An upstream that errors as it is torn down is recorded, not raised."""
+        import asyncio
+
+        started = asyncio.Event()
+
+        async def _fails_on_cancel() -> AsyncIterator[CompletionsStreamChunk]:
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise RuntimeError("upstream died during teardown") from None
+            yield _chunk(delta=CompletionsStreamDelta(content="unreachable"))
+
+        encoder = encode_completions_sse(_fails_on_cancel())
+        assert await encoder.__anext__() == _KEEPALIVE_FRAME
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        # aclose() completes rather than surfacing the upstream's error.
+        await encoder.aclose()

--- a/tests/server/chat_completions_api/test_streaming.py
+++ b/tests/server/chat_completions_api/test_streaming.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator
 
+import pytest
+
 from lilbee.server.chat_completions_api.models import (
     CompletionsStreamChoice,
     CompletionsStreamChunk,
@@ -176,3 +178,32 @@ class TestEncodeCompletionsSse:
         assert text.count(keepalive) >= 2
         assert "finally" in text
         assert text.endswith("data: [DONE]\n\n")
+
+
+class TestCleanupSuppression:
+    """The cleanup cancels its in-flight future and awaits it. Suppressing
+    BaseException there also discarded KeyboardInterrupt and SystemExit."""
+
+    async def test_consumer_cancellation_still_propagates(self) -> None:
+        """Regression guard: cancelling the consumer must cancel the task."""
+        import asyncio
+
+        started = asyncio.Event()
+
+        async def _never_yields() -> AsyncIterator[CompletionsStreamChunk]:
+            started.set()
+            await asyncio.Event().wait()
+            yield _chunk(delta=CompletionsStreamDelta(content="unreachable"))
+
+        async def _consume() -> None:
+            async for _frame in encode_completions_sse(_never_yields()):
+                pass
+
+        task = asyncio.create_task(_consume())
+        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -573,17 +573,25 @@ class TestAddIngestMutex:
         registry.release(held)
         assert registry._locks == {}
 
-    async def test_acquire_add_locks_dedups_repeated_paths(self, isolated_env):
-        """Duplicate paths in one request collapse to a single acquired lock."""
+    async def test_acquire_dedups_repeated_names(self, isolated_env):
+        """The registry locks each distinct name once."""
         from lilbee.app.services import get_services
 
         registry = get_services().ingest_lock_registry
-        acquired, busy = await registry.acquire(["/x/doc.txt", "/y/doc.txt"])
+        acquired, busy = await registry.acquire(["doc.txt", "doc.txt"])
         try:
             assert busy == []
             assert [name for name, _ in acquired] == ["doc.txt"]
         finally:
             registry.release(acquired)
+
+    def test_add_locks_server_paths_by_basename(self):
+        """/api/add flattens into documents_dir, so two paths sharing a
+        basename are one source and must share one lock."""
+        from lilbee.runtime.ingest_lock import IngestLockRegistry
+
+        assert IngestLockRegistry.canonical_source_name("/x/doc.txt") == "doc.txt"
+        assert IngestLockRegistry.canonical_source_name("/y/doc.txt") == "doc.txt"
 
     async def test_second_concurrent_add_emits_already_ingesting(self, isolated_env, tmp_path):
         """Second /api/add for a held source yields already_ingesting, no done."""
@@ -640,6 +648,24 @@ class TestAddIngestMutex:
         # done as "all ingested" and never retries the contended file.
         assert summary["already_ingesting"] == ["held.txt"]
         assert "held.txt" not in summary["skipped"]
+
+    async def test_distinct_relative_paths_get_distinct_locks(self, isolated_env):
+        """Two uploads that land at different paths must not share one lock.
+
+        The registry reduced every key to its basename. That is right for
+        /api/add, where copy_files flattens into documents_dir, but uploads
+        keep their relative layout, so src/util.py and tests/util.py are
+        different files that were being serialized against each other.
+        """
+        from lilbee.app.services import get_services
+
+        registry = get_services().ingest_lock_registry
+        acquired, busy = await registry.acquire(["src/util.py", "tests/util.py"])
+        try:
+            assert busy == []
+            assert sorted(name for name, _lock in acquired) == ["src/util.py", "tests/util.py"]
+        finally:
+            registry.release(acquired)
 
     async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
         """Disjoint sources do not contend: both requests complete with done."""

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -922,3 +922,60 @@ class TestWikiDisabledStatusIsCheap:
         assert resp.status_code == 200
         assert resp.json()["wiki_enabled"] is False
         lint_all.assert_not_called()
+
+
+class TestEveryWikiWriterSharesTheBuildMutex:
+    """The mutex exists because concurrent writers corrupt the tree and index.
+
+    Build, update and synthesize took it; prune and draft-accept did not, even
+    though prune archives pages and both refresh index.md, which is the file the
+    lock's own comment names.
+
+    Drives the handlers directly rather than through AsyncTestClient, which
+    serializes requests and so cannot tell a held lock from an absent one.
+    """
+
+    @pytest.fixture(autouse=True)
+    def enable_wiki(self):
+        cfg.wiki = True
+
+    async def test_prune_serializes_against_a_build(self, monkeypatch, isolated_env: Path):
+        import asyncio
+        import time
+        from unittest import mock
+
+        from lilbee.server import wiki as _wiki_mod
+
+        _wiki_mod._reset_wiki_build_lock()
+        spans: list[tuple[str, float, float]] = []
+        hold_s = 0.1
+        skew_s = 0.01
+
+        def _record(label, result):
+            def _run(*_args, **_kwargs):
+                start = time.monotonic()
+                time.sleep(hold_s)
+                spans.append((label, start, time.monotonic()))
+                return result
+
+            return _run
+
+        monkeypatch.setattr(
+            "lilbee.server.wiki.run_full_build",
+            _record("build", {"paths": [], "entities": 0, "count": 0}),
+        )
+        monkeypatch.setattr(
+            "lilbee.server.wiki.prune_mod.prune_wiki",
+            _record("prune", mock.MagicMock(records=[], archived_count=0, flagged_count=0)),
+        )
+
+        try:
+            await asyncio.gather(
+                _wiki_mod.wiki_build_route.fn(),
+                _wiki_mod.wiki_prune_route.fn(),
+            )
+            assert len(spans) == 2
+            first, second = sorted(spans, key=lambda s: s[1])
+            assert second[1] >= first[2] - skew_s, f"prune and build overlapped: {spans}"
+        finally:
+            _wiki_mod._reset_wiki_build_lock()


### PR DESCRIPTION
Stacked on #574, which is stacked on #570. Review those first; the diff here is only the three follow-up commits.

## Problem

The wiki build mutex exists because concurrent writers corrupt the pages, the index and the log. Build, update and synthesize took it. Prune, which archives and flags pages, and draft-accept, which overwrites a published page and re-indexes its chunks, did not. Both refresh `index.md`, the file the lock's own comment names.

The ingest lock registry reduced every key to its basename. That is right for `/api/add`, where `copy_files` flattens into `documents_dir`, but uploads keep their relative layout, so `src/util.py` and `tests/util.py` are different files that were serialized against each other and reported as contending.

The SSE cleanup cancels its in-flight future and awaited it under `contextlib.suppress(BaseException)`, which also covers `KeyboardInterrupt` and `SystemExit`, so a Ctrl-C landing on that await was discarded.

## Solution

Prune and draft-accept take the build mutex.

The ingest caller derives the lock identity, because how a path maps to a stored source differs per surface. `add` passes the basename explicitly; uploads pass the relative path they actually write.

The SSE cleanup catches `CancelledError` and `Exception` by name, and logs an upstream failure instead of dropping it silently.

## Notes for review

The serialization test drives the route handlers directly. Going through `AsyncTestClient` does not work: it serializes the requests it is given, so such a test passes whether or not the lock is there. The existing build-vs-build test has that flaw and is filed separately.

The bead behind the SSE change also claimed the suppression let a cancelled request task resume as if it had never been cancelled. That does not hold: `contextlib.suppress` inside a `finally` only suppresses exceptions raised within its own block, so a `CancelledError` already unwinding keeps propagating. Verified against both versions. Only the `BaseException` width was real, so the fix is just the narrowing.
