### PR TITLE
Fix the Windows-only flake in the catalog out-of-range-digit test

### DIFF
--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -171,11 +171,17 @@ async def test_on_key_non_digit_is_passthrough() -> None:
 
 async def test_on_key_out_of_range_digit_is_passthrough() -> None:
     """A digit past the tab count is ignored, not clamped, and does not switch tabs."""
+    from tests._async_wait import wait_until
+
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         screen = pilot.app.query_one(CatalogScreen)
-        screen._activation_settled = True
         tabs = screen.query_one("#catalog-tabs", TabbedContent)
+        # Wait for the deferred initial activation to reach Chat before probing.
+        # On Windows it can otherwise land during the post-keypress pause and be
+        # misread as the digit switching tabs.
+        await wait_until(pilot, lambda: tabs.active == "chat")
+        screen._activation_settled = True
         before = tabs.active
         event = Key(key="9", character="9")
         screen.on_key(event)


### PR DESCRIPTION
Main's Windows CI lane was chronically red across consecutive commits for unrelated reasons, so it stopped giving any Windows regression signal: a real break would land invisibly behind the existing red.

The remaining cause is a Windows-only timing flake in `test_on_key_out_of_range_digit_is_passthrough`. The test captured the active tab after a single `pilot.pause()`, before the deferred initial activation (scheduled via `call_after_refresh` on mount) had moved the tab from the compose-order Discover to Chat. On the slower Windows runner that activation instead landed during the post-keypress pause, so the discover->chat transition was misread as the out-of-range "9" switching tabs and the assertion failed. `on_key` correctly ignores out-of-range digits, so this is a test-side race, not a product bug. The fix waits for activation to settle on Chat before capturing the baseline, matching the sibling transition tests and reusing the repo's own `wait_until` helper instead of a fixed pause. The assertion stays load-bearing: a real tab switch on "9" still breaks it.

The other failure the tracking issue described, the POSIX-only coverage gap at `setup.py:276`, was already fixed earlier: a SIGTERM-handler test with no platform skip drives the handler directly, so the line is covered on Windows and coverage passes on current main. No change needed here.

Verified 8/8 in a loop and the full `test_catalog_actions.py` at 67/67 on macOS; ruff and the project style checker are clean. The flake itself is Windows-timing-specific and does not reproduce on macOS, so the Windows CI lane on this PR is the real confirmation.
