### PR TITLE
Let scripted side_effect sequences absorb surplus mock calls

### DIFF
--- a/tests/_mock_effects.py
+++ b/tests/_mock_effects.py
@@ -1,0 +1,18 @@
+"""side_effect sequences that tolerate more calls than scripted.
+
+An exact-length ``side_effect=[...]`` list raises ``StopIteration`` the
+moment the mocked call happens once more than the author assumed, which
+presents as an unrelated failure. ``repeat_last`` keeps yielding the final
+effect instead, so a surplus call trips the test's own assertions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from itertools import chain, repeat
+from typing import Any
+
+
+def repeat_last(*effects: Any) -> Iterator[Any]:
+    """Yield each effect in order, then the last one forever."""
+    return chain(effects, repeat(effects[-1]))

--- a/tests/cli/test_hermes_mcp.py
+++ b/tests/cli/test_hermes_mcp.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from lilbee.cli.launchers import hermes_mcp
+from tests._mock_effects import repeat_last
 
 
 def _script(tmp_path, shebang: str):
@@ -70,7 +71,7 @@ def test_ensure_installs_pinned_extra_when_missing_and_allowed(tmp_path):
     binary = _script(tmp_path, "#!/opt/venv/bin/python")
     msgs: list[str] = []
     with (
-        patch.object(hermes_mcp, "has_http_mcp", side_effect=[False, True]),
+        patch.object(hermes_mcp, "has_http_mcp", side_effect=repeat_last(False, True)),
         patch.object(hermes_mcp, "_mcp_extra_requirements", return_value=["mcp==1.26.0"]),
         patch.object(hermes_mcp.subprocess, "run") as run,
     ):
@@ -98,7 +99,7 @@ def test_ensure_guides_when_install_did_not_take(tmp_path):
     msgs: list[str] = []
     proc = SimpleNamespace(returncode=1, stderr="error: externally-managed-environment", stdout="")
     with (
-        patch.object(hermes_mcp, "has_http_mcp", side_effect=[False, False]),
+        patch.object(hermes_mcp, "has_http_mcp", side_effect=repeat_last(False, False)),
         patch.object(hermes_mcp, "_mcp_extra_requirements", return_value=["mcp"]),
         patch.object(hermes_mcp.subprocess, "run", return_value=proc),
     ):

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -16,6 +16,7 @@ import pytest
 
 from lilbee.cli.launchers import server as server_mod
 from lilbee.core.config import cfg
+from tests._mock_effects import repeat_last
 
 
 @pytest.fixture()
@@ -193,13 +194,17 @@ class TestEnsureServerRunningRetries:
     def test_retries_with_a_fresh_port_then_succeeds(self, monkeypatch) -> None:
         first, second = self._proc(), self._proc()
         monkeypatch.setattr(
-            server_mod, "running_server_session", mock.MagicMock(side_effect=[None, ("tok", 2222)])
+            server_mod,
+            "running_server_session",
+            mock.MagicMock(side_effect=repeat_last(None, ("tok", 2222))),
         )
-        monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[1111, 2222]))
-        spawn = mock.MagicMock(side_effect=[first, second])
+        monkeypatch.setattr(
+            server_mod, "free_port", mock.MagicMock(side_effect=repeat_last(1111, 2222))
+        )
+        spawn = mock.MagicMock(side_effect=repeat_last(first, second))
         monkeypatch.setattr(server_mod, "spawn_server", spawn)
         monkeypatch.setattr(
-            server_mod, "wait_for_health", mock.MagicMock(side_effect=[False, True])
+            server_mod, "wait_for_health", mock.MagicMock(side_effect=repeat_last(False, True))
         )
 
         session, spawned = server_mod.ensure_server_running()
@@ -218,7 +223,9 @@ class TestEnsureServerRunningRetries:
 
         procs = [self._proc() for _ in range(server_mod._SPAWN_ATTEMPTS)]
         monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
-        monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[1, 2, 3]))
+        monkeypatch.setattr(
+            server_mod, "free_port", mock.MagicMock(side_effect=repeat_last(1, 2, 3))
+        )
         spawn = mock.MagicMock(side_effect=procs)
         monkeypatch.setattr(server_mod, "spawn_server", spawn)
         monkeypatch.setattr(server_mod, "wait_for_health", lambda _p: False)
@@ -236,7 +243,9 @@ class TestEnsureServerRunningRetries:
 
         monkeypatch.setattr(cfg, "server_port", 8080)
         monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
-        monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[1, 2, 3]))
+        monkeypatch.setattr(
+            server_mod, "free_port", mock.MagicMock(side_effect=repeat_last(1, 2, 3))
+        )
         seen: list[int] = []
         monkeypatch.setattr(
             server_mod, "_spawn_and_wait", lambda port, **_kw: seen.append(port) or None
@@ -251,7 +260,9 @@ class TestEnsureServerRunningRetries:
 
         monkeypatch.setattr(cfg, "server_port", 0)
         monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
-        monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[7, 8, 9]))
+        monkeypatch.setattr(
+            server_mod, "free_port", mock.MagicMock(side_effect=repeat_last(7, 8, 9))
+        )
         seen: list[int] = []
         monkeypatch.setattr(
             server_mod, "_spawn_and_wait", lambda port, **_kw: seen.append(port) or None

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -66,6 +66,17 @@ class _CatalogTestApp(LilbeeAppHost):
         yield CatalogScreen()
 
 
+def _unmounted_tab_strip_active(*args: object) -> str:
+    """PropertyMock side_effect for a tab strip whose Tab children never mounted.
+
+    Any get reports "discover"; any set raises the way Textual's active
+    validator does, no matter how many times the code under test retries.
+    """
+    if args:
+        raise ValueError("No Tab with id '--content-tab-chat'")
+    return "discover"
+
+
 def _fake_tabs_query_one(screen: CatalogScreen, fake_tabs: object):
     """A ``query_one`` substitute faking only the ``#catalog-tabs`` strip.
 
@@ -606,13 +617,7 @@ async def test_activate_initial_tab_retries_while_tab_strip_mounts(monkeypatch) 
         screen._activation_settled = False
         screen._active_tab_id_cache = "chat"
         fake_tabs = mock.MagicMock()
-        type(fake_tabs).active = mock.PropertyMock(
-            return_value="discover",
-            side_effect=[  # get, then set raises
-                "discover",
-                ValueError("No Tab with id '--content-tab-chat'"),
-            ],
-        )
+        type(fake_tabs).active = mock.PropertyMock(side_effect=_unmounted_tab_strip_active)
         rescheduled: list[object] = []
         monkeypatch.setattr(screen, "query_one", _fake_tabs_query_one(screen, fake_tabs))
         monkeypatch.setattr(screen, "call_after_refresh", lambda fn, *a: rescheduled.append(fn))
@@ -634,10 +639,7 @@ async def test_activate_initial_tab_retry_budget_exhausts(monkeypatch) -> None:
         screen._active_tab_id_cache = "chat"
         screen._activation_retries = 0
         fake_tabs = mock.MagicMock()
-        type(fake_tabs).active = mock.PropertyMock(
-            return_value="discover",
-            side_effect=["discover", ValueError("No Tab with id '--content-tab-chat'")],
-        )
+        type(fake_tabs).active = mock.PropertyMock(side_effect=_unmounted_tab_strip_active)
         rescheduled: list[object] = []
         monkeypatch.setattr(screen, "query_one", _fake_tabs_query_one(screen, fake_tabs))
         monkeypatch.setattr(screen, "call_after_refresh", lambda fn, *a: rescheduled.append(fn))

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from lilbee.data.chunk import chunk_text
+from tests._mock_effects import repeat_last
 
 
 @dataclass
@@ -400,7 +401,9 @@ class Greeter:
         from lilbee.data.code_chunker import PackConfig, _ensure_language
 
         with (
-            patch("lilbee.data.code_chunker.has_language", side_effect=[False, True]) as has,
+            patch(
+                "lilbee.data.code_chunker.has_language", side_effect=repeat_last(False, True)
+            ) as has,
             patch("lilbee.data.code_chunker.init") as init_mock,
         ):
             assert _ensure_language("python") is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from lilbee.core.security import PathTraversalError
 from lilbee.data.ingest import SyncResult
 from lilbee.data.store import SearchChunk
 from lilbee.modelhub.models import list_installed_models
+from tests._mock_effects import repeat_last
 
 runner = CliRunner()
 
@@ -3862,7 +3863,7 @@ class TestSelfCheck:
         with (
             mock.patch(
                 "lilbee.cli.commands.setup._download_self_check_model",
-                side_effect=[chat, emb],
+                side_effect=repeat_last(chat, emb),
             ),
             chat_patch,
             embed_patch,
@@ -4344,7 +4345,7 @@ class TestDownloadSelfCheckModel:
                 return b"ok"
 
         urlopen = mock.Mock(
-            side_effect=[urllib.error.URLError("flaky"), _Resp()],
+            side_effect=repeat_last(urllib.error.URLError("flaky"), _Resp()),
         )
         with (
             mock.patch("tempfile.mkdtemp", return_value=str(tmp_path)),

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -38,6 +38,7 @@ from lilbee.crawler.save import (
     normalize_crawled_markdown,
 )
 from lilbee.runtime.progress import EventType
+from tests._mock_effects import repeat_last
 from tests._sys_modules import inject_modules
 
 
@@ -524,7 +525,7 @@ class TestCrawlSingle:
             side_effect=RuntimeError("launch: Executable doesn't exist at chromium-1208/...")
         )
         fail_instance.__aexit__ = AsyncMock(return_value=False)
-        mock_crawler_cls = MagicMock(side_effect=[fail_instance, ok_instance])
+        mock_crawler_cls = MagicMock(side_effect=repeat_last(fail_instance, ok_instance))
         mock_mod = _mock_crawl4ai(mock_crawler_cls)
         bootstrapped: list[bool] = []
 
@@ -548,7 +549,7 @@ class TestCrawlSingle:
         retry_fail = AsyncMock()
         retry_fail.__aenter__ = AsyncMock(side_effect=RuntimeError("still broken after bootstrap"))
         retry_fail.__aexit__ = AsyncMock(return_value=False)
-        mock_crawler_cls = MagicMock(side_effect=[fail_instance, retry_fail])
+        mock_crawler_cls = MagicMock(side_effect=repeat_last(fail_instance, retry_fail))
         mock_mod = _mock_crawl4ai(mock_crawler_cls)
 
         async def fake_bootstrap(on_progress):

--- a/tests/test_mock_effects.py
+++ b/tests/test_mock_effects.py
@@ -1,0 +1,25 @@
+"""Tests for the shared side_effect tail helper."""
+
+from unittest import mock
+
+import pytest
+
+from tests._mock_effects import repeat_last
+
+
+def test_surplus_calls_return_the_last_effect():
+    m = mock.Mock(side_effect=repeat_last(1, 2))
+    assert [m(), m(), m(), m()] == [1, 2, 2, 2]
+
+
+def test_exception_effects_still_raise():
+    m = mock.Mock(side_effect=repeat_last(ValueError("boom"), "ok"))
+    with pytest.raises(ValueError, match="boom"):
+        m()
+    assert m() == "ok"
+    assert m() == "ok"
+
+
+def test_single_effect_repeats():
+    m = mock.Mock(side_effect=repeat_last("only"))
+    assert [m(), m()] == ["only", "only"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@ import pytest
 
 from lilbee.modelhub import models
 from lilbee.modelhub.models import MODEL_CATALOG, ModelInfo
+from tests._mock_effects import repeat_last
 
 
 class TestModelCatalog:
@@ -182,7 +183,7 @@ class TestPromptModelChoice:
 
     @mock.patch.object(models, "get_free_disk_gb", return_value=50.0)
     def test_invalid_then_valid(self, mock_disk_estimate):
-        with mock.patch("builtins.input", side_effect=["abc", "99", "2"]):
+        with mock.patch("builtins.input", side_effect=repeat_last("abc", "99", "2")):
             result = models.prompt_model_choice(8.0)
         assert result == MODEL_CATALOG[1]
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -19,6 +19,7 @@ from lilbee.data.store import (
     scope_to_chunk_type,
 )
 from lilbee.runtime.lock import write_lock
+from tests._mock_effects import repeat_last
 
 
 @pytest.fixture()
@@ -1964,7 +1965,7 @@ class TestEmbeddingModelGate:
             "schema_version": 1,
             "updated_at": "2026-04-26T00:00:00+00:00",
         }
-        with mock.patch.object(store, "get_meta", side_effect=[None, winning_meta]):
+        with mock.patch.object(store, "get_meta", side_effect=repeat_last(None, winning_meta)):
             assert store.initialize_meta_if_legacy() is False
 
 


### PR DESCRIPTION
## Problem

Eighteen tests script mocks with an exact-length `side_effect=[...]` list. The moment the mocked call happens once more than the author assumed, the list exhausts and raises StopIteration, which presents as an unrelated failure with no useful traceback. On a loaded CI host that extra call is exactly what happens: the Windows 3.12 lane has failed this way on a fully mocked test whose only upstream change was comment text.

## Solution

Add a small shared helper, `tests/_mock_effects.repeat_last`, which chains the scripted effects into an endless repeat of the last one, and convert all 18 list-literal sites to it. A surplus call now returns the last scripted value and the test fails, if at all, on its own assertions with a readable diff. The two PropertyMock sites in the catalog tests script a get followed by a raising set, so they become a callable instead: any get reports the current tab and any set raises the way Textual's active validator does, however many times the code under test retries.