### PR TITLE
Make document removal folder-aware and durable across all surfaces

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,6 +67,12 @@ After that you're in chat. `/add` indexes documents, `/crawl` indexes a website
 Press `/add` to add files, directories, or web pages. Paths tab-complete; the
 job runs in the Task Center, so you can keep chatting while indexing happens.
 
+`add` copies the files into lilbee's own documents directory, so the copy is a
+snapshot taken at that moment. Editing the originals later has no effect until
+you add them again, and files you delete at the source stay indexed until you
+remove them. To drop a whole directory you added, remove it by name with
+`/delete myfolder` (or `lilbee remove myfolder`).
+
 If a file with the same name is already indexed, `add` skips it. To re-index in
 place, remove the document first with `/delete name`, or pass `--force` from
 the CLI.
@@ -594,6 +600,7 @@ lilbee ask "Explain this" --model qwen3
 | Command | Description |
 |---------|-------------|
 | `lilbee remove manual.pdf` | Remove from the index (keeps source file) |
+| `lilbee remove myfolder` | Remove every document indexed under a folder (prompts first; `--yes` to skip) |
 | `lilbee remove manual.pdf --delete` | Remove and delete the source file |
 | `lilbee chunks manual.pdf` | Inspect how a document was chunked |
 | `lilbee sync` | Re-index changed files |

--- a/src/lilbee/api.py
+++ b/src/lilbee/api.py
@@ -145,9 +145,11 @@ class Lilbee:
             return asyncio.run(_sync(quiet=True))
 
     def remove(self, name: str) -> None:
-        """Remove a document from the index by source name."""
+        """Remove a document by source name; a folder name removes everything beneath it."""
+        from lilbee.app.ingest import remove_documents_durably
+
         with config_scope(self._config), services_scope(self._services):
-            self._services.store.remove_documents([name], delete_files=True)
+            remove_documents_durably([name], delete_files=True)
 
     def status(self) -> dict[str, object]:
         """Return index stats (document count, data directory, etc.)."""

--- a/src/lilbee/app/ingest.py
+++ b/src/lilbee/app/ingest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -54,14 +54,25 @@ def copy_files(paths: list[Path], *, force: bool = False) -> CopyResult:
 _REMOVED_SKIP_REASON = "removed via delete (re-add the file or run retry-skipped to restore)"
 
 
+def folder_members(name: str, known: Iterable[str]) -> list[str]:
+    """Indexed sources under folder *name*, matched on whole path segments.
+
+    ``myrepo`` covers ``myrepo/a.py`` but never ``myrepo-2/x``. Empty when *name*
+    is not a parent directory of any known source. This is the single definition
+    of the folder-boundary rule, shared by expansion and the delete-guard.
+    """
+    prefix = name.rstrip("/") + "/"
+    return [source for source in known if source.startswith(prefix)]
+
+
 def expand_folder_names(names: list[str]) -> list[str]:
     """Expand any folder name to the indexed sources beneath it.
 
     A name that matches an indexed source exactly is kept. A name that matches no
     source but is a parent directory of one or more sources expands to all of
-    them, matched on whole path segments (``myrepo`` covers ``myrepo/a.py`` but
-    never ``myrepo-2/x``). A name that matches neither is kept unchanged so the
-    caller reports it not-found. Order and de-duplication are preserved.
+    them (see :func:`folder_members`). A name that matches neither is kept
+    unchanged so the caller reports it not-found. Order and de-duplication are
+    preserved.
     """
     from lilbee.app.services import get_services
 
@@ -79,8 +90,7 @@ def expand_folder_names(names: list[str]) -> list[str]:
         if name in known_set:
             _add(name)
             continue
-        prefix = name.rstrip("/") + "/"
-        members = [source for source in known if source.startswith(prefix)]
+        members = folder_members(name, known)
         if members:
             for member in members:
                 _add(member)

--- a/src/lilbee/app/ingest.py
+++ b/src/lilbee/app/ingest.py
@@ -54,13 +54,55 @@ def copy_files(paths: list[Path], *, force: bool = False) -> CopyResult:
 _REMOVED_SKIP_REASON = "removed via delete (re-add the file or run retry-skipped to restore)"
 
 
-def remove_documents_durably(names: list[str]) -> RemoveResult:
+def expand_folder_names(names: list[str]) -> list[str]:
+    """Expand any folder name to the indexed sources beneath it.
+
+    A name that matches an indexed source exactly is kept. A name that matches no
+    source but is a parent directory of one or more sources expands to all of
+    them, matched on whole path segments (``myrepo`` covers ``myrepo/a.py`` but
+    never ``myrepo-2/x``). A name that matches neither is kept unchanged so the
+    caller reports it not-found. Order and de-duplication are preserved.
+    """
+    from lilbee.app.services import get_services
+
+    known = [s["filename"] for s in get_services().store.get_sources()]
+    known_set = set(known)
+    expanded: list[str] = []
+    seen: set[str] = set()
+
+    def _add(candidate: str) -> None:
+        if candidate not in seen:
+            seen.add(candidate)
+            expanded.append(candidate)
+
+    for name in names:
+        if name in known_set:
+            _add(name)
+            continue
+        prefix = name.rstrip("/") + "/"
+        members = [source for source in known if source.startswith(prefix)]
+        if members:
+            for member in members:
+                _add(member)
+        else:
+            _add(name)
+    return expanded
+
+
+def remove_documents_durably(
+    names: list[str],
+    *,
+    delete_files: bool = False,
+    documents_dir: Path | None = None,
+) -> RemoveResult:
     """Remove documents from the index and skip-mark them so sync won't re-ingest.
 
-    The source files stay on disk (non-destructive), but each removed file gets a
-    skip-marker keyed on its current hash, so the next sync treats it as
-    unchanged-and-skipped instead of re-ingesting it and resurrecting the doc.
-    Editing the file (new hash), ``retry-skipped``, or ``rebuild`` restores it.
+    A folder name (a parent directory of indexed sources) removes every source
+    beneath it. Unless *delete_files* is set the source files stay on disk, and
+    each removed file gets a skip-marker keyed on its current hash so the next
+    sync treats it as unchanged-and-skipped instead of re-ingesting it and
+    resurrecting the doc. Editing the file (new hash), ``retry-skipped``, or
+    ``rebuild`` restores it.
     """
     from lilbee.app.services import get_services
     from lilbee.data.ingest.discovery import file_hash
@@ -71,15 +113,20 @@ def remove_documents_durably(names: list[str]) -> RemoveResult:
         write_skip_reasons,
     )
 
-    result = get_services().store.remove_documents(names)
+    docs_dir = documents_dir or cfg.documents_dir
+    targets = expand_folder_names(names)
+    result = get_services().store.remove_documents(
+        targets, delete_files=delete_files, documents_dir=docs_dir
+    )
     if not result.removed:
         return result
     markers = load_skip_markers(cfg.data_root)
     reasons = load_skip_reasons(cfg.data_root)
     for name in result.removed:
-        path = cfg.documents_dir / name
-        # Imported sources have no file on disk; sync never re-ingests them, so a
-        # marker is only needed for real files that would otherwise be re-found.
+        path = docs_dir / name
+        # Imported sources and files removed with delete_files have nothing on
+        # disk; sync never re-ingests those, so a marker is only needed for real
+        # files that would otherwise be re-found.
         if path.exists():
             markers[name] = file_hash(path)
             reasons[name] = _REMOVED_SKIP_REASON

--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -573,17 +573,35 @@ _delete_file_option = typer.Option(
     False, "--delete", help="Also delete the file from the documents directory."
 )
 
+_remove_yes_option = typer.Option(
+    False, "--yes", "-y", help="Skip the confirmation prompt when removing a folder."
+)
+
 
 def remove(
     names: list[str] = _remove_names_argument,
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,
     delete_file: bool = _delete_file_option,
+    yes: bool = _remove_yes_option,
 ) -> None:
-    """Remove documents from the knowledge base by source name."""
+    """Remove documents from the knowledge base by source name.
+
+    A folder name removes every document indexed beneath it.
+    """
     apply_overrides(data_dir=data_dir, use_global=use_global)
 
-    result = get_services().store.remove_documents(
+    from lilbee.app.ingest import expand_folder_names, remove_documents_durably
+
+    targets = expand_folder_names(names)
+    is_folder_removal = sorted(set(targets)) != sorted(set(names))
+    if is_folder_removal and not yes and not cfg.json_mode:
+        typer.confirm(
+            f"Remove {len(targets)} documents? Files on disk are kept unless you pass --delete.",
+            abort=True,
+        )
+
+    result = remove_documents_durably(
         names, delete_files=delete_file, documents_dir=cfg.documents_dir
     )
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1027,8 +1027,9 @@ class ChatScreen(Screen[None]):
 
         # A folder name (parent directory of one or more sources) removes
         # everything beneath it; remove_documents_durably expands it.
-        is_folder = any(source.startswith(name.rstrip("/") + "/") for source in known)
-        if name not in known and not is_folder:
+        from lilbee.app.ingest import folder_members
+
+        if name not in known and not folder_members(name, known):
             message = msg.CMD_DELETE_NOT_FOUND.format(name=name)
             suggestion = _closest_source(name, known)
             if suggestion is not None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1025,7 +1025,10 @@ class ChatScreen(Screen[None]):
             call_from_thread(self, self.notify, usage)
             return
 
-        if name not in known:
+        # A folder name (parent directory of one or more sources) removes
+        # everything beneath it; remove_documents_durably expands it.
+        is_folder = any(source.startswith(name.rstrip("/") + "/") for source in known)
+        if name not in known and not is_folder:
             message = msg.CMD_DELETE_NOT_FOUND.format(name=name)
             suggestion = _closest_source(name, known)
             if suggestion is not None:

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -118,6 +118,29 @@ _ANN_REFINE_FACTOR = 10
 # in place with the SOURCE_STAT_UNKNOWN sentinel.
 _SOURCE_STAT_COLUMNS = ("size_bytes", "mtime_ns", "stat_captured_ns")
 
+def _prune_empty_dirs(dirs: list[Path], *, stop: Path) -> None:
+    """Remove now-empty directories under *stop* after their files were deleted.
+
+    Climbs upward from each directory, removing empty ones until a non-empty
+    directory or *stop* is reached; *stop* (the documents dir) is never removed.
+    Nested trees prune fully because each path climbs the whole chain, so a
+    parent emptied only by removing its last child directory still gets cleaned.
+
+    ``os.removedirs`` climbs the same way but has no lower bound, so an emptied
+    documents dir would be deleted and the climb would continue above it; the
+    ``stop`` guard is why this is hand-rolled rather than that one call.
+    """
+    stop = stop.resolve()
+    for start in dirs:
+        current = start
+        while current != stop and stop in current.parents:
+            try:
+                current.rmdir()
+            except OSError:
+                break  # still holds entries, or already gone; stop climbing
+            current = current.parent
+
+
 # (table, source column) pairs deleted when a source's rows are replaced. The
 # concept nodes/edges tables carry no source column (corpus-level aggregates),
 # so only the per-chunk concept mapping is source-scoped.
@@ -1160,6 +1183,7 @@ class Store:
             self._invalidate_source_cache()
 
         if delete_files:
+            emptied: list[Path] = []
             for name in removed:
                 try:
                     path = validate_path_within(documents_dir / name, documents_dir)
@@ -1168,6 +1192,8 @@ class Store:
                     continue
                 if path.exists():
                     path.unlink()
+                emptied.append(path.parent)
+            _prune_empty_dirs(emptied, stop=documents_dir)
 
         return RemoveResult(removed=removed, not_found=not_found)
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -445,8 +445,13 @@ def init(path: str = "") -> dict[str, Any]:
 
 @_tool
 def remove(names: list[str], delete_files: bool = False) -> dict[str, Any]:
-    """Remove documents by source name; ``delete_files=true`` also deletes the file on disk."""
-    result = get_services().store.remove_documents(
+    """Remove documents by source name; a folder name removes everything beneath it.
+
+    ``delete_files=true`` also deletes the file on disk.
+    """
+    from lilbee.app.ingest import remove_documents_durably
+
+    result = remove_documents_durably(
         names, delete_files=delete_files, documents_dir=cfg.documents_dir
     )
     return {"command": "remove", "removed": result.removed, "not_found": result.not_found}

--- a/src/lilbee/server/handlers/documents.py
+++ b/src/lilbee/server/handlers/documents.py
@@ -69,8 +69,10 @@ def _imported_source_markdown(source: str) -> str | None:
 async def delete_documents(
     names: list[str], *, delete_files: bool = False
 ) -> DocumentRemoveResponse:
-    """Remove documents from the knowledge base by source name."""
-    result = get_services().store.remove_documents(names, delete_files=delete_files)
+    """Remove documents by source name; a folder name removes everything beneath it."""
+    from lilbee.app.ingest import remove_documents_durably
+
+    result = remove_documents_durably(names, delete_files=delete_files)
     return DocumentRemoveResponse(removed=result.removed, not_found=result.not_found)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1463,6 +1463,73 @@ class TestRemove:
         assert result.exit_code == 0
         assert not doc.exists()
 
+    def test_remove_folder_confirms_and_expands(self, isolated_env, mock_svc):
+        from lilbee.data.store import RemoveResult
+
+        mock_svc.store.get_sources.return_value = [
+            {"filename": "myrepo/a.pdf"},
+            {"filename": "myrepo/b.pdf"},
+        ]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["myrepo/a.pdf", "myrepo/b.pdf"], not_found=[]
+        )
+        result = runner.invoke(app, ["remove", "myrepo"], input="y\n")
+        assert result.exit_code == 0
+        assert "2 documents" in result.output
+        assert mock_svc.store.remove_documents.call_args.args[0] == [
+            "myrepo/a.pdf",
+            "myrepo/b.pdf",
+        ]
+
+    def test_remove_folder_aborts_on_no(self, isolated_env, mock_svc):
+        from lilbee.data.store import RemoveResult
+
+        mock_svc.store.get_sources.return_value = [{"filename": "myrepo/a.pdf"}]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["myrepo/a.pdf"], not_found=[]
+        )
+        result = runner.invoke(app, ["remove", "myrepo"], input="n\n")
+        assert result.exit_code != 0
+        mock_svc.store.remove_documents.assert_not_called()
+
+    def test_remove_folder_yes_skips_confirm(self, isolated_env, mock_svc):
+        from lilbee.data.store import RemoveResult
+
+        mock_svc.store.get_sources.return_value = [{"filename": "myrepo/a.pdf"}]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["myrepo/a.pdf"], not_found=[]
+        )
+        result = runner.invoke(app, ["remove", "myrepo", "--yes"])
+        assert result.exit_code == 0
+        mock_svc.store.remove_documents.assert_called_once()
+
+    def test_remove_exact_file_needs_no_confirm(self, isolated_env, mock_svc):
+        from lilbee.data.store import RemoveResult
+
+        mock_svc.store.get_sources.return_value = [{"filename": "test.pdf"}]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["test.pdf"], not_found=[]
+        )
+        # No stdin provided: an exact filename must not prompt.
+        result = runner.invoke(app, ["remove", "test.pdf"])
+        assert result.exit_code == 0
+        mock_svc.store.remove_documents.assert_called_once()
+
+    def test_remove_skip_marks_kept_file(self, isolated_env, mock_svc):
+        """A plain remove writes a skip-marker so the next sync won't re-ingest it."""
+        from lilbee.data.ingest.skip_marker import load_skip_markers
+        from lilbee.data.store import RemoveResult
+
+        doc = cfg.documents_dir / "keep.txt"
+        doc.write_text("content")
+        mock_svc.store.get_sources.return_value = [{"filename": "keep.txt"}]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["keep.txt"], not_found=[]
+        )
+        result = runner.invoke(app, ["remove", "keep.txt"])
+        assert result.exit_code == 0
+        assert "keep.txt" in load_skip_markers(cfg.data_root)
+
     def test_remove_json(self, isolated_env, mock_svc):
         from lilbee.data.store import RemoveResult
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3225,9 +3225,7 @@ class TestRemoveDocumentsDurably:
         doc.write_text("x")
         mock_svc.store.get_sources.side_effect = lambda: [{"filename": "d.txt"}]
         mock_svc.store.remove_documents.side_effect = None
-        mock_svc.store.remove_documents.return_value = RemoveResult(
-            removed=["d.txt"], not_found=[]
-        )
+        mock_svc.store.remove_documents.return_value = RemoveResult(removed=["d.txt"], not_found=[])
 
         remove_documents_durably(["d.txt"], delete_files=True)
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3184,3 +3184,97 @@ class TestRemoveDocumentsDurably:
         mock_svc.store.remove_documents.return_value = RemoveResult(removed=[], not_found=["gone"])
         remove_documents_durably(["gone"])
         assert load_skip_markers(cfg.data_root) == {}
+
+    def test_folder_name_expands_and_marks_members(self, isolated_env, mock_svc):
+        """A folder name removes and skip-marks every source beneath it."""
+        from lilbee.app.ingest import remove_documents_durably
+        from lilbee.data.ingest.discovery import file_hash
+        from lilbee.data.ingest.skip_marker import load_skip_markers
+        from lilbee.data.store.types import RemoveResult
+
+        (isolated_env / "myrepo" / "sub").mkdir(parents=True)
+        a = isolated_env / "myrepo" / "a.txt"
+        a.write_text("x")
+        b = isolated_env / "myrepo" / "sub" / "b.txt"
+        b.write_text("y")
+        mock_svc.store.get_sources.side_effect = lambda: [
+            {"filename": "myrepo/a.txt"},
+            {"filename": "myrepo/sub/b.txt"},
+            {"filename": "keep.md"},
+        ]
+        mock_svc.store.remove_documents.side_effect = None
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["myrepo/a.txt", "myrepo/sub/b.txt"], not_found=[]
+        )
+
+        remove_documents_durably(["myrepo"])
+
+        # The store is asked to remove the expanded members, not the folder name.
+        called = mock_svc.store.remove_documents.call_args
+        assert called.args[0] == ["myrepo/a.txt", "myrepo/sub/b.txt"]
+        markers = load_skip_markers(cfg.data_root)
+        assert markers["myrepo/a.txt"] == file_hash(a)
+        assert markers["myrepo/sub/b.txt"] == file_hash(b)
+
+    def test_delete_files_passthrough(self, isolated_env, mock_svc):
+        """delete_files reaches the store, and unlinked files get no marker."""
+        from lilbee.app.ingest import remove_documents_durably
+        from lilbee.data.store.types import RemoveResult
+
+        doc = isolated_env / "d.txt"
+        doc.write_text("x")
+        mock_svc.store.get_sources.side_effect = lambda: [{"filename": "d.txt"}]
+        mock_svc.store.remove_documents.side_effect = None
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["d.txt"], not_found=[]
+        )
+
+        remove_documents_durably(["d.txt"], delete_files=True)
+
+        assert mock_svc.store.remove_documents.call_args.kwargs["delete_files"] is True
+
+
+class TestExpandFolderNames:
+    def test_folder_expands_to_members_in_order(self, isolated_env, mock_svc):
+        from lilbee.app.ingest import expand_folder_names
+
+        mock_svc.store.get_sources.side_effect = lambda: [
+            {"filename": "myrepo/a.py"},
+            {"filename": "myrepo/sub/b.py"},
+            {"filename": "other.md"},
+        ]
+        assert expand_folder_names(["myrepo"]) == ["myrepo/a.py", "myrepo/sub/b.py"]
+
+    def test_trailing_slash_accepted(self, isolated_env, mock_svc):
+        from lilbee.app.ingest import expand_folder_names
+
+        mock_svc.store.get_sources.side_effect = lambda: [{"filename": "myrepo/a.py"}]
+        assert expand_folder_names(["myrepo/"]) == ["myrepo/a.py"]
+
+    def test_exact_source_kept(self, isolated_env, mock_svc):
+        from lilbee.app.ingest import expand_folder_names
+
+        mock_svc.store.get_sources.side_effect = lambda: [{"filename": "other.md"}]
+        assert expand_folder_names(["other.md"]) == ["other.md"]
+
+    def test_unknown_name_passthrough(self, isolated_env, mock_svc):
+        from lilbee.app.ingest import expand_folder_names
+
+        mock_svc.store.get_sources.side_effect = lambda: [{"filename": "a.md"}]
+        assert expand_folder_names(["ghost"]) == ["ghost"]
+
+    def test_prefix_must_be_a_directory_boundary(self, isolated_env, mock_svc):
+        """``my`` must not match ``myrepo/...``; only whole path segments count."""
+        from lilbee.app.ingest import expand_folder_names
+
+        mock_svc.store.get_sources.side_effect = lambda: [{"filename": "myrepo/a.py"}]
+        assert expand_folder_names(["my"]) == ["my"]
+
+    def test_dedup_when_folder_and_member_both_requested(self, isolated_env, mock_svc):
+        from lilbee.app.ingest import expand_folder_names
+
+        mock_svc.store.get_sources.side_effect = lambda: [
+            {"filename": "myrepo/a.py"},
+            {"filename": "myrepo/b.py"},
+        ]
+        assert expand_folder_names(["myrepo", "myrepo/a.py"]) == ["myrepo/a.py", "myrepo/b.py"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -369,6 +369,24 @@ class TestRemove:
         result = remove([traversal_name], delete_files=True)
         assert result["removed"] == [traversal_name]
 
+    def test_folder_name_removes_everything_beneath_it(self, mock_svc):
+        from lilbee.data.store import RemoveResult
+
+        mock_svc.store.get_sources.return_value = [
+            {"filename": "myrepo/a.md"},
+            {"filename": "myrepo/b.md"},
+            {"filename": "other.md"},
+        ]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["myrepo/a.md", "myrepo/b.md"], not_found=[]
+        )
+        result = remove(["myrepo"])
+        assert result["removed"] == ["myrepo/a.md", "myrepo/b.md"]
+        assert mock_svc.store.remove_documents.call_args.args[0] == [
+            "myrepo/a.md",
+            "myrepo/b.md",
+        ]
+
 
 class TestListDocuments:
     def test_returns_documents(self, mock_svc):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -3069,7 +3069,7 @@ class TestDeleteDocuments:
         f = tmp_path / "a.md"
         f.write_text("content")
 
-        def fake_remove(names, *, delete_files=False):
+        def fake_remove(names, *, delete_files=False, documents_dir=None):
             if delete_files and f.exists():
                 f.unlink()
             return RemoveResult(removed=["a.md"], not_found=[])
@@ -3078,6 +3078,23 @@ class TestDeleteDocuments:
         result = await handlers.delete_documents(["a.md"], delete_files=True)
         assert result.removed == ["a.md"]
         assert not f.exists()
+
+    async def test_folder_name_removes_everything_beneath_it(self, mock_svc):
+        from lilbee.data.store import RemoveResult
+
+        mock_svc.store.get_sources.return_value = [
+            {"filename": "myrepo/a.md"},
+            {"filename": "myrepo/b.md"},
+        ]
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["myrepo/a.md", "myrepo/b.md"], not_found=[]
+        )
+        result = await handlers.delete_documents(["myrepo"])
+        assert result.removed == ["myrepo/a.md", "myrepo/b.md"]
+        assert mock_svc.store.remove_documents.call_args.args[0] == [
+            "myrepo/a.md",
+            "myrepo/b.md",
+        ]
 
 
 class TestUpdateConfig:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1034,6 +1034,43 @@ class TestRemoveDocuments:
             assert result.removed == ["a.md"]
             assert not f.exists()
 
+    def test_delete_files_prunes_emptied_dirs(self, store, tmp_path):
+        """A folder --delete leaves no empty directory tree behind."""
+        (tmp_path / "myrepo" / "sub").mkdir(parents=True)
+        a = tmp_path / "myrepo" / "a.txt"
+        a.write_text("x")
+        b = tmp_path / "myrepo" / "sub" / "b.txt"
+        b.write_text("y")
+        with (
+            mock.patch.object(
+                store,
+                "get_sources",
+                return_value=[{"filename": "myrepo/a.txt"}, {"filename": "myrepo/sub/b.txt"}],
+            ),
+            mock.patch.object(store, "_remove_many_unlocked"),
+        ):
+            store.remove_documents(
+                ["myrepo/a.txt", "myrepo/sub/b.txt"], delete_files=True, documents_dir=tmp_path
+            )
+        assert not (tmp_path / "myrepo").exists()  # whole emptied tree pruned
+        assert tmp_path.exists()  # documents_dir itself is never removed
+
+    def test_delete_files_keeps_nonempty_dirs(self, store, tmp_path):
+        """Pruning stops at a directory that still holds a sibling file."""
+        (tmp_path / "myrepo").mkdir()
+        a = tmp_path / "myrepo" / "a.txt"
+        a.write_text("x")
+        keep = tmp_path / "myrepo" / "keep.txt"
+        keep.write_text("z")
+        with (
+            mock.patch.object(store, "get_sources", return_value=[{"filename": "myrepo/a.txt"}]),
+            mock.patch.object(store, "_remove_many_unlocked"),
+        ):
+            store.remove_documents(["myrepo/a.txt"], delete_files=True, documents_dir=tmp_path)
+        assert not a.exists()
+        assert (tmp_path / "myrepo").exists()  # sibling keeps the dir
+        assert keep.exists()
+
     def test_blocks_path_traversal(self, store, tmp_path):
         with (
             mock.patch.object(

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2776,6 +2776,24 @@ class TestChatSlashCommands:
             mock_notify.assert_called_once()
             assert "monokai" in mock_notify.call_args[0][0]
 
+    async def test_cmd_delete_folder_removes_everything_beneath(self, _mock_resolve):
+        """/delete <folder> is accepted and removes every source beneath it."""
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            with (
+                mock.patch("lilbee.cli.tui.screens.chat.get_services") as mock_svc,
+                mock.patch("lilbee.app.ingest.remove_documents_durably") as mock_remove,
+            ):
+                mock_svc.return_value.store.get_sources.return_value = [
+                    {"filename": "myrepo/a.md"},
+                    {"filename": "myrepo/b.md"},
+                ]
+                app.screen._handle_slash("/delete myrepo")
+                await app.workers.wait_for_complete()
+                await pilot.pause()
+            mock_remove.assert_called_once_with(["myrepo"])
+
     async def test_cmd_delete_no_docs(self, _mock_resolve):
         """/delete with no docs shows warning."""
         app = ChatTestApp()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2729,9 +2729,12 @@ async def test_chat_slash_delete_with_match(mock_svc):
 
     Awaits the worker before asserting so the dispatch lands first.
     """
+    from lilbee.data.store.types import RemoveResult
+
     mock_svc.store.get_sources.return_value = [
         {"filename": "notes.md", "source": "notes.md"},
     ]
+    mock_svc.store.remove_documents.return_value = RemoveResult(removed=["notes.md"], not_found=[])
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         # Re-inject mock after mount (model bar events may call reset_services)
@@ -2739,7 +2742,11 @@ async def test_chat_slash_delete_with_match(mock_svc):
         app.screen._cmd_delete("notes.md")
         await app.screen.workers.wait_for_complete()
         await _pilot.pause()
-        mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
+        # /delete routes through remove_documents_durably, so the store is called
+        # with the durable signature (delete_files, documents_dir) rather than
+        # bare positional names.
+        mock_svc.store.remove_documents.assert_called_once()
+        assert mock_svc.store.remove_documents.call_args.args[0] == ["notes.md"]
 
 
 async def test_chat_slash_delete_not_found(mock_svc):


### PR DESCRIPTION
## Problem

Removing a document meant three different things depending on where you asked. The TUI's `/delete` wrote a skip-marker so the next sync wouldn't re-ingest a file left on disk, but the CLI, MCP, and REST removes called the store directly and skipped that step. So any removal that kept the file on disk (the default, without `--delete`) silently undid itself on the very next sync.

There was also no way to drop a whole directory in one step. `remove` matched exact source names only, so clearing an added repo meant naming every file under it. A plugin user who synced a GitHub repo and later wanted the stale content gone had to delete the folder by hand in Obsidian.

Underlying both: `add` copies files into the vault, so the copy is a point-in-time snapshot. Nothing in the docs said so, which is why the tracking expectation formed in the first place.

## Solution

Route every user-facing removal (CLI, MCP, REST, the library API, and the TUI) through `remove_documents_durably`, so a removal sticks regardless of entry point. The wrapper now also expands a folder name to every source indexed beneath it, matched on whole path segments (`myrepo` covers `myrepo/a.py` but never `myrepo-2/x`; a trailing slash forces the folder reading when a same-named file also exists). The CLI prompts before a folder removal and takes `--yes` to skip; the prompt is auto-skipped in json mode and for the non-interactive callers.

The two internal sync-reconciliation calls stay on the direct store path on purpose: the file is already gone from disk there, so writing a skip-marker would be wrong.

Docs now state that `add` copies into the vault, that the copy is a snapshot, and that dropping a stale directory is a `remove`, not an edit at the source.

No new TUI screen: the Status view already lists every source, so folder removal rides the existing `/delete` and `lilbee remove` surfaces rather than a dedicated panel.