### PR TITLE
Fix the Windows CI wedge: skip the per-event fsync barrier in the sessions load tests

### DIFF
--- a/tests/test_sessions_load.py
+++ b/tests/test_sessions_load.py
@@ -41,8 +41,17 @@ SEED = 20260715
 
 
 @pytest.fixture
-def store(tmp_path) -> SessionStore:
+def store(tmp_path, monkeypatch) -> SessionStore:
     cfg.data_dir = tmp_path / "data"
+    # Neutralize os.fsync for this suite only. It writes thousands of events in a
+    # tight loop, and on Windows os.fsync is a real FlushFileBuffers barrier
+    # (~4ms each vs ~0.05ms on macOS), so the per-event disk barrier -- not the
+    # code under test -- is what wedged these tests in Windows CI. None of the
+    # invariants below depend on fsync: they hold on O_APPEND + one write per
+    # event + flush + the FileLock. Production is untouched (real usage appends
+    # one event per user turn, seconds apart, where the barrier is cheap and
+    # buys genuine crash durability); monkeypatch reverts after each test.
+    monkeypatch.setattr("lilbee.sessions.store.os.fsync", lambda _fd: None)
     return SessionStore()
 
 


### PR DESCRIPTION
## Problem

- The Windows CI `test` job wedged (27 min to the 120 min timeout) on `test_no_turn_is_ever_lost` and `test_listing_stays_correct_at_volume`.
- Both fire thousands of `SessionStore` writes in a tight loop, each ending in `os.fsync`. On Windows `os.fsync` is a real `FlushFileBuffers` disk barrier (~4ms/event measured locally vs ~0.05ms on macOS, a 77x gap); ~2200 back-to-back barriers on a throttled CI disk ran for tens of minutes. macOS/Linux never saw it (their `os.fsync` isn't a real barrier).

## Solution

- Neutralize `os.fsync` in this suite's fixture only (`monkeypatch`, reverts per test). No production change.
- Safe: none of the invariants these tests assert depend on fsync — append-only, nothing-lost, torn-tail, and concurrent-writer safety rest on `O_APPEND` + one write per event + flush + the `FileLock`. All 8 tests pass fsync-free.
- Production is untouched: real usage appends one event per user turn, seconds apart, where the barrier is cheap and buys genuine crash durability. The 2000-event volume still stresses the append/lock/read paths; only the unrealistic barrier density is removed.
