### PR TITLE
Decode embedding responses from base64 instead of JSON float literals

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,53 +227,62 @@ on a single core. The rest of this section is why, and what fixed it.
 #### Embedding responses are binary, not JSON floats
 
 Ingest dispatches embed calls from a thread pool, so many files are in flight at once.
-The network wait overlaps well, because httpx releases the GIL while it waits. Decoding
-the response does not. If vectors arrive as JSON arrays of decimal literals, every
-element becomes a Python float parsed one at a time under the GIL, so a 4096-dimensional
-vector is 4096 individually parsed numbers. However many threads or GPUs are running,
-one core ends up decoding all of them, and that core's rate is the whole fleet's rate.
+The network wait overlaps well, because httpx releases the GIL while waiting. Decoding
+the response does not.
 
-lilbee therefore asks the server for `encoding_format: base64` and decodes the raw
-float32 buffer with `numpy.frombuffer`. The parse becomes a memory copy: one C call per
-vector instead of thousands of Python-level conversions.
+That is the whole problem. A vector arriving as JSON decimal literals becomes one Python
+float per dimension, parsed individually under the GIL. A 4096-dimensional vector is
+4096 separately parsed numbers. However many threads or GPUs are running, one core
+decodes all of them, and that core's rate is the fleet's rate.
 
-Measured through the client's own embed path on one core, 4096-dimensional vectors,
+So lilbee asks for `encoding_format: base64`. The response is still JSON, with the same
+envelope and the same fields. Only the vector itself is written differently:
+
+```jsonc
+// before: 4096 decimal literals to parse, one Python float each
+"embedding": [-0.0029101597, -0.0131583912, 0.0144413067, ...]
+
+// after: one string, decoded by numpy.frombuffer in a single C call
+"embedding": "Ybg+u0uWV7w7m2w8foWVvaJerzvbiCq8C1Yo..."
+```
+
+Measured through the client's own embed path, one core, 4096-dimensional vectors,
 64 per batch:
 
-| Response encoding | CPU per 1k vectors | Payload |
+| | Before (JSON floats) | After (base64) |
 |---|---|---|
-| JSON float literals | 785 ms | 5.41 MB |
-| base64 float32 buffer | 110 ms | 1.40 MB |
+| CPU per 1k vectors | 785 ms | **110 ms** |
+| Response body per batch | 5.41 MB | **1.40 MB** |
+| One-core decode ceiling | ~1,300 vectors/sec | **~9,000 vectors/sec** |
+| Work per vector | 4096 Python float objects | 1 buffer copy |
+| 8xA100 observed | 161 docs/sec, cards 10-98% util | GPU-bound |
 
-That is roughly seven times cheaper, and it moves the decode ceiling from about 1,300
-vectors/sec to about 9,000. At roughly eight chunks per document, the old figure works
-out to about 160 docs/sec, which is what the 8-card host was actually stuck at. That
-arithmetic is the quickest way to check whether decode is the limit on a given box:
-divide one core's decode rate by the chunks per document and compare it to observed
-throughput.
+Roughly seven times cheaper. The last row is the point: at about eight chunks per
+document, 1,300 vectors/sec works out to about 160 docs/sec, which is exactly where the
+8-card host was stuck. That arithmetic is the quickest field test for whether decode is
+your limit. Divide one core's decode rate by chunks per document and compare it to
+observed throughput.
 
-The same encoding applies to reranking, which shares the `/v1/embeddings` endpoint under
-rank pooling. Both callers decode through one helper, so the wire format cannot leak
-into the score path.
+Reranking shares the `/v1/embeddings` endpoint under rank pooling, so it receives the
+same encoding. Both callers decode through one helper, which keeps the wire format out
+of the score path.
 
-Three design notes:
+**Why not a real binary protocol?** MessagePack or protobuf would drop base64's 33% size
+inflation, but most of the remaining 110 ms is building Python floats for the caller, not
+the wire format. On the decode alone a raw binary buffer costs 55 ms per 1k vectors
+against base64's 97, so the entire protocol change is worth about 40 ms. It is also not
+reachable: the endpoint is llama.cpp's OpenAI-compatible API, which speaks JSON. Base64
+takes most of the available win using a format the engine already implements.
 
-- **A binary protocol would buy little.** MessagePack or protobuf would remove base64's
-  33% size inflation, but the remaining cost is dominated by materializing Python floats
-  for the caller, not by the wire format. Measured on the decode alone, a raw binary
-  buffer costs 55 ms per 1k vectors against base64's 97, so the whole protocol change is
-  worth about 40 ms. It is not reachable anyway: the endpoint is llama.cpp's
-  OpenAI-compatible API, which speaks JSON. Base64 captures most of the available win
-  using a format the engine already supports.
-- **Strict base64 validation is not worth its cost here.** Rejecting non-alphabet
-  characters during decode measured 12% slower on this path, to guard against corruption
-  that loopback HTTP already excludes. A wrong buffer length, a wrong response shape, and
-  a wrong vector dimension are each still caught, the last by the store on write.
-- **The remaining headroom is the provider contract, not the wire.** Returning numpy
-  arrays instead of `list[float]` measures 40 ms per 1k vectors, but it would change the
-  embedding contract across every provider backend. At current fleet sizes the GPUs
-  saturate well before the decode path does, so that change is not worth its blast
-  radius yet.
+**Why no strict base64 validation?** Rejecting non-alphabet characters during decode
+measured 12% slower, to guard against corruption that loopback HTTP already excludes. A
+wrong buffer length, a wrong response shape, and a wrong vector dimension are each still
+caught, the last by the store on write.
+
+**What headroom is left?** Returning numpy arrays instead of `list[float]` measures
+40 ms per 1k vectors, but it changes the embedding contract across every provider
+backend. GPUs saturate well before decode does at current fleet sizes, so that trade is
+not worth its blast radius yet.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,51 @@ Safety limits are identical across both adaptive profiles; only the climb speed 
 | free RAM soft / min | — | — | 20% / 10% |
 | GPU temp warn / critical | — | — | 80°C / 85°C |
 
+### Embedding responses are binary, not JSON floats
+
+Admission control keeps the GPUs fed, but it can only help if the CPU can absorb what
+they produce. Embedding vectors come back over HTTP, and how they are encoded turns out
+to set a hard throughput ceiling that no amount of extra dispatch concurrency can lift.
+
+Ingest dispatches embed calls from a thread pool, so many files are in flight at once.
+The network wait overlaps well, because httpx releases the GIL while it waits. Decoding
+the response does not. If vectors arrive as JSON arrays of decimal literals, every
+element becomes a Python float parsed one at a time under the GIL, so a 4096-dimensional
+vector is 4096 individually parsed numbers. However many threads or GPUs are running,
+one core ends up decoding all of them, and that core's rate is the whole fleet's rate.
+
+lilbee therefore asks the server for `encoding_format: base64` and decodes the raw
+float32 buffer with `numpy.frombuffer`. The parse becomes a memory copy: one C call per
+vector instead of thousands of Python-level conversions.
+
+Measured through the client's own embed path on one core, 4096-dimensional vectors,
+64 per batch:
+
+| Response encoding | CPU per 1k vectors | Payload |
+|---|---|---|
+| JSON float literals | 785 ms | 5.41 MB |
+| base64 float32 buffer | 110 ms | 1.40 MB |
+
+That is roughly seven times cheaper, and it moves the decode ceiling from about 1,300
+vectors/sec to about 9,000. The symptom it removes is specific: on fast multi-GPU
+hosts, aggregate throughput would flatten while GPU utilization sagged and individual
+cards sat starved and uneven. On slower cards the GPU is the limiter, so the ceiling
+stays invisible, which is why it only appears as the hardware gets faster.
+
+Two design notes:
+
+- **A binary protocol would buy little.** MessagePack or protobuf would remove base64's
+  33% size inflation, but the remaining cost is dominated by materializing Python floats
+  for the caller, not by the wire format. A raw binary buffer measures 55 ms per 1k
+  vectors against base64's 97 on the decode itself, and it is not reachable anyway: the endpoint is
+  llama.cpp's OpenAI-compatible API, which speaks JSON. Base64 captures most of the
+  available win using a format the engine already supports.
+- **The remaining headroom is the provider contract, not the wire.** Returning numpy
+  arrays instead of `list[float]` measures 40 ms per 1k vectors, but it would change the
+  embedding contract across every provider backend. At current fleet sizes the GPUs
+  saturate well before the decode path does, so that change is not worth its blast
+  radius yet.
+
 ---
 
 ## Provider Abstraction

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,11 +198,33 @@ Safety limits are identical across both adaptive profiles; only the climb speed 
 | free RAM soft / min | — | — | 20% / 10% |
 | GPU temp warn / critical | — | — | 80°C / 85°C |
 
-### Embedding responses are binary, not JSON floats
+### Three ceilings govern ingest throughput
 
-Admission control keeps the GPUs fed, but it can only help if the CPU can absorb what
-they produce. Embedding vectors come back over HTTP, and how they are encoded turns out
-to set a hard throughput ceiling that no amount of extra dispatch concurrency can lift.
+Admission control keeps the GPUs fed, but it is only one of three limits, and tuning the
+wrong one wastes effort. Ingest throughput is the minimum of:
+
+1. **The GPU ceiling.** How fast the cards can actually run the model.
+2. **The admission ceiling.** How many documents the controller lets in flight, which is
+   what the adaptive profiles above tune.
+3. **The CPU decode ceiling.** How fast one core can turn embed responses back into
+   Python objects, because that step holds the GIL and therefore does not scale with
+   threads or with GPUs.
+
+The third is the least obvious and the easiest to misread as a GPU problem, so it is
+worth knowing how to tell them apart:
+
+| What you observe | Which ceiling is binding |
+|---|---|
+| All cards near 100% util, throughput flat | GPU. Add or upgrade cards. |
+| Cards well under 100%, CPU cores all moderate | Admission. The controller is holding back. |
+| Cards uneven and starved, **one** core pegged at 100% | CPU decode. More concurrency will not help. |
+
+The third row is a real failure lilbee hit: 8 A100s capped near 161 docs/sec at roughly
+78% util with cards ranging 10 to 98 percent, while 2 slower L40S cards sat at an even
+97/97 percent. The slower pair was GPU-bound and healthy; the faster eight were waiting
+on a single core. The rest of this section is why, and what fixed it.
+
+#### Embedding responses are binary, not JSON floats
 
 Ingest dispatches embed calls from a thread pool, so many files are in flight at once.
 The network wait overlaps well, because httpx releases the GIL while it waits. Decoding
@@ -224,19 +246,29 @@ Measured through the client's own embed path on one core, 4096-dimensional vecto
 | base64 float32 buffer | 110 ms | 1.40 MB |
 
 That is roughly seven times cheaper, and it moves the decode ceiling from about 1,300
-vectors/sec to about 9,000. The symptom it removes is specific: on fast multi-GPU
-hosts, aggregate throughput would flatten while GPU utilization sagged and individual
-cards sat starved and uneven. On slower cards the GPU is the limiter, so the ceiling
-stays invisible, which is why it only appears as the hardware gets faster.
+vectors/sec to about 9,000. At roughly eight chunks per document, the old figure works
+out to about 160 docs/sec, which is what the 8-card host was actually stuck at. That
+arithmetic is the quickest way to check whether decode is the limit on a given box:
+divide one core's decode rate by the chunks per document and compare it to observed
+throughput.
 
-Two design notes:
+The same encoding applies to reranking, which shares the `/v1/embeddings` endpoint under
+rank pooling. Both callers decode through one helper, so the wire format cannot leak
+into the score path.
+
+Three design notes:
 
 - **A binary protocol would buy little.** MessagePack or protobuf would remove base64's
   33% size inflation, but the remaining cost is dominated by materializing Python floats
-  for the caller, not by the wire format. A raw binary buffer measures 55 ms per 1k
-  vectors against base64's 97 on the decode itself, and it is not reachable anyway: the endpoint is
-  llama.cpp's OpenAI-compatible API, which speaks JSON. Base64 captures most of the
-  available win using a format the engine already supports.
+  for the caller, not by the wire format. Measured on the decode alone, a raw binary
+  buffer costs 55 ms per 1k vectors against base64's 97, so the whole protocol change is
+  worth about 40 ms. It is not reachable anyway: the endpoint is llama.cpp's
+  OpenAI-compatible API, which speaks JSON. Base64 captures most of the available win
+  using a format the engine already supports.
+- **Strict base64 validation is not worth its cost here.** Rejecting non-alphabet
+  characters during decode measured 12% slower on this path, to guard against corruption
+  that loopback HTTP already excludes. A wrong buffer length, a wrong response shape, and
+  a wrong vector dimension are each still caught, the last by the store on write.
 - **The remaining headroom is the provider contract, not the wire.** Returning numpy
   arrays instead of `list[float]` measures 40 ms per 1k vectors, but it would change the
   embedding contract across every provider backend. At current fleet sizes the GPUs

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import json
 import logging
@@ -14,6 +15,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal, TypedDict, TypeVar, overload
 
 import httpx
+import numpy as np
+import numpy.typing as npt
 
 from lilbee.core.config import cfg
 from lilbee.providers.base import (
@@ -303,6 +306,20 @@ def _fetch_log_tail(url: str) -> str:
 # collapsed to +-1 by normalization. The server only exposes this per request
 # body, not as a startup flag.
 _EMBD_NORMALIZE_NONE = -1
+# Vectors come back as a base64 float32 buffer: parsing thousands of JSON float
+# literals per batch is CPU-bound and holds the GIL, which caps embedding
+# throughput below what the GPUs can feed regardless of how many are dispatching.
+_EMBED_ENCODING_FORMAT = "base64"
+# The engine writes the raw float buffer in host byte order; supported targets are
+# all little-endian.
+_EMBED_VECTOR_DTYPE = "<f4"
+# Rank pooling puts the pair's relevance score in the vector's first slot.
+_RANK_SCORE_INDEX = 0
+_UNREADABLE_EMBEDDING_ERROR = (
+    "The embedding server returned vectors lilbee could not read. Update the "
+    "inference engine: base64 embedding responses need llama-server b4391 or newer."
+)
+_NO_RERANK_SCORE_ERROR = "The reranker returned no relevance score for a candidate."
 _HEALTH_PATH = "/health"
 _CHAT_PATH = "/v1/chat/completions"
 _EMBED_PATH = "/v1/embeddings"
@@ -841,7 +858,7 @@ class LlamaServerClient:
         vectors: list[list[float]] = []
         for sub_batch in self._truncate_and_subbatch(texts, estimate=True):
             data = self._embed_subbatch(sub_batch)
-            vectors.extend(list(item["embedding"]) for item in data)
+            vectors.extend(_embedding_vector(item).tolist() for item in data)
         return vectors
 
     def _embed_subbatch(self, sub_batch: list[str]) -> list[dict[str, Any]]:
@@ -929,6 +946,7 @@ class LlamaServerClient:
                         "model": self._model,
                         "input": inputs,
                         "embd_normalize": _EMBD_NORMALIZE_NONE,
+                        "encoding_format": _EMBED_ENCODING_FORMAT,
                     },
                 )
                 _raise_for_status(resp)
@@ -1078,14 +1096,24 @@ class _InFlight:
             self._client.in_flight -= 1
 
 
+def _embedding_vector(item: dict[str, Any]) -> npt.NDArray[np.float32]:
+    """Decode one ``/v1/embeddings`` item's vector from its base64 float buffer."""
+    embedding = item.get("embedding")
+    # Untyped server JSON: a non-string means the encoding format was not honored.
+    if not isinstance(embedding, str):
+        raise ProviderError(_UNREADABLE_EMBEDDING_ERROR, provider=_PROVIDER_NAME)
+    try:
+        return np.frombuffer(base64.b64decode(embedding), dtype=_EMBED_VECTOR_DTYPE)
+    except ValueError as exc:
+        raise ProviderError(_UNREADABLE_EMBEDDING_ERROR, provider=_PROVIDER_NAME) from exc
+
+
 def _rerank_score(item: dict[str, Any]) -> float:
     """Pull one relevance score from a rank-pooling ``/v1/embeddings`` item."""
-    embedding = item.get("embedding")
-    if isinstance(embedding, list) and embedding and isinstance(embedding[0], (int, float)):
-        return float(embedding[0])
-    raise ProviderError(
-        f"Reranker returned unexpected score shape: {embedding!r}", provider=_PROVIDER_NAME
-    )
+    vector = _embedding_vector(item)
+    if not vector.size:
+        raise ProviderError(_NO_RERANK_SCORE_ERROR, provider=_PROVIDER_NAME)
+    return float(vector[_RANK_SCORE_INDEX])
 
 
 def _first_token_top_logprobs(response: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/integration/_llama_server_stub.py
+++ b/tests/integration/_llama_server_stub.py
@@ -10,7 +10,9 @@ chat endpoint, so a multipart image request gets the same stub answer.
 
 from __future__ import annotations
 
+import base64
 import json
+import struct
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -59,7 +61,8 @@ class _Handler(BaseHTTPRequestHandler):
                 self._send_json({"choices": [{"message": {"content": "stub-chat"}}]})
         elif self.path == "/v1/embeddings":
             count = len(body.get("input", []))
-            self._send_json({"data": [{"embedding": [0.5, 0.5]} for _ in range(count)]})
+            vector = base64.b64encode(struct.pack("<2f", 0.5, 0.5)).decode()
+            self._send_json({"data": [{"embedding": vector} for _ in range(count)]})
         else:
             self.send_error(404)
 

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from itertools import pairwise
 
 import httpx
+import numpy as np
 import pytest
 
 from lilbee.providers.base import ProviderError
@@ -18,6 +20,21 @@ from lilbee.providers.fleet.client import (
     _ThinkInliner,
 )
 from lilbee.providers.roles import RerankMode
+
+
+def _embed_body(vectors: list[list[float]]) -> dict[str, object]:
+    """A ``/v1/embeddings`` response body shaped as the server encodes base64 vectors."""
+    return {
+        "data": [
+            {
+                "embedding": base64.b64encode(np.asarray(vec, dtype="<f4").tobytes()).decode(),
+                "index": index,
+                "object": "embedding",
+                "encoding_format": "base64",
+            }
+            for index, vec in enumerate(vectors)
+        ]
+    }
 
 _STREAM_BODY = (
     'data: {"choices":[{"delta":{"content":"He"}}]}\n\n'
@@ -36,7 +53,7 @@ def _handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, text=_STREAM_BODY)
         return httpx.Response(200, json={"choices": [{"message": {"content": "Hello"}}]})
     if path == "/v1/embeddings":
-        return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}, {"embedding": [0.3]}]})
+        return httpx.Response(200, json=_embed_body([[0.25, 0.5], [0.75]]))
     return httpx.Response(404)
 
 
@@ -63,7 +80,7 @@ def test_rerank_scores_pairs_via_rank_pooling() -> None:
         seen["input"] = body["input"]
         # rank pooling returns a 1-element embedding (the score) per pair, in order
         n = len(body["input"])
-        return httpx.Response(200, json={"data": [{"embedding": [float(i)]} for i in range(n)]})
+        return httpx.Response(200, json=_embed_body([[float(i)] for i in range(n)]))
 
     scores = _client(handler).rerank("q", ["a", "b", "c"])
     assert scores == [0.0, 1.0, 2.0]
@@ -118,9 +135,9 @@ def test_embed_retries_transient_gateway_error_then_succeeds(monkeypatch) -> Non
         calls["n"] += 1
         if calls["n"] < 3:
             return httpx.Response(502, text="Bad Gateway")
-        return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}]})
+        return httpx.Response(200, json=_embed_body([[0.25, 0.5]]))
 
-    assert _client(handler).embed(["hello"]) == [[0.1, 0.2]]
+    assert _client(handler).embed(["hello"]) == [[0.25, 0.5]]
     assert calls["n"] == 3
 
 
@@ -153,9 +170,9 @@ def test_embed_retries_on_busy_then_succeeds(monkeypatch) -> None:
         calls["n"] += 1
         if calls["n"] < 3:
             return httpx.Response(429, json={"error": "Too many requests"})
-        return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}]})
+        return httpx.Response(200, json=_embed_body([[0.25, 0.5]]))
 
-    assert _client(handler).embed(["hello"]) == [[0.1, 0.2]]
+    assert _client(handler).embed(["hello"]) == [[0.25, 0.5]]
     assert calls["n"] == 3  # two 429s retried, third succeeds
 
 
@@ -191,9 +208,9 @@ def test_embed_rides_out_cold_start_past_interactive_budget(monkeypatch) -> None
         calls["n"] += 1
         if calls["n"] <= warmup:
             return httpx.Response(429, json={"error": "warming"})
-        return httpx.Response(200, json={"data": [{"embedding": [0.3]}]})
+        return httpx.Response(200, json=_embed_body([[0.75]]))
 
-    assert _client(handler).embed(["x"]) == [[0.3]]
+    assert _client(handler).embed(["x"]) == [[0.75]]
     assert calls["n"] == warmup + 1
 
 
@@ -215,12 +232,12 @@ def test_embed_with_cold_load_deadline_rides_out_more_429s_than_attempt_cap(monk
         calls["n"] += 1
         if calls["n"] <= warmup:
             return httpx.Response(429, json={"error": "warming"})
-        return httpx.Response(200, json={"data": [{"embedding": [0.3]}]})
+        return httpx.Response(200, json=_embed_body([[0.75]]))
 
     http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://gpu0")
     client = LlamaServerClient("http://gpu0", "test-model", http=http, embed_busy_deadline_s=600.0)
     client._needs_alternation = False
-    assert client.embed(["x"]) == [[0.3]]
+    assert client.embed(["x"]) == [[0.75]]
     assert calls["n"] == warmup + 1
 
 
@@ -456,7 +473,7 @@ def test_rerank_empty_candidates_returns_empty() -> None:
 
 def test_rerank_raises_on_count_mismatch() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"data": [{"embedding": [0.5]}]})  # 1 for 2 pairs
+        return httpx.Response(200, json=_embed_body([[0.5]]))  # 1 for 2 pairs
 
     with pytest.raises(ProviderError, match="vectors for"):
         _client(handler).rerank("q", ["a", "b"])
@@ -464,9 +481,9 @@ def test_rerank_raises_on_count_mismatch() -> None:
 
 def test_rerank_raises_on_bad_score_shape() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"data": [{"embedding": "nope"}]})
+        return httpx.Response(200, json={"data": [{"embedding": {"not": "a vector"}}]})
 
-    with pytest.raises(ProviderError, match="unexpected score shape"):
+    with pytest.raises(ProviderError, match="could not read"):
         _client(handler).rerank("q", ["a"])
 
 
@@ -663,7 +680,73 @@ def test_chat_stream_items_requests_include_usage() -> None:
 
 
 def test_embed_returns_vectors() -> None:
-    assert _client().embed(["a", "b"]) == [[0.1, 0.2], [0.3]]
+    assert _client().embed(["a", "b"]) == [[0.25, 0.5], [0.75]]
+
+
+def test_embed_requests_base64_encoded_vectors() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        seen["encoding_format"] = body.get("encoding_format")
+        return httpx.Response(200, json=_embed_body([[0.25, -0.5]]))
+
+    assert _client(handler).embed(["a"]) == [[0.25, -0.5]]
+    assert seen["encoding_format"] == "base64"
+
+
+def test_embed_decodes_base64_vectors_exactly() -> None:
+    vectors = [[0.1, -2.5, 3.75], [1e-7, 6.0e3, -0.0]]
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_embed_body(vectors))
+
+    decoded = _client(handler).embed(["a", "b"])
+    expected = np.asarray(vectors, dtype="<f4").tolist()
+    assert decoded == expected
+
+
+def test_embed_raises_when_server_returns_unencoded_floats() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}]})
+
+    with pytest.raises(ProviderError, match="could not read"):
+        _client(handler).embed(["a"])
+
+
+def test_embed_raises_on_truncated_vector_buffer() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Three bytes cannot form whole float32 values.
+        return httpx.Response(
+            200, json={"data": [{"embedding": base64.b64encode(b"abc").decode()}]}
+        )
+
+    with pytest.raises(ProviderError, match="could not read"):
+        _client(handler).embed(["a"])
+
+
+def test_embed_raises_on_non_base64_vector_text() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"embedding": "not!base64!"}]})
+
+    with pytest.raises(ProviderError, match="could not read"):
+        _client(handler).embed(["a"])
+
+
+def test_rerank_reads_score_from_base64_vector() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        count = len(json.loads(request.content)["input"])
+        return httpx.Response(200, json=_embed_body([[float(i), 9.0] for i in range(count)]))
+
+    assert _client(handler).rerank("q", ["a", "b", "c"]) == [0.0, 1.0, 2.0]
+
+
+def test_rerank_raises_on_empty_score_vector() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_embed_body([[]]))
+
+    with pytest.raises(ProviderError, match="no relevance score"):
+        _client(handler).rerank("q", ["a"])
 
 
 def test_embed_empty_returns_empty_without_request() -> None:
@@ -693,7 +776,7 @@ def test_embed_truncates_oversize_input_via_server_tokenizer() -> None:
             seen["detok_tokens"] = body["tokens"]
             return httpx.Response(200, json={"content": "trunc"})
         seen["embedded"] = body["input"]
-        return httpx.Response(200, json={"data": [{"embedding": [0.5]}]})
+        return httpx.Response(200, json=_embed_body([[0.5]]))
 
     out = _capped_client(handler, cap=3).embed(["a very long input"])
     assert out == [[0.5]]
@@ -710,7 +793,7 @@ def test_embed_keeps_input_within_cap_unchanged() -> None:
         if request.url.path.endswith("/detokenize"):
             raise AssertionError("must not detokenize an input within the cap")
         seen["embedded"] = json.loads(request.content)["input"]
-        return httpx.Response(200, json={"data": [{"embedding": [0.5]}]})
+        return httpx.Response(200, json=_embed_body([[0.5]]))
 
     assert _capped_client(handler, cap=3).embed(["short"]) == [[0.5]]
     assert seen["embedded"] == ["short"]  # original text passed through
@@ -723,7 +806,7 @@ def test_embed_tokenize_request_matches_in_process_flags() -> None:
         if request.url.path.endswith("/tokenize"):
             seen.update(json.loads(request.content))
             return httpx.Response(200, json={"tokens": [1]})
-        return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(200, json=_embed_body([[0.1]]))
 
     # A long input whose char estimate exceeds the cap forces the /tokenize probe.
     _capped_client(handler, cap=2).embed(["x" * 30])
@@ -742,7 +825,7 @@ def test_embed_estimates_tokens_without_per_input_tokenize() -> None:
             raise AssertionError("normal-sized chunks must not hit the server tokenizer")
         inputs = json.loads(request.content)["input"]
         sent.append(list(inputs))
-        return httpx.Response(200, json={"data": [{"embedding": [0.5]} for _ in inputs]})
+        return httpx.Response(200, json=_embed_body([[0.5] for _ in inputs]))
 
     chunks = ["a normal chunk of text"] * 5
     out = _capped_client(handler, cap=8192).embed(chunks)
@@ -758,9 +841,9 @@ def test_rerank_truncates_oversize_pairs() -> None:
         if request.url.path.endswith("/detokenize"):
             return httpx.Response(200, json={"content": "t"})
         # one score per (truncated) pair
-        return httpx.Response(200, json={"data": [{"embedding": [0.9]} for _ in body["input"]]})
+        return httpx.Response(200, json=_embed_body([[0.875] for _ in body["input"]]))
 
-    assert _capped_client(handler, cap=4).rerank("q", ["cand"]) == [0.9]
+    assert _capped_client(handler, cap=4).rerank("q", ["cand"]) == [0.875]
 
 
 def test_embed_surfaces_server_error_body() -> None:
@@ -1120,7 +1203,7 @@ def test_embed_subbatches_when_token_budget_exceeded() -> None:
             raise AssertionError("estimation must not hit the server tokenizer here")
         inputs = json.loads(request.content)["input"]
         sent.append(list(inputs))
-        return httpx.Response(200, json={"data": [{"embedding": [0.0]} for _ in inputs]})
+        return httpx.Response(200, json=_embed_body([[0.0] for _ in inputs]))
 
     out = _capped_client(handler, cap=4).embed(["x" * 7, "y" * 7, "z" * 7])
     assert sent == [["x" * 7], ["y" * 7], ["z" * 7]]  # 3+3 > 4, so never two per request
@@ -1139,7 +1222,7 @@ def test_embed_subbatches_when_sequence_count_exceeded() -> None:
         if request.url.path.endswith("/tokenize"):
             return httpx.Response(200, json={"tokens": [1]})  # 1 token each
         sizes.append(len(body["input"]))
-        return httpx.Response(200, json={"data": [{"embedding": [0.0]} for _ in body["input"]]})
+        return httpx.Response(200, json=_embed_body([[0.0] for _ in body["input"]]))
 
     n = _EMBED_N_SEQ_MAX + 5
     out = _capped_client(handler, cap=100_000).embed([f"t{i}" for i in range(n)])
@@ -1154,7 +1237,7 @@ def test_embed_requests_no_normalization() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.update(json.loads(request.content))
-        return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(200, json=_embed_body([[0.1]]))
 
     _client(handler).embed(["a"])
     assert seen["embd_normalize"] == -1
@@ -1167,7 +1250,7 @@ def test_rerank_requests_no_normalization() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.update(json.loads(request.content))
-        return httpx.Response(200, json={"data": [{"embedding": [0.7]}]})
+        return httpx.Response(200, json=_embed_body([[0.7]]))
 
     _client(handler).rerank("q", ["a"])
     assert seen["embd_normalize"] == -1
@@ -1782,7 +1865,7 @@ def test_embed_retries_with_exact_tokenize_on_context_overflow() -> None:
             calls["embed"] += 1
             if calls["embed"] == 1:
                 return httpx.Response(400, text='{"error":{"message":"exceed_context_size_error"}}')
-            return httpx.Response(200, json={"data": [{"embedding": [0.5]}]})
+            return httpx.Response(200, json=_embed_body([[0.5]]))
         return httpx.Response(404)
 
     # cap=10 so "dense" (est 2) is trusted and sent untruncated on the first try.
@@ -1811,7 +1894,7 @@ def test_embed_retries_exact_on_batch_overflow_500() -> None:
                     text='{"error":{"code":500,"message":"input (136 tokens) is too large'
                     ' to process. increase the physical batch size","type":"server_error"}}',
                 )
-            return httpx.Response(200, json={"data": [{"embedding": [0.5]}]})
+            return httpx.Response(200, json=_embed_body([[0.5]]))
         return httpx.Response(404)
 
     assert _capped_client(handler, 10).embed(["dense"]) == [[0.5]]

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -706,28 +706,17 @@ def test_embed_decodes_base64_vectors_exactly() -> None:
     assert decoded == expected
 
 
-def test_embed_raises_when_server_returns_unencoded_floats() -> None:
+@pytest.mark.parametrize(
+    "embedding",
+    [
+        pytest.param([0.1, 0.2], id="server_ignored_the_requested_encoding"),
+        pytest.param(base64.b64encode(b"abc").decode(), id="buffer_is_not_whole_float32s"),
+        pytest.param("not!base64!", id="not_base64_text"),
+    ],
+)
+def test_embed_raises_on_unreadable_embedding(embedding: object) -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}]})
-
-    with pytest.raises(ProviderError, match="could not read"):
-        _client(handler).embed(["a"])
-
-
-def test_embed_raises_on_truncated_vector_buffer() -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:
-        # Three bytes cannot form whole float32 values.
-        return httpx.Response(
-            200, json={"data": [{"embedding": base64.b64encode(b"abc").decode()}]}
-        )
-
-    with pytest.raises(ProviderError, match="could not read"):
-        _client(handler).embed(["a"])
-
-
-def test_embed_raises_on_non_base64_vector_text() -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"data": [{"embedding": "not!base64!"}]})
+        return httpx.Response(200, json={"data": [{"embedding": embedding}]})
 
     with pytest.raises(ProviderError, match="could not read"):
         _client(handler).embed(["a"])

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -36,6 +36,7 @@ def _embed_body(vectors: list[list[float]]) -> dict[str, object]:
         ]
     }
 
+
 _STREAM_BODY = (
     'data: {"choices":[{"delta":{"content":"He"}}]}\n\n'
     'data: {"choices":[{"delta":{"content":"llo"}}]}\n\n'

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import logging
 import os
+import struct
 import threading
 import time
 from pathlib import Path
@@ -2742,7 +2744,8 @@ class TestReplicaHealthRouting:
         def _handler(name: str):
             def handler(_request: _httpx.Request) -> _httpx.Response:
                 calls[name] += 1
-                return _httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+                vector = base64.b64encode(struct.pack("<f", 0.25)).decode()
+                return _httpx.Response(200, json={"data": [{"embedding": vector}]})
 
             return handler
 

--- a/tests/test_ingest_offload.py
+++ b/tests/test_ingest_offload.py
@@ -13,13 +13,20 @@ import pytest
 
 from lilbee.core.config import cfg
 from lilbee.data.ingest import offload
+from lilbee.providers.fleet import replicas
 
 
 @pytest.fixture(autouse=True)
 def _pin_sizing_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Clear the ambient ``LILBEE_INGEST_MAX_WORKERS`` and inflight floor before each test."""
+    """Drop the env override, zero the inflight floor, stub the fleet probe to one replica.
+
+    ``_max_workers`` floors its CPU-derived result at ``ingest_max_inflight``, or at the
+    probed embed-replica count when that is zero, so leaving either ambient makes these
+    assertions depend on what ran earlier.
+    """
     monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
     monkeypatch.setattr(cfg, "ingest_max_inflight", 0)
+    monkeypatch.setattr(replicas, "resolve_replica_count", lambda *_a, **_k: 1)
 
 
 def test_default_caps_at_32_on_a_big_box(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -57,10 +64,14 @@ def test_embed_inflight_target_is_zero_when_the_fleet_cannot_be_probed(
 ) -> None:
     # The fleet may not be resolvable yet (probe raises); admission sizing must
     # fall back to the CPU-bound quota rather than crash the ingest run.
-    import lilbee.providers.fleet.replicas as replicas_mod
+    probed = False
 
     def _raise(*_args: object, **_kwargs: object) -> int:
+        nonlocal probed
+        probed = True
         raise RuntimeError("fleet not resolvable yet")
 
-    monkeypatch.setattr(replicas_mod, "resolve_replica_count", _raise)
+    monkeypatch.setattr(replicas, "resolve_replica_count", _raise)
     assert offload.embed_inflight_target() == 0
+    # A single-replica stub also returns 0, so pin that the raising probe ran.
+    assert probed

--- a/tests/test_ingest_offload.py
+++ b/tests/test_ingest_offload.py
@@ -17,11 +17,7 @@ from lilbee.data.ingest import offload
 
 @pytest.fixture(autouse=True)
 def _pin_sizing_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Pin every input ``_max_workers`` reads, not just the env override.
-
-    It also floors the result at ``ingest_max_inflight``, so a value left on the
-    config singleton by an earlier test makes these assertions order-dependent.
-    """
+    """Pin both inputs ``_max_workers`` reads: the env override and the inflight floor."""
     monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
     monkeypatch.setattr(cfg, "ingest_max_inflight", 0)
 

--- a/tests/test_ingest_offload.py
+++ b/tests/test_ingest_offload.py
@@ -17,7 +17,7 @@ from lilbee.data.ingest import offload
 
 @pytest.fixture(autouse=True)
 def _pin_sizing_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Pin both inputs ``_max_workers`` reads: the env override and the inflight floor."""
+    """Clear the ambient ``LILBEE_INGEST_MAX_WORKERS`` and inflight floor before each test."""
     monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
     monkeypatch.setattr(cfg, "ingest_max_inflight", 0)
 

--- a/tests/test_ingest_offload.py
+++ b/tests/test_ingest_offload.py
@@ -11,12 +11,19 @@ from __future__ import annotations
 
 import pytest
 
+from lilbee.core.config import cfg
 from lilbee.data.ingest import offload
 
 
 @pytest.fixture(autouse=True)
-def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _pin_sizing_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin every input ``_max_workers`` reads, not just the env override.
+
+    It also floors the result at ``ingest_max_inflight``, so a value left on the
+    config singleton by an earlier test makes these assertions order-dependent.
+    """
     monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
+    monkeypatch.setattr(cfg, "ingest_max_inflight", 0)
 
 
 def test_default_caps_at_32_on_a_big_box(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

Embedding throughput hit a CPU ceiling that did not move with GPU count. The embed response was decoded from JSON float literals on Python threads, so each 4096-dimensional vector cost 4096 individually parsed floats under the GIL. Network I/O overlaps across the dispatch pool; that decode does not, so one core decoded every vector no matter how many GPUs were feeding it.

Measured at 785 ms of CPU per 1k vectors, about 1,300 vectors/sec. At roughly eight chunks per document that is about 160 docs/sec, which is where 8 A100s were stuck while cards sat uneven and starved at 10 to 98 percent util. Two slower L40S cards never hit it, because there the GPU is the limiter.

## Solution

Request `encoding_format: base64` on `/v1/embeddings` and decode the float32 buffer with `numpy.frombuffer`. The response is still JSON with the same envelope; only the vector field changes:

```jsonc
// before: 4096 decimal literals, one Python float allocated per dimension
"embedding": [-0.0029101597, -0.0131583912, 0.0144413067, ...]

// after: one string, decoded by numpy.frombuffer in a single C call
"embedding": "Ybg+u0uWV7w7m2w8foWVvaJerzvbiCq8C1Yo..."
```

### Performance

Measured by driving the client's own `embed()` through a mock transport, base against head, three reps each with a build-independent compute control. One core, 4096-dimensional vectors, 64 per batch.

| Metric | Before | After | Change |
|---|---|---|---|
| CPU per 1k vectors | 785 ms | 110 ms | **7.1x faster** |
| Response body per batch | 5.41 MB | 1.40 MB | **3.9x smaller** |
| One-core decode ceiling | ~1,300 vectors/sec | ~9,000 vectors/sec | **6.9x higher** |
| Python objects per vector | 4096 floats | 1 buffer copy | allocation removed |

Reading the table:

- **CPU per 1k vectors** is processor time spent turning 1,000 embedding vectors from an HTTP response into Python values. It is CPU time, not wall clock, because this step holds the GIL and therefore does not overlap across threads.
- **Response body per batch** is the size of one `/v1/embeddings` response for 64 vectors. Smaller means less to read off the socket as well as less to parse.
- **One-core decode ceiling** is the throughput one core can sustain, which is the fleet-wide limit for this step regardless of thread or GPU count. Divide it by chunks per document to get a docs/sec ceiling: at ~8 chunks/doc the old figure is ~160 docs/sec, matching the 8-card host that was stuck at 161.
- **Python objects per vector** is why the rest moves. The old path allocated one Python float per dimension; the new path copies bytes into a numpy buffer.

Small workloads do not regress. The crossover where base64 loses is a 1-dimensional vector, by 0.1 microseconds; a single 384-dimensional interactive query already decodes 7.5x faster.

### Notes

Reranking shares the same endpoint and so receives the same encoding. Both callers decode through one helper, which keeps the wire format out of the score path rather than leaving it as something each caller has to remember.

Verified against a live llama-server that base64 is honored for both mean and rank pooling, and that vectors are bit-identical between the two encodings.

A binary protocol such as MessagePack was measured and rejected: it is worth about 40 ms of the remaining 110, and the endpoint is llama.cpp's OpenAI-compatible API, which speaks JSON. Strict base64 validation was also measured and rejected at 12 percent slower, guarding corruption that loopback HTTP already excludes.

No fallback for servers that return float arrays: both client construction sites use the bundled pinned engine, which is far past the release that added base64, so that branch would be unreachable.

Also documents the three ceilings that govern ingest throughput and how to tell which one is binding, and pins a config input in the offload sizing tests that made them order-dependent under xdist.
