### PR TITLE
Condense the README and document TUI terminal expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,26 +87,22 @@ Two recommended ways to use lilbee, depending on whether you're the one driving:
 - **Run `lilbee`** for the full-screen terminal app. A welcome wizard picks a chat and embedding model, then you index files, search, and chat without leaving the TUI. The Settings screen exposes every retrieval knob (search depth, distance threshold, reranker, chunking) so you can tune lilbee to your library shape.
 - **Connect it to your agent over MCP.** Any MCP-aware coding agent calls `lilbee_search` / `lilbee_add` and gets back cited snippets it can quote. Agents can also _fine-tune lilbee on the fly_ via `lilbee_settings_set`. Drop in the [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) and the agent reads the full surface: every tool, every retrieval knob, and when to widen for prose vs narrow for code. See [Agent integration](#agent-integration).
 
-Defaults are sane for chatting with code, documentation, crawled sites, and long PDFs. Every retrieval setting is writable from the TUI Settings screen, the `/set` slash command, MCP `lilbee_settings_set`, or `config.toml`. When answers feel thin or noisy, the usual knobs are `top_k`, `max_distance`, or `diversity_max_per_source`.
-
-CLI, the HTTP API, env vars, and `config.toml` are there for scripting, headless runs, and custom integrations. See the [usage guide](docs/usage.md).
+Retrieval defaults are sane, and every setting is tunable from the TUI, `/set`, MCP, env vars, or `config.toml`. The CLI and HTTP API cover scripting and headless runs. See the [usage guide](docs/usage.md).
 
 ## Highlights
 
-- **Answers cite the source line.** Click a citation, jump to the file at the exact line. When the answer isn't in your library, lilbee says so instead of inventing one.
-- **It works, and the demos prove it.** Every GIF and tutorial reel here is recorded live on real hardware, nothing staged. Backed by 100% test coverage, full typing, and CI on macOS, Linux, and Windows.
-- **Up and running in one command.** Install, run `lilbee`, and a first-run wizard pulls a model and drops you straight into chat.
-- **Reads almost anything you point it at.** Documents, scanned pages, spreadsheets, ebooks, web pages, and source code: [90+ formats and 150+ languages](#supported-formats) in all. Whatever you give it becomes searchable.
-- **Splits it into pieces that stand on their own.** [Prose and code are chunked differently](#documents-code-and-scanned-images), so each piece keeps its meaning instead of getting cut mid-thought. A search engine is only as good as the chunks underneath it, and this is where most of the quality lives.
-- **A sophisticated [search engine](docs/architecture.md#search-pipeline) on top, built on published research.** It ranks every result by how well it answers you, so the best match comes back first. 50+ knobs to [tune from the Settings screen](docs/usage.md#settings-screen) or hand to your agent, with sane defaults if you'd rather not.
-- **It brings and runs the models itself.** Browse Hugging Face, pull a model, give it a role (chat, embedding, vision, reranking); lilbee runs it on Metal, Vulkan, or CUDA. You never point it at a server you set up.
-- **A model too big for one card runs across all of them.** lilbee sizes each role with gguf-parser and tensor-splits your chat model across the fewest GPUs that fit, placing the embedder, reranker, and vision models alongside it behind a load-balancing router. It happens automatically, or you can pin each role to the cards you choose. [Run a model bigger than one card](#run-a-model-bigger-than-one-card).
-- **Already on Ollama or LM Studio? Keep them.** You don't need either one: lilbee's own manager handles everything, across the same [model families](#tested-model-families) they run. But lilbee also works with both, so you never have to switch. Their models show up in the same catalog and role pickers, alongside lilbee's own.
-- **Your hardware, put to work.** Your machine can do a lot more than you're using it for. lilbee runs local models on hardware you already own, no cloud account required.
-- **Per-project libraries.** Keep one library for everything, or give each project its own.
-- **One install, many surfaces.** TUI, CLI, [MCP server](#agent-integration), [REST API](https://lilbee.sh/api/), and Python library. Nothing to stand up.
-- **Everything in one file, nothing to operate.** The standalone binary bundles the whole thing (search engine, web crawler, MCP server, HTTP server, terminal UI, Python, and llama.cpp) in ~290-420 MB, or ~0.6-1.2 GB with CUDA. No Docker, no vector database, no model server, nothing to keep running; it loads on demand. Comparable desktop AI apps (often Electron) ship hundreds of MB to several GB and do less.
-- **Works with your coding agent.** Connect lilbee to your AI coding assistant and it answers from your actual files and code, with citations, instead of guessing. It can even adjust its own search as it works.
+- **Answers cite the source line.** Click a citation, jump to the file at the exact line; when the answer isn't in your library, lilbee says so instead of inventing one.
+- **It works, and the demos prove it.** Every GIF and reel here is recorded live on real hardware, nothing staged, backed by 100% test coverage, full typing, and CI on macOS, Linux, and Windows.
+- **One command to running.** Install, run `lilbee`, and a first-run wizard pulls a model and drops you into chat.
+- **Reads almost anything:** [90+ formats and 150+ languages](#supported-formats) across documents, scanned pages, spreadsheets, ebooks, web pages, and source code.
+- **Chunks that stand on their own.** [Prose and code are split differently](#documents-code-and-scanned-images) so each piece keeps its meaning, which is where most of the retrieval quality lives.
+- **A real [search engine](docs/architecture.md#search-pipeline) on top,** ranking every result by how well it answers you, with 50+ [tunable knobs](docs/usage.md#settings-screen) and sane defaults.
+- **It brings and runs the models itself,** on Metal, Vulkan, or CUDA, with no server to point at and no cloud account. Browse Hugging Face, pull a model, give it a role (chat, embedding, vision, rerank).
+- **A model too big for one card runs across all of them,** sized with gguf-parser and tensor-split automatically, or pinned by hand. [Run a model bigger than one card](#run-a-model-bigger-than-one-card).
+- **Already on Ollama or LM Studio? Keep them.** lilbee's own manager handles everything across the same [model families](#tested-model-families) they run, and their models also show up in the same pickers.
+- **One install, many surfaces:** TUI, CLI, [MCP server](#agent-integration), [REST API](https://lilbee.sh/api/), and Python library, so your coding agent answers from your real files, with citations.
+- **Everything in one file, nothing to operate.** The binary bundles the whole stack (search engine, crawler, MCP + HTTP servers, TUI, Python, llama.cpp) in ~290-420 MB, or ~0.6-1.2 GB with CUDA; it loads on demand and nothing stays running.
+- **Per-project libraries.** One library for everything, or one per project.
 
 ## Why lilbee
 
@@ -185,10 +181,6 @@ Ask it something with a real answer at stake and you get the answer, not a parap
 
 ![ask whether a car can tow a 3,500 lb boat trailer; lilbee says no, gives the real limits, and cites the manual page](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.gif)
 
-### Already using an MCP-aware agent? Hand setup to it.
-
-If you've already got an MCP-aware coding agent running, it can do the setup: browse the catalog, pull picks, assign them to the embedding / reranker / vision roles, and tune retrieval. No TUI, no config file, no restart. Agents already understand search engines, so the right knobs are obvious to them. See the [`lilbee-mcp` skill](src/lilbee/skills/lilbee_mcp/SKILL.md) for the workflow and example prompts.
-
 ### Launch your coding agent on local models
 
 `lilbee launch opencode` and `lilbee launch hermes` set up lilbee's local models in your agent in one command. lilbee registers itself as a provider and an MCP server in the agent's own config, leaves your existing setup intact, warms a model, and opens the agent pointed at it. No API keys, no provider setup, and nothing leaves your machine. Tool-calling works across many GGUF families; [docs/agent-models.md](docs/agent-models.md) has the verified list and how the QA harness measures it.
@@ -199,11 +191,7 @@ These reels show each agent, launched on a local model, doing real work on lilbe
 
 ![hermes, launched on a local lilbee model, adds a launch-list subcommand and lands a passing test](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-hermes.gif)
 
-It tunes itself, too. Give a small local model a thin first result and tell it to widen lilbee's search, and the second pass returns full function bodies with file:line citations. A more capable model would do the same from a higher-level prompt like "improve your search results." Read the [lilbee-mcp skill](docs/agent-skills/lilbee-mcp/SKILL.md) to teach your own model the pattern.
-
-![hermes running a local model against lilbee's tools](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-hermes.gif)
-
-In this demo a small local model is told: when its first search comes back thin, widen lilbee's search settings and search again. The second pass returns the full function bodies with file:line citations. A more capable model would do the same from a higher-level prompt like "improve your search results." Read the [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) to teach your own model the pattern.
+It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 
 ![agent fine-tunes lilbee mid-conversation: outline, then widened retrieval, then source with file:line citations](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/mcp-code-self-tune.gif)
 
@@ -586,12 +574,6 @@ lilbee stands on a stack of established open-source projects, all bundled into o
 - [Nuitka] compiles the whole thing into the standalone single-file binary, bundling its own Python runtime so there is nothing to install and nothing to compile.
 
 ## FAQ
-
-**What is lilbee, in one line?** A local AI search engine: it runs the models and searches your files, code, and the web, with answers that cite the source.
-
-**Is it really one program?** Yes. The model runtime (llama.cpp) and the index (LanceDB) run inside lilbee. No separate model server, no vector database, no container.
-
-**Is lilbee a model manager?** Yes, a complete one. It browses Hugging Face, downloads models, assigns roles, runs them on Metal, Vulkan, or CUDA, and places large models across multiple GPUs, so you do not need a separate model runner. Already use Ollama or LM Studio? Point lilbee at them instead.
 
 **Does my data leave my machine?** No. Your files stay on disk and search runs locally. A cloud model is used only when you pick one.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,6 +47,28 @@ Press `?` at any time for the keybinding cheat sheet, `Ctrl+P` for the Textual
 command palette, and `/help` for the slash-command catalog. Every action lilbee
 can take is reachable from one of those three.
 
+### Terminal recommendations
+
+The TUI is a full-screen Textual app, so it looks its best in a terminal with
+24-bit "true color" and a monospaced font that covers box-drawing and
+block/braille glyphs. Anything current handles both: iTerm2, kitty, WezTerm,
+Alacritty, or Ghostty on macOS and Linux; Windows Terminal on Windows; the
+built-in GNOME and KDE terminals. An 8/256-color terminal still runs everything,
+just with a flatter palette.
+
+- **Give it room.** The model bar and layout want about 100 columns; narrower
+  and panels start to wrap.
+- **Over SSH is fine,** but redraws are only as fast as the link, so a laggy
+  connection makes scrolling and model switches feel heavier than they are.
+- **One multiplexer layer, not two.** tmux and screen work well. Nested tmux (a
+  local tmux, then SSH into a second tmux on the remote) is the one setup to
+  avoid: two multiplexers fight over the same escape sequences and mangle
+  box-drawing and the cursor. Attach to the remote session directly, or start
+  lilbee outside the inner tmux.
+- **Colors look washed out?** The terminal is probably in 256-color mode. Pick a
+  truecolor `TERM` such as `xterm-256color`; most terminals then export
+  `COLORTERM=truecolor` and the full palette comes back.
+
 ### First run
 
 The welcome screen walks you through:


### PR DESCRIPTION
Two documentation changes.

**README: condense by cutting repeated prose, not proof.** The same value props were restated across Highlights, Quick start, What-you-can-do, Agent integration, and the FAQ, which is what read as dense. Trimmed to one home each: Highlights goes from 14 multi-sentence bullets to 12 one-liners with every link kept; the FAQ drops the three entries that only restate the pitch and keeps the three real questions (data privacy, GPU fit, agent) plus their unique lilbee.sh/gpu and lilbee.sh/mcp links; the pure-prose "Already using an MCP-aware agent" subsection is removed (covered by Quick start and Agent integration, no demo lost); and the self-duplicated agent-launcher block is fixed, where the hermes GIF was embedded twice and the self-tune paragraph written twice, one behind a broken docs/agent-skills link.

Nothing was lost: a before/after diff of all 167 links and images shows the only removed reference is that broken skill path. All 20 GIFs, every benchmark, table, and working link survive.

**Usage guide: add a Terminal recommendations section** under the TUI, setting expectations for the Textual app: truecolor and a Unicode-capable monospaced font for the full look, the ~100-column width, that SSH is fine but redraw-bound, and that nested tmux (a local tmux plus a second tmux over SSH) mangles box-drawing and the cursor. So a washed-out palette or a garbled border reads as a terminal setting, not a bug.
