### PR TITLE
Build the Pages site even when tests or coverage fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,13 +100,10 @@ docs-api:  ## Generate OpenAPI schema and Redoc static HTML
 	rm -f openapi.json
 
 docs-site: docs-api  ## Build the full dev portal (coverage + API docs)
-	# Tests gate CI and releases, not the site build; publish whatever coverage was produced.
+	# Tests gate CI and releases, not the site build; the coverage report deploys regardless of the test outcome.
 	-$(MAKE) test-ci
-	@if [ -d htmlcov ]; then \
-		cp -r htmlcov site/coverage; \
-	else \
-		echo "warning: no coverage report; deploying the site without coverage pages"; \
-	fi
+	cp -r htmlcov site/coverage
+	uv run python tools/update_site_coverage.py
 
 docs: docs-site  ## Alias for docs-site
 

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,13 @@ docs-api:  ## Generate OpenAPI schema and Redoc static HTML
 	rm -f openapi.json
 
 docs-site: docs-api  ## Build the full dev portal (coverage + API docs)
-	$(MAKE) test-ci
-	cp -r htmlcov site/coverage
+	# Tests gate CI and releases, not the site build; publish whatever coverage was produced.
+	-$(MAKE) test-ci
+	@if [ -d htmlcov ]; then \
+		cp -r htmlcov site/coverage; \
+	else \
+		echo "warning: no coverage report; deploying the site without coverage pages"; \
+	fi
 
 docs: docs-site  ## Alias for docs-site
 

--- a/tools/update_site_coverage.py
+++ b/tools/update_site_coverage.py
@@ -1,0 +1,37 @@
+"""Sync the marketing site's coverage numbers with the generated htmlcov report."""
+
+import re
+import sys
+from pathlib import Path
+
+HTMLCOV_INDEX = Path("htmlcov/index.html")
+SITE_INDEX = Path("site/index.html")
+
+PC_COV_RE = re.compile(r'<span class="pc_cov">(\d+(?:\.\d+)?%)</span>')
+PILL_ANCHOR = '<span class="pill">100% coverage</span>'
+DESC_ANCHOR = '<span class="desc">100%</span>'
+
+
+def report_percent() -> str:
+    match = PC_COV_RE.search(HTMLCOV_INDEX.read_text(encoding="utf-8"))
+    if not match:
+        sys.exit(f"error: no coverage percent in {HTMLCOV_INDEX}; the htmlcov report did not build")
+    return match.group(1)
+
+
+def main() -> None:
+    percent = report_percent()
+    html = SITE_INDEX.read_text(encoding="utf-8")
+    for anchor, replacement in [
+        (PILL_ANCHOR, f'<span class="pill">{percent} coverage</span>'),
+        (DESC_ANCHOR, f'<span class="desc">{percent}</span>'),
+    ]:
+        if html.count(anchor) != 1:
+            sys.exit(f"error: expected one {anchor!r} in {SITE_INDEX}; update the anchors to match the markup")
+        html = html.replace(anchor, replacement)
+    SITE_INDEX.write_text(html, encoding="utf-8")
+    print(f"site coverage numbers set to {percent}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The Pages workflow's build-site job runs make docs-site, and that recipe hard-depended on make test-ci. pytest exits non-zero on any test failure and on the fail_under = 100 coverage gate, which killed make, failed build-site, and left the deploy job (which needs both build jobs) never running. A red test suite took the whole site down with it. Meanwhile the marketing site hardcodes "100%" in the top pill and the coverage link, so any dip below the gate would publish a stale number.

## Solution

The docs-site recipe now ignores pytest's exit status, so failing tests no longer block the build. The coverage report itself is mandatory: pytest-cov writes the HTML report at end of session even when tests fail or the gate trips, it is copied into the site unconditionally, and if no report was produced at all the build fails loudly rather than deploying without coverage. A new tools/update_site_coverage.py then reads the total percent straight out of the generated report and rewrites the pill and the coverage link in site/index.html to match, failing the build if either anchor has drifted.

The quality gates themselves are untouched: ci.yml and release.yml call make test-ci directly, so the 100% coverage requirement still blocks CI and releases exactly as before. Only the site build is decoupled from the test outcome.