### PR TITLE
Fix the ollama segfault in the integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,12 +188,18 @@ jobs:
           # On Windows, GITHUB_PATH needs a native path (C:\...), not the git-bash
           # /c/... form, or Python's shutil.which won't find the binary. cygpath
           # is a no-op fallback on Linux/macOS. Co-located DLLs are found via PATH.
+          #
+          # PATH only, deliberately no loader variable: llama-server and every
+          # library it pulls in carry RUNPATH $ORIGIN on Linux and LC_RPATH
+          # @loader_path on macOS, so the engine resolves its own libraries. A
+          # GITHUB_ENV export would apply to every later step in the job, and
+          # ollama's bundled runner links the same libggml/libllama SONAMEs this
+          # tarball ships, so it would load these instead of its own and
+          # segfault on the model warm-up.
           if command -v cygpath >/dev/null 2>&1; then
             cygpath -w "${bindir}" >> "${GITHUB_PATH}"
           else
             echo "${bindir}" >> "${GITHUB_PATH}"
-            echo "LD_LIBRARY_PATH=${bindir}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
-            echo "DYLD_LIBRARY_PATH=${bindir}:${DYLD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
           fi
 
       # The engine also needs llama-swap (process supervisor / OpenAI proxy) and


### PR DESCRIPTION
## Problem

The integration job dies on Linux with `Error: 500 Internal Server Error: llama-server process has terminated: signal: segmentation fault (core dumped)` during the ollama model warm-up.

The engine setup step exports `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` through `GITHUB_ENV`, which applies them to every later step in the job, not just the ones that run lilbee. The ollama step runs after it. Ollama's bundled llama-server runner links `libggml-base.so`, `libggml.so` and `libllama.so`, and the llama.cpp release tarball ships those same SONAMEs, so with the engine directory ahead of ollama's own the loader binds its runner against ABI-incompatible builds and it segfaults. Linux only: Windows takes the `GITHUB_PATH` branch instead, and macOS strips `DYLD_` variables for the system-installed ollama.

## Solution

Drop both exports. Neither was doing anything for the engine: `llama-server` and every library in its chain carry `RUNPATH $ORIGIN` on the ubuntu asset, and the macos-arm64 build carries `LC_RPATH @loader_path` with `@rpath` dependencies, so it resolves its own libraries with no loader variable set. `GITHUB_PATH` already puts the binary where `shutil.which` finds it.

Verification is this PR's own integration run, since the failure only reproduces on a Linux runner with ollama installed.
