### PR TITLE
Auto-dispatch the compat packaging fan-out on release

### DIFF
--- a/.github/workflows/publish-compat-packages.yml
+++ b/.github/workflows/publish-compat-packages.yml
@@ -2,9 +2,10 @@ name: Publish compat packages
 
 # Pins a tag's pre-Haswell Linux binary into the lilbee-compat channels: the
 # Homebrew lilbee-compat formula, the AUR lilbee-compat PKGBUILD, the Nix flake
-# compat entry, and a lilbee-compat snap. Runs manually after release.yml has
-# attached lilbee-compat-linux-x86_64. Separate from publish-packages.yml (like
-# publish-cuda-packages.yml) so the default channels are never touched.
+# compat entry, and a lilbee-compat snap. release-candidate.yml dispatches it
+# after attach-prerelease; workflow_dispatch remains for manual re-runs.
+# Separate from publish-packages.yml (like publish-cuda-packages.yml) so the
+# default channels are never touched.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -315,6 +315,21 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh workflow run publish-cuda-packages.yml --repo "${REPO}" -f tag="${TAG}"
 
+  # Auto-dispatch the compat packaging fan-out once the compat executables are
+  # on the release. Fire-and-forget: a compat failure never blocks the release.
+  dispatch-compat:
+    needs: [resolve, attach-prerelease]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: gh workflow run publish-compat-packages.yml --repo "${REPO}" -f tag="${TAG}"
+
   # Supplementary opt-in lilbee[multi-gpu] artifacts on their OWN path. Fully
   # decoupled: not in attach-prerelease's needs and not gating dispatch-publish,
   # so a failure here never blocks the release. Builds are continue-on-error.


### PR DESCRIPTION
## Problem

The lilbee-compat channels (Homebrew formula, AUR PKGBUILD, Nix flake entry, snap) are published by publish-compat-packages.yml, which until now only ran on a manual workflow_dispatch. Every other packaging fan-out (default packages, CUDA, Docker) is dispatched automatically by release-candidate.yml once the release assets land, so the compat publish depended on someone remembering to trigger it. dev724 shipped without its compat snap and flatpak attached until the publish was run by hand after the fact.

## Solution

Dispatch publish-compat-packages.yml from release-candidate.yml after attach-prerelease, mirroring the existing dispatch-cuda job. The compat workflow's resolve step requires lilbee-compat-linux-x86_64 on the release, and attach-prerelease is the job that attaches it, so the ordering is guaranteed by the needs edge. The dispatch is fire-and-forget (gh workflow run, no waiting), so a compat failure never blocks the release. The workflow stays dispatchable by hand for re-runs.