### PR TITLE
Fix answers showing made-up sources, count questions silently failing, and deleted files still affecting search

### DIFF
--- a/src/lilbee/app/memory.py
+++ b/src/lilbee/app/memory.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
+from lilbee.core.llm_json import json_reply_format
 from lilbee.data.store import (
     LOCAL_OWNER,
     MemoryKind,
@@ -158,7 +159,9 @@ def auto_extract(question: str, answer: str) -> list[SavedMemory]:
     services = get_services()
 
     def _chat_text(messages: list[dict[str, str]], **_kwargs: object) -> str:
-        return services.provider.chat(messages, stream=False).text
+        return services.provider.chat(
+            messages, stream=False, options={"response_format": json_reply_format()}
+        ).text
 
     extracted = extract_memories(question, answer, _chat_text)
     stored: list[SavedMemory] = []

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -296,7 +296,7 @@ class CatalogScreen(Screen[None]):
         self._spinner_frame: int = 0
         # Active-tab cache + per-tab widget memoization. Avoids a second
         # query_one on every _grid_container / _list_widget access. Default
-        # matches the TabbedContent's initial= value below.
+        # matches the tab _activate_initial_tab selects on mount.
         self._active_tab_id_cache: str = TAB_CHAT
         self._tab_grid_cache: dict[str, VerticalScroll] = {}
         self._tab_list_cache: dict[str, ModelList] = {}

--- a/src/lilbee/core/llm_json.py
+++ b/src/lilbee/core/llm_json.py
@@ -1,0 +1,54 @@
+"""Extract the first JSON value from an LLM reply.
+
+Models wrap JSON in prose, fences, and trailing commentary. A greedy
+``\\{.*\\}`` span runs to the LAST brace in the reply, so any trailing text
+containing one drops the whole value; a hand-rolled brace counter miscounts
+braces inside string literals. ``raw_decode`` scanned from each opener lets the
+stdlib own the parsing state, which is the only thing that gets both right.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TypeVar
+
+_DECODER = json.JSONDecoder()
+
+
+def json_reply_format() -> dict[str, str]:
+    """Provider option asking for a bare JSON value rather than JSON in prose.
+
+    llama.cpp's server and OpenAI-compatible remotes both honour it; providers
+    that do not drop it rather than refusing (see the litellm adapter). Returns
+    a fresh dict per call because it is handed to a third-party SDK that is free
+    to mutate the request it is given. The scans below stay the fallback: a
+    provider can ignore the request and a model can comply imperfectly, and
+    neither should cost the caller its answer.
+    """
+    return {"type": "json_object"}
+
+
+_JsonT = TypeVar("_JsonT", dict, list)
+
+
+def _first_json_value(text: str, opener: str, expected: type[_JsonT]) -> _JsonT | None:
+    """The first *expected*-typed JSON value starting at an *opener*, or None."""
+    start = text.find(opener)
+    while start >= 0:
+        try:
+            parsed, _ = _DECODER.raw_decode(text, start)
+        except json.JSONDecodeError:
+            start = text.find(opener, start + 1)
+            continue
+        return parsed if isinstance(parsed, expected) else None
+    return None
+
+
+def first_json_object(text: str) -> dict | None:
+    """The first JSON object in *text*, or None."""
+    return _first_json_value(text, "{", dict)
+
+
+def first_json_array(text: str) -> list | None:
+    """The first JSON array in *text*, or None."""
+    return _first_json_value(text, "[", list)

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -508,7 +508,15 @@ async def sync(
 
     # Ingest files (with optional progress bar)
     if files_to_process:
-        get_services().embedder.validate_model()
+        # Ingest has no degraded mode: without an embedding model every chunk
+        # fails to embed, after the run has already paid the parse and OCR cost
+        # for the whole corpus. Refuse up front instead. Search and chat, which
+        # fall back to keyword, ask embedding_available() and carry on.
+        if not get_services().embedder.validate_model():
+            raise RuntimeError(
+                f"Ingest needs an embedding model. {active_config().embedding_model!r} is not "
+                "available: pull it, or set a different embedding_model."
+            )
         await ingest_batch(
             files_to_process,
             added,

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -73,6 +73,9 @@ class LLMOptions(BaseModel):
     # token budget inside <think> and emit nothing. llama-server maps this
     # to chat_template_kwargs; hosted-API translators drop it.
     think: bool | None = None
+    # Structured-output request for the internal calls that want a bare JSON
+    # value back. Must be listed here or the allowlist above silently drops it.
+    response_format: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return only non-None values as a dict."""

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -515,6 +515,11 @@ class LitellmSdkBackend:
             kwargs["api_key"] = request.api_key
         if request.options:
             kwargs.update(request.options)
+        if "response_format" in kwargs:
+            # Best-effort: a provider without structured-output support should
+            # drop the field and answer normally, not refuse the call. Callers
+            # that send it parse the reply defensively either way.
+            kwargs["drop_params"] = True
         return kwargs
 
     def embed(self, request: EmbeddingRequest) -> EmbeddingResult:

--- a/src/lilbee/retrieval/concepts/graph.py
+++ b/src/lilbee/retrieval/concepts/graph.py
@@ -52,6 +52,10 @@ class _PmiInputs(NamedTuple):
     cooccurrences: Counter[tuple[str, str]]
     concept_counts: Counter[str]
     total_chunks: int
+    # A missing map means concepts were never built; an existing but empty one
+    # means the corpus was emptied. Both give total_chunks == 0, and only the
+    # second should clear the graph.
+    map_exists: bool
 
 
 class ConceptGraph:
@@ -354,7 +358,7 @@ class ConceptGraph:
         concept_counts: Counter[str] = Counter()
         table = self._store.open_table(CHUNK_CONCEPTS_TABLE)
         if table is None:
-            return _PmiInputs(cooccurrences, concept_counts, 0)
+            return _PmiInputs(cooccurrences, concept_counts, 0, map_exists=False)
         per_chunk: dict[tuple[str, int], set[str]] = {}
         for rows in _iter_row_batches(table):
             for row in rows:
@@ -367,7 +371,7 @@ class ConceptGraph:
             for i, a in enumerate(ordered):
                 for b in ordered[i + 1 :]:
                     cooccurrences[(a, b)] += 1
-        return _PmiInputs(cooccurrences, concept_counts, len(per_chunk))
+        return _PmiInputs(cooccurrences, concept_counts, len(per_chunk), map_exists=True)
 
     def rebuild_clusters(self) -> None:
         """Recompute corpus PMI from the chunk_concepts map, re-run Leiden, compact.
@@ -382,8 +386,14 @@ class ConceptGraph:
         without this rewrite the edges table grows monotonically across syncs
         and expand_query keeps serving edges for concepts that left the corpus.
         """
-        cooccurrences, concept_counts, total_chunks = self._corpus_pmi_inputs()
-        if total_chunks == 0 or not cooccurrences:
+        cooccurrences, concept_counts, total_chunks, map_exists = self._corpus_pmi_inputs()
+        if total_chunks == 0:
+            # The corpus was emptied: leaving the last graph in place would keep
+            # expansion serving concepts no document carries any more.
+            if map_exists:
+                self._clear_graph()
+            return
+        if not cooccurrences:
             return
         pmi_weights = _compute_pmi(cooccurrences, concept_counts, total_chunks)
         if not pmi_weights:
@@ -412,6 +422,15 @@ class ConceptGraph:
             CONCEPT_EDGES_TABLE, _concept_edges_schema(), edge_rows, "source IS NOT NULL"
         )
         self.compact_tables()
+
+    def _clear_graph(self) -> None:
+        """Drop every node and edge, keeping both tables present for readers."""
+        self._store.clear_and_add(
+            CONCEPT_NODES_TABLE, _concept_nodes_schema(), [], "concept IS NOT NULL"
+        )
+        self._store.clear_and_add(
+            CONCEPT_EDGES_TABLE, _concept_edges_schema(), [], "source IS NOT NULL"
+        )
 
     def compact_tables(self) -> None:
         """Compact the concept tables; per-file adds otherwise accrete tiny versions."""

--- a/src/lilbee/retrieval/entities/extractor.py
+++ b/src/lilbee/retrieval/entities/extractor.py
@@ -12,7 +12,6 @@ therefore dominated by how many LLM-kind types the schema keeps.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from collections.abc import Mapping
@@ -21,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 import regex
 
+from lilbee.core.llm_json import first_json_object, json_reply_format
 from lilbee.retrieval.entities.schema import (
     EntitySchema,
     EntityType,
@@ -88,26 +88,6 @@ LLM_EXTRACTION_PROMPT = (
 )
 
 
-def _first_json_object(text: str) -> dict | None:
-    """The first JSON object in *text*, or None.
-
-    ``raw_decode`` from each ``{`` position lets the stdlib own the parsing
-    state; a hand-rolled brace counter miscounts braces inside string
-    literals (a regex pattern or entity text containing ``}``).
-    """
-    decoder = json.JSONDecoder()
-    start = text.find("{")
-    while start >= 0:
-        try:
-            parsed, _ = decoder.raw_decode(text, start)
-        except json.JSONDecodeError:
-            start = text.find("{", start + 1)
-            continue
-        # A value starting at "{" can only decode to a dict.
-        return parsed if isinstance(parsed, dict) else None
-    return None
-
-
 def normalize_value(text: str) -> str:
     """Canonical form for grouping: casefold, collapse spaces, and strip
     leading zeros from purely numeric values so 00482 and 482 group together."""
@@ -153,12 +133,17 @@ def induce_schema(sample_texts: list[str], provider: LLMProvider) -> EntitySchem
             # until the budget is gone and emit no JSON at all. temperature 0:
             # induction wants one deterministic, well-formed schema, not a
             # creative sample that parses only some of the time.
-            options={"num_predict": INDUCTION_MAX_TOKENS, "think": False, "temperature": 0},
+            options={
+                "num_predict": INDUCTION_MAX_TOKENS,
+                "think": False,
+                "temperature": 0,
+                "response_format": json_reply_format(),
+            },
         )
     except Exception:
         log.warning("Entity schema induction failed at the provider", exc_info=True)
         return None
-    payload = _first_json_object(strip_reasoning(response.text))
+    payload = first_json_object(strip_reasoning(response.text))
     if payload is None:
         log.warning("Entity schema induction returned no parseable JSON")
         return None
@@ -277,7 +262,7 @@ def _extract_llm_batch(
     except Exception:
         log.warning("LLM entity extraction failed for a batch", exc_info=True)
         return None
-    payload = _first_json_object(strip_reasoning(response.text))
+    payload = first_json_object(strip_reasoning(response.text))
     if payload is None:
         return empty
     results = empty

--- a/src/lilbee/retrieval/entities/lifecycle.py
+++ b/src/lilbee/retrieval/entities/lifecycle.py
@@ -173,11 +173,12 @@ def _sample_chunks(store: Store, limit: int) -> list[str]:
     total = table.count_rows()
     if total == 0:
         return []
-    # Ceiling division: flooring makes the stride too small, so the sample is
-    # the first `limit` contiguous rows and the table's tail -- the most
-    # recently ingested documents, exactly what re-induction exists to catch --
-    # is never reached.
-    step = max(1, -(-total // limit))
+    # Pick the target indices outright rather than striding. A stride wide
+    # enough to span the table also thins the sample (total=41 yielded 21 rows,
+    # not 40), while a narrow one never reaches the tail -- the most recently
+    # ingested documents, exactly what re-induction exists to catch. Spreading
+    # across the closed range fills the budget and hits both ends at any size.
+    wanted = {round(i * (total - 1) / max(1, limit - 1)) for i in range(limit)}
     texts: list[str] = []
     # Projection is pushed into LanceDB: a bare to_arrow() would drag every
     # column, embedding vectors included, into memory before selecting.
@@ -185,7 +186,7 @@ def _sample_chunks(store: Store, limit: int) -> list[str]:
     index = 0
     for batch in arrow.to_batches(max_chunksize=_BACKFILL_BATCH):
         for text in batch.column("chunk").to_pylist():
-            if index % step == 0:
+            if index in wanted:
                 texts.append(text)
                 if len(texts) >= limit:
                     return texts

--- a/src/lilbee/retrieval/entities/schema.py
+++ b/src/lilbee/retrieval/entities/schema.py
@@ -57,7 +57,7 @@ class EntityType(BaseModel):
 
 
 class EntitySchema(BaseModel):
-    """The editable extraction contract for one corpus."""
+    """The induced extraction contract for one corpus."""
 
     types: list[EntityType]
 

--- a/src/lilbee/retrieval/query/formatting.py
+++ b/src/lilbee/retrieval/query/formatting.py
@@ -26,16 +26,19 @@ _MAX_CITE_RANGE = 32
 # start of the text as well as to a preceding newline, so an answer that is
 # nothing but a fabricated block (heading at position 0) is still stripped.
 _CITE_HEADING = (
-    r"(?:\n{1,3}|\A)(?:#+\s*)?(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*"
+    r"(?:\n{1,3}|\A)[ \t]*(?:#+\s*)?"
+    r"(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*"
 )
 # One list line: a bullet, arrow, "[1]" or "1." marker and the rest of its line.
 _CITE_LIST_LINE = r"[ \t]*(?:[-*•→\[]|\d+[.)])[^\n]*"
 
 # A heading line followed by a list. The list is required so prose discussing
 # such a heading is not clipped; the match ends with the list, not end-of-text,
-# so an answer resuming after its citations keeps the continuation.
+# so an answer resuming after its citations keeps the continuation. Items may be
+# blank-line separated, which markdown does routinely; stopping at the first
+# blank line would leave the rest of a fabricated list in the answer.
 _LLM_CITATION_BLOCK_RE = re.compile(
-    _CITE_HEADING + r"\n\s*" + _CITE_LIST_LINE + r"(?:\n" + _CITE_LIST_LINE + r")*",
+    _CITE_HEADING + r"\n\s*" + _CITE_LIST_LINE + r"(?:\n+" + _CITE_LIST_LINE + r")*",
     re.IGNORECASE,
 )
 

--- a/src/lilbee/retrieval/query/intent.py
+++ b/src/lilbee/retrieval/query/intent.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from lilbee.core.llm_json import first_json_object
 from lilbee.retrieval.language import QueryLanguage, query_language
 
 
@@ -233,7 +234,6 @@ When unsure, use "topical".
 Question: {question}
 """
 
-_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 
 _LLM_KINDS = {
     "total_sources": AggregateKind.TOTAL_SOURCES,
@@ -252,15 +252,8 @@ def parse_llm_aggregate(text: str) -> AggregateQuery | None:
     ``UNSUPPORTED`` is never produced here; declining is reserved for the
     deterministic layer, whose patterns prove the question is count-shaped.
     """
-    import json
-
-    match = _JSON_OBJECT_RE.search(text)
-    if not match:
-        return None
-    try:
-        # A brace-delimited match parses to a dict or raises; no shape check needed.
-        data = json.loads(match.group(0))
-    except json.JSONDecodeError:
+    data = first_json_object(text)
+    if data is None:
         return None
     raw_kind = data.get("kind", "")
     # A non-string kind (list, dict) is malformed, not a crash: an unhashable

--- a/src/lilbee/retrieval/query/memory_extract.py
+++ b/src/lilbee/retrieval/query/memory_extract.py
@@ -9,11 +9,11 @@ review and remove in ``/memories``.
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from lilbee.core.llm_json import first_json_array
 from lilbee.data.store import MemoryKind
 
 log = logging.getLogger(__name__)
@@ -37,27 +37,6 @@ _EXTRACT_SYSTEM_PROMPT = (
 )
 
 _EXTRACT_USER_TEMPLATE = "User said:\n{question}\n\nAssistant replied:\n{answer}"
-
-
-def _first_json_array(text: str) -> list | None:
-    """The first JSON array in *text*, or None.
-
-    ``raw_decode`` from each ``[`` lets the stdlib find where the array
-    actually ends. A greedy ``\\[.*\\]`` span runs to the LAST bracket in the
-    reply, so a conforming array followed by prose containing any ``]`` (a
-    footnote marker, a second fence) fails to parse and drops every memory.
-    """
-    decoder = json.JSONDecoder()
-    start = text.find("[")
-    while start >= 0:
-        try:
-            parsed, _ = decoder.raw_decode(text, start)
-        except json.JSONDecodeError:
-            start = text.find("[", start + 1)
-            continue
-        # A value starting at "[" can only decode to a list.
-        return parsed if isinstance(parsed, list) else None
-    return None
 
 
 @dataclass(frozen=True)
@@ -96,7 +75,7 @@ def parse_extraction(raw: str) -> list[ExtractedMemory]:
     code fence), keeps only objects with a usable-length ``text``, and decodes
     the kind. Any parse failure yields an empty list.
     """
-    items = _first_json_array(raw)
+    items = first_json_array(raw)
     if items is None:
         return []
 

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -14,6 +14,7 @@ from typing_extensions import TypedDict
 
 from lilbee.core.config import Config
 from lilbee.core.config.enums import ChatMode
+from lilbee.core.llm_json import json_reply_format
 from lilbee.data.store import (
     ChunkType,
     MemoryKind,
@@ -1208,7 +1209,10 @@ class Searcher:
             response = self._provider.chat(
                 [{"role": "user", "content": prompt}],
                 stream=False,
-                options={"num_predict": INTENT_CLASSIFY_MAX_TOKENS},
+                options={
+                    "num_predict": INTENT_CLASSIFY_MAX_TOKENS,
+                    "response_format": json_reply_format(),
+                },
             )
         except Exception:
             log.debug("LLM intent classification failed; using pattern result", exc_info=True)
@@ -1335,7 +1339,13 @@ class Searcher:
             )
         raw = result.text
         clean = raw if self._config.show_reasoning else strip_reasoning(raw)
-        return AskResult(answer=clean, sources=results, cited_sources=cited_subset(clean, results))
+        # Citations are read off the prose only: a model that echoes its own
+        # Sources list would otherwise mark every retrieved file cited.
+        return AskResult(
+            answer=clean,
+            sources=results,
+            cited_sources=cited_subset(strip_llm_citations(clean), results),
+        )
 
     def ask(
         self,

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -24,7 +24,11 @@ from lilbee.retrieval.query.compaction import (
     history_budget,
     prompt_history,
 )
-from lilbee.retrieval.query.formatting import StreamingCitationFilter, cited_subset
+from lilbee.retrieval.query.formatting import (
+    StreamingCitationFilter,
+    cited_subset,
+    strip_llm_citations,
+)
 from lilbee.retrieval.query.searcher import (
     GROUNDED_REFUSAL,
     SEARCH_NEEDS_EMBEDDER,
@@ -526,7 +530,10 @@ async def chat(
     return AskResponse(
         answer=answer,
         sources=[CleanedChunk(**clean_result(s)) for s in sources],
-        cited_sources=[CleanedChunk(**clean_result(s)) for s in cited_subset(answer, sources)],
+        cited_sources=[
+            CleanedChunk(**clean_result(s))
+            for s in cited_subset(strip_llm_citations(answer), sources)
+        ],
         compaction=compaction,
     )
 

--- a/tests/providers/test_sdk_backend_contract.py
+++ b/tests/providers/test_sdk_backend_contract.py
@@ -463,3 +463,23 @@ class TestPullModel:
     def test_refused_for_read_only_lm_studio(self, backend: LlmSdkBackend) -> None:
         with pytest.raises(ProviderError, match="LM Studio"):
             backend.pull_model("m", base_url="http://localhost:1234/v1")
+
+
+def test_response_format_is_sent_best_effort(backend: LlmSdkBackend) -> None:
+    """A provider without structured-output support must drop the field and
+    answer normally rather than refuse the call: callers parse the reply
+    defensively either way, so refusing would cost an answer to gain nothing."""
+    req = CompletionRequest(
+        ref=parse_model_ref("ollama/m"),
+        messages=[{"role": "user", "content": "hi"}],
+        api_base="http://localhost:11434",
+        options={"response_format": {"type": "json_object"}},
+    )
+    kwargs = backend._completion_kwargs(req, stream=False)
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["drop_params"] is True
+
+
+def test_drop_params_is_not_set_without_response_format(backend: LlmSdkBackend) -> None:
+    kwargs = backend._completion_kwargs(_completion_request(), stream=False)
+    assert "drop_params" not in kwargs

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -43,7 +43,7 @@ def mock_svc():
     embedder = mock.MagicMock()
     embedder.embed.return_value = [0.1] * 768
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
-    embedder.validate_model.return_value = None
+    embedder.validate_model.return_value = True
     services = make_mock_services(embedder=embedder)
     # /api/chat now goes through chat_dispatch, which validates the requested
     # model against the KnownModelCache. Pre-load both the registry and the

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,11 @@ def _mock_embedder():
         "lilbee.providers.factory.create_provider",
         return_value=mock.MagicMock(
             embed=mock.MagicMock(side_effect=lambda texts: [_fake_embed(t) for t in texts]),
+            # A provider that can embed lists the model, so the ingest
+            # availability gate sees it. Without this the gate reports the model
+            # missing while embed works, which is not a state a real provider
+            # reaches.
+            list_models=mock.MagicMock(return_value=[cfg.embedding_model]),
             pull_model=mock.MagicMock(),
             shutdown=mock.MagicMock(),
         ),

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -825,10 +825,22 @@ class TestRebuildClusters:
 
     @patch("lilbee.retrieval.concepts.graph._leiden_partition")
     def test_rebuild_empty_chunk_concepts(self, mock_leiden, cg, mock_svc):
+        """An emptied corpus clears the graph instead of leaving the last one.
+
+        Returning early here is what let a vault whose documents were all
+        deleted keep serving its old concepts through query expansion forever.
+        """
+        from lilbee.core.config import CONCEPT_EDGES_TABLE, CONCEPT_NODES_TABLE
+
         _cc, side = self._chunk_concepts({"chunk_source": [], "chunk_index": [], "concept": []})
         mock_svc.store.open_table.side_effect = side
         cg.rebuild_clusters()
         mock_leiden.assert_not_called()
+        cleared = {
+            call.args[0]: call.args[2] for call in mock_svc.store.clear_and_add.call_args_list
+        }
+        assert cleared[CONCEPT_NODES_TABLE] == []
+        assert cleared[CONCEPT_EDGES_TABLE] == []
 
     @patch("lilbee.retrieval.concepts.graph._leiden_partition")
     def test_rebuild_recomputes_corpus_pmi(self, mock_leiden, cg, mock_svc):

--- a/tests/test_entities_extractor.py
+++ b/tests/test_entities_extractor.py
@@ -247,36 +247,6 @@ class TestInduceSchema:
         assert induce_schema([], MagicMock()) is None
 
 
-class TestFirstJsonObjectEdges:
-    def test_malformed_json_is_none(self):
-        from lilbee.retrieval.entities.extractor import _first_json_object
-
-        assert _first_json_object('{"a": }') is None
-
-    def test_unbalanced_is_none(self):
-        from lilbee.retrieval.entities.extractor import _first_json_object
-
-        assert _first_json_object("{unclosed") is None
-
-    def test_braces_inside_string_values_do_not_derail_the_scan(self):
-        """A regex pattern or entity text containing a brace is legal JSON;
-        a naive brace counter truncates mid-string and loses the object."""
-        from lilbee.retrieval.entities.extractor import _first_json_object
-
-        text = '{"types": [{"name": "x", "pattern": "\\\\}"}]}'
-        parsed = _first_json_object(text)
-        assert parsed == {"types": [{"name": "x", "pattern": "\\}"}]}
-
-        assert _first_json_object('{"0": [{"type": "note", "text": "a } b"}]}') == {
-            "0": [{"type": "note", "text": "a } b"}]
-        }
-
-    def test_object_after_stray_brace_in_prose_is_found(self):
-        from lilbee.retrieval.entities.extractor import _first_json_object
-
-        assert _first_json_object('opening { thoughts... {"kind": "x"}') == {"kind": "x"}
-
-
 class TestInduceSchemaEdges:
     def test_non_dict_type_entry_dropped(self):
         provider = MagicMock()

--- a/tests/test_entities_lifecycle.py
+++ b/tests/test_entities_lifecycle.py
@@ -350,21 +350,42 @@ class TestChunkScanProjection:
         # the last half of the table unreachable; an even spread reaches it.
         assert max(sampled) >= total - 10
 
-    def test_sample_chunks_stops_reading_once_the_sample_is_full(self):
+    @pytest.mark.parametrize("total", [41, 60, 81, 400], ids=str)
+    def test_sample_fills_its_budget_at_every_corpus_size(self, total):
+        """Reach is not enough: a stride wide enough to span the table also
+        thins the sample, so a 41-chunk corpus induced its schema from 21
+        chunks. The budget must be filled whenever the table can fill it."""
+        from lilbee.retrieval.entities.lifecycle import _sample_chunks
+
+        batch = mock.MagicMock()
+        batch.column.return_value.to_pylist.return_value = [f"chunk-{i}" for i in range(total)]
+        table = self._projecting_table([batch])
+        table.count_rows.return_value = total
+        store = mock.MagicMock()
+        store.open_table.return_value = table
+
+        sampled = [int(t.split("-")[1]) for t in _sample_chunks(store, 40)]
+        assert len(sampled) == 40
+        assert max(sampled) >= total - total // 40 - 1
+
+    def test_sample_reads_through_to_the_tail_then_stops(self):
+        """The last sample is the table's last row, so the scan spans every
+        batch; it must stop there rather than reading past a full sample."""
         from lilbee.retrieval.entities.lifecycle import _sample_chunks
 
         first = mock.MagicMock()
         first.column.return_value.to_pylist.return_value = ["a", "b", "c"]
         second = mock.MagicMock()
-        table = self._projecting_table([first, second])
+        second.column.return_value.to_pylist.return_value = ["d"]
+        third = mock.MagicMock()
+        table = self._projecting_table([first, second, third])
         table.count_rows.return_value = 4
         store = mock.MagicMock()
         store.open_table.return_value = table
 
-        # step = 4 // 2 = 2 -> indexes 0 and 2, both in the first batch.
         texts = _sample_chunks(store, 2)
-        assert texts == ["a", "c"]
-        second.column.assert_not_called()
+        assert texts == ["a", "d"]
+        third.column.assert_not_called()
 
     def test_full_pass_projects_the_needed_columns(self):
         from lilbee.retrieval.entities.lifecycle import _full_pass

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -43,7 +43,7 @@ def mock_svc():
     embedder = mock.MagicMock()
     embedder.embed.return_value = [0.1] * 768
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
-    embedder.validate_model.return_value = None
+    embedder.validate_model.return_value = True
     services = make_mock_services(embedder=embedder)
     set_services(services)
     yield services

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1397,6 +1397,26 @@ class TestStatShortCircuit:
         assert plan_threads
         assert all(t != loop_thread for t in plan_threads)
 
+    async def test_sync_refuses_without_an_embedding_model(self, isolated_env, mock_svc):
+        """Ingest cannot degrade the way search can. Warning and continuing pays
+        the full parse and OCR cost for every file and then fails to embed all
+        of them, so the run must stop before any of that work happens."""
+        from lilbee.data.ingest import sync
+
+        (isolated_env / "doc.txt").write_text("content")
+        mock_svc.embedder.validate_model.return_value = False
+
+        with (
+            mock.patch(
+                "kreuzberg.extract_file_sync",
+                new_callable=Mock,
+                return_value=_make_kreuzberg_result(),
+            ) as extract,
+            pytest.raises(RuntimeError, match="embedding model"),
+        ):
+            await sync(quiet=True)
+        extract.assert_not_called()
+
     async def test_sync_backfills_stats_via_store(self, isolated_env, mock_svc):
         from lilbee.data.ingest import file_hash, sync
 

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -95,6 +95,19 @@ class TestParseLlmAggregate:
         parsed = parse_llm_aggregate('{"kind": "total_sources"}')
         assert parsed == AggregateQuery(AggregateKind.TOTAL_SOURCES)
 
+    @pytest.mark.parametrize(
+        "reply",
+        [
+            '{"kind": "total_sources"} (note: the } is fine)',
+            'Sure! {"kind": "total_sources"} hope that helps.',
+        ],
+        ids=["trailing-brace", "surrounding-prose"],
+    )
+    def test_route_survives_prose_around_the_object(self, reply):
+        """A greedy brace span runs to the last brace in the reply, so any
+        trailing text containing one silently dropped the route."""
+        assert parse_llm_aggregate(reply) == AggregateQuery(AggregateKind.TOTAL_SOURCES)
+
     def test_distinct_type(self):
         parsed = parse_llm_aggregate('{"kind": "distinct_type", "noun": "people"}')
         assert parsed == AggregateQuery(AggregateKind.DISTINCT_TYPE, noun="people")

--- a/tests/test_llm_json.py
+++ b/tests/test_llm_json.py
@@ -1,0 +1,60 @@
+"""The shared first-JSON-value scan every LLM reply parser depends on.
+
+Three call sites previously carried their own copy or a greedy brace/bracket
+span; these cases are the ones those copies got wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.core.llm_json import first_json_array, first_json_object
+
+
+class TestFirstJsonObject:
+    @pytest.mark.parametrize(
+        "text",
+        ['{"a": }', "{unclosed", "no json here"],
+        ids=["malformed", "unbalanced", "absent"],
+    )
+    def test_unparseable_is_none(self, text):
+        assert first_json_object(text) is None
+
+    def test_braces_inside_string_values_do_not_derail_the_scan(self):
+        """A regex pattern or entity text containing a brace is legal JSON;
+        a naive brace counter truncates mid-string and loses the object."""
+        text = '{"types": [{"name": "x", "pattern": "\\\\}"}]}'
+        assert first_json_object(text) == {"types": [{"name": "x", "pattern": "\\}"}]}
+        assert first_json_object('{"0": [{"type": "note", "text": "a } b"}]}') == {
+            "0": [{"type": "note", "text": "a } b"}]
+        }
+
+    def test_object_after_stray_brace_in_prose_is_found(self):
+        assert first_json_object('opening { thoughts... {"kind": "x"}') == {"kind": "x"}
+
+    def test_trailing_prose_containing_a_brace_is_ignored(self):
+        """A greedy span runs to the LAST brace in the reply and drops the value."""
+        assert first_json_object('{"kind": "x"} (note: the } is fine)') == {"kind": "x"}
+
+    def test_first_of_several_wins(self):
+        assert first_json_object('{"a": 1} and {"b": 2}') == {"a": 1}
+
+    def test_an_object_nested_in_an_array_is_still_found(self):
+        """The scan starts at the first opener of the requested kind, wherever
+        it sits, so a reply that wraps its object in a list still parses."""
+        assert first_json_object('[{"a": 1}]') == {"a": 1}
+
+
+class TestFirstJsonArray:
+    def test_trailing_prose_containing_a_bracket_is_ignored(self):
+        assert first_json_array('[{"a": 1}] see footnote [2]') == [{"a": 1}]
+
+    def test_brackets_inside_string_values_do_not_derail_the_scan(self):
+        assert first_json_array('[{"text": "a ] b"}]') == [{"text": "a ] b"}]
+
+    @pytest.mark.parametrize("text", ["[unclosed", "no json here"], ids=["unbalanced", "absent"])
+    def test_unparseable_is_none(self, text):
+        assert first_json_array(text) is None
+
+    def test_an_object_is_not_an_array(self):
+        assert first_json_array('{"a": 1}') is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2346,6 +2346,24 @@ class TestLLMOptions:
         assert result["temperature"] == 0.5
         assert result["seed"] == 42
 
+    def test_response_format_survives_the_allowlist(self) -> None:
+        """The allowlist drops unknown keys silently, so a structured-output
+        request that is not a declared field never reaches the provider and the
+        caller is left parsing prose while believing it asked for JSON."""
+        from lilbee.providers.base import filter_options, normalize_generation_options
+
+        opts = {"num_predict": 64, "response_format": {"type": "json_object"}}
+        assert filter_options(opts)["response_format"] == {"type": "json_object"}
+        assert normalize_generation_options(opts)["response_format"] == {"type": "json_object"}
+
+    def test_credentials_are_still_rejected(self) -> None:
+        """Widening the allowlist must not widen it to sensitive parameters."""
+        from lilbee.providers.base import filter_options
+
+        assert filter_options({"api_key": "secret", "api_base": "http://x", "seed": 1}) == {
+            "seed": 1
+        }
+
 
 class TestFilterOptions:
     def test_filters_valid_options(self) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1120,6 +1120,21 @@ class TestAskRaw:
         assert len(result.sources) == 1
         assert result.sources[0].source == "test.pdf"
 
+    def test_a_source_only_named_in_the_models_own_block_is_not_cited(self, mock_svc):
+        """cited_sources is the grounding signal JSON callers read, so it must
+        reflect what the answer used, not what the model echoed back. A model
+        that ends with its own Sources list naming every retrieved file would
+        otherwise mark all of them cited."""
+        mock_svc.store.search.return_value = [
+            _make_result(source="used.pdf", chunk="oil is 5 quarts"),
+            _make_result(source="never-used.pdf", chunk="unrelated"),
+        ]
+        mock_svc.provider.chat.return_value = _text_result(
+            "The engine holds 5 quarts, see used.pdf.\n\nSources:\n- used.pdf\n- never-used.pdf"
+        )
+        result = get_services().searcher.ask_raw("oil capacity?")
+        assert [s.source for s in result.cited_sources] == ["used.pdf"]
+
     def test_no_results_returns_grounded_refusal(self, mock_svc):
         """Zero RAG hits in RAG mode return a grounded refusal instead of
         free-wheeling on the model's parametric knowledge (bb-0i0). The model is
@@ -3571,6 +3586,30 @@ class TestStripLlmCitations:
     def test_removes_dangling_heading(self):
         text = "The answer is 42.\n\nSources:\n"
         assert strip_llm_citations(text) == "The answer is 42."
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            (
+                "Sources:\n- made-up.pdf\n\n- also-fake.pdf\n\nThe engine holds 5 quarts.",
+                "The engine holds 5 quarts.",
+            ),
+            (
+                "Answer.\n\nSources:\n1. a.pdf\n\n2. b.pdf\n\nMore prose.",
+                "Answer.\n\nMore prose.",
+            ),
+        ],
+        ids=["bulleted", "numbered"],
+    )
+    def test_removes_a_block_whose_items_are_blank_line_separated(self, text, expected):
+        """Markdown routinely spaces list items apart. Ending the block at the
+        first blank line leaves the remaining fabricated names in the answer,
+        with lilbee's own authoritative sources block stacked underneath."""
+        assert strip_llm_citations(text).strip() == expected
+
+    def test_removes_an_indented_block(self):
+        """The heading may be indented even when the list items are not."""
+        assert strip_llm_citations("Answer.\n   Sources:\n   - a.pdf") == "Answer."
 
 
 class TestExtractCitedIndices:


### PR DESCRIPTION
## Problem

An audit of the 56 fixes merged in #571 checked whether each was the *right* solution, not just whether it passed its tests. Most held up. These did not.

**Answers could show sources the model invented.** When a model ends with its own "Sources:" list and spaces the items apart (routine markdown), only the first item was stripped. The rest reached the reader with lilbee's real sources block stacked underneath. An earlier fix in the same batch had just closed this; a second fix reopened it from the other end. An indented heading also bypassed stripping entirely.

**Files the answer never used were reported as cited.** The cited-sources list was computed from text that still contained the model's own Sources list, so every file the model echoed counted as cited. That list is the grounding signal JSON and MCP callers read.

**Counting questions silently fell back to ordinary search.** "How many documents mention X" is routed by parsing a small JSON reply. Any trailing prose containing a `}` broke the parse and dropped the route. Three copies of "find the first JSON value in an LLM reply" existed in one package, two written in that same commit: one got the stdlib fix, one got a hand-copied twin, and this one kept the old greedy pattern.

**Deleting every document left its concepts in search.** The graph rebuild returned early on an empty corpus, so query expansion kept serving concepts no document carried. That is the failure the original issue was filed against.

**Small vaults trained their entity schema on half their content.** A 41-chunk corpus sampled 21 chunks instead of 40; an 81-chunk one sampled 27.

## Solution

- Citation blocks may span blank lines between items, and the heading may be indented.
- Cited sources are read off the prose only, at both call sites that needed it. The streaming path was already correct.
- One shared JSON-value scan serves all three reply parsers, typed by the value it returns.
- An emptied corpus clears the concept graph; a corpus that never had one is left alone. That distinction is carried in the rebuild's inputs rather than re-derived by reopening the table.
- The sampler picks indices across the whole range, filling its budget and reaching both ends at any corpus size.

Plus docstring corrections where a fix moved the drift instead of removing it.

The OCR cache also carries an unbounded pile of files from its previous implementation that its size cap cannot see. That fix is deliberately not here: `feat/kreuzberg-5` deletes the OCR cache module outright, so it belongs with whatever replaces it.
