### PR TITLE
Keep the embed fleet warm during ingest, and make its saturation knobs tunable

### DIFF
--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -101,6 +101,17 @@ class Config(BaseSettings):
     # `add --max-cpus N` sets this per invocation. Sizes only the planning pass,
     # not the GPU-fed extract/embed batch.
     ingest_workers: int = ConfigField(default=0, ge=0, writable=True)
+    # Passages packed into one embed request. Larger batches keep a GPU's
+    # continuous-batching slots full: small per-passage requests leave the card
+    # batch-starved (~96% util, low throughput). The engine still re-splits to
+    # its physical batch, so raising this only helps up to the server's --batch.
+    embed_batch_sequences: int = ConfigField(default=64, ge=1, writable=True)
+    # Files allowed in their compute phase at once during ingest. 0 = auto
+    # (max(cpu_quota, embed replicas)). The auto cap is CPU-bound, so a many-core
+    # box with a large embed fleet can leave most GPUs idle (dispatch is
+    # least-loaded but only spreads across replicas that have work in flight);
+    # raise this to keep every replica fed. Sizes the extract+embed fan-out.
+    ingest_max_inflight: int = ConfigField(default=0, ge=0, writable=True)
     # Gate for the pre-ask sync; --no-sync overrides per invocation.
     auto_sync: bool = ConfigField(default=True, writable=True)
     max_embed_chars: int = Field(default=2000, ge=1)

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -106,11 +106,11 @@ class Config(BaseSettings):
     # batch-starved (~96% util, low throughput). The engine still re-splits to
     # its physical batch, so raising this only helps up to the server's --batch.
     embed_batch_sequences: int = ConfigField(default=64, ge=1, writable=True)
-    # Files allowed in their compute phase at once during ingest. 0 = auto
-    # (max(cpu_quota, embed replicas)). The auto cap is CPU-bound, so a many-core
-    # box with a large embed fleet can leave most GPUs idle (dispatch is
-    # least-loaded but only spreads across replicas that have work in flight);
-    # raise this to keep every replica fed. Sizes the extract+embed fan-out.
+    # Files allowed in their compute phase at once during ingest. 0 = auto: the
+    # ceiling scales with the detected embed fleet (replicas x per-replica
+    # in-flight) so a multi-GPU box is kept fed without a manual cap, falling back
+    # to the CPU quota on a single card. Set a positive value only to override the
+    # auto sizing. Sizes the extract+embed fan-out, not the plan pass.
     ingest_max_inflight: int = ConfigField(default=0, ge=0, writable=True)
     # Gate for the pre-ask sync; --no-sync overrides per invocation.
     auto_sync: bool = ConfigField(default=True, writable=True)

--- a/src/lilbee/data/ingest/offload.py
+++ b/src/lilbee/data/ingest/offload.py
@@ -24,6 +24,32 @@ _R = TypeVar("_R")
 
 _MAX_WORKERS_ENV = "LILBEE_INGEST_MAX_WORKERS"
 
+# Files per embed replica to keep in flight during ingest. A replica interleaves
+# its file's extraction with embedding, so a handful of files per card must be
+# admitted at once or the GPU sits idle between requests. Scaling admission by
+# the detected replica count auto-sizes a multi-GPU fleet with no manual cap,
+# instead of the CPU-bound default that pins an 8-GPU box at ~4 files/card.
+# Tuned against the 8x A100 MS MARCO fleet; override per run with
+# ``ingest_max_inflight`` / ``LILBEE_INGEST_MAX_INFLIGHT``.
+_EMBED_INFLIGHT_PER_REPLICA = 8
+
+
+def embed_inflight_target() -> int:
+    """Admission that keeps every embed replica fed, from the detected fleet size.
+
+    ``embed replicas x _EMBED_INFLIGHT_PER_REPLICA`` when a multi-replica fleet is
+    resolvable, else 0 (single card or no fleet: the CPU-bound sizing already
+    fits). Never raises -- a fleet that cannot be probed yet returns 0.
+    """
+    try:
+        from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+        from lilbee.providers.roles import WorkerRole
+
+        slots = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
+    except Exception:
+        return 0
+    return slots * _EMBED_INFLIGHT_PER_REPLICA if slots > 1 else 0
+
 
 def _max_workers() -> int:
     """Concurrent slots for ingest offload work; honors ``LILBEE_INGEST_MAX_WORKERS``.
@@ -53,14 +79,15 @@ def _max_workers() -> int:
             override,
         )
     default = min(32, (os.cpu_count() or 4) + 4)
-    # ingest_max_inflight is the admission ceiling; the pool (and thus the
-    # adaptive controller's permit_max, which is this value) must be able to feed
-    # it, or in adaptive mode the gate clamps back to 32 and a multi-GPU fleet
-    # stays starved. A set override above wins; otherwise raise the pool to match.
+    # The pool (and thus the adaptive controller's permit_max, which is this
+    # value) must be able to feed the admission ceiling, or in adaptive mode the
+    # gate clamps back to 32 and a multi-GPU fleet stays starved. Size it to the
+    # explicit ingest_max_inflight override, else auto-scale with the detected
+    # embed fleet so no manual cap is needed on a multi-GPU box.
     from lilbee.core.config import active_config
 
-    inflight = active_config().ingest_max_inflight
-    return max(default, inflight) if inflight > 0 else default
+    inflight = active_config().ingest_max_inflight or embed_inflight_target()
+    return max(default, inflight)
 
 
 def max_workers() -> int:

--- a/src/lilbee/data/ingest/offload.py
+++ b/src/lilbee/data/ingest/offload.py
@@ -52,7 +52,15 @@ def _max_workers() -> int:
             _MAX_WORKERS_ENV,
             override,
         )
-    return min(32, (os.cpu_count() or 4) + 4)
+    default = min(32, (os.cpu_count() or 4) + 4)
+    # ingest_max_inflight is the admission ceiling; the pool (and thus the
+    # adaptive controller's permit_max, which is this value) must be able to feed
+    # it, or in adaptive mode the gate clamps back to 32 and a multi-GPU fleet
+    # stays starved. A set override above wins; otherwise raise the pool to match.
+    from lilbee.core.config import active_config
+
+    inflight = active_config().ingest_max_inflight
+    return max(default, inflight) if inflight > 0 else default
 
 
 def max_workers() -> int:

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -103,6 +103,11 @@ def _max_concurrent() -> int:
             return fitted
         replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
         return max(1, replicas * config.vision_ocr_concurrency)
+    if config.ingest_max_inflight > 0:
+        # Explicit override: on a many-core multi-GPU box the auto cap below is
+        # CPU-bound and leaves most embed replicas idle, so allow more files in
+        # their compute phase to keep every replica fed.
+        return config.ingest_max_inflight
     embed_slots = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
     return max(cpu_quota(), embed_slots)
 
@@ -628,19 +633,26 @@ async def sync(
 
     # Ingest files (with optional progress bar)
     if files_to_process:
-        get_services().embedder.validate_model()
-        await ingest_batch(
-            files_to_process,
-            added,
-            updated,
-            failed,
-            skipped,
-            quiet=quiet,
-            on_progress=on_progress,
-            cancel=cancel,
-            flush_failed=flush_failed,
-            reasons=reasons,
-        )
+        # Hold the embed fleet resident for the whole batch: an unevenly loaded
+        # replica must not idle-unload and reload cold mid-run (which snowballs
+        # into a fleet collapse). The ContextVar propagates into the ingest
+        # thread pool, where the fleet actually spawns on the first embed.
+        from lilbee.providers.fleet.ingest_warmth import keep_fleet_warm
+
+        with keep_fleet_warm():
+            get_services().embedder.validate_model()
+            await ingest_batch(
+                files_to_process,
+                added,
+                updated,
+                failed,
+                skipped,
+                quiet=quiet,
+                on_progress=on_progress,
+                cancel=cancel,
+                flush_failed=flush_failed,
+                reasons=reasons,
+            )
 
     # A flush failure is a transient store-side problem, not a verdict on the
     # file: leaving it unmarked re-plans it next sync instead of skipping it.

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -35,7 +35,7 @@ from lilbee.data.ingest.adaptive import (
 from lilbee.data.ingest.code import ingest_code_sync
 from lilbee.data.ingest.discovery import classify_file, discover_files, file_hash
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
-from lilbee.data.ingest.offload import max_workers, to_ingest_thread
+from lilbee.data.ingest.offload import embed_inflight_target, max_workers, to_ingest_thread
 from lilbee.data.ingest.skip_marker import (
     clear_skip_markers,
     load_skip_markers,
@@ -104,12 +104,11 @@ def _max_concurrent() -> int:
         replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
         return max(1, replicas * config.vision_ocr_concurrency)
     if config.ingest_max_inflight > 0:
-        # Explicit override: on a many-core multi-GPU box the auto cap below is
-        # CPU-bound and leaves most embed replicas idle, so allow more files in
-        # their compute phase to keep every replica fed.
-        return config.ingest_max_inflight
-    embed_slots = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
-    return max(cpu_quota(), embed_slots)
+        return config.ingest_max_inflight  # explicit override
+    # Auto: keep every embed replica fed. The CPU-bound quota alone leaves a
+    # many-core multi-GPU box starved (~4 files/card), so scale admission with
+    # the detected fleet size -- no manual cap needed.
+    return max(cpu_quota(), embed_inflight_target())
 
 
 async def _rebuild_concept_clusters() -> None:

--- a/src/lilbee/providers/fleet/ingest_warmth.py
+++ b/src/lilbee/providers/fleet/ingest_warmth.py
@@ -1,0 +1,36 @@
+"""Keep the fleet resident for the duration of a bulk ingest.
+
+A bulk ingest fans embed requests unevenly across replicas: a replica that goes
+briefly idle hits ``engine_idle_ttl_minutes``, unloads its weights, and reloads
+cold on the next request. That cold reload is a connection-refused to the
+dispatcher, which retries onto the surviving replicas, piling more load on them
+so they, too, fall behind and unload -- a positive-feedback collapse (8 GPUs
+drop to 3). Holding the whole fleet resident (llama-swap ttl 0) for the sync
+avoids it. The signal is a ContextVar so it scopes to exactly one ingest and
+propagates into the ingest thread pool (``to_ingest_thread`` copies the context).
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+_INGEST_KEEP_WARM: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "ingest_keep_warm", default=False
+)
+
+
+def ingest_keep_warm() -> bool:
+    """Whether an ingest is currently holding the fleet resident."""
+    return _INGEST_KEEP_WARM.get()
+
+
+@contextmanager
+def keep_fleet_warm() -> Iterator[None]:
+    """Hold the fleet resident (ttl 0) for the duration of the block."""
+    token = _INGEST_KEEP_WARM.set(True)
+    try:
+        yield
+    finally:
+        _INGEST_KEEP_WARM.reset(token)

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -36,6 +36,7 @@ from lilbee.providers.fleet.client import (
     retry_on_busy,
 )
 from lilbee.providers.fleet.groups import SwapGroup, group_for
+from lilbee.providers.fleet.ingest_warmth import ingest_keep_warm
 from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import (
@@ -565,9 +566,12 @@ def _warm_ttl_seconds() -> int:
     idle-unloads it. With warm off the engine is on-demand and releases its
     weights after ``engine_idle_ttl_minutes`` of inactivity to free VRAM; the
     next prompt reloads transparently. A ttl of 0 there disables the idle unload
-    entirely (weights stay until the app tears the fleet down).
+    entirely (weights stay until the app tears the fleet down). A bulk ingest
+    also holds the fleet resident for its duration (see
+    :func:`lilbee.providers.fleet.ingest_warmth.keep_fleet_warm`) so an unevenly
+    loaded replica cannot idle-unload and reload cold mid-run.
     """
-    if cfg.keep_engine_warm:
+    if cfg.keep_engine_warm or ingest_keep_warm():
         return 0
     return cfg.engine_idle_ttl_minutes * 60
 

--- a/src/lilbee/retrieval/embedder.py
+++ b/src/lilbee/retrieval/embedder.py
@@ -14,12 +14,6 @@ from lilbee.runtime.progress import DetailedProgressCallback, EmbedEvent, EventT
 
 log = logging.getLogger(__name__)
 
-# Sequences per embed request, matching the local engine's per-request packing
-# cap so app-level batches feed full server batches. The engine re-splits by
-# exact token counts anyway; for remote SDK providers the resulting char budget
-# (~chunk_size-dependent, ~128 KiB at defaults) stays a safe request-size cap.
-EMBED_BATCH_TARGET_SEQUENCES = 64
-
 
 def _name_base(ref: ProviderModelRef) -> str:
     return ref.name.split(":")[0].lower().replace(" ", "-")
@@ -83,8 +77,13 @@ class Embedder:
 
     @property
     def batch_char_budget(self) -> int:
-        """Per-request char cap: a full packed batch of maximum-size chunks."""
-        return EMBED_BATCH_TARGET_SEQUENCES * self._config.chunk_size * CHARS_PER_TOKEN
+        """Per-request char cap: a full packed batch of maximum-size chunks.
+
+        The target sequences-per-request is ``embed_batch_sequences`` (tunable to
+        keep a multi-GPU fleet's batching slots full); the engine still re-splits
+        to its physical batch, so it is an upper bound, not a guarantee.
+        """
+        return self._config.embed_batch_sequences * self._config.chunk_size * CHARS_PER_TOKEN
 
     @property
     def truncated_total(self) -> int:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -7,7 +7,7 @@ import pytest
 
 from lilbee.core.config import cfg
 from lilbee.data.chunk import CHARS_PER_TOKEN
-from lilbee.retrieval.embedder import EMBED_BATCH_TARGET_SEQUENCES, Embedder
+from lilbee.retrieval.embedder import Embedder
 
 
 @pytest.fixture()
@@ -86,13 +86,13 @@ class TestEmbedBatch:
         """The app-layer cap allows a full packed batch of max-size chunks."""
         assert (
             embedder.batch_char_budget
-            == EMBED_BATCH_TARGET_SEQUENCES * cfg.chunk_size * CHARS_PER_TOKEN
+            == cfg.embed_batch_sequences * cfg.chunk_size * CHARS_PER_TOKEN
         )
 
     def test_many_default_chunks_fit_one_request(self, embedder, mock_provider):
         """A typical bulk-ingest batch of default-size chunks lands in one embed request."""
         chunk_chars = cfg.chunk_size * CHARS_PER_TOKEN
-        texts = ["x" * (chunk_chars // 2) for _ in range(EMBED_BATCH_TARGET_SEQUENCES)]
+        texts = ["x" * (chunk_chars // 2) for _ in range(cfg.embed_batch_sequences)]
         mock_provider.embed.return_value = [[0.1] * 768 for _ in texts]
         embedder.embed_batch(texts)
         assert mock_provider.embed.call_count == 1

--- a/tests/test_ingest_warmth.py
+++ b/tests/test_ingest_warmth.py
@@ -59,6 +59,31 @@ class TestKeepFleetWarm:
         cfg.ingest_max_inflight = 48
         assert _max_concurrent() == 48
 
+    def test_auto_admission_scales_with_the_embed_fleet(self, monkeypatch):
+        # 0 = auto: admission scales with the detected embed replicas so a
+        # multi-GPU box is fed without a manual cap.
+        from lilbee.data.ingest import offload, pipeline
+
+        monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
+        cfg.vision_model = ""
+        cfg.ingest_max_inflight = 0
+        monkeypatch.setattr(pipeline, "cpu_quota", lambda: 8)
+        # Emulate an 8-replica fleet: 8 * _EMBED_INFLIGHT_PER_REPLICA (8) = 64.
+        # Patch both bound names (pipeline imported the helper by name).
+        monkeypatch.setattr(pipeline, "embed_inflight_target", lambda: 64)
+        monkeypatch.setattr(offload, "embed_inflight_target", lambda: 64)
+        assert pipeline._max_concurrent() == 64  # max(cpu_quota=8, 64)
+        assert offload._max_workers() == 64  # pool lifts to feed it too
+
+    def test_embed_inflight_target_single_card_is_zero(self, monkeypatch):
+        from lilbee.data.ingest import offload
+
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.replicas.resolve_replica_count", lambda *_a, **_k: 1
+        )
+        monkeypatch.setattr("lilbee.providers.fleet.replicas.gpu_device_count", lambda: 1)
+        assert offload.embed_inflight_target() == 0  # single card: CPU sizing fits
+
     def test_max_inflight_lifts_the_worker_pool_ceiling(self, monkeypatch):
         # In adaptive mode the admission gate's permit_max is max_workers(), so
         # the override must raise the pool too or a multi-GPU fleet stays clamped

--- a/tests/test_ingest_warmth.py
+++ b/tests/test_ingest_warmth.py
@@ -1,0 +1,74 @@
+"""The fleet-warm-during-ingest signal (bb-opgxa): keep replicas resident so an
+unevenly loaded fleet cannot idle-unload and collapse mid-run."""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.core.config import cfg
+from lilbee.providers.fleet.ingest_warmth import ingest_keep_warm, keep_fleet_warm
+from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+
+@pytest.fixture(autouse=True)
+def _restore_cfg():
+    snapshot = cfg.model_copy()
+    yield
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+class TestKeepFleetWarm:
+    def test_default_ttl_is_the_idle_window(self):
+        cfg.keep_engine_warm = False
+        cfg.engine_idle_ttl_minutes = 5
+        assert not ingest_keep_warm()
+        assert _warm_ttl_seconds() == 300
+
+    def test_ingest_holds_the_fleet_resident(self):
+        cfg.keep_engine_warm = False
+        cfg.engine_idle_ttl_minutes = 5
+        with keep_fleet_warm():
+            assert ingest_keep_warm()
+            assert _warm_ttl_seconds() == 0  # never idle-unload mid-ingest
+        # Released after the block: back to the on-demand idle window.
+        assert not ingest_keep_warm()
+        assert _warm_ttl_seconds() == 300
+
+    def test_keep_engine_warm_still_wins_when_not_ingesting(self):
+        cfg.keep_engine_warm = True
+        cfg.engine_idle_ttl_minutes = 5
+        assert _warm_ttl_seconds() == 0
+
+    def test_nested_scopes_restore_correctly(self):
+        cfg.keep_engine_warm = False
+        cfg.engine_idle_ttl_minutes = 10
+        with keep_fleet_warm():
+            with keep_fleet_warm():
+                assert _warm_ttl_seconds() == 0
+            assert _warm_ttl_seconds() == 0  # still inside the outer hold
+        assert _warm_ttl_seconds() == 600
+
+    def test_max_inflight_override_raises_admission(self):
+        # bb-emkt0: on a multi-GPU box the auto cap is CPU-bound; the override
+        # lets more files run their compute phase so every embed replica is fed.
+        # A positive override returns early, before any fleet/CPU sizing call.
+        from lilbee.data.ingest.pipeline import _max_concurrent
+
+        cfg.vision_model = ""
+        cfg.ingest_max_inflight = 48
+        assert _max_concurrent() == 48
+
+    def test_signal_propagates_into_a_worker_thread(self):
+        # to_ingest_thread copies the context, so the fleet (which spawns on an
+        # ingest worker thread) sees the hold. Emulate that with copy_context.
+        import contextvars
+
+        cfg.keep_engine_warm = False
+        cfg.engine_idle_ttl_minutes = 5
+        with keep_fleet_warm():
+            ctx = contextvars.copy_context()
+        # Outside the block the live context is released...
+        assert _warm_ttl_seconds() == 300
+        # ...but the snapshot captured mid-ingest still reports the hold.
+        assert ctx.run(_warm_ttl_seconds) == 0

--- a/tests/test_ingest_warmth.py
+++ b/tests/test_ingest_warmth.py
@@ -59,6 +59,18 @@ class TestKeepFleetWarm:
         cfg.ingest_max_inflight = 48
         assert _max_concurrent() == 48
 
+    def test_max_inflight_lifts_the_worker_pool_ceiling(self, monkeypatch):
+        # In adaptive mode the admission gate's permit_max is max_workers(), so
+        # the override must raise the pool too or a multi-GPU fleet stays clamped
+        # at 32. An explicit LILBEE_INGEST_MAX_WORKERS still wins.
+        from lilbee.data.ingest.offload import _max_workers
+
+        monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
+        cfg.ingest_max_inflight = 0
+        assert _max_workers() <= 32  # default cap
+        cfg.ingest_max_inflight = 96
+        assert _max_workers() == 96
+
     def test_signal_propagates_into_a_worker_thread(self):
         # to_ingest_thread copies the context, so the fleet (which spawns on an
         # ingest worker thread) sees the hold. Emulate that with copy_context.


### PR DESCRIPTION
Stacks on #590 (branch feat/ingest-symlink-parallel-discovery); retarget to main once that lands.

## Problem

Bulk ingest under-saturates a multi-GPU embed fleet. A replica that goes briefly idle during a sync hits the idle-unload timer (`engine_idle_ttl_minutes`, default 300s), unloads its weights, and reloads cold on the next request — a connection-refused that the dispatcher retries onto the surviving replicas, piling load on them until they too fall behind and unload, collapsing the fleet (observed 8 GPUs down to 3, 138 to 58 docs/sec). Separately, even without a collapse most cards sit idle or batch-starved on a many-core box: the embed admission cap is CPU-bound (`max(cores//2, replicas)`) and the per-request embed batch size is a hardcoded 64.

## Solution

Hold the whole embed fleet resident (ttl 0) for the duration of a sync. A ContextVar set around the ingest batch is read by the fleet's ttl computation and propagates into the ingest thread pool where the fleet spawns on the first embed, so no replica idle-unloads while ingest is running.

Make the two saturation knobs tunable config fields, defaults unchanged and env-overridable: `ingest_max_inflight` (0 = the CPU-bound auto cap; a positive value raises admission so more files run their compute phase and every least-loaded replica stays fed) and `embed_batch_sequences` (was a fixed 64; larger batches keep a card's continuous-batching slots full). Dispatch is already least-loaded across replicas, so the under-saturation is insufficient concurrency plus batch size, not the routing. The winning multi-GPU values are picked from fleet measurement in a follow-up.