### PR TITLE
Strip emphasis-wrapped citation headings from model answers

### DIFF
--- a/src/lilbee/retrieval/query/formatting.py
+++ b/src/lilbee/retrieval/query/formatting.py
@@ -21,13 +21,18 @@ _CITE_RANGE_RE = re.compile(r"(\d+)\s*-\s*(\d+)")
 # Ranges wider than this are page spans or line numbers, not citation lists.
 _MAX_CITE_RANGE = 32
 
-# An LLM-generated citation block: a "Sources:"/"References:"/... heading line
-# followed by a list (bullets, arrows, "[1]" or "1." numbering). Requiring the
-# list keeps an answer that legitimately discusses such a heading in prose
-# (e.g. "References:\n\nIt lists 40 works.") from being clipped.
+# A citation-block heading line: "Sources:"/"References:"/..., optionally
+# markdown-decorated (ATX hashes, emphasis around the word or the colon:
+# "**Sources:**", "*References:*", "**Sources**:").
+_HEADING_WORDS = r"(?:(?:Key\s+)?Sources|References|Bibliography|Citations)"
+_HEADING_LINE = rf"\n{{1,3}}(?:#+\s*)?[*_]{{0,3}}{_HEADING_WORDS}[*_]{{0,3}}\s*:?\s*[*_]{{0,3}}"
+
+# An LLM-generated citation block: a heading line followed by a list (bullets,
+# arrows, "[1]" or "1." numbering). Requiring the list keeps an answer that
+# legitimately discusses such a heading in prose (e.g. "References:\n\nIt
+# lists 40 works.") from being clipped.
 _LLM_CITATION_BLOCK_RE = re.compile(
-    r"\n{1,3}(?:#+\s*)?(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*\n"
-    r"\s*(?:[-*•→\[]|\d+[.)]).*",
+    _HEADING_LINE + r"\n\s*(?:[-*•→\[]|\d+[.)]).*",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -36,7 +41,7 @@ _LLM_CITATION_BLOCK_RE = re.compile(
 # held back rather than shown; at end of stream it is a dangling artifact of a
 # citation block the model never finished, and is dropped either way.
 _TRAILING_HEADING_RE = re.compile(
-    r"\n{1,3}(?:#+\s*)?(?:(?:Key\s+)?Sources|References|Bibliography|Citations)\s*:?\s*$",
+    _HEADING_LINE + r"\s*$",
     re.IGNORECASE,
 )
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -758,6 +758,47 @@ class TestStreamingCitationFilter:
         assert shown == "Grounded answer [1]."
         assert f.answer == "Grounded answer [1]."
 
+    def test_drops_a_bold_sources_block(self):
+        shown, f = self._run(["Grounded answer [1].", "\n\n**Sources:**\n- made-up.pdf"])
+        assert "made-up.pdf" not in shown
+        assert "Sources" not in shown
+        assert shown.startswith("Grounded answer [1].")
+        assert "made-up.pdf" not in f.answer
+
+    def test_drops_a_dangling_bold_heading_at_stream_end(self):
+        # The model emitted a bold citation heading and stopped; left in place it
+        # would sit directly above lilbee's authoritative block as a second header.
+        shown, f = self._run(["Grounded answer [1].", "\n\n**Sources:**\n"])
+        assert "Sources" not in shown
+        assert shown == "Grounded answer [1]."
+        assert f.answer == "Grounded answer [1]."
+
+    def test_drops_a_dangling_italic_heading_at_stream_end(self):
+        shown, _f = self._run(["Grounded answer [1].", "\n\n*References:*"])
+        assert "References" not in shown
+        assert shown == "Grounded answer [1]."
+
+    def test_drops_a_heading_with_colon_outside_the_emphasis(self):
+        shown, _ = self._run(["Grounded answer [1].", "\n\n**Sources**:\n- made-up.pdf"])
+        assert "made-up.pdf" not in shown
+        assert "Sources" not in shown
+
+    def test_bold_heading_split_across_chunks_never_leaks(self):
+        chunks = ["Body text.", "\n\n**Sou", "rces:**", "\n- x.pdf"]
+        shown, _ = self._run(chunks)
+        assert "Sources" not in shown
+        assert "x.pdf" not in shown
+        assert shown.startswith("Body text.")
+
+    def test_prose_after_a_bold_heading_line_streams_through(self):
+        # A bold heading the answer legitimately discusses is not a citation
+        # block: no list follows, so heading and prose both reach the reader.
+        chunks = ["The paper is structured simply.", "\n\n**References:**", "\nIt lists 40 works."]
+        shown, f = self._run(chunks)
+        assert "**References:**" in shown
+        assert "It lists 40 works." in shown
+        assert f.answer.endswith("It lists 40 works.")
+
     def test_heading_is_held_not_shown_while_ambiguous(self):
         # Mid-stream, a bare heading must not be emitted until the next line
         # decides list (drop) versus prose (show).


### PR DESCRIPTION
## Problem

Some chat answers render a doubled Sources header: an empty Sources line from the model, then lilbee's own numbered source list right after. The citation filter that removes model-authored Sources/References blocks only recognized plain headings and ATX markdown (## Sources:), so a heading wrapped in emphasis (**Sources:**, *References:*) streamed through to the reader and collided with the authoritative block lilbee appends. Models that lean on bold markdown hit this regularly, and multi-turn chat makes it more likely since earlier answers carry lilbee's own Sources block in their history, teaching the model to imitate the pattern.

## Solution

Both citation-heading patterns now allow emphasis markers around the heading word and its colon, so **Sources:**, *References:*, and **Sources**: are stripped just like their plain-text forms. A heading the answer genuinely discusses in prose is still preserved, and regression tests cover bold/italic blocks, dangling headings, headings split across stream chunks, and the prose-mention case.