### PR TITLE
Run CI only when code-affecting files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
+    paths: &ci-paths
       - 'src/**'
       - 'tests/**'
       - 'pyproject.toml'
@@ -20,19 +20,7 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/actions/restore-ci-models/**'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'Makefile'
-      - '.coveragerc-windows'
-      - 'engine-versions.env'
-      - 'scripts/check_style_rules.py'
-      - 'tools/qa/**'
-      - 'scripts/qa/**'
-      - '.github/workflows/ci.yml'
-      - '.github/actions/restore-ci-models/**'
+    paths: *ci-paths
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,38 @@
 name: CI
 
+# Full CI only runs when the app, its tests, or their toolchain change;
+# docs/site edits skip it. release.yml re-runs lint+test itself when a tag
+# has no green CI run, so a skipped push never strands a release.
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Makefile'
+      - '.coveragerc-windows'
+      - 'engine-versions.env'
+      - 'scripts/check_style_rules.py'
+      - 'tools/qa/**'
+      - 'scripts/qa/**'
+      - '.github/workflows/ci.yml'
+      - '.github/actions/restore-ci-models/**'
   pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Makefile'
+      - '.coveragerc-windows'
+      - 'engine-versions.env'
+      - 'scripts/check_style_rules.py'
+      - 'tools/qa/**'
+      - 'scripts/qa/**'
+      - '.github/workflows/ci.yml'
+      - '.github/actions/restore-ci-models/**'
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem

Every push to main and every pull request triggered the full CI matrix — lint, a 7-lane unit-test matrix, and the heavyweight integration matrix (Tesseract, Ollama, llama-server builds, Playwright) — even for changes that cannot affect any of it, like marketing-site edits, docs, or release plumbing. That burns runner minutes and puts unrelated commits in the queue behind a half-hour of pointless work.

## Solution

The push and pull_request triggers now carry a paths filter listing exactly what the workflow's jobs consume: src/, tests/, pyproject.toml, uv.lock, the Makefile, the Windows coverage config, engine-versions.env (sourced by the integration job), the lint gate's script, the linted tools/qa and scripts/qa trees, the workflow itself, and the restore-ci-models composite action. Anything else — site/, docs/, other workflows, release tooling — no longer starts a run.

This is safe for the two ways CI results are consumed. There are no required status checks (no branch protection or rulesets on main), so a skipped run never wedges a PR. And release.yml's gate already re-runs lint and test itself whenever a tag points at a commit with no green CI run, so a release cut from a docs-only HEAD is unaffected. workflow_dispatch and workflow_call are unfiltered and always run the full matrix.