### PR TITLE
Dump wedged-worker stacks with a faulthandler watchdog in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,31 @@ jobs:
         shell: bash
         env:
           LILBEE_DATA: ${{ runner.temp }}/lilbee
+          # Backstop for the xdist worker wedge (ProactorEventLoop /
+          # reactive-timing thread-accumulation), which pytest-timeout's thread
+          # method cannot break on Windows: its callback is Python and never runs
+          # while the GIL is held. Above the 60s per-test pytest-timeout so this
+          # only fires when that fails; faulthandler's C watchdog dumps every
+          # thread and _exits the worker, so a wedge fails fast with a traceback
+          # instead of hanging to timeout-minutes. See tests/_hang_watchdog.py.
+          LILBEE_TEST_HANG_DUMP_S: "90"
+          LILBEE_TEST_HANG_DUMP_DIR: ${{ runner.temp }}/hang-dumps
+
+      - name: Surface hang-watchdog stack dumps
+        # Runs even when the test step failed/was killed: the wedged worker
+        # cannot print its own dump. Empty dirs/files mean no wedge fired.
+        if: always()
+        shell: bash
+        run: |
+          dir="${{ runner.temp }}/hang-dumps"
+          found=""
+          for f in "$dir"/hang-*.txt; do
+            [ -s "$f" ] || continue
+            found=1
+            echo "===== $f ====="
+            cat "$f"
+          done
+          [ -n "$found" ] || echo "no hang-watchdog dumps (no worker wedged)"
 
   integration:
     timeout-minutes: 120

--- a/tests/_hang_watchdog.py
+++ b/tests/_hang_watchdog.py
@@ -1,0 +1,86 @@
+"""Dump every thread's stack when a test wedges, then kill the worker.
+
+pytest-timeout is already configured (``timeout = 60``), but on Windows it runs
+its ``thread`` method: a ``threading.Timer`` whose callback is Python. If a test
+wedges inside a native call that holds the GIL, no Python bytecode runs, the
+timer callback never fires, and the worker hangs silently until the job's
+``timeout-minutes`` kills it with no traceback (seen on CI, Windows py3.13).
+
+``faulthandler.dump_traceback_later`` is the stdlib answer to exactly that case:
+its watchdog is a C thread that walks the interpreter's thread states and writes
+their stacks WITHOUT acquiring the GIL, so it fires on a GIL-frozen worker where
+pytest-timeout cannot. ``exit=True`` then ``_exit``\\s the wedged worker so the
+run fails fast instead of burning the job budget.
+
+Opt-in via ``LILBEE_TEST_HANG_DUMP_S`` (seconds); unset or ``0`` is a no-op, so
+local runs are untouched. Set it above pytest-timeout's value in CI so this is
+only ever the backstop for the frozen case, never a pre-empt of a merely slow
+test. The dump is written to ``LILBEE_TEST_HANG_DUMP_DIR/hang-<workerid>.txt``
+(default: the pytest rootdir) so a CI step can surface it after the killed step;
+the frozen worker cannot print it itself.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import os
+from pathlib import Path
+
+import pytest
+
+_ENV_SECONDS = "LILBEE_TEST_HANG_DUMP_S"
+_ENV_DIR = "LILBEE_TEST_HANG_DUMP_DIR"
+
+# The open dump-file handle. faulthandler writes to its raw fd from a C thread,
+# so it must outlive every test; keep a module reference so it is not closed.
+_dump_handle = None
+_timeout_s = 0.0
+
+
+def _worker_id(config: pytest.Config) -> str:
+    """xdist worker id (``gw0``), or ``master`` when running single-process."""
+    return getattr(config, "workerinput", {}).get("workerid", "master")
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    global _dump_handle, _timeout_s
+    raw = os.environ.get(_ENV_SECONDS, "").strip()
+    _timeout_s = float(raw) if raw else 0.0
+    if _timeout_s <= 0:
+        return
+    dump_dir = Path(os.environ.get(_ENV_DIR) or config.rootpath)
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    # One file per worker: xdist workers share a rootdir but not a process.
+    _dump_handle = (dump_dir / f"hang-{_worker_id(config)}.txt").open("w")
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if _dump_handle is None:
+        return
+    # Record which test armed the timer, so a dump names its trigger even though
+    # faulthandler itself only prints stacks. Rewinds each test (no accumulation).
+    _dump_handle.seek(0)
+    _dump_handle.truncate()
+    _dump_handle.write(f"hang watchdog armed for {item.nodeid} ({_timeout_s}s)\n")
+    _dump_handle.flush()
+    # Re-arms (resets) the single C-thread timer for this test. dump_traceback_later
+    # dumps every thread by default, which is what we want on a wedged worker.
+    faulthandler.dump_traceback_later(_timeout_s, file=_dump_handle, exit=True)
+
+
+def pytest_runtest_teardown(item: pytest.Item) -> None:
+    if _dump_handle is None:
+        return
+    faulthandler.cancel_dump_traceback_later()
+    # The test finished, so its armed dump is stale; clear it.
+    _dump_handle.seek(0)
+    _dump_handle.truncate()
+    _dump_handle.flush()
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    global _dump_handle
+    if _dump_handle is not None:
+        faulthandler.cancel_dump_traceback_later()
+        _dump_handle.close()
+        _dump_handle = None

--- a/tests/_hang_watchdog_selftest.py
+++ b/tests/_hang_watchdog_selftest.py
@@ -1,0 +1,35 @@
+"""Manual self-test for the hang watchdog. Not collected in the normal suite.
+
+Run explicitly:
+    LILBEE_TEST_HANG_DUMP_S=3 LILBEE_TEST_HANG_DUMP_DIR=/tmp/hd \
+      uv run pytest tests/_hang_watchdog_selftest.py -p no:xdist -p no:cacheprovider \
+      --no-cov -o addopts='' -s
+Expect: each test wedges, the watchdog dumps its stack after 3s and _exits the
+worker; /tmp/hd/hang-master.txt holds the traceback naming the wedged frame.
+"""
+
+import os
+import time
+
+import pytest
+
+# These tests wedge on purpose to exercise the watchdog, so they must never run
+# in a normal or CI suite (where they would trip it and fail). Gated behind a
+# dedicated var, separate from the LILBEE_TEST_HANG_DUMP_S that arms the
+# watchdog, so CI can set the latter without collecting these.
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("LILBEE_HANG_SELFTEST"),
+    reason="watchdog self-test; set LILBEE_HANG_SELFTEST=1 to run",
+)
+
+
+def test_hang_via_sleep():
+    # sleep releases the GIL; the easy case.
+    time.sleep(120)
+
+
+def test_hang_via_busy_loop():
+    # A tight loop holds the GIL at the eval level; the hard case that proves
+    # faulthandler's C watchdog does not need the GIL to dump.
+    while True:
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,9 @@ from lilbee.data.ingest import file_hash
 from lilbee.data.store import CitationRecord
 from lilbee.modelhub.registry import ModelManifest, ModelRegistry
 
+# Stack-dump watchdog for wedged tests (opt-in via LILBEE_TEST_HANG_DUMP_S).
+pytest_plugins = ["tests._hang_watchdog"]
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 


### PR DESCRIPTION
## Problem

- A wedged pytest-xdist worker (ProactorEventLoop / reactive-timing thread accumulation) hangs the job silently until `timeout-minutes` kills it, with no traceback.
- pytest-timeout is configured but on Windows runs its thread method: the timeout callback is Python and never runs while a worker holds the GIL, so it cannot break this wedge.

## Solution

- Opt-in `faulthandler` watchdog (`tests/_hang_watchdog.py`, gated on `LILBEE_TEST_HANG_DUMP_S`), armed per test above the 60s pytest-timeout. faulthandler's C watchdog thread dumps every thread without acquiring the GIL, so it fires where pytest-timeout can't; `exit=True` then `_exit`s the worker so the run fails fast with a traceback (exit 1 serial, 3 under xdist) instead of hanging.
- CI sets the var on the test jobs and prints the per-worker dump in an `if: always()` step, since the wedged worker can't print its own.

Diagnostic only, no-op when the var is unset. Verified locally: dumps the exact frozen frame for a GIL-releasing sleep and a GIL-holding busy loop; no misfire on fast tests under xdist.
