### PR TITLE
Fix the random ValueError from the catalog tab strip under parallel pytest

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -407,7 +407,7 @@ class CatalogScreen(Screen[None]):
         with Horizontal(id="catalog-body"):
             with (
                 Container(id="catalog-tabs-wrap"),
-                TabbedContent(initial=TAB_CHAT, id="catalog-tabs"),
+                TabbedContent(id="catalog-tabs"),
             ):
                 with TabPane(msg.CATALOG_TAB_DISCOVER, id=TAB_DISCOVER):
                     yield DiscoverRails(id="discover-rails")
@@ -443,11 +443,12 @@ class CatalogScreen(Screen[None]):
 
     def on_mount(self) -> None:
         self._fetch_installed_names()
-        # Force Chat as the initial active tab. `TabbedContent(initial=...)`
-        # doesn't take effect when panes are added via `with TabPane(...)`
-        # (Textual resolves initial at construction time but the panes mount
-        # after), so we set active explicitly via call_after_refresh so the
-        # TabActivated cascade has already settled before our setter runs.
+        # Force Chat as the initial active tab. Deliberately not
+        # `TabbedContent(initial=...)`: that arms `Tabs._on_mount` to assign the
+        # active tab unconditionally, and when the app tears down mid-mount
+        # Textual's `mount_all` no-ops, so the strip has no Tab children yet and
+        # the assignment raises `ValueError: No Tab with id`. Setting it here via
+        # call_after_refresh also lets the TabActivated cascade settle first.
         # Chat is the most common landing destination; users opt into
         # Discover via keyboard shortcut.
         self.call_after_refresh(self._activate_initial_tab)

--- a/tests/test_catalog_teardown_mid_mount.py
+++ b/tests/test_catalog_teardown_mid_mount.py
@@ -1,0 +1,55 @@
+"""Tearing the app down while the catalog is still mounting must not raise.
+
+Textual's ``Widget.mount``/``mount_all`` no-op once the app is exiting or the
+widget is being pruned, so a ``TabbedContent`` caught in that window mounts its
+tab strip with no ``Tab`` children. A strip built with ``initial=`` then hits
+``Tabs._on_mount``, which assigns the initial tab unconditionally and raises
+``ValueError: No Tab with id ...``. Under parallel pytest the teardown lands in
+that window often enough to redden CI at random.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Footer, TabbedContent
+
+from lilbee.cli.tui.screens.catalog import CatalogScreen
+from lilbee.cli.tui.screens.catalog_utils import TAB_CHAT
+from tests._lilbee_app_test_host import LilbeeAppHost, pump_until
+
+
+class _CatalogApp(LilbeeAppHost):
+    def compose(self) -> ComposeResult:
+        yield Footer()
+
+
+@pytest.mark.parametrize("hops", range(9))
+async def test_teardown_during_catalog_mount_is_clean(hops: int) -> None:
+    """Shutting down `hops` event-loop hops into the mount must not raise."""
+    app = _CatalogApp()
+    with patch.object(CatalogScreen, "_fetch_remote_models"):
+        async with app.run_test():
+            app.push_screen(CatalogScreen())
+            for _ in range(hops):
+                await asyncio.sleep(0)
+
+
+async def test_catalog_still_lands_on_chat_tab() -> None:
+    """Dropping ``initial=`` must not cost the Chat landing tab.
+
+    Without ``initial=`` the strip starts on the first pane and Chat is
+    activated a refresh later, so this waits the activation out rather than
+    assuming one pause covers it; a bare pause passes locally and fails on a
+    loaded runner.
+    """
+    app = _CatalogApp()
+    with patch.object(CatalogScreen, "_fetch_remote_models"):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.push_screen(CatalogScreen())
+            tabs = app.screen.query_one("#catalog-tabs", TabbedContent)
+            await pump_until(pilot, lambda: tabs.active == TAB_CHAT)
+            assert tabs.active == TAB_CHAT


### PR DESCRIPTION
## Problem

Several TUI tests fail at random under parallel pytest, on main as well as feature branches, with `ValueError: No Tab with id '--content-tab-chat'` rather than an assertion. A full run has hit nine at once, then one, then none across three runs of the same tree.

Root cause: Textual's `Widget.mount`/`mount_all` silently no-op once the app is exiting or the widget is being pruned. A `TabbedContent` caught in that window mounts its tab strip with no `Tab` children, and a strip built with `initial=` then reaches `Tabs._on_mount`, which assigns the initial tab unconditionally and raises. Without `initial=` the same method takes a `NoMatches`-guarded path and stays quiet. Under parallel load the app teardown lands inside that window often enough to redden CI at random. It is not test-only: quitting the TUI while the catalog is still painting hits the same path.

## Solution

The catalog already activates Chat explicitly after mount, so `initial=` was redundant. Dropping it leaves the guarded activation as the only mechanism and removes the crash entirely.

The trade is that Chat now becomes active a refresh after mount rather than at construction, so on a heavily loaded machine the strip can show Discover for a frame first. The `_focus_task` on-ramp already went through that same path, so the window is not new, just wider.

New tests tear the app down at each hop of the catalog mount window, which reproduces the failure deterministically on the old code, and pin the Chat landing tab so the removal cannot silently change where the screen opens.

The hang-shaped flakes tracked alongside this one (a worker blocking in the asyncio selector, pytest-timeout staying silent on Windows) are a separate root cause and are not addressed here.
