### PR TITLE
Make the vision-dispatch and grid-focus tests deterministic under load

### DIFF
--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -685,6 +685,36 @@ def test_vision_dispatcher_caps_each_replica_at_its_slots() -> None:
     assert set(peaks) == {id(replica_a), id(replica_b)}  # both replicas pulled work
 
 
+def test_vision_dispatcher_blocks_on_a_full_pool_until_a_slot_frees() -> None:
+    # Every slot held up front, so the waiter's first pick returns None and it
+    # parks on the condition's timed re-poll; freeing a slot must wake it. Filling
+    # the pool before the waiter starts makes the block deterministic rather than
+    # relying on threads racing into a full pool.
+    import threading
+
+    dispatcher = prov_mod._VisionDispatcher()
+    only = _fake_client()
+    pool = [prov_mod._VisionReplica(only, 1)]
+
+    acquired = threading.Event()
+
+    def _wait_for_slot() -> None:
+        with dispatcher.slot(pool):
+            acquired.set()
+
+    with dispatcher.slot(pool) as held:
+        assert held is only  # the pool's one slot is now taken
+        waiter = threading.Thread(target=_wait_for_slot)
+        waiter.start()
+        # The waiter cannot get in while the slot is held; it is parked in the
+        # condition wait, not spinning on a busy pool.
+        assert not acquired.wait(timeout=0.2)
+    # Slot released here; release notifies the waiter, which wakes and acquires.
+    assert acquired.wait(timeout=5.0)
+    waiter.join(timeout=5.0)
+    assert not waiter.is_alive()
+
+
 def test_vision_dispatcher_prefers_replica_with_most_free_slots() -> None:
     # Balanced routing drains fastest: the next request goes to the replica with
     # the most free slots, not to whichever raced ahead.

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -10235,7 +10235,13 @@ async def test_catalog_grid_leave_down_focuses_next():
             if len(grids) < 2:
                 pytest.skip("test requires at least two grids mounted")
             grids[0].focus()
-            await pilot.pause()
+            # focus() lands over one or more refresh hops, not synchronously; a
+            # bare pause here lets LeaveDown post before grids[0] is actually the
+            # focused widget, so focus_next moves from the wrong anchor and can
+            # land back on grids[0]. Wait for the anchor to settle first, and
+            # assert it landed: without focus on grids[0] the post-condition
+            # ("focus moved off grids[0]") would pass for the wrong reason.
+            assert await pump_until(pilot, lambda: screen.focused is grids[0])
             grids[0].post_message(ModelGrid.LeaveDown(grids[0]))
             await pump_until(pilot, lambda: screen.focused is not grids[0])
             assert screen.focused is not grids[0]
@@ -10268,9 +10274,15 @@ async def test_catalog_grid_leave_down_at_last_grid_with_no_more_keeps_focus():
             grids = list(screen.query("#grid-chat ModelGrid"))
             last = grids[-1]
             last.focus()
-            await pilot.pause()
+            # Wait for focus to actually land before exercising LeaveDown: a bare
+            # pause can post the event while focus is still in flight, so the
+            # "focus stays put" assertion would pass for the wrong reason.
+            await pump_until(pilot, lambda: screen.focused is last)
             last.post_message(ModelGrid.LeaveDown(last))
-            await pilot.pause()
+            # Drain several hops so a mistaken focus_next would have moved focus
+            # off `last` by now; the guarantee is that it does not.
+            for _ in range(5):
+                await pilot.pause()
             assert screen.focused is last
 
 
@@ -10323,9 +10335,14 @@ async def test_catalog_grid_leave_up_at_first_grid_keeps_focus():
             if not grids:
                 pytest.skip("test requires at least one grid mounted in chat tab")
             grids[0].focus()
-            await pilot.pause()
+            # Settle focus onto grids[0] before exercising LeaveUp so the "stays
+            # put" assertion can't pass simply because focus was still in flight.
+            await pump_until(pilot, lambda: screen.focused is grids[0])
             grids[0].post_message(ModelGrid.LeaveUp(grids[0]))
-            await pilot.pause()
+            # Drain several hops so a mistaken focus_previous would have leaked
+            # focus upward by now; the guarantee is that it does not.
+            for _ in range(5):
+                await pilot.pause()
             assert screen.focused is grids[0]
 
 


### PR DESCRIPTION
## Problem

- `_VisionDispatcher._acquire`'s condition re-poll was only covered when two test files' threads happened to race into a full pool; under load the race missed and the 100% gate failed on that line.
- The catalog grid-leave focus tests posted `LeaveDown`/`LeaveUp` one `pilot.pause()` after `.focus()`. Focus lands over several refresh hops, so the event fired mid-flight and `focus_next` ran from the wrong anchor.

## Solution

- New dispatcher test holds every slot up front, so the waiter's first pick returns None and reaches the wait; freeing a slot wakes it. Covers the line in isolation.
- Grid-leave tests `pump_until` focus settles (and assert it) before posting; stays-put tests drain 5 hops to catch a stray move.

Verified 0 failures under 24-way xdist oversubscription. Does not close the broader cross-platform flake family.
