### PR TITLE
Spread embed dispatch evenly across replicas, and make the plan pass observable

### DIFF
--- a/src/lilbee/data/ingest/discovery.py
+++ b/src/lilbee/data/ingest/discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import time
 from pathlib import Path
 
 from lilbee.core.config import active_config
@@ -13,6 +14,47 @@ from lilbee.data.code_chunker import is_code_file
 from lilbee.data.ingest.types import DOCUMENT_EXTENSION_MAP
 
 log = logging.getLogger(__name__)
+
+# How often the discovery walk logs progress. The walk runs before the file count
+# is known (it is what produces the count), so it cannot show an ETA; it just
+# proves the run is alive. A large or NFS-backed tree can take minutes to walk,
+# during which the plan pass has not started and nothing else logs.
+_SCAN_LOG_INTERVAL_S = 10.0
+
+
+class _ScanProgress:
+    """Periodic progress for the pre-plan discovery walk.
+
+    Emitted at warning level, not info: the default LILBEE_LOG_LEVEL is WARNING,
+    so an info line would be filtered before any handler and a headless
+    ``lilbee sync`` would show nothing while the tree is walked. Interval-gated,
+    so a fast walk (the common case) stays silent -- the first line appears only
+    once the walk has run longer than the interval.
+    """
+
+    def __init__(self) -> None:
+        self._examined = 0
+        self._matched = 0
+        self._started = time.monotonic()
+        self._last = self._started
+
+    def tick(self, *, matched: bool) -> None:
+        self._examined += 1
+        if matched:
+            self._matched += 1
+        now = time.monotonic()
+        if now - self._last < _SCAN_LOG_INTERVAL_S:
+            return
+        self._last = now
+        elapsed = now - self._started
+        rate = self._examined / elapsed if elapsed > 0 else 0.0
+        log.warning(
+            "Scanning for files: examined %d, matched %d (%.0f files/s, %.0fs elapsed)",
+            self._examined,
+            self._matched,
+            rate,
+            elapsed,
+        )
 
 
 def file_hash(path: Path) -> str:
@@ -86,6 +128,7 @@ def _walk_root(
     base: Path,
     label: str | None,
     ignore_dirs: frozenset[str],
+    progress: _ScanProgress,
 ) -> None:
     """Record supported files under *base*, keyed relative to it (prefixed by *label*).
 
@@ -99,7 +142,11 @@ def _walk_root(
             if fname.startswith("."):
                 continue
             path = Path(root) / fname
-            if classify_file(path) is None:
+            content_type = classify_file(path)
+            # tick per file visited, not per match: a skip-heavy tree still walks
+            # slowly and must still show a heartbeat.
+            progress.tick(matched=content_type is not None)
+            if content_type is None:
                 continue
             rel = path.relative_to(base).as_posix()
             files[f"{label}/{rel}" if label else rel] = path
@@ -117,12 +164,13 @@ def discover_files() -> dict[str, Path]:
     """
     config = active_config()
     files: dict[str, Path] = {}
+    progress = _ScanProgress()
     if config.documents_dir.exists():
-        _walk_root(files, config.documents_dir, None, config.ignore_dirs)
+        _walk_root(files, config.documents_dir, None, config.ignore_dirs, progress)
     for label, root in config.linked_roots.items():
         root_path = Path(root)
         if root_path.is_dir():
-            _walk_root(files, root_path, label, config.ignore_dirs)
+            _walk_root(files, root_path, label, config.ignore_dirs, progress)
         elif root_path.is_file() and classify_file(root_path) is not None:
             files[label] = root_path
     return files

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -317,6 +317,46 @@ def _plan_workers() -> int:
     return configured if configured > 0 else available_cpu_count()
 
 
+# How often the plan pass logs progress. The pass can run for tens of minutes on
+# a multi-million-file corpus while the Rich bar renders nothing without a TTY
+# and stdout is block-buffered when piped; a periodic line (which logging flushes
+# per record) keeps a headless run observable instead of looking hung.
+_PLAN_LOG_INTERVAL_S = 10.0
+
+
+class _PlanProgress:
+    """Periodic progress for the plan/hash pass, with rate and ETA.
+
+    Emitted at warning level, not info: the default LILBEE_LOG_LEVEL is WARNING,
+    so an info line would be filtered before any handler and a headless
+    ``lilbee sync`` would show nothing during the plan pass and still look hung.
+    """
+
+    def __init__(self, total: int) -> None:
+        self._total = total
+        self._done = 0
+        self._started = time.monotonic()
+        self._last = self._started
+
+    def tick(self) -> None:
+        self._done += 1
+        now = time.monotonic()
+        if now - self._last < _PLAN_LOG_INTERVAL_S:
+            return
+        self._last = now
+        elapsed = now - self._started
+        rate = self._done / elapsed if elapsed > 0 else 0.0
+        remaining = (self._total - self._done) / rate if rate > 0 else 0.0
+        log.warning(
+            "Planning: examined %d/%d files (%.0f%%, %.0f files/s, ~%.0fs left)",
+            self._done,
+            self._total,
+            100.0 * self._done / self._total,
+            rate,
+            remaining,
+        )
+
+
 def _classify_changes(
     items: list[tuple[str, Path]],
     existing_sources: dict[str, SourceRecord],
@@ -336,12 +376,15 @@ def _classify_changes(
         return _classify_file_change(name, path, existing_sources.get(name), skip_markers)
 
     verdicts: dict[str, _FileChangeVerdict] = {}
+    total = len(items)
+    progress = _PlanProgress(total)
     workers = _plan_workers()
-    if workers <= 1 or len(items) <= 1:
+    if workers <= 1 or total <= 1:
         for name, path in items:
             if cancel and cancel.is_set():
                 break
             verdicts[name] = _classify(name, path)
+            progress.tick()
         return verdicts
     with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="lilbee-plan") as pool:
         futures: dict[Future[_FileChangeVerdict], str] = {}
@@ -356,6 +399,7 @@ def _classify_changes(
                     pending.cancel()
                 break
             verdicts[futures[future]] = future.result()
+            progress.tick()
     return verdicts
 
 
@@ -773,7 +817,9 @@ def _build_admission(
         permit_max=permit_max,
     )
     task = asyncio.ensure_future(controller.run())
-    log.info(
+    # warning, not info: the default LILBEE_LOG_LEVEL is WARNING, so the
+    # auto-chosen concurrency would otherwise never surface on a headless sync.
+    log.warning(
         "Adaptive ingest concurrency (%s): start %d, max %d", profile.name, gate.limit, permit_max
     )
     return gate, permit_max * _TASK_WINDOW_MULTIPLIER, task

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -466,6 +466,24 @@ class LlamaServerClient:
         with self._in_flight_lock:
             self._healthy = True
 
+    def reserve(self) -> None:
+        """Mark a routed request assigned to this replica, at selection time.
+
+        The router balances on ``in_flight`` but the per-request tracking only
+        bumps it once the HTTP call starts. Under a bulk ingest many threads pick
+        a replica at the same instant, all see the momentarily-idlest one at the
+        same low count, and pile onto it (a thundering herd that leaves the other
+        cards idle). Reserving at selection makes the assignment visible to the
+        next picker so requests spread across replicas. Paired with :meth:`release`.
+        """
+        with self._in_flight_lock:
+            self.in_flight += 1
+
+    def release(self) -> None:
+        """Release a reservation taken by :meth:`reserve`."""
+        with self._in_flight_lock:
+            self.in_flight -= 1
+
     def health(self) -> bool:
         """True iff ``GET /health`` returns 200 (liveness, not readiness)."""
         try:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -147,16 +147,37 @@ def _least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
     return min(healthy or clients, key=lambda c: c.in_flight)
 
 
+# Serializes pick-and-reserve so concurrent routers see each other's assignment.
+# Held only for the O(replicas) selection, never across the request itself.
+_ROUTE_LOCK = threading.Lock()
+
+
+def _reserve_least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
+    """Atomically pick the least-loaded healthy client and reserve a slot on it.
+
+    Selection and reservation are one critical section: without it, concurrent
+    callers all read the same idlest replica before any of them increments its
+    counter and route there together (a thundering herd that starves the rest of
+    the fleet). The caller must :meth:`~LlamaServerClient.release` the slot.
+    """
+    with _ROUTE_LOCK:
+        client = _least_in_flight(clients)
+        client.reserve()
+        return client
+
+
 def _call_with_failover(
     clients: list[LlamaServerClient],
     call: Callable[[LlamaServerClient], _T],
 ) -> _T:
     """Run *call* on the least-busy healthy client, retrying once on another replica.
 
-    A connection-level failure marks the client unhealthy and retries once on a
-    different replica; with no other replica the failure surfaces.
+    The client is reserved at selection so concurrent ingest threads spread
+    across replicas. A connection-level failure marks the client unhealthy and
+    retries once on a different replica; with no other replica the failure
+    surfaces. The reservation is released once the call resolves.
     """
-    client = _least_in_flight(clients)
+    client = _reserve_least_in_flight(clients)
     try:
         result = call(client)
     except Exception as exc:
@@ -164,8 +185,11 @@ def _call_with_failover(
             raise
         client.mark_unhealthy()
         return _retry_on_other_replica(clients, client, call, exc)
-    client.mark_healthy()
-    return result
+    else:
+        client.mark_healthy()
+        return result
+    finally:
+        client.release()
 
 
 def _retry_on_other_replica(
@@ -178,15 +202,18 @@ def _retry_on_other_replica(
     others = [c for c in clients if c is not failed]
     if not others:
         raise _no_healthy_replica_error() from cause
-    retry = _least_in_flight(others)
+    retry = _reserve_least_in_flight(others)
     try:
         retry_result = call(retry)
     except Exception as retry_exc:
         if is_connection_failure(retry_exc):
             retry.mark_unhealthy()
         raise
-    retry.mark_healthy()
-    return retry_result
+    else:
+        retry.mark_healthy()
+        return retry_result
+    finally:
+        retry.release()
 
 
 def _no_healthy_replica_error() -> ProviderError:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2180,6 +2180,12 @@ class _FakeReplica:
     def mark_healthy(self) -> None:
         self.healthy = True
 
+    def reserve(self) -> None:
+        self.in_flight += 1
+
+    def release(self) -> None:
+        self.in_flight -= 1
+
     def embed(self, texts: list[str]) -> list[list[float]]:
         self.calls += 1
         if self.fail is not None:
@@ -2199,6 +2205,52 @@ class _FakeReplica:
         if self.fail is not None:
             raise self.fail
         return "ocr text"
+
+
+class TestReserveSpreadsLoad:
+    def test_reserve_at_selection_spreads_concurrent_picks(self) -> None:
+        # Every picker reserves before the next selects, so four idle replicas
+        # each get exactly one request instead of all landing on the first
+        # (the thundering herd that left cards idle on the 8x A100 fleet).
+        replicas = [_FakeReplica() for _ in range(4)]
+        picked = [prov_mod._reserve_least_in_flight(replicas) for _ in range(4)]
+        assert {id(c) for c in picked} == {id(c) for c in replicas}
+        assert all(r.in_flight == 1 for r in replicas)
+
+    def test_call_with_failover_releases_the_reservation(self) -> None:
+        replicas = [_FakeReplica(), _FakeReplica()]
+        prov_mod._call_with_failover(replicas, lambda c: c.embed(["x"]))
+        assert all(r.in_flight == 0 for r in replicas)  # reservation released
+
+    def test_failover_releases_both_reservations(self) -> None:
+        import httpx
+
+        bad = _FakeReplica(fail=httpx.ConnectError("refused"))
+        good = _FakeReplica()
+        prov_mod._call_with_failover([bad, good], lambda c: c.embed(["x"]))
+        assert bad.in_flight == 0 and good.in_flight == 0  # both released
+        assert good.calls == 1 and not bad.healthy  # retried onto the healthy one
+
+    def test_concurrent_dispatch_does_not_pile_on_one_replica(self) -> None:
+        import threading
+
+        replicas = [_FakeReplica() for _ in range(4)]
+        # Each request holds its reservation at the barrier until all 8 have been
+        # reserved, so every reservation is live while the others are selecting.
+        # With the atomic reserve the 8 requests spread evenly (2 per replica);
+        # without it the herd piled onto whichever replica read idlest first.
+        overlap = threading.Barrier(8)
+
+        def _dispatch() -> None:
+            prov_mod._call_with_failover(replicas, lambda c: (overlap.wait(), c.embed(["x"]))[1])
+
+        threads = [threading.Thread(target=_dispatch) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert all(r.calls == 2 for r in replicas)  # perfectly spread, no herd
+        assert all(r.in_flight == 0 for r in replicas)  # all released
 
 
 class TestReplicaHealthRouting:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1203,6 +1203,77 @@ class TestZeroChunkPageTextPersistence:
         assert flush_spy.call_count >= 2
 
 
+class TestPlanProgress:
+    def test_logs_periodic_progress_at_warning(self, caplog, monkeypatch):
+        import logging
+
+        from lilbee.data.ingest import pipeline
+
+        # Log on every tick so a fast unit test still exercises the periodic path.
+        monkeypatch.setattr(pipeline, "_PLAN_LOG_INTERVAL_S", 0.0)
+        progress = pipeline._PlanProgress(total=3)
+        # Capture at WARNING, the default LILBEE_LOG_LEVEL: an info line is
+        # filtered here exactly as it is under a real headless `lilbee sync`, so
+        # this fails if the progress ever drops back below warning and goes
+        # silent in the very case it exists to make observable.
+        with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"):
+            progress.tick()
+            progress.tick()
+            progress.tick()
+        records = [r for r in caplog.records if "Planning: examined" in r.getMessage()]
+        assert records
+        assert all(r.levelno >= logging.WARNING for r in records)
+        assert any("3/3" in r.getMessage() for r in records)
+
+    def test_silent_below_the_interval(self, caplog, monkeypatch):
+        import logging
+
+        from lilbee.data.ingest import pipeline
+
+        # A short sync (ticks faster than the interval) stays quiet -- no noise.
+        monkeypatch.setattr(pipeline, "_PLAN_LOG_INTERVAL_S", 3600.0)
+        progress = pipeline._PlanProgress(total=100)
+        with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"):
+            for _ in range(50):
+                progress.tick()
+        assert not any("Planning:" in r.getMessage() for r in caplog.records)
+
+
+class TestScanProgress:
+    def test_logs_periodic_scan_progress_at_warning(self, caplog, monkeypatch):
+        import logging
+
+        from lilbee.data.ingest import discovery
+
+        # Log on every tick so a fast unit test still exercises the periodic path.
+        monkeypatch.setattr(discovery, "_SCAN_LOG_INTERVAL_S", 0.0)
+        progress = discovery._ScanProgress()
+        # WARNING, the default level: the discovery walk runs before the plan
+        # pass and is otherwise silent, so its heartbeat must survive the default
+        # or a headless sync over a large tree looks hung during the walk.
+        with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.discovery"):
+            progress.tick(matched=True)
+            progress.tick(matched=False)
+        records = [r for r in caplog.records if "Scanning for files" in r.getMessage()]
+        assert records
+        assert all(r.levelno >= logging.WARNING for r in records)
+        # examined counts every visited file; matched only the supported ones.
+        assert any("examined 2, matched 1" in r.getMessage() for r in records)
+
+    def test_silent_below_the_interval(self, caplog, monkeypatch):
+        import logging
+
+        from lilbee.data.ingest import discovery
+
+        # A quick walk (ticks faster than the interval) stays quiet -- no noise.
+        monkeypatch.setattr(discovery, "_SCAN_LOG_INTERVAL_S", 3600.0)
+        progress = discovery._ScanProgress()
+        with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.discovery"):
+            for _ in range(50):
+                progress.tick(matched=True)
+        assert not any("Scanning for files" in r.getMessage() for r in caplog.records)
+
+
 class TestDetectPending:
     """Cheap detection: filesystem walk + hash compare against the sources table."""
 

--- a/tests/test_ingest_offload.py
+++ b/tests/test_ingest_offload.py
@@ -47,3 +47,17 @@ def test_invalid_env_override_is_ignored(monkeypatch: pytest.MonkeyPatch, bad: s
     monkeypatch.setattr(offload.os, "cpu_count", lambda: 8)
     monkeypatch.setenv("LILBEE_INGEST_MAX_WORKERS", bad)
     assert offload._max_workers() == 12
+
+
+def test_embed_inflight_target_is_zero_when_the_fleet_cannot_be_probed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The fleet may not be resolvable yet (probe raises); admission sizing must
+    # fall back to the CPU-bound quota rather than crash the ingest run.
+    import lilbee.providers.fleet.replicas as replicas_mod
+
+    def _raise(*_args: object, **_kwargs: object) -> int:
+        raise RuntimeError("fleet not resolvable yet")
+
+    monkeypatch.setattr(replicas_mod, "resolve_replica_count", _raise)
+    assert offload.embed_inflight_target() == 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -350,12 +350,14 @@ class TestMaxConcurrent:
         assert pipeline._max_concurrent() == 4
 
     def test_scales_to_embed_replicas_when_no_vision(self, monkeypatch) -> None:
-        from lilbee.data.ingest import pipeline
+        from lilbee.data.ingest import offload, pipeline
 
         monkeypatch.setattr(pipeline, "cpu_quota", lambda: 2)
         monkeypatch.setattr(cfg, "vision_model", "")
         monkeypatch.setattr(cfg, "embed_replicas", 8)
-        assert pipeline._max_concurrent() == 8
+        # No vision: admission scales with the embed fleet at ~8 in-flight per
+        # replica, so 8 replicas admit far past the 2-core cpu quota.
+        assert pipeline._max_concurrent() == 8 * offload._EMBED_INFLIGHT_PER_REPLICA
 
     def test_auto_embed_replicas_fans_out_to_gpu_count(self, monkeypatch) -> None:
         # embed_replicas=0 (the auto default) must fan out to one slot per GPU so


### PR DESCRIPTION
Stacks on #590 (branch feat/ingest-symlink-parallel-discovery); retarget to main once that lands.

## Problem

On a multi-GPU bulk ingest two things starve the embed fleet. The router picks the least-in-flight replica but only increments that replica's counter once the request starts, so concurrent ingest threads all select the same momentarily-idlest replica and pile onto it: uneven per-card utilization (measured 10-98% at the same instant on 8x A100), capping throughput well short of a linear fleet. Separately, the plan/hash pass can run for tens of minutes on a multi-million-file corpus while the Rich bar renders nothing without a TTY and piped stdout is block-buffered, so a headless ingest looks hung with no output.

## Solution

Reserve the picked replica atomically with the selection: `_reserve_least_in_flight` holds a lock across the pick and the `in_flight` increment, and the failover paths release it once the call resolves, so concurrent selectors see each other's assignment and spread across replicas instead of thundering onto one. The lock is held only for the O(replicas) selection, never the request.

Log the plan pass's progress (files examined, rate, ETA) at INFO. Logging flushes per record, so the output streams even when stdout is piped and there is no TTY for the live bar.

The dispatch fix is unit-proven for even spread; the utilization/throughput lift is confirmed by the fleet ingest run.