### PR TITLE
Take placement handlers off the event loop and bound top_k at the MCP and CLI entry points

### DIFF
--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -102,7 +102,7 @@ def _display_score(result: dict[str, Any]) -> float:
 
 def search(
     query: str = typer.Argument(..., help="Search query"),
-    top_k: int = typer.Option(None, "--top-k", "-k", help="Number of results"),
+    top_k: int = typer.Option(None, "--top-k", "-k", min=1, help="Number of results"),
     scope: SearchScope = _scope_option,
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,

--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -1,4 +1,4 @@
-"""Default values and constants for :mod:`lilbee.config`.
+"""Default values and constants for :mod:`lilbee.core.config`.
 
 Holds frozen literal data: directory ignore lists, the NER label allow-list,
 LanceDB table names, the default HTTP timeout and context size, the crawl URL

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -210,6 +210,11 @@ def search(
         # "both" rather than a hard failure so the request still does work.
         log.warning("lilbee_search: unknown scope %r, falling back to %r", scope, SearchScope.BOTH)
         chunk_type = scope_to_chunk_type(SearchScope.BOTH.value)
+    if top_k is not None and top_k < 1:
+        # Same lenient stance as the scope fallback above: do the search with
+        # the configured default rather than hard-failing the agent's call.
+        log.warning("lilbee_search: top_k %d is not positive, using the default", top_k)
+        top_k = None
     effective_top_k = top_k if top_k is not None else cfg.top_k
     try:
         results = get_services().searcher.search(

--- a/src/lilbee/server/chat_dispatch/tool_args.py
+++ b/src/lilbee/server/chat_dispatch/tool_args.py
@@ -13,7 +13,9 @@ def parse_tool_arguments(raw: str) -> dict[str, Any]:
     a non-object value, so the canonical layer holds invariants the route
     layer would otherwise have to defend.
     """
-    if not raw:
+    if not raw.strip():
+        # Whitespace-only counts as empty: json.loads would otherwise turn it
+        # into {"_raw": "  "} while "" yields {}.
         return {}
     try:
         parsed = json.loads(raw)

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import time
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, Callable, Sequence
 from typing import TYPE_CHECKING, Literal
 
 from lilbee.app.services import get_services
@@ -204,7 +204,7 @@ async def placement() -> PlacementResponse:
     """Current effective placement."""
     from lilbee.app.placement import get_placement
 
-    return _placement_response(get_placement())
+    return await _placement_response_off_loop(get_placement)
 
 
 async def placement_preview(spec_json: str | None) -> PlacementResponse:
@@ -213,7 +213,7 @@ async def placement_preview(spec_json: str | None) -> PlacementResponse:
     from lilbee.providers.fleet.placement_spec import PlacementSpec
 
     spec = PlacementSpec.from_json(spec_json) if spec_json else None
-    return _placement_response(preview_placement(spec))
+    return await _placement_response_off_loop(lambda: preview_placement(spec))
 
 
 async def placement_set(spec_json: str) -> PlacementResponse:
@@ -221,14 +221,24 @@ async def placement_set(spec_json: str) -> PlacementResponse:
     from lilbee.app.placement import set_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
 
-    return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
+    spec = PlacementSpec.from_json(spec_json)
+    return await _placement_response_off_loop(lambda: set_placement(spec))
 
 
 async def placement_clear() -> PlacementResponse:
     """Clear manual placement; returns to the auto planner and rebuilds the fleet."""
     from lilbee.app.placement import set_placement
 
-    return _placement_response(set_placement(None))
+    return await _placement_response_off_loop(lambda: set_placement(None))
+
+
+async def _placement_response_off_loop(action: Callable[[], PlacementView]) -> PlacementResponse:
+    """Run a placement action and serialize it off the event loop.
+
+    Placement actions and the Intel util notice both shell out to GPU probes,
+    so neither may run on the loop.
+    """
+    return await asyncio.to_thread(lambda: _placement_response(action()))
 
 
 def _placement_response(view: PlacementView) -> PlacementResponse:
@@ -251,11 +261,14 @@ async def gpus() -> GpusResponse:
     """Detected GPUs with free/total VRAM, plus the host-level Intel util notice."""
     from lilbee.app.placement import get_placement
 
-    view = get_placement()
-    return GpusResponse(
-        gpus=PlacementResponse.from_view(view).gpus,
-        notice=_intel_notice_text(view.gpus),
-    )
+    def _body() -> GpusResponse:
+        view = get_placement()
+        return GpusResponse(
+            gpus=PlacementResponse.from_view(view).gpus,
+            notice=_intel_notice_text(view.gpus),
+        )
+
+    return await asyncio.to_thread(_body)
 
 
 __all__ = [

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -171,8 +171,8 @@ async def search_route(
         raise ValidationException(str(exc)) from exc
     except Exception as exc:
         # str(exc) here routinely carries data-root paths, LanceDB table names,
-        # and model ids, and this route has no token gate. Log the real cause
-        # for the operator; return a generic message on the wire.
+        # and model ids. Log the real cause for the operator; return a generic
+        # message on the wire.
         log.exception("Search failed")
         raise HTTPException(status_code=503, detail="Search is temporarily unavailable.") from exc
 

--- a/tests/server/chat_dispatch/test_tool_args.py
+++ b/tests/server/chat_dispatch/test_tool_args.py
@@ -1,0 +1,20 @@
+"""Direct tests for the shared tool-arguments parser."""
+
+from lilbee.server.chat_dispatch.tool_args import parse_tool_arguments
+
+
+def test_empty_and_whitespace_only_both_parse_to_an_empty_dict():
+    assert parse_tool_arguments("") == {}
+    assert parse_tool_arguments("  \n\t") == {}
+
+
+def test_malformed_json_falls_back_to_raw():
+    assert parse_tool_arguments("not json{") == {"_raw": "not json{"}
+
+
+def test_non_object_json_falls_back_to_raw():
+    assert parse_tool_arguments("[1, 2]") == {"_raw": "[1, 2]"}
+
+
+def test_object_json_parses():
+    assert parse_tool_arguments('{"a": 1}') == {"a": 1}

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -215,6 +215,25 @@ class TestAddEndpoint:
         summary = [d for t, d in events if t == "done" and "copied" in d][-1]
         assert "/no/such/file.txt" in summary["errors"]
 
+    async def test_add_where_nothing_reaches_the_corpus_skips_the_sync(
+        self, mock_extract_file, isolated_env
+    ):
+        """A batch with no copied and no skipped file must not run the
+        whole-vault sync, which holds the ingest lock for nothing."""
+        from lilbee.server.app import create_app
+
+        with mock.patch("lilbee.data.ingest.sync", new_callable=Mock) as sync_mock:
+            async with AsyncTestClient(create_app()) as client:
+                resp = await client.post(
+                    "/api/add", json={"paths": ["/no/such/file.txt"]}, headers=_auth_headers()
+                )
+
+        assert resp.status_code == 201
+        events = _parse_sse_events(resp.content)
+        summary = [d for t, d in events if t == "done" and "copied" in d][-1]
+        assert summary["copied"] == [] and summary["skipped"] == []
+        sync_mock.assert_not_called()
+
     async def test_add_with_force_flag(self, mock_extract_file, isolated_env, tmp_path):
         """The force flag allows overwriting existing files."""
         from lilbee.server.app import create_app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1230,6 +1230,12 @@ class TestSearch:
         assert result.exit_code == 0
         assert mock_svc.searcher.search.call_args.kwargs["top_k"] == 100
 
+    def test_search_rejects_non_positive_top_k(self, mock_svc):
+        for bad in ("0", "-3"):
+            result = runner.invoke(app, ["search", "q", "--top-k", bad])
+            assert result.exit_code != 0
+        mock_svc.searcher.search.assert_not_called()
+
     def test_search_rejects_empty_query(self, mock_svc):
         result = runner.invoke(app, ["search", "   "])
         assert result.exit_code != 0

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -165,6 +165,19 @@ class TestSearch:
         assert call_kwargs["chunk_type"] is None
         assert any("unknown scope" in record.message for record in caplog.records)
 
+    def test_non_positive_top_k_falls_back_to_the_default(self, mock_svc, caplog):
+        """Same lenient stance as the scope fallback: a model passing top_k=0
+        or a negative still gets a search with the configured default instead
+        of a negative limit reaching the store."""
+        import logging
+
+        mock_svc.searcher.search.return_value = []
+        with caplog.at_level(logging.WARNING, logger="lilbee.mcp_server"):
+            result = search("q", top_k=-3)
+        assert result == []
+        assert mock_svc.searcher.search.call_args.kwargs["top_k"] == cfg.top_k
+        assert any("not positive" in record.message for record in caplog.records)
+
     def test_returns_searcher_results_unfiltered(self, mock_svc):
         """The relevance cutoff lives in Searcher.search (with the
         lexical-support exemption); MCP must not re-filter on bare distance,

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2899,6 +2899,60 @@ class TestModelHandlersRunBlockingWorkOffLoop:
         assert threads and threads[0] != loop_tid
 
 
+class TestPlacementHandlersRunOffTheLoop:
+    """Placement actions and the Intel util notice shell out to GPU probes,
+    so every placement handler must run them on a worker thread."""
+
+    @staticmethod
+    def _view():
+        from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+        from lilbee.providers.roles import WorkerRole
+
+        gib = 1024**3
+        return PlacementView(
+            gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * gib, 72 * gib),),
+            roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+            unplaceable=(),
+            manual=False,
+            spec_json=None,
+        )
+
+    async def test_placement_and_gpus_run_off_the_loop(self, monkeypatch):
+        import threading
+
+        loop_tid = threading.get_ident()
+        threads, stub = _thread_recorder(self._view())
+        monkeypatch.setattr("lilbee.app.placement.get_placement", stub)
+
+        await handlers.placement()
+        await handlers.gpus()
+
+        assert len(threads) == 2 and all(tid != loop_tid for tid in threads)
+
+    async def test_preview_runs_off_the_loop(self, monkeypatch):
+        import threading
+
+        loop_tid = threading.get_ident()
+        threads, stub = _thread_recorder(self._view())
+        monkeypatch.setattr("lilbee.app.placement.preview_placement", stub)
+
+        await handlers.placement_preview(None)
+
+        assert threads and threads[0] != loop_tid
+
+    async def test_set_and_clear_run_off_the_loop(self, monkeypatch):
+        import threading
+
+        loop_tid = threading.get_ident()
+        threads, stub = _thread_recorder(self._view())
+        monkeypatch.setattr("lilbee.app.placement.set_placement", stub)
+
+        await handlers.placement_set('{"chat": {"devices": [0]}}')
+        await handlers.placement_clear()
+
+        assert len(threads) == 2 and all(tid != loop_tid for tid in threads)
+
+
 class TestModelsPull:
     async def test_yields_progress_events_native(self):
         mock_manager = MagicMock()

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -139,7 +139,7 @@ class TestSearchRoute:
 
 
 class TestSearchDoesNotLeakInternals:
-    """/api/search is reachable without a token, so its errors stay generic."""
+    """/api/search errors stay generic even for authorized callers."""
 
     def test_unexpected_failure_hides_the_exception_text(self, client, caplog):
         boom = RuntimeError("no such table '/home/tobias/data/lancedb/chunks'")


### PR DESCRIPTION
## Problem

A review of all 80 closed server/core audit findings (fixed in #570) checked each fix against its finding: does it address the root cause, is it the solution a plan would have produced, and do its tests exercise it. 73 held up with no changes needed. Two fixes had stopped at the audited call site: the event-loop fix offloaded one placement route while the five sibling handlers kept running the same blocking GPU subprocess probes inline, and the top_k lower bound covered the HTTP routes while the MCP search tool and CLI search still passed unclamped values to the store. Four smaller residues: whitespace-only tool arguments parsed inconsistently with empty ones, the no-op ingest early return had no test, and two comments went stale (a nonexistent module name; a claim that /api/search has no token gate, from before auth middleware covered every route).

## Solution

All five placement handlers now run their action and its serialization through one off-loop helper, which also covers the Intel util notice probe; thread-ident tests pin each handler. The MCP search tool treats a non-positive top_k like its unknown-scope fallback, warning and using the configured default, and the CLI rejects non-positive values at parse time. Whitespace-only tool arguments parse to an empty dict, the ingest early return has a test asserting the whole-vault sync is skipped, and both stale comments are corrected.