### PR TITLE
Fix engine keep-warm, model-switch UX, and local mmap defaults in the TUI

### DIFF
--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -284,20 +284,3 @@ def chat_warm_error() -> str | None:
     if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
         return snapshot.error or ""
     return None
-
-
-def warm_chat_after_swap(*, should_abort: Callable[[], bool] | None = None) -> bool:
-    """Load the newly selected chat model instead of deferring it to the next prompt.
-
-    Every chat-model swap ends here, whichever surface started it: the chat
-    model bar, the same bar mounted off the chat screen, or the Settings pane.
-    Warming from one place is what makes the task-bar line appear for all of
-    them (it renders whatever ``active_chat_warm_progress`` reports, on any
-    screen) and what stops a swap reporting "done" while the engine is still
-    cold -- which read as a live input that silently answered nothing.
-
-    Returns True once the model can serve. Worker thread; never call on the
-    event loop, since the load takes seconds.
-    """
-    request_engine_warm()
-    return wait_chat_ready(should_abort=should_abort)

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -284,3 +284,20 @@ def chat_warm_error() -> str | None:
     if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
         return snapshot.error or ""
     return None
+
+
+def warm_chat_after_swap(*, should_abort: Callable[[], bool] | None = None) -> bool:
+    """Load the newly selected chat model instead of deferring it to the next prompt.
+
+    Every chat-model swap ends here, whichever surface started it: the chat
+    model bar, the same bar mounted off the chat screen, or the Settings pane.
+    Warming from one place is what makes the task-bar line appear for all of
+    them (it renders whatever ``active_chat_warm_progress`` reports, on any
+    screen) and what stops a swap reporting "done" while the engine is still
+    cold -- which read as a live input that silently answered nothing.
+
+    Returns True once the model can serve. Worker thread; never call on the
+    event loop, since the load takes seconds.
+    """
+    request_engine_warm()
+    return wait_chat_ready(should_abort=should_abort)

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -159,6 +159,12 @@ class _ServicesState:
         self.override: ContextVar[Services | None] = ContextVar(
             "lilbee_services_override", default=None
         )
+        # Whether this process is an interactive session (the TUI). Recorded by
+        # the interactive entry point before anything builds the container, and
+        # read once at build so the provider it creates holds its fleet resident
+        # for the session. Build-time intent only; the state that matters after
+        # that lives on the provider itself.
+        self.interactive: bool = False
 
 
 _state = _ServicesState()
@@ -169,6 +175,7 @@ def build_services(
     *,
     provider: LLMProvider | None = None,
     registry: ModelRegistry | None = None,
+    interactive: bool = False,
 ) -> Services:
     """Build a full Services container bound to *config*, without caching it.
 
@@ -194,7 +201,7 @@ def build_services(
     from lilbee.retrieval.reranker import Reranker
     from lilbee.runtime.ingest_lock import IngestLockRegistry
 
-    provider = provider or create_provider(config)
+    provider = provider or create_provider(config, hold_warm=interactive)
     registry = registry or ModelRegistry(config.models_dir)
     store = Store(config)
     embedder = Embedder(config, provider)
@@ -250,7 +257,7 @@ def get_services() -> Services:
     # Pin the store width to the embedder before Store(); pass the registry so
     # resolution doesn't re-enter this half-built get_services.
     reconcile_embedding_dim(registry)
-    _state.singleton = build_services(cfg, registry=registry)
+    _state.singleton = build_services(cfg, registry=registry, interactive=_state.interactive)
     # Eager start is the default: pay the spawn cost per role server at TUI mount
     # so the first user action lands on a warm fleet. Roles whose model is unset
     # are skipped, so a setup with only chat + embed never spawns rerank or
@@ -277,6 +284,18 @@ def services_scope(services: Services) -> Iterator[None]:
         yield
     finally:
         _state.override.reset(token)
+
+
+def mark_interactive_session() -> None:
+    """Record that this process is an interactive session before services build.
+
+    The TUI owns the process for its whole lifetime, so the fleet it builds keeps
+    its weights resident rather than idle-unloading under a user who is still in
+    the app; closing lilbee releases it. Called by the interactive entry point
+    before anything touches ``get_services``, so the provider is constructed with
+    that intent; a one-shot CLI or the MCP server never calls it.
+    """
+    _state.interactive = True
 
 
 def set_services(services: Services | None) -> None:

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -121,10 +121,18 @@ CMD_SET_CHOICES = "{key} must be one of {choices}"
 CMD_SET_READONLY = "{key} is read-only; use the Models screen"
 CMD_MODEL_SET = "Model set to {name}"
 # Shown while a model swap's fleet reload runs off the event loop, so the swap
-# reads as in-progress instead of a frozen TUI.
-MODEL_SWAP_APPLYING = "Switching model, loading..."
+# reads as in-progress instead of a frozen TUI. Role-neutral: shared by the chat
+# swap and the embed/vision/rerank swaps in model_pick, which name the model in
+# their own surfaces (the chat input placeholder and warm footer for chat).
+MODEL_SWAP_APPLYING = "Switching model, loading…"
 MODEL_SWAP_DONE = "Now using {name}"
 MODEL_SWAP_FAILED = "Could not switch model: {error}"
+# Chat-input placeholder while a swap holds the input disabled: names the target
+# model and says the input is waiting on it, so the disabled box is never a
+# silent dead end. The warm progress itself shows in the task-bar footer.
+CHAT_INPUT_SWITCHING = "Switching to {name} · chat unlocks when the model is ready…"
+# Chat-input placeholder while a placement change reloads the whole fleet.
+CHAT_INPUT_RELOADING = "Reloading the engine · one moment…"
 # Shown when the user tries to send a prompt while the new chat model is still loading.
 CHAT_MODEL_SWITCHING = "Still switching model. One moment, then send your prompt."
 FLEET_RELOADING = "Applying placement, reloading the fleet. One moment, then send your prompt."
@@ -563,15 +571,18 @@ STATUS_DOCS_EMPTY = "(no documents yet)"
 STATUS_DOCS_TITLE = "Documents"
 TASKBAR_STARTING_WORKER = "Starting {labels} worker..."
 TASKBAR_STARTING_WORKERS = "Starting {labels} workers..."
-# Cold-start chat warm line: phase (and byte % while paging weights) so the held
-# input reads as "loading", not "stuck".
-TASKBAR_WARM = "warming up chat · {detail}"
-TASKBAR_WARM_STARTING = "starting"
+# Cold-start chat warm line: a spinner, the model being loaded, and the phase
+# (with byte % while paging weights) so the held input reads as "loading {model}",
+# not "stuck". The name is the model's display label, or this fallback before the
+# warm has stamped which model it is loading.
+TASKBAR_WARM_LINE = "{spinner}  warming up {name} · {detail}"
+TASKBAR_WARM_FALLBACK_NAME = "chat"
+TASKBAR_WARM_STARTING = "starting engine"
 TASKBAR_WARM_READING = "reading weights {pct}%"
 # Names the phase, like its two siblings above. "almost ready" predicted a
 # finish time the engine has not promised, and was the one phase saying nothing
 # about what is happening.
-TASKBAR_WARM_LOADING = "loading the engine"
+TASKBAR_WARM_LOADING = "loading into VRAM"
 
 TASK_CENTER_TITLE = "Background Tasks"
 TASK_CENTER_COUNTS = "{active} running  ·  {queued} queued  ·  {done} done"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -575,7 +575,7 @@ TASKBAR_STARTING_WORKERS = "Starting {labels} workers..."
 # (with byte % while paging weights) so the held input reads as "loading {model}",
 # not "stuck". The name is the model's display label, or this fallback before the
 # warm has stamped which model it is loading.
-TASKBAR_WARM_LINE = "{spinner}  warming up {name} · {detail}"
+TASKBAR_WARM_LINE = "warming up {name} · {detail}"
 TASKBAR_WARM_FALLBACK_NAME = "chat"
 TASKBAR_WARM_STARTING = "starting engine"
 TASKBAR_WARM_READING = "reading weights {pct}%"

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -66,6 +66,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
     row_delete_id,
     variant_to_row,
 )
+from lilbee.cli.tui.spinner import SPINNER_FRAMES
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.cli.tui.widgets.bottom_bars import BottomBars
 from lilbee.cli.tui.widgets.catalog_detail import CatalogDetailDrawer
@@ -134,11 +135,10 @@ _TAB_ACTIVATION_RETRY_BUDGET = 20
 
 _SORT_CYCLE: tuple[str, ...] = ("Name", "Downloads", "Size", "Params")
 
-# Braille spinner frames for the catalog pagination/search loading
-# indicator. Cycled on a 100 ms timer while the catalog is fetching
-# more HF rows or a remote search is in flight, so the user always
-# has a moving signal during the wait instead of an empty pane.
-_SPINNER_FRAMES: tuple[str, ...] = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+# Spinner cadence for the catalog pagination/search loading indicator: cycled on
+# a 100 ms timer while the catalog fetches more HF rows or a remote search is in
+# flight, so the wait always shows a moving signal instead of an empty pane. The
+# frames come from the shared, Rich-sourced ``SPINNER_FRAMES``.
 _SPINNER_INTERVAL_S = 0.1
 
 _RowCacheKey = tuple[int, int, int, int, int, int]
@@ -1355,7 +1355,7 @@ class CatalogScreen(Screen[None]):
     def _grid_scroll_hint_text(self, hf_count: int) -> str:
         """Pick the bottom scroll-hint text based on fetch state."""
         if self._loading_more:
-            return msg.CATALOG_GRID_LOADING_MORE.format(frame=_SPINNER_FRAMES[self._spinner_frame])
+            return msg.CATALOG_GRID_LOADING_MORE.format(frame=SPINNER_FRAMES[self._spinner_frame])
         if self._active_task_has_more():
             return msg.CATALOG_GRID_LOAD_MORE.format(count=hf_count)
         return msg.CATALOG_GRID_ALL_LOADED.format(count=hf_count)
@@ -1658,7 +1658,7 @@ class CatalogScreen(Screen[None]):
         active = self._loading_more or self._search_in_flight
         if active:
             spinner.styles.display = "block"
-            spinner.update(f"{_SPINNER_FRAMES[self._spinner_frame]} loading…")
+            spinner.update(f"{SPINNER_FRAMES[self._spinner_frame]} loading…")
             if self._spinner_timer is None:
                 self._spinner_timer = self.set_interval(
                     _SPINNER_INTERVAL_S, self._tick_loading_spinner
@@ -1671,7 +1671,7 @@ class CatalogScreen(Screen[None]):
                     hint = self._grid_container.query_one(".scroll-hint", Static)
                     hint.update(
                         msg.CATALOG_GRID_LOADING_MORE.format(
-                            frame=_SPINNER_FRAMES[self._spinner_frame]
+                            frame=SPINNER_FRAMES[self._spinner_frame]
                         )
                     )
         else:
@@ -1694,15 +1694,15 @@ class CatalogScreen(Screen[None]):
 
     def _tick_loading_spinner(self) -> None:
         """Advance the spinner one braille frame; called by the interval timer."""
-        self._spinner_frame = (self._spinner_frame + 1) % len(_SPINNER_FRAMES)
+        self._spinner_frame = (self._spinner_frame + 1) % len(SPINNER_FRAMES)
         with contextlib.suppress(Exception):
             spinner = self.query_one("#catalog-loading-spinner", Static)
-            spinner.update(f"{_SPINNER_FRAMES[self._spinner_frame]} loading…")
+            spinner.update(f"{SPINNER_FRAMES[self._spinner_frame]} loading…")
         if self._loading_more:
             with contextlib.suppress(Exception):
                 hint = self._grid_container.query_one(".scroll-hint", Static)
                 hint.update(
-                    msg.CATALOG_GRID_LOADING_MORE.format(frame=_SPINNER_FRAMES[self._spinner_frame])
+                    msg.CATALOG_GRID_LOADING_MORE.format(frame=SPINNER_FRAMES[self._spinner_frame])
                 )
 
     def _update_sort_label(self) -> None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1981,18 +1981,32 @@ class ChatScreen(Screen[None]):
         self._reload_chat_model_worker()
 
     def _apply_input_busy_state(self) -> None:
-        """Disable the chat input while a swap or placement reload is loading.
+        """Disable the chat input while a swap or placement reload is loading, and
+        say why in the placeholder so a person is never left facing a dead input
+        with no explanation.
 
-        Restores focus when the fleet is idle again so the user can type without
-        re-clicking the input that was disabled out from under them. Guarded
-        because the unblock can fire (via ``call_from_thread`` or a bubbled
-        message) after the user navigated away and the input is no longer mounted.
+        Restores focus and the default placeholder when the fleet is idle again so
+        the user can type without re-clicking the input that was disabled out from
+        under them. Guarded because the unblock can fire (via ``call_from_thread``
+        or a bubbled message) after the user navigated away and the input is no
+        longer mounted.
         """
         busy = self.swapping_model or self.reloading_placement
         with contextlib.suppress(NoMatches):
-            self._chat_input.disabled = busy
+            inp = self._chat_input
+            inp.disabled = busy
+            if self.swapping_model:
+                from lilbee.catalog.formatting import display_label_for_ref
+
+                inp.placeholder = msg.CHAT_INPUT_SWITCHING.format(
+                    name=display_label_for_ref(cfg.chat_model)
+                )
+            elif self.reloading_placement:
+                inp.placeholder = msg.CHAT_INPUT_RELOADING
+            else:
+                inp.placeholder = msg.CHAT_INPUT_PLACEHOLDER_DEFAULT
             if not busy and self._insert_mode:
-                self._chat_input.focus()
+                inp.focus()
 
     def watch_swapping_model(self, swapping: bool) -> None:
         self._apply_input_busy_state()
@@ -2006,26 +2020,46 @@ class ChatScreen(Screen[None]):
 
     @work(thread=True, name=_MODEL_SWAP_WORKER, exit_on_error=False)
     def _reload_chat_model_worker(self) -> None:
-        """Reload only the chat role off the event loop, then unblock the input.
+        """Reload the chat role and warm the new model before unblocking the input.
 
         ``reload_role(wait=True)`` re-plans and restarts the fleet for the new chat
-        model while keeping the store and searcher (a chat-model change doesn't
-        touch retrieval), and returns once the fleet proxy is back up; the model
-        itself loads on the next request (the same lazy load every role swap uses).
-        The provider serializes overlapping reloads, so a rapid second swap
-        coalesces onto the latest cfg.
+        model (retrieval is untouched) and returns once the proxy is back up. The
+        model is then warmed here rather than deferred to the user's next prompt:
+        ``request_engine_warm`` drives the load and populates the provider warm
+        tracker, which the task-bar footer renders (spinner, model, phase), and
+        ``wait_chat_ready`` holds the input disabled until the model actually
+        serves -- so the switch never hands back a live input in front of a model
+        that has not loaded. The provider serializes overlapping reloads, so a
+        rapid second swap coalesces onto the latest cfg.
         """
+        from lilbee.app.placement import (
+            chat_warm_error,
+            request_engine_warm,
+            wait_chat_ready,
+        )
+
+        worker = _get_worker()
         try:
             get_services().reload_role(WorkerRole.CHAT, wait=True)
+            request_engine_warm()
+            ready = wait_chat_ready(should_abort=lambda: worker.is_cancelled)
         except Exception as exc:  # any reload failure becomes a toast, never a crash
             call_from_thread(self, self._on_model_swap_failed, str(exc))
             return
-        call_from_thread(self, self._on_model_swapped)
+        if worker.is_cancelled:
+            return
+        error = None if ready else chat_warm_error()
+        if error:
+            call_from_thread(self, self._on_model_swap_failed, error)
+        else:
+            call_from_thread(self, self._on_model_swapped)
 
     def _on_model_swapped(self) -> None:
         """Main-thread completion: unblock the input and confirm the new model."""
+        from lilbee.catalog.formatting import display_label_for_ref
+
         self.swapping_model = False
-        self.app.notify(msg.MODEL_SWAP_DONE.format(name=cfg.chat_model))
+        self.app.notify(msg.MODEL_SWAP_DONE.format(name=display_label_for_ref(cfg.chat_model)))
 
     def _on_model_swap_failed(self, error: str) -> None:
         """Main-thread failure: unblock the input and surface the error."""

--- a/src/lilbee/cli/tui/spinner.py
+++ b/src/lilbee/cli/tui/spinner.py
@@ -1,0 +1,19 @@
+"""Braille spinner frames, sourced from Rich's canonical ``dots`` spinner.
+
+Rich already ships the cli-spinners frame data that backs its own ``Spinner``;
+the task bar and the catalog loader index into these frames on their own poll
+tick, so there is one definition here rather than a hand-copied braille tuple at
+each call site.
+"""
+
+from __future__ import annotations
+
+from rich.spinner import SPINNERS
+
+# Rich stores the frames as one glyph-per-character string.
+SPINNER_FRAMES: tuple[str, ...] = tuple(SPINNERS["dots"]["frames"])
+
+
+def spinner_frame(tick: int) -> str:
+    """The braille spinner glyph for *tick*, wrapping over the frame set."""
+    return SPINNER_FRAMES[tick % len(SPINNER_FRAMES)]

--- a/src/lilbee/cli/tui/spinner.py
+++ b/src/lilbee/cli/tui/spinner.py
@@ -8,10 +8,13 @@ each call site.
 
 from __future__ import annotations
 
+from typing import cast
+
 from rich.spinner import SPINNERS
 
-# Rich stores the frames as one glyph-per-character string.
-SPINNER_FRAMES: tuple[str, ...] = tuple(SPINNERS["dots"]["frames"])
+# Rich stores the frames as one glyph-per-character string, but types the spinner
+# table loosely (the entry values are ``object``), so narrow it here.
+SPINNER_FRAMES: tuple[str, ...] = tuple(cast(str, SPINNERS["dots"]["frames"]))
 
 
 def spinner_frame(tick: int) -> str:

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -12,7 +12,9 @@ from textual.app import ComposeResult
 from textual.timer import Timer
 from textual.widgets import Label, Static
 
+from lilbee.catalog.formatting import display_label_for_ref
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.spinner import spinner_frame
 from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
 from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
 from lilbee.providers.warm_progress import WarmPhase, WarmProgress
@@ -38,9 +40,6 @@ _DOT_GLYPH = "●"
 _WARM_BAR_FILL = "▓"
 _WARM_BAR_TRACK = "░"
 _WARM_BAR_WIDTH = 12
-# Indeterminate sweep (the engine-load phase has no byte signal): a lit window that walks
-# the track so the bar reads as "working", not stalled. Advanced by the poll tick.
-_WARM_SWEEP_WIDTH = 3
 
 
 def _progress_bar(fraction: float) -> str:
@@ -49,32 +48,22 @@ def _progress_bar(fraction: float) -> str:
     return _WARM_BAR_FILL * filled + _WARM_BAR_TRACK * (_WARM_BAR_WIDTH - filled)
 
 
-def _sweep_bar(tick: int) -> str:
-    """An indeterminate bar with a lit window of fixed width walking (and wrapping)
-    across the track, keyed to *tick*, so it always shows motion, never a blank."""
-    start = tick % _WARM_BAR_WIDTH
-    lit = {(start + offset) % _WARM_BAR_WIDTH for offset in range(_WARM_SWEEP_WIDTH)}
-    return "".join(_WARM_BAR_FILL if i in lit else _WARM_BAR_TRACK for i in range(_WARM_BAR_WIDTH))
+def _warm_detail(progress: WarmProgress | None) -> str | None:
+    """The phase text, with a byte bar while reading weights, for the warm line.
 
-
-def _warm_detail(progress: WarmProgress | None, tick: int = 0) -> str | None:
-    """Phase word plus a progress bar for the cold-start chat warm line.
-
-    A determinate byte bar while paging weights, an indeterminate sweep while the
-    engine loads (no byte signal). None once past an active phase, so the line
-    reads as live progress, not a stalled spinner.
+    None once past an active phase, so the caller drops the line entirely instead
+    of showing a stalled indicator.
     """
     if progress is None:
         return None
     if progress.phase is WarmPhase.STARTING:
-        return f"{_sweep_bar(tick)}  {msg.TASKBAR_WARM_STARTING}"
+        return msg.TASKBAR_WARM_STARTING
     if progress.phase is WarmPhase.LOADING_ENGINE:
-        return f"{_sweep_bar(tick)}  {msg.TASKBAR_WARM_LOADING}"
+        return msg.TASKBAR_WARM_LOADING
     if progress.phase is WarmPhase.READING_WEIGHTS:
         fraction = progress.bytes_done / progress.bytes_total if progress.bytes_total else 0.0
-        return (
-            f"{_progress_bar(fraction)}  {msg.TASKBAR_WARM_READING.format(pct=int(fraction * 100))}"
-        )
+        pct = int(fraction * 100)
+        return f"{msg.TASKBAR_WARM_READING.format(pct=pct)}  {_progress_bar(fraction)}"
     return None
 
 
@@ -310,8 +299,18 @@ class TaskBar(Static):
         """The cold-start chat warm line, or None when chat isn't warming."""
         from lilbee.app.placement import active_chat_warm_progress
 
-        detail = _warm_detail(active_chat_warm_progress(), self._tick_count)
-        return msg.TASKBAR_WARM.format(detail=detail) if detail else None
+        progress = active_chat_warm_progress()
+        detail = _warm_detail(progress)
+        if detail is None:
+            return None
+        name = (
+            display_label_for_ref(progress.model_ref)
+            if progress is not None and progress.model_ref
+            else msg.TASKBAR_WARM_FALLBACK_NAME
+        )
+        return msg.TASKBAR_WARM_LINE.format(
+            spinner=spinner_frame(self._tick_count), name=name, detail=detail
+        )
 
     def _spawning_workers_template(self, roles: list[str]) -> str:
         """Render the active worker-warmup hint for the bottom bar."""

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -14,7 +14,6 @@ from textual.widgets import Label, Static
 
 from lilbee.catalog.formatting import display_label_for_ref
 from lilbee.cli.tui import messages as msg
-from lilbee.cli.tui.spinner import spinner_frame
 from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
 from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
 from lilbee.providers.warm_progress import WarmPhase, WarmProgress
@@ -42,28 +41,44 @@ _WARM_BAR_TRACK = "░"
 _WARM_BAR_WIDTH = 12
 
 
+# Indeterminate sweep (the engine-load phases have no byte signal): a lit window
+# that walks the track so the bar reads as "working", not stalled. Advanced by the
+# poll tick. Preferred over a spinner glyph: the moving bar reads as progress at a
+# glance, which is what a multi-second model load needs.
+_WARM_SWEEP_WIDTH = 3
+
+
 def _progress_bar(fraction: float) -> str:
     """A determinate fill bar for the byte-progress (reading-weights) phase."""
     filled = round(max(0.0, min(1.0, fraction)) * _WARM_BAR_WIDTH)
     return _WARM_BAR_FILL * filled + _WARM_BAR_TRACK * (_WARM_BAR_WIDTH - filled)
 
 
-def _warm_detail(progress: WarmProgress | None) -> str | None:
-    """The phase text, with a byte bar while reading weights, for the warm line.
+def _sweep_bar(tick: int) -> str:
+    """An indeterminate bar with a lit window of fixed width walking (and wrapping)
+    across the track, keyed to *tick*, so it always shows motion, never a blank."""
+    start = tick % _WARM_BAR_WIDTH
+    lit = {(start + offset) % _WARM_BAR_WIDTH for offset in range(_WARM_SWEEP_WIDTH)}
+    return "".join(_WARM_BAR_FILL if i in lit else _WARM_BAR_TRACK for i in range(_WARM_BAR_WIDTH))
 
-    None once past an active phase, so the caller drops the line entirely instead
-    of showing a stalled indicator.
+
+def _warm_detail(progress: WarmProgress | None, tick: int = 0) -> str | None:
+    """A moving bar plus the phase word for the warm line.
+
+    A determinate byte bar while paging weights, an indeterminate sweep while the
+    engine starts and loads (no byte signal). None once past an active phase, so
+    the caller drops the line entirely instead of showing a stalled indicator.
     """
     if progress is None:
         return None
     if progress.phase is WarmPhase.STARTING:
-        return msg.TASKBAR_WARM_STARTING
+        return f"{_sweep_bar(tick)}  {msg.TASKBAR_WARM_STARTING}"
     if progress.phase is WarmPhase.LOADING_ENGINE:
-        return msg.TASKBAR_WARM_LOADING
+        return f"{_sweep_bar(tick)}  {msg.TASKBAR_WARM_LOADING}"
     if progress.phase is WarmPhase.READING_WEIGHTS:
         fraction = progress.bytes_done / progress.bytes_total if progress.bytes_total else 0.0
         pct = int(fraction * 100)
-        return f"{msg.TASKBAR_WARM_READING.format(pct=pct)}  {_progress_bar(fraction)}"
+        return f"{_progress_bar(fraction)}  {msg.TASKBAR_WARM_READING.format(pct=pct)}"
     return None
 
 
@@ -240,7 +255,10 @@ class TaskBar(Static):
         idle = not active and not queued and not in_flash and self._flash_outcome is None
         pending = self._controller.pending_sync_count if idle else 0
         spawning_roles = sorted(self._controller.spawning_roles) if idle else []
-        warm_line = self._warm_line() if idle else None
+        # Computed regardless of task activity: a chat warm holds the user's input
+        # disabled, so it outranks a passive task summary (which stays in the Task
+        # Center). Hiding it behind a background sync left a dead input unexplained.
+        warm_line = self._warm_line()
         fully_idle = idle and pending == 0 and not spawning_roles and warm_line is None
         self._sync_poll_cadence(fully_idle)
         if fully_idle:
@@ -287,7 +305,7 @@ class TaskBar(Static):
         idle: bool,
     ) -> tuple[str, str]:
         """Pick the dot color and summary text for the current bar state."""
-        if idle and warm_line is not None:
+        if warm_line is not None:
             return "$primary", warm_line
         if idle and spawning_roles:
             return "$primary", self._spawning_workers_template(spawning_roles)
@@ -300,7 +318,7 @@ class TaskBar(Static):
         from lilbee.app.placement import active_chat_warm_progress
 
         progress = active_chat_warm_progress()
-        detail = _warm_detail(progress)
+        detail = _warm_detail(progress, self._tick_count)
         if detail is None:
             return None
         name = (
@@ -308,9 +326,7 @@ class TaskBar(Static):
             if progress is not None and progress.model_ref
             else msg.TASKBAR_WARM_FALLBACK_NAME
         )
-        return msg.TASKBAR_WARM_LINE.format(
-            spinner=spinner_frame(self._tick_count), name=name, detail=detail
-        )
+        return msg.TASKBAR_WARM_LINE.format(name=name, detail=detail)
 
     def _spawning_workers_template(self, roles: list[str]) -> str:
         """Render the active worker-warmup hint for the bottom bar."""

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -12,14 +12,20 @@ if TYPE_CHECKING:
     from lilbee.providers.base import LLMProvider
 
 
-def create_provider(config: Config) -> LLMProvider:
-    """Create a new LLM provider instance from the given config."""
+def create_provider(config: Config, *, hold_warm: bool = False) -> LLMProvider:
+    """Create a new LLM provider instance from the given config.
+
+    *hold_warm* marks the provider as serving an interactive session, so the local
+    fleet it composes keeps its weights resident instead of idle-unloading for as
+    long as that session owns the process. Irrelevant to a remote provider, which
+    has no local engine to hold.
+    """
     match config.llm_provider:
         case LlmProvider.AUTO:
             # heavy: routing_provider eagerly imports litellm_sdk (>50ms; litellm fanout)
             from lilbee.providers.routing_provider import RoutingProvider
 
-            return RoutingProvider()
+            return RoutingProvider(hold_warm=hold_warm)
 
         case LlmProvider.REMOTE:
             # THIS is the swap line: the single import that changes when

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -116,19 +116,14 @@ _LLM_RERANK_VRAM_FRACTION = 0.5
 _SYSTEM_MEMORY_FLOOR_CAP_BYTES = 4 * 1024**3
 _SYSTEM_MEMORY_FLOOR_DIVISOR = 4
 
-# The chat server loads its weights into a malloc'd host copy (--no-mmap) when
-# they fit in at most this fraction of total system RAM: a buffered sequential
-# read beats mmap's page-fault-driven upload measured on a hot cache (#474:
-# 33s vs 43s for a 112GB model on 3 GPUs), but the copy is unevictable, so a
-# host where the weights crowd RAM keeps mmap. Keyed on TOTAL memory (stable),
-# not free (fluctuates), so replans do not flap the launch argv and force
-# needless chat restarts. Replicated roles keep mmap regardless: their
-# replicas share one set of page-cache pages, and per-replica host copies
-# would multiply RAM use for no load-time win.
-_NO_MMAP_MAX_RAM_FRACTION = 0.5
 # A network filesystem makes mmap dangerous (page faults served over the wire can
-# wedge the loader in uninterruptible I/O), so prefer a buffered read whenever the
-# host copy fits, at a higher RAM fraction than the local-disk hot-cache case. The
+# wedge the loader in uninterruptible I/O), so the chat server loads its weights
+# into a malloc'd host copy (--no-mmap) whenever that copy fits in this fraction
+# of total system RAM. Local disk keeps mmap: its lazy paging gives a faster first
+# token on a cold cache -- the common desktop first launch -- and --no-mmap's
+# buffered full read only wins on an already-hot cache (#474: 33s vs 43s for a
+# 112GB model on 3 GPUs) while pessimizing cold start. Keyed on TOTAL memory
+# (stable), not free (fluctuates), so replans do not flap the launch argv. The
 # exact ceiling is tuned on a network-volume host.
 _NO_MMAP_NETWORK_RAM_FRACTION = 0.85
 
@@ -1465,12 +1460,17 @@ def _plan_free_system_memory() -> int:
 def _chat_no_mmap(weights_bytes: int, *, on_network_fs: bool = False) -> bool:
     """Whether the chat server should malloc its weights instead of mmapping them.
 
-    See ``_NO_MMAP_MAX_RAM_FRACTION`` for the tradeoff and why the gate reads
-    total (not free) system memory. A model on a network filesystem prefers the
-    buffered read at a higher RAM fraction, since mmap over the network can hang.
+    Local disk mmaps: lazy page-fault paging gives a faster first token on a cold
+    cache -- the common desktop first launch -- matching mmap-by-default engines.
+    ``--no-mmap``'s buffered full read only wins on an already-hot cache and it
+    pessimizes cold start, so it is not worth defaulting on for local disk. A
+    network filesystem still prefers the buffered read whenever the host copy
+    fits, because mmap page faults served over the wire can wedge the loader in
+    uninterruptible I/O (see ``_NO_MMAP_NETWORK_RAM_FRACTION``).
     """
-    fraction = _NO_MMAP_NETWORK_RAM_FRACTION if on_network_fs else _NO_MMAP_MAX_RAM_FRACTION
-    return weights_bytes <= model_cache.total_system_memory() * fraction
+    if not on_network_fs:
+        return False
+    return weights_bytes <= model_cache.total_system_memory() * _NO_MMAP_NETWORK_RAM_FRACTION
 
 
 def _device_names(devices: tuple[FleetDevice, ...]) -> tuple[str, ...]:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -756,18 +756,20 @@ def _can_build_engine(wanted: set[tuple[WorkerRole, str]]) -> bool:
     return True
 
 
-def _warm_ttl_seconds() -> int:
+def _warm_ttl_seconds(*, hold_warm_for_session: bool = False) -> int:
     """llama-swap idle-unload timer in seconds for the spawned fleet.
 
-    Normally ``engine_idle_ttl_minutes``: an idle engine releases its weights and
-    reloads transparently on the next prompt, whether or not it outlives lilbee
-    (``keep_engine_warm`` governs that lifetime, not this timer). A bulk ingest
-    holds the fleet resident for its duration by returning a ttl of 0 (see
-    :func:`lilbee.providers.fleet.ingest_warmth.keep_fleet_warm`), so an unevenly
-    loaded replica cannot idle-unload and reload cold mid-run. A ttl of 0 keeps
-    weights resident until the engine is stopped.
+    A ttl of 0 keeps weights resident until the engine is stopped; otherwise an
+    idle engine releases its weights after ``engine_idle_ttl_minutes`` and reloads
+    transparently on the next prompt. The timer is held off (ttl 0) whenever
+    someone is actively depending on an instant response: *hold_warm_for_session*
+    is set for a provider serving an interactive session, which owns the process
+    for its whole lifetime (close lilbee to release the engine); a bulk ingest
+    holds the fleet resident for its run so an unevenly loaded replica cannot
+    idle-unload and reload cold mid-run; and ``keep_engine_warm`` pins the weights
+    for a process meant to stay ready.
     """
-    if ingest_keep_warm():
+    if hold_warm_for_session or ingest_keep_warm() or cfg.keep_engine_warm:
         return 0
     return cfg.engine_idle_ttl_minutes * 60
 
@@ -775,7 +777,12 @@ def _warm_ttl_seconds() -> int:
 class FleetProvider:
     """Routes every role to the managed llama-server fleet (a fleet-of-one on one box)."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, hold_warm: bool = False) -> None:
+        # An interactive session (the TUI) owns this process for its whole
+        # lifetime, so its fleet stays resident instead of idle-unloading under a
+        # user who is still in the app; closing lilbee releases it. Set by the
+        # container that built this provider, never mutated afterwards.
+        self._hold_warm_for_session = hold_warm
         # One llama-swap per placed group, so restarting one group's servers (a
         # placement or per-role model change) never unloads another group's. A
         # co-tenant group holds chat and vision, which evict each other on load.
@@ -1067,7 +1074,9 @@ class FleetProvider:
                 swap = SwapManager(data_dir, group)
                 swap.start(
                     list(group_launches),
-                    ttl_seconds=_warm_ttl_seconds(),
+                    ttl_seconds=_warm_ttl_seconds(
+                        hold_warm_for_session=self._hold_warm_for_session
+                    ),
                     bind_lifetime=not cfg.keep_engine_warm,
                 )
                 started[group] = swap
@@ -2315,7 +2324,9 @@ class FleetProvider:
                     swap = SwapManager(reload_dir, group)
                     swap.start(
                         group_launches,
-                        ttl_seconds=_warm_ttl_seconds(),
+                        ttl_seconds=_warm_ttl_seconds(
+                            hold_warm_for_session=self._hold_warm_for_session
+                        ),
                         bind_lifetime=not cfg.keep_engine_warm,
                     )
                     with self._lock:

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -41,9 +41,12 @@ class RoutingProvider(LLMProvider):
     unchanged, rather than silently falling through to a remote backend.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, hold_warm: bool = False) -> None:
         self._local: LLMProvider | None = None
         self._sdk_provider: SdkLLMProvider | None = None
+        # Carried until the local fleet is lazily built, so a provider created for
+        # an interactive session hands that down to the FleetProvider it composes.
+        self._hold_warm = hold_warm
         # Guards both lazy inits so two concurrent first-callers on the shared
         # daemon don't each build a backend and leak the loser. (Construction is
         # cheap field init; FleetProvider defers the role-server spawn to first
@@ -60,7 +63,7 @@ class RoutingProvider(LLMProvider):
                 if self._local is None:
                     from lilbee.providers.fleet.provider import FleetProvider
 
-                    self._local = FleetProvider()
+                    self._local = FleetProvider(hold_warm=self._hold_warm)
         return self._local
 
     def _get_sdk_provider(self) -> SdkLLMProvider:

--- a/src/lilbee/runtime/launcher.py
+++ b/src/lilbee/runtime/launcher.py
@@ -50,7 +50,14 @@ def main() -> None:
         app()
         return
 
+    from lilbee.app.services import mark_interactive_session
     from lilbee.runtime.splash import start, stop
+
+    # A person is at the TUI for its whole lifetime, so hold the engine resident
+    # (no idle-unload) until they close lilbee. Recorded here, on the sole
+    # interactive entry point and before anything builds the services container,
+    # so a one-shot CLI or the MCP server never trips it.
+    mark_interactive_session()
 
     handle = start()
 

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -256,3 +256,18 @@ async def test_await_engine_builds_services_when_none_exist(_warming_services):
         ):
             assert await asyncio.to_thread(screen._await_chat_engine, widget) is True
         build.assert_called_once()
+
+
+def test_active_chat_warm_progress_is_none_once_the_role_is_ready():
+    """A warm that has finished must not keep the surface in a loading state."""
+    from lilbee.app.placement import active_chat_warm_progress
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    services = mock.MagicMock()
+    services.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.LOADING_ENGINE)
+    services.provider.role_ready.return_value = True
+    set_services(services)
+    try:
+        assert active_chat_warm_progress() is None
+    finally:
+        set_services(None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3904,6 +3904,20 @@ class TestSelfCheck:
             os.kill(os.getpid(), signal.SIGTERM)
         assert signal.getsignal(signal.SIGTERM) is before
 
+    def test_sigterm_handler_converts_to_an_interrupt_without_delivery(self) -> None:
+        """Windows registers the handler but never delivers SIGTERM, so the test
+        above skips there and the handler body goes unexercised. Drive it directly
+        so the conversion that makes teardown run is covered on every platform."""
+        import signal
+
+        from lilbee.cli.commands import setup
+
+        with setup._teardown_on_sigterm():
+            handler = signal.getsignal(signal.SIGTERM)
+            assert callable(handler)
+            with pytest.raises(KeyboardInterrupt):
+                handler(signal.SIGTERM, None)
+
     def test_self_check_server_cleans_work_dir_on_start_failure(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -642,7 +642,7 @@ class TestCatalogCommandsNeverWarmTheFleet:
         from lilbee.providers import factory
 
         provider = mock.MagicMock()
-        monkeypatch.setattr(factory, "create_provider", lambda _config: provider)
+        monkeypatch.setattr(factory, "create_provider", lambda _config, **_kw: provider)
         monkeypatch.setattr(model_mod, "apply_overrides", lambda **_kwargs: None)
         cfg.worker_pool_eager_start = True
 

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1851,23 +1851,24 @@ def test_server_spec_other_role_uses_role_default() -> None:
 
 
 class TestChatNoMmap:
-    def test_no_mmap_when_weights_fit_half_of_ram(self, monkeypatch) -> None:
+    def test_local_disk_always_mmaps(self, monkeypatch) -> None:
+        # Local disk keeps mmap regardless of size: --no-mmap's buffered read only
+        # wins on an already-hot cache and pessimizes the cold-start first token.
         monkeypatch.setattr(
             "lilbee.providers.model_cache.total_system_memory", lambda: 1000 * 10**9
         )
-        assert planning_mod._chat_no_mmap(112 * 10**9) is True
-
-    def test_mmap_kept_when_weights_crowd_ram(self, monkeypatch) -> None:
-        # A malloc'd copy is unevictable; a model over half of RAM keeps mmap.
-        monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: 32 * 10**9)
+        assert planning_mod._chat_no_mmap(112 * 10**9) is False
         assert planning_mod._chat_no_mmap(20 * 10**9) is False
 
-    def test_network_fs_prefers_no_mmap_at_higher_fraction(self, monkeypatch) -> None:
-        # A model at 70% of RAM keeps mmap on local disk but takes --no-mmap on a
-        # network volume, where mmap page faults can wedge the loader.
+    def test_network_fs_uses_no_mmap_only_when_host_copy_fits(self, monkeypatch) -> None:
+        # A network filesystem prefers a buffered read (mmap page faults over the
+        # wire can wedge the loader), but only when the malloc'd copy fits the RAM
+        # fraction; an oversized model still mmaps. The same model on local disk
+        # keeps mmap either way.
         monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: 100 * 10**9)
-        assert planning_mod._chat_no_mmap(70 * 10**9) is False
         assert planning_mod._chat_no_mmap(70 * 10**9, on_network_fs=True) is True
+        assert planning_mod._chat_no_mmap(90 * 10**9, on_network_fs=True) is False
+        assert planning_mod._chat_no_mmap(70 * 10**9) is False
 
 
 class TestPlanProbe:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -3887,8 +3887,15 @@ def test_warm_leaves_the_engine_even_when_last(monkeypatch, tmp_path: Path) -> N
     assert stopped == []
 
 
-def test_ttl_applies_even_with_warm_on(monkeypatch) -> None:
+def test_warm_on_pins_weights_resident(monkeypatch) -> None:
+    # keep_engine_warm means the model stays loaded, so the idle unload is off.
     monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", True, raising=False)
+    monkeypatch.setattr(prov_mod.cfg, "engine_idle_ttl_minutes", 7, raising=False)
+    assert prov_mod._warm_ttl_seconds() == 0
+
+
+def test_ttl_applies_with_warm_off(monkeypatch) -> None:
+    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
     monkeypatch.setattr(prov_mod.cfg, "engine_idle_ttl_minutes", 7, raising=False)
     assert prov_mod._warm_ttl_seconds() == 420
 

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -212,18 +212,30 @@ class TestHealthCheckTimeoutScaling:
 
 
 class TestWarmTtlSeconds:
-    def test_warm_engine_still_idle_unloads(self, monkeypatch) -> None:
-        # keep_engine_warm decides whether the engine outlives lilbee, never
-        # whether weights stay resident: the idle ttl applies in every mode.
+    def test_keep_engine_warm_pins_weights_resident(self, monkeypatch) -> None:
+        # keep_engine_warm means the model stays ready, so the idle unload is off.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet.provider import _warm_ttl_seconds
 
         monkeypatch.setattr(cfg, "keep_engine_warm", True)
         monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
+        assert _warm_ttl_seconds() == 0
+
+    def test_interactive_session_pins_weights_resident(self, monkeypatch) -> None:
+        # A provider serving an interactive session (the TUI) holds the engine warm
+        # for its whole lifetime, regardless of the idle window or keep_engine_warm.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", False)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
+        assert _warm_ttl_seconds(hold_warm_for_session=True) == 0
+        # A provider not serving one still unloads on the idle window.
         assert _warm_ttl_seconds() == 900
 
     def test_on_demand_unloads_after_idle_ttl(self, monkeypatch) -> None:
-        # Warm off: the fleet releases its weights after the idle window.
+        # No interactive session and no keep_engine_warm: the fleet releases its
+        # weights after the idle window.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet.provider import _warm_ttl_seconds
 

--- a/tests/test_ingest_warmth.py
+++ b/tests/test_ingest_warmth.py
@@ -35,15 +35,14 @@ class TestKeepFleetWarm:
         assert not ingest_keep_warm()
         assert _warm_ttl_seconds() == 300
 
-    def test_keep_engine_warm_does_not_change_the_ttl(self):
-        # keep_engine_warm governs whether the engine outlives lilbee
-        # (bind_lifetime), not the idle-unload timer. Only an active ingest forces
-        # ttl 0, so a warm engine that is not ingesting still idle-unloads on the
-        # normal window.
+    def test_keep_engine_warm_pins_weights_resident(self):
+        # keep_engine_warm keeps the model resident (ttl 0), not merely alive
+        # across restarts: a user who opted to keep it warm never waits out a
+        # mid-session reload. Independent of an active ingest.
         cfg.keep_engine_warm = True
         cfg.engine_idle_ttl_minutes = 5
         assert not ingest_keep_warm()
-        assert _warm_ttl_seconds() == 300
+        assert _warm_ttl_seconds() == 0
 
     def test_nested_scopes_restore_correctly(self):
         cfg.keep_engine_warm = False

--- a/tests/test_interactive_session_warmth.py
+++ b/tests/test_interactive_session_warmth.py
@@ -1,0 +1,43 @@
+"""An interactive session (the TUI) holds its fleet resident for the session.
+
+The intent is recorded on the services state before anything builds the
+container, threaded through the provider factory, and ends up as provider
+instance state -- so the ttl decision reads the provider it belongs to rather
+than a process-wide flag.
+"""
+
+from __future__ import annotations
+
+from lilbee.providers.fleet.provider import FleetProvider
+
+
+def test_provider_defaults_to_not_holding_warm() -> None:
+    assert FleetProvider()._hold_warm_for_session is False
+
+
+def test_provider_carries_the_session_hold() -> None:
+    assert FleetProvider(hold_warm=True)._hold_warm_for_session is True
+
+
+def test_routing_provider_hands_the_hold_to_its_fleet() -> None:
+    from lilbee.providers.routing_provider import RoutingProvider
+
+    assert RoutingProvider(hold_warm=True)._get_local()._hold_warm_for_session is True
+    assert RoutingProvider()._get_local()._hold_warm_for_session is False
+
+
+def test_factory_threads_the_hold_from_the_container(monkeypatch) -> None:
+    from lilbee.core.config import cfg
+    from lilbee.core.config.enums import LlmProvider
+    from lilbee.providers.factory import create_provider
+
+    monkeypatch.setattr(cfg, "llm_provider", LlmProvider.AUTO)
+    assert create_provider(cfg, hold_warm=True)._get_local()._hold_warm_for_session is True
+
+
+def test_mark_interactive_session_records_build_intent(monkeypatch) -> None:
+    from lilbee.app import services as services_mod
+
+    monkeypatch.setattr(services_mod._state, "interactive", False)
+    services_mod.mark_interactive_session()
+    assert services_mod._state.interactive is True

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -536,7 +536,7 @@ class TestRoutingProvider:
         count_lock = threading.Lock()
 
         class FakeFleet:
-            def __init__(self) -> None:
+            def __init__(self, *, hold_warm: bool = False) -> None:
                 with count_lock:
                     construct_count["n"] += 1
                 # Widen the check-then-set window: without it the cheap __init__

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -101,7 +101,9 @@ class TestEagerStartBranch:
 
         services_mod.set_services(None)
         provider = MagicMock()
-        monkeypatch.setattr("lilbee.providers.factory.create_provider", lambda _cfg: provider)
+        monkeypatch.setattr(
+            "lilbee.providers.factory.create_provider", lambda _cfg, **_kw: provider
+        )
         try:
             services_mod.get_services()
         finally:
@@ -117,7 +119,9 @@ class TestEagerStartBranch:
         services_mod.set_services(None)
         provider = MagicMock()
         provider.warm_up_pool.side_effect = RuntimeError("simulated warm-up failure")
-        monkeypatch.setattr("lilbee.providers.factory.create_provider", lambda _cfg: provider)
+        monkeypatch.setattr(
+            "lilbee.providers.factory.create_provider", lambda _cfg, **_kw: provider
+        )
         try:
             svc = services_mod.get_services()
             assert svc is not None
@@ -131,7 +135,9 @@ class TestEagerStartBranch:
 
         services_mod.set_services(None)
         provider = MagicMock()
-        monkeypatch.setattr("lilbee.providers.factory.create_provider", lambda _cfg: provider)
+        monkeypatch.setattr(
+            "lilbee.providers.factory.create_provider", lambda _cfg, **_kw: provider
+        )
         try:
             services_mod.get_services()
         finally:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -13423,3 +13423,61 @@ async def test_model_swap_warms_the_new_model_before_unblocking():
         # Warm is requested after the reload and waited out before completing.
         assert calls == ["reload", "warm", "wait"]
         assert screen.swapping_model is False
+
+
+async def test_input_reason_says_reloading_during_a_placement_change():
+    """A placement reload holds the input too; the placeholder must explain that
+    case, not just a model swap."""
+    from lilbee.cli.tui import messages as msg
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        screen.reloading_placement = True
+        await pilot.pause()
+        assert screen._chat_input.disabled is True
+        assert screen._chat_input.placeholder == msg.CHAT_INPUT_RELOADING
+        screen.reloading_placement = False
+        await pilot.pause()
+        assert screen._chat_input.placeholder == msg.CHAT_INPUT_PLACEHOLDER_DEFAULT
+
+
+async def test_model_swap_surfaces_a_warm_failure():
+    """A warm that fails must toast the reason and release the input, never leave
+    it locked forever."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        services = MagicMock()
+        with (
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services),
+            patch("lilbee.app.placement.request_engine_warm", lambda: None),
+            patch("lilbee.app.placement.wait_chat_ready", lambda **_kw: False),
+            patch("lilbee.app.placement.chat_warm_error", return_value="out of VRAM"),
+            patch.object(app, "notify") as notify,
+        ):
+            screen.swapping_model = True
+            screen._reload_chat_model_worker()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+        assert screen.swapping_model is False  # input released
+        assert any("out of VRAM" in str(c.args[0]) for c in notify.call_args_list)
+
+
+async def test_model_swap_reload_failure_is_toasted():
+    """A reload that raises becomes a toast, never a crashed worker."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        services = MagicMock()
+        services.reload_role.side_effect = RuntimeError("engine gone")
+        with (
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services),
+            patch.object(app, "notify") as notify,
+        ):
+            screen.swapping_model = True
+            screen._reload_chat_model_worker()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+        assert screen.swapping_model is False
+        assert any("engine gone" in str(c.args[0]) for c in notify.call_args_list)

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -13114,14 +13114,15 @@ async def test_catalog_get_highlighted_model_name_model_grid_out_of_range():
 
 def test_catalog_tick_loading_spinner_advances_frame_with_no_widgets():
     """_tick_loading_spinner advances the frame counter even when widgets are missing."""
-    from lilbee.cli.tui.screens.catalog import _SPINNER_FRAMES, CatalogScreen
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.spinner import SPINNER_FRAMES
 
     screen = CatalogScreen()
     start = screen._spinner_frame
     # query_one will raise NoMatches off-mount; the suppress wrappers
     # still let _spinner_frame advance and exit cleanly.
     screen._tick_loading_spinner()
-    assert screen._spinner_frame == (start + 1) % len(_SPINNER_FRAMES)
+    assert screen._spinner_frame == (start + 1) % len(SPINNER_FRAMES)
 
 
 def test_catalog_sync_loading_spinner_exception_path():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -13365,3 +13365,61 @@ async def test_i_returns_to_insert_even_when_the_pill_has_focus():
         await pilot.press("i")
         await pilot.pause()
         assert screen._insert_mode is True
+
+
+async def test_model_swap_locks_input_with_a_reason_until_ready():
+    """While a swap runs the chat input is disabled AND says which model it is
+    waiting on, so a held input is never an unexplained dead box; it returns to
+    the default prompt once the swap finishes."""
+    from lilbee.cli.tui import messages as msg
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        inp = screen._chat_input
+
+        screen.swapping_model = True
+        await pilot.pause()
+        assert inp.disabled is True
+        # The placeholder names the target model and explains the wait.
+        assert "unlocks" in inp.placeholder
+        assert msg.CHAT_INPUT_SWITCHING.split("{name}")[0].strip() in inp.placeholder
+
+        screen.swapping_model = False
+        await pilot.pause()
+        assert inp.disabled is False
+        assert inp.placeholder == msg.CHAT_INPUT_PLACEHOLDER_DEFAULT
+
+
+async def test_model_swap_warms_the_new_model_before_unblocking():
+    """The swap reloads the role, eagerly warms the new model, and only unblocks
+    once it actually serves -- so the input never re-enables in front of a model
+    that has not loaded (which read as 'typing does nothing')."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        calls: list[str] = []
+        services = MagicMock()
+        services.reload_role.side_effect = lambda *a, **k: calls.append("reload")
+
+        def _warm() -> None:
+            calls.append("warm")
+
+        def _wait(**_kw) -> bool:
+            calls.append("wait")
+            return True
+
+        with (
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services),
+            patch("lilbee.app.placement.request_engine_warm", _warm),
+            patch("lilbee.app.placement.wait_chat_ready", _wait),
+            patch("lilbee.app.placement.chat_warm_error", return_value=None),
+        ):
+            screen.swapping_model = True
+            screen._reload_chat_model_worker()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+        # Warm is requested after the reload and waited out before completing.
+        assert calls == ["reload", "warm", "wait"]
+        assert screen.swapping_model is False

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -13481,3 +13481,26 @@ async def test_model_swap_reload_failure_is_toasted():
             await pilot.pause()
         assert screen.swapping_model is False
         assert any("engine gone" in str(c.args[0]) for c in notify.call_args_list)
+
+
+async def test_model_swap_worker_returns_quietly_when_cancelled():
+    """A superseded swap (the user picked another model mid-load) must not toast a
+    completion or release the gate: the newer swap owns both."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        services = MagicMock()
+        cancelled_worker = SimpleNamespace(is_cancelled=True)
+        with (
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services),
+            patch("lilbee.cli.tui.screens.chat._get_worker", return_value=cancelled_worker),
+            patch("lilbee.app.placement.request_engine_warm", lambda: None),
+            patch("lilbee.app.placement.wait_chat_ready", lambda **_kw: True),
+            patch.object(app, "notify") as notify,
+        ):
+            screen.swapping_model = True
+            screen._reload_chat_model_worker()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+        assert screen.swapping_model is True  # gate still held by the newer swap
+        assert not any("Now using" in str(c.args[0]) for c in notify.call_args_list)

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -567,18 +567,18 @@ class TestTaskBar:
 
         assert _warm_detail(None) is None
         assert _warm_detail(WarmProgress(phase=WarmPhase.READY)) is None
-        # Indeterminate phases carry just the phase word; the spinner the caller
-        # prepends is the animation, so there is no bar here.
-        assert _warm_detail(WarmProgress(phase=WarmPhase.STARTING)) == msg.TASKBAR_WARM_STARTING
-        assert (
-            _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == msg.TASKBAR_WARM_LOADING
-        )
-        # Reading weights: the phase word with byte %, then a determinate bar.
+        # Indeterminate phases carry a moving sweep bar plus the phase word: a
+        # multi-second load has to read as working, not stalled.
+        starting = _warm_detail(WarmProgress(phase=WarmPhase.STARTING))
+        assert msg.TASKBAR_WARM_STARTING in starting and "▓" in starting
+        loading = _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE))
+        assert msg.TASKBAR_WARM_LOADING in loading and "▓" in loading
+        # Reading weights: a determinate byte bar, then the phase word with %.
         reading = _warm_detail(
             WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=42, bytes_total=100)
         )
         assert "reading weights 42%" in reading
-        assert "▓▓▓▓▓" in reading  # round(0.42 * 12) = 5 filled cells
+        assert reading.startswith("▓▓▓▓▓")  # round(0.42 * 12) = 5 filled cells
         # No total yet: percent floors to 0 instead of dividing by zero.
         zero = _warm_detail(WarmProgress(phase=WarmPhase.READING_WEIGHTS))
         assert "reading weights 0%" in zero
@@ -608,6 +608,14 @@ class TestTaskBar:
             bar._refresh_display()
             await pilot.pause()
             assert bar.display is True
+
+    def test_sweep_bar_animates_and_keeps_width(self) -> None:
+        from lilbee.cli.tui.widgets.task_bar import _WARM_BAR_WIDTH, _sweep_bar
+
+        frames = [_sweep_bar(t) for t in range(_WARM_BAR_WIDTH + 4)]
+        assert all(len(f) == _WARM_BAR_WIDTH for f in frames)  # fixed width every frame
+        assert len({*frames}) > 1  # the lit window moves, so frames differ
+        assert all("▓" in f for f in frames)  # always shows a lit window
 
     def test_spinner_frames_cycle_from_rich(self) -> None:
         from lilbee.cli.tui.spinner import SPINNER_FRAMES, spinner_frame
@@ -7060,3 +7068,31 @@ def test_size_variant_strip_disambiguates_same_quant_families():
         SizeVariant(label="8B Q5_K_M", quant="Q5_K_M", size_gb=5.7, ref="r/q5"),
     ]
     assert str(_build_size_variant_strip(distinct)) == "Q4_K_M · Q5_K_M"
+
+
+async def test_warm_line_survives_an_active_background_task() -> None:
+    """A chat warm holds the user's input disabled, so its line must show even
+    while an unrelated task (a document sync) is running. Hiding it behind the
+    task summary left the user staring at a dead input with no explanation."""
+    from unittest import mock
+
+    from lilbee.app.services import set_services
+    from lilbee.cli.tui.widgets.task_bar import TaskBar
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    services = mock.MagicMock()
+    services.provider.role_ready.return_value = False
+    services.provider.warm_progress.return_value = WarmProgress(
+        phase=WarmPhase.LOADING_ENGINE, model_ref=None
+    )
+    set_services(services)
+
+    app = _TaskBarApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(TaskBar)
+        warm = bar._warm_line()
+        assert warm is not None
+        # Not idle: a task is active, yet the warm line still wins the summary.
+        _dot, summary = bar._status_line([mock.MagicMock()], [], [], 0, warm, idle=False)
+        assert summary == warm

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -561,21 +561,24 @@ class TestTaskBar:
             assert out == "Starting chat, embed workers..."
 
     def test_warm_detail_phases(self) -> None:
+        from lilbee.cli.tui import messages as msg
         from lilbee.cli.tui.widgets.task_bar import _warm_detail
         from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
         assert _warm_detail(None) is None
         assert _warm_detail(WarmProgress(phase=WarmPhase.READY)) is None
-        # Each active phase carries a progress bar plus the phase word.
-        starting = _warm_detail(WarmProgress(phase=WarmPhase.STARTING))
-        assert "starting" in starting and "▓" in starting
-        loading = _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE))
-        assert "loading the engine" in loading and ("▓" in loading or "░" in loading)
+        # Indeterminate phases carry just the phase word; the spinner the caller
+        # prepends is the animation, so there is no bar here.
+        assert _warm_detail(WarmProgress(phase=WarmPhase.STARTING)) == msg.TASKBAR_WARM_STARTING
+        assert (
+            _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == msg.TASKBAR_WARM_LOADING
+        )
+        # Reading weights: the phase word with byte %, then a determinate bar.
         reading = _warm_detail(
             WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=42, bytes_total=100)
         )
         assert "reading weights 42%" in reading
-        assert reading.startswith("▓▓▓▓▓")  # round(0.42 * 12) = 5 filled cells
+        assert "▓▓▓▓▓" in reading  # round(0.42 * 12) = 5 filled cells
         # No total yet: percent floors to 0 instead of dividing by zero.
         zero = _warm_detail(WarmProgress(phase=WarmPhase.READING_WEIGHTS))
         assert "reading weights 0%" in zero
@@ -599,19 +602,21 @@ class TestTaskBar:
             await pilot.pause()
             bar = app.query_one(TaskBar)
             warm = bar._warm_line()
-            assert warm.startswith("warming up chat · ")
+            # model_ref is None here, so the line uses the fallback name.
+            assert "warming up chat · " in warm
             assert "reading weights 25%" in warm and "▓" in warm
             bar._refresh_display()
             await pilot.pause()
             assert bar.display is True
 
-    def test_sweep_bar_animates_and_keeps_width(self) -> None:
-        from lilbee.cli.tui.widgets.task_bar import _WARM_BAR_WIDTH, _sweep_bar
+    def test_spinner_frames_cycle_from_rich(self) -> None:
+        from lilbee.cli.tui.spinner import SPINNER_FRAMES, spinner_frame
 
-        frames = [_sweep_bar(t) for t in range(_WARM_BAR_WIDTH + 4)]
-        assert all(len(f) == _WARM_BAR_WIDTH for f in frames)  # fixed width every frame
-        assert len({*frames}) > 1  # the lit window moves, so frames differ
-        assert all("▓" in f for f in frames)  # always shows a lit window
+        assert len(SPINNER_FRAMES) > 1  # sourced from Rich's "dots" spinner
+        assert spinner_frame(0) == SPINNER_FRAMES[0]
+        assert spinner_frame(len(SPINNER_FRAMES)) == SPINNER_FRAMES[0]  # wraps
+        distinct = {spinner_frame(t) for t in range(len(SPINNER_FRAMES))}
+        assert len(distinct) == len(SPINNER_FRAMES)  # every frame is used
 
     async def test_warm_line_none_when_not_warming(self) -> None:
         from lilbee.cli.tui.widgets.task_bar import TaskBar

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -7096,3 +7096,28 @@ async def test_warm_line_survives_an_active_background_task() -> None:
         # Not idle: a task is active, yet the warm line still wins the summary.
         _dot, summary = bar._status_line([mock.MagicMock()], [], [], 0, warm, idle=False)
         assert summary == warm
+
+
+async def test_warm_line_names_the_model_being_loaded() -> None:
+    """The line carries the model's display label, not the raw ref, so a swap says
+    which model the wait is for."""
+    from unittest import mock
+
+    from lilbee.app.services import set_services
+    from lilbee.cli.tui.widgets.task_bar import TaskBar
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    services = mock.MagicMock()
+    services.provider.role_ready.return_value = False
+    services.provider.warm_progress.return_value = WarmProgress(
+        phase=WarmPhase.LOADING_ENGINE, model_ref=TEST_LOCAL_REF
+    )
+    set_services(services)
+
+    app = _TaskBarApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        warm = app.query_one(TaskBar)._warm_line()
+        assert warm is not None
+        assert "chat ·" not in warm  # not the fallback name
+        assert "warming up " in warm

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,6 +1,6 @@
 --- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
 +++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
-@@ -446,6 +446,175 @@
+@@ -446,6 +446,179 @@
  
  #if _NUITKA_ONEFILE_TEMP_BOOL
  static bool payload_created = false;
@@ -171,12 +171,16 @@
 +        fputs(keep_logo ? "\033[A" : "\033[A\033[2K", stderr);
 +    }
 +    fputc('\r', stderr);
++    // Hide the parked cursor so it does not sit blinking on the wordmark between
++    // this frame and the Python splash, which keeps it hidden until Textual takes
++    // over. A launch with arguments returns to the shell, so show it there.
++    fputs(keep_logo ? "\033[?25l" : "\033[?25h", stderr);
 +    fflush(stderr);
 +}
  #endif
  
  #define MAX_CREATED_DIRS 1024
-@@ -1151,6 +1320,13 @@
+@@ -1151,6 +1324,13 @@
      wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
  #endif
  
@@ -190,7 +194,7 @@
      if (process_role == NULL) {
  #if defined(_WIN32)
          bool_res = SetConsoleCtrlHandler(ourConsoleCtrlHandler, true);
-@@ -1169,6 +1345,7 @@
+@@ -1169,6 +1349,7 @@
  #endif
  
  #if _NUITKA_ONEFILE_HAS_PAYLOAD_BOOL == 1
@@ -198,7 +202,7 @@
      NUITKA_PRINT_TIMING("ONEFILE: Checking header for compression.");
  
      char header[3];
-@@ -1202,6 +1379,11 @@
+@@ -1202,6 +1383,11 @@
  
      NUITKA_PRINT_TIMING("ONEFILE: Entering decompression.");
  
@@ -210,7 +214,7 @@
  #if _NUITKA_ONEFILE_TEMP_BOOL
      payload_created = true;
  #endif
-@@ -1336,10 +1518,22 @@
+@@ -1336,10 +1522,22 @@
                  fatalErrorTempFiles();
              }
          }


### PR DESCRIPTION
## Problem

On a real box driving the TUI over ssh, four things read as regressions:

- "Keep engine warm" re-warmed on every return. The idle TTL unloaded the model after `engine_idle_ttl_minutes` (default 5) regardless of the setting, and nothing kept the engine resident while the TUI was open.
- Switching chat models locked the input with no indication of why, and the new model only loaded on the next prompt, so the input came back before the model was ready and typing silently did nothing.
- Cold model load felt slower than it should. The chat server defaulted to `--no-mmap` on local disk, forcing a full upfront read of the weights instead of mmap's lazy paging.
- The first-start splash left a cursor blinking on the wordmark.

## Solution

- `_warm_ttl_seconds` returns 0 (weights resident) whenever an interactive session owns the process, `keep_engine_warm` is set, or a bulk ingest is holding the fleet. A TUI session keeps the engine warm for its lifetime; closing lilbee releases it. The intent is recorded on the services state before the container builds and threaded through `create_provider` -> `RoutingProvider` -> `FleetProvider`, so it ends up as provider instance state rather than a process-wide flag.
- The model swap keeps the chat input disabled until the new model actually serves, with a placeholder naming the target and saying why the box is locked, and eagerly warms the new model instead of deferring its cold load to the next prompt.
- The warm line is computed regardless of task activity and outranks the task summary. It was previously computed only when the task bar was idle, so the document sync that starts on launch suppressed it entirely — leaving a locked input with no explanation for the whole load.
- The indeterminate phases use the sweeping bar (a spinner glyph read worse in use); the line now also carries the model name and phase.
- Local-disk chat weights use mmap; `--no-mmap` is kept only for a network filesystem, where it avoids wedging the loader in uninterruptible I/O.
- The onefile bootstrap hides the parked cursor at handoff so it stays hidden until Textual takes over.

## Verified on hardware

Measured on a GTX 1070 Ti box running Jan v3.5 4B and Qwen3 0.6B, from source:

- **Keep-warm:** with `keep_engine_warm = false`, the live llama-swap configs wrote `ttl: 0` and both servers stayed resident continuously past the 5-minute idle window (GPU held at 4917 MiB). Under the previous `ttl: 300` they were evicted at 5 minutes.
- **Model switch:** instrumented end to end. The input is disabled at +0.00s and released at +37.1s, exactly when `wait_chat_ready` reports the model can serve — so it never re-enables in front of an unloaded model.
- **mmap:** the chat `llama-server` argv no longer carries `--no-mmap` on this local-disk host.
- **Splash cursor:** not verifiable from source, since it lives in the C onefile bootstrap that only exists in a built executable. The patch hunk arithmetic was corrected and validated; the visual check needs a build.
