### PR TITLE
fix(tui): run dataset import/export as task-center tasks with path completion

### DIFF
--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -84,7 +84,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         "_cmd_export",
         aliases=(),
         args_hint="<path>",
-        has_arg_completion=True,
         help_text="Export a per-page text dataset (parquet or jsonl)",
     ),
     SlashCommand(
@@ -92,7 +91,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         "_cmd_import",
         aliases=(),
         args_hint="<path>",
-        has_arg_completion=True,
         help_text="Import a per-page text dataset, re-embedding it",
     ),
     SlashCommand("/status", "_cmd_status", help_text="Show knowledge-base status"),

--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -84,6 +84,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         "_cmd_export",
         aliases=(),
         args_hint="<path>",
+        has_arg_completion=True,
         help_text="Export a per-page text dataset (parquet or jsonl)",
     ),
     SlashCommand(
@@ -91,6 +92,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         "_cmd_import",
         aliases=(),
         args_hint="<path>",
+        has_arg_completion=True,
         help_text="Import a per-page text dataset, re-embedding it",
     ),
     SlashCommand("/status", "_cmd_status", help_text="Show knowledge-base status"),

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -113,6 +113,10 @@ CMD_REBUILD_CONFIRM_MESSAGE = (
 )
 TASK_NAME_SYNC = "Sync documents"
 TASK_NAME_REBUILD = "Rebuild index"
+TASK_NAME_IMPORT = "Import {file}"
+TASK_NAME_EXPORT = "Export {file}"
+IMPORT_STATUS_LOADING = "Loading dataset..."
+EXPORT_STATUS_RUNNING = "Exporting..."
 CMD_SET_UNKNOWN = "Unknown setting: {key}"
 CMD_SET_SUCCESS = "{key} = {value}"
 CMD_SET_INVALID = "Invalid value for {key}: {error}"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -42,6 +42,7 @@ from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp, apply_active_model
 from lilbee.cli.tui.screens.chat_helpers import (
     build_add_progress_callback,
+    build_import_progress_callback,
     build_sync_progress_callback,
     close_stream,
     open_local_file,
@@ -51,6 +52,7 @@ from lilbee.cli.tui.screens.chat_helpers import (
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.cli.tui.widgets.arg_hint import ArgHintLine
 from lilbee.cli.tui.widgets.autocomplete import (
+    PATH_ARG_COMMANDS,
     CompletionOverlay,
     get_completions,
     longest_common_prefix,
@@ -1051,24 +1053,30 @@ class ChatScreen(Screen[None]):
         call_from_thread(self, self.notify, msg.CMD_DELETE_SUCCESS.format(name=name))
 
     def _cmd_export(self, args: str) -> None:
-        """Run /export in a worker so the chat screen stays interactive."""
+        """Enqueue /export as a task so progress shows in the task bar."""
         path = args.strip()
         if not path:
             self.notify(msg.CMD_EXPORT_USAGE, severity="warning")
             return
-        self._cmd_export_worker(path)
+        from lilbee.cli.tui.task_queue import TaskType
 
-    @work(thread=True, name="chat_cmd_export", exit_on_error=False)
-    def _cmd_export_worker(self, raw_path: str) -> None:
-        """Build and write the dataset off the UI thread; notify back via dispatch."""
+        def _target(reporter: ProgressReporter) -> None:
+            self._do_export(path, reporter)
+
+        name = msg.TASK_NAME_EXPORT.format(file=Path(path).name)
+        self._task_bar.start_task(name, TaskType.EXPORT, _target, indeterminate=True)
+
+    def _do_export(self, raw_path: str, reporter: ProgressReporter) -> None:
+        """Export body. Runs on the task worker thread."""
         from lilbee.app.dataset import DatasetError, export_to_path
 
         output = Path(raw_path).expanduser()
+        reporter.update(0, msg.EXPORT_STATUS_RUNNING, indeterminate=True)
         try:
             summary = export_to_path(output, "", None)
         except DatasetError as exc:
             call_from_thread(self, self.notify, str(exc), severity="error")
-            return
+            raise RuntimeError(str(exc)) from exc
         call_from_thread(
             self,
             self.notify,
@@ -1076,24 +1084,45 @@ class ChatScreen(Screen[None]):
         )
 
     def _cmd_import(self, args: str) -> None:
-        """Run /import in a worker so re-embedding doesn't block the UI."""
+        """Enqueue /import as a task so re-embedding progress shows in the task bar."""
         path = args.strip()
         if not path:
             self.notify(msg.CMD_IMPORT_USAGE, severity="warning")
             return
-        self._cmd_import_worker(path)
+        if self._sync_active:
+            self.notify(msg.SYNC_ALREADY_ACTIVE, severity="warning")
+            return
+        from lilbee.cli.tui.task_queue import TaskType
 
-    @work(thread=True, name="chat_cmd_import", exit_on_error=False)
-    def _cmd_import_worker(self, raw_path: str) -> None:
-        """Load and re-embed the dataset off the UI thread; notify back via dispatch."""
+        self._sync_active = True
+
+        def _target(reporter: ProgressReporter) -> None:
+            try:
+                self._do_import(path, reporter)
+            finally:
+                self._sync_active = False
+                self._task_bar.start_detect_pending()
+
+        name = msg.TASK_NAME_IMPORT.format(file=Path(path).name)
+        self._task_bar.start_task(name, TaskType.IMPORT, _target)
+
+    def _do_import(self, raw_path: str, reporter: ProgressReporter) -> None:
+        """Import body. Runs on the task worker thread."""
         from lilbee.app.dataset import DatasetError, import_from_path
         from lilbee.cli.tui.widgets.autocomplete import invalidate_document_cache
 
+        reporter.update(0, msg.IMPORT_STATUS_LOADING, indeterminate=True)
         try:
-            summary = asyncio_loop.run(import_from_path(Path(raw_path).expanduser(), ""))
+            summary = asyncio_loop.run(
+                import_from_path(
+                    Path(raw_path).expanduser(),
+                    "",
+                    on_progress=build_import_progress_callback(reporter),
+                )
+            )
         except DatasetError as exc:
             call_from_thread(self, self.notify, str(exc), severity="error")
-            return
+            raise RuntimeError(str(exc)) from exc
         invalidate_document_cache()
         call_from_thread(
             self,
@@ -1610,10 +1639,10 @@ class ChatScreen(Screen[None]):
         self._extract_memories_worker(question, answer)
 
     def _indexing_active(self) -> bool:
-        """True while a sync/add task is running (embed worker is busy)."""
+        """True while a sync/add/import task is running (embed worker is busy)."""
         from lilbee.cli.tui.task_queue import TaskType
 
-        busy = {TaskType.SYNC.value, TaskType.ADD.value}
+        busy = {TaskType.SYNC.value, TaskType.ADD.value, TaskType.IMPORT.value}
         return any(task.task_type in busy for task in self._task_bar.queue.active_tasks)
 
     @work(thread=True, name="chat_memory_extract", exit_on_error=False)
@@ -2280,7 +2309,7 @@ class ChatScreen(Screen[None]):
         if " " not in text:
             return display
         cmd, _, partial = text.partition(" ")
-        if cmd.lower() == "/add":
+        if cmd.lower() in PATH_ARG_COMMANDS:
             head = path_completion_prefix(partial)
             return f"{cmd} {head}{display}"
         return f"{cmd} {display}"

--- a/src/lilbee/cli/tui/screens/chat_helpers.py
+++ b/src/lilbee/cli/tui/screens/chat_helpers.py
@@ -145,6 +145,22 @@ def unregister_added_roots(labels: list[str]) -> None:
         unregister_roots(labels)
 
 
+def _throttled_embed_tick(reporter: ProgressReporter) -> Callable[[EmbedEvent], None]:
+    """Return the throttled EMBED tick shared by the add/sync/import callbacks."""
+    last_update = 0.0
+
+    def _tick(data: EmbedEvent) -> None:
+        nonlocal last_update
+        now = time.monotonic()
+        if now - last_update < _ADD_EMBED_THROTTLE_SECONDS:
+            return
+        last_update = now
+        pct = int(data.chunk * 100 / data.total_chunks) if data.total_chunks else 0
+        reporter.update(pct, msg.SYNC_EMBEDDING.format(file=data.file), indeterminate=False)
+
+    return _tick
+
+
 def build_add_progress_callback(reporter: ProgressReporter) -> DetailedProgressCallback:
     """Build the on_progress callback used by /add.
 
@@ -155,10 +171,9 @@ def build_add_progress_callback(reporter: ProgressReporter) -> DetailedProgressC
     as a hang; EMBED ticks per chunk, throttled to a steady cadence.
     """
     in_flight: list[str] = []
-    last_embed_update = 0.0
+    embed_tick = _throttled_embed_tick(reporter)
 
     def on_progress(event_type: EventType, data: ProgressEvent) -> None:
-        nonlocal last_embed_update
         reporter.check_cancelled()
         if event_type == EventType.FILE_START and isinstance(data, FileStartEvent):
             in_flight.append(data.file)
@@ -178,12 +193,7 @@ def build_add_progress_callback(reporter: ProgressReporter) -> DetailedProgressC
                 indeterminate=True,
             )
         elif event_type == EventType.EMBED and isinstance(data, EmbedEvent):
-            now = time.monotonic()
-            if now - last_embed_update < _ADD_EMBED_THROTTLE_SECONDS:
-                return
-            last_embed_update = now
-            pct = int(data.chunk * 100 / data.total_chunks) if data.total_chunks else 0
-            reporter.update(pct, msg.SYNC_EMBEDDING.format(file=data.file), indeterminate=False)
+            embed_tick(data)
 
     return on_progress
 
@@ -196,10 +206,9 @@ def build_sync_progress_callback(
     EXTRACT mirrors the /add path: a 44MB scanned PDF needs a per-page
     tick or the row reads as frozen.
     """
-    last_embed_update = 0.0
+    embed_tick = _throttled_embed_tick(reporter)
 
     def on_progress(event_type: EventType, data: ProgressEvent) -> None:
-        nonlocal last_embed_update
         # Mirror /add: explicit cancel check on every event so a SYNC task
         # cancelled mid-batch stops at the next progress tick instead of
         # finishing the current file. update() also checks, but events
@@ -223,14 +232,21 @@ def build_sync_progress_callback(
                 indeterminate=True,
             )
         elif event_type == EventType.EMBED and isinstance(data, EmbedEvent):
-            now = time.monotonic()
-            if now - last_embed_update < _ADD_EMBED_THROTTLE_SECONDS:
-                return
-            last_embed_update = now
-            pct = int(data.chunk * 100 / data.total_chunks) if data.total_chunks else 0
-            reporter.update(pct, msg.SYNC_EMBEDDING.format(file=data.file), indeterminate=False)
+            embed_tick(data)
         elif event_type == EventType.DONE and isinstance(data, SyncDoneEvent):
             total = data.added + data.updated + data.removed
             reporter.update(100, msg.SYNC_STATUS_DONE.format(count=total), indeterminate=False)
+
+    return on_progress
+
+
+def build_import_progress_callback(reporter: ProgressReporter) -> DetailedProgressCallback:
+    """Build the on_progress callback used by /import (EMBED events only)."""
+    embed_tick = _throttled_embed_tick(reporter)
+
+    def on_progress(event_type: EventType, data: ProgressEvent) -> None:
+        reporter.check_cancelled()
+        if event_type == EventType.EMBED and isinstance(data, EmbedEvent):
+            embed_tick(data)
 
     return on_progress

--- a/src/lilbee/cli/tui/task_queue.py
+++ b/src/lilbee/cli/tui/task_queue.py
@@ -37,6 +37,8 @@ class TaskType(StrEnum):
     ADD = "add"
     REMOVE = "remove"
     SETUP = "setup"
+    IMPORT = "import"
+    EXPORT = "export"
 
 
 STATUS_ICONS: dict[TaskStatus, str] = {

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -38,9 +38,14 @@ def _option_prompt(value: str) -> Content:
 
 
 _MAX_VISIBLE = 8  # max dropdown items shown at once
-# Hard cap on path completions surfaced for /add so a deep directory doesn't
-# stall the dropdown rebuild.
+# Hard cap on path completions surfaced for path-argument commands so a deep
+# directory doesn't stall the dropdown rebuild.
 _MAX_PATH_COMPLETIONS = 20
+
+# Commands whose argument is a filesystem path. They share _path_options and
+# the path-specific accept rules (typed-directory prefix kept, existing-path
+# collapse).
+PATH_ARG_COMMANDS = frozenset({"/add", "/import", "/export"})
 
 _CSS_FILE = Path(__file__).parent / "autocomplete.tcss"
 
@@ -68,7 +73,7 @@ def _get_arg_completions(cmd: str, partial: str) -> list[str]:
     sources = _ARG_SOURCES.get(cmd)
     if sources is None:
         return []
-    if cmd == "/add":
+    if cmd in PATH_ARG_COMMANDS:
         # A fully-typed existing path (no trailing separator) should submit on
         # Enter rather than keep offering completions, so collapse the dropdown.
         # Without this a complete directory path lists its contents forever and
@@ -211,6 +216,8 @@ _ARG_SOURCES: dict[str, Callable[[], list[str]]] = {
     "/remove": _model_options,
     "/theme": _theme_options,
     "/add": _path_options,
+    "/import": _path_options,
+    "/export": _path_options,
 }
 
 

--- a/src/lilbee/cli/tui/widgets/task_row.py
+++ b/src/lilbee/cli/tui/widgets/task_row.py
@@ -40,7 +40,7 @@ _STATUS_CLASS: dict[TaskStatus, str] = {
 
 _STATUS_CLASSES: tuple[str, ...] = tuple(_STATUS_CLASS.values())
 
-# Pill palette: background color per task type. Sync/add/remove share
+# Pill palette: background color per task type. Sync/add/remove/import share
 # $secondary (data-mutating ops), download uses $accent (network), wiki
 # uses $warning (CPU-heavy generation), crawl uses $primary (external).
 _TASK_TYPE_BG: dict[str, str] = {
@@ -48,6 +48,8 @@ _TASK_TYPE_BG: dict[str, str] = {
     TaskType.SYNC.value: "$secondary",
     TaskType.ADD.value: "$secondary",
     TaskType.REMOVE.value: "$secondary",
+    TaskType.IMPORT.value: "$secondary",
+    TaskType.EXPORT.value: "$primary",
     TaskType.CRAWL.value: "$primary",
     TaskType.WIKI.value: "$warning",
     TaskType.SETUP.value: "$warning-darken-1",

--- a/tests/test_chat_wiki_controller_integration.py
+++ b/tests/test_chat_wiki_controller_integration.py
@@ -731,6 +731,70 @@ async def test_run_sync_submits_task_to_controller() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cmd_import_submits_task_to_controller() -> None:
+    """_cmd_import routes through TaskBarController.start_task with IMPORT type."""
+
+    app = LilbeeApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await await_chat(app, pilot)
+        assert screen is not None
+        with patch.object(app.task_bar, "start_task", return_value="tid") as mock_start:
+            screen._cmd_import("/tmp/pages.parquet")
+        assert mock_start.called
+        assert mock_start.call_args.args[1] == TaskType.IMPORT
+
+
+@pytest.mark.asyncio
+async def test_cmd_export_submits_task_to_controller() -> None:
+    """_cmd_export routes through TaskBarController.start_task with EXPORT type."""
+
+    app = LilbeeApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await await_chat(app, pilot)
+        assert screen is not None
+        with patch.object(app.task_bar, "start_task", return_value="tid") as mock_start:
+            screen._cmd_export("/tmp/pages.parquet")
+        assert mock_start.called
+        assert mock_start.call_args.args[1] == TaskType.EXPORT
+
+
+@pytest.mark.asyncio
+async def test_cmd_import_rejects_when_sync_active() -> None:
+    """_cmd_import refuses while an ingest task holds the store."""
+
+    app = LilbeeApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await await_chat(app, pilot)
+        assert screen is not None
+        screen._sync_active = True
+        notified: list[str] = []
+        screen.notify = lambda *a, **kw: notified.append(str(a[0]))  # type: ignore[assignment]
+        with patch.object(app.task_bar, "start_task", return_value="tid") as mock_start:
+            screen._cmd_import("/tmp/pages.parquet")
+        assert not mock_start.called
+        assert notified
+
+
+@pytest.mark.asyncio
+async def test_indexing_active_true_during_import_task() -> None:
+    """Memory extraction stays gated while an import re-embeds."""
+
+    app = LilbeeApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = await await_chat(app, pilot)
+        assert screen is not None
+        tid = app.task_bar.queue.enqueue(lambda: None, "Import x", TaskType.IMPORT.value)
+        app.task_bar.queue.advance(TaskType.IMPORT.value)
+        assert screen._indexing_active() is True
+        app.task_bar.queue.complete_task(tid)
+        assert screen._indexing_active() is False
+
+
+@pytest.mark.asyncio
 async def test_run_sync_rejects_when_already_active() -> None:
     """_run_sync refuses when another sync is already running."""
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2821,7 +2821,13 @@ async def test_chat_slash_delete_empty_sources(mock_svc):
 class _DatasetStubEmbedder:
     truncated_total = 0
 
-    def embed_batch(self, texts, **_kwargs):
+    def embed_batch(self, texts, *, source="", on_progress=None, **_kwargs):
+        if on_progress is not None:
+            from lilbee.runtime.progress import EmbedEvent, EventType
+
+            total = len(texts)
+            for i, _text in enumerate(texts, 1):
+                on_progress(EventType.EMBED, EmbedEvent(file=source, chunk=i, total_chunks=total))
         return [[0.1] * cfg.embedding_dim for _ in texts]
 
 
@@ -2839,8 +2845,30 @@ def _dataset_services(tmp_path, *, seed=True):
     return store, make_mock_services(store=store, embedder=_DatasetStubEmbedder())
 
 
+async def _wait_for_dataset_task(app, _pilot, task_type):
+    """Spin until the queued dataset task reaches a terminal state; return the row."""
+    import time
+
+    from lilbee.cli.tui.task_queue import TaskStatus
+
+    terminal = {TaskStatus.DONE, TaskStatus.FAILED, TaskStatus.CANCELLED}
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        await _pilot.pause()
+        done = [
+            t
+            for t in app.task_bar.queue.history
+            if t.task_type == task_type.value and t.status in terminal
+        ]
+        if done:
+            return done[0]
+    raise AssertionError(f"{task_type} task did not finish")
+
+
 async def test_chat_slash_export_writes_file(tmp_path):
     """``/export <path>`` writes the dataset and notifies success."""
+    from lilbee.cli.tui.task_queue import TaskStatus, TaskType
+
     _store, services = _dataset_services(tmp_path)
     out = tmp_path / "pages.parquet"
     app = ChatTestApp()
@@ -2848,8 +2876,8 @@ async def test_chat_slash_export_writes_file(tmp_path):
         set_services(services)
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._cmd_export(str(out))
-            await app.screen.workers.wait_for_complete()
-            await _pilot.pause()
+            task = await _wait_for_dataset_task(app, _pilot, TaskType.EXPORT)
+            assert task.status == TaskStatus.DONE
             assert out.exists()
             assert "Exported" in mock_notify.call_args[0][0]
     set_services(None)
@@ -2870,20 +2898,24 @@ async def test_chat_slash_export_no_arg(tmp_path):
 
 async def test_chat_slash_export_error(tmp_path):
     """An empty store surfaces the DatasetError via an error notification."""
+    from lilbee.cli.tui.task_queue import TaskStatus, TaskType
+
     _store, services = _dataset_services(tmp_path, seed=False)
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         set_services(services)
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._cmd_export(str(tmp_path / "pages.parquet"))
-            await app.screen.workers.wait_for_complete()
-            await _pilot.pause()
+            task = await _wait_for_dataset_task(app, _pilot, TaskType.EXPORT)
+            assert task.status == TaskStatus.FAILED
             assert "Nothing to export" in mock_notify.call_args[0][0]
     set_services(None)
 
 
 async def test_chat_slash_import_round_trip(tmp_path):
     """``/import <path>`` re-embeds the dataset and notifies success."""
+    from lilbee.cli.tui.task_queue import TaskStatus, TaskType
+
     _store, services = _dataset_services(tmp_path)
     out = tmp_path / "pages.jsonl"
     from lilbee.app.dataset import export_to_path
@@ -2902,8 +2934,8 @@ async def test_chat_slash_import_round_trip(tmp_path):
             ) as mock_invalidate,
         ):
             app.screen._cmd_import(str(out))
-            await app.screen.workers.wait_for_complete()
-            await _pilot.pause()
+            task = await _wait_for_dataset_task(app, _pilot, TaskType.IMPORT)
+            assert task.status == TaskStatus.DONE
             assert "Imported" in mock_notify.call_args[0][0]
             mock_invalidate.assert_called_once()
     set_services(None)
@@ -2923,15 +2955,46 @@ async def test_chat_slash_import_no_arg(tmp_path):
 
 
 async def test_chat_slash_import_missing_file(tmp_path):
+    from lilbee.cli.tui.task_queue import TaskStatus, TaskType
+
     _store, services = _dataset_services(tmp_path)
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         set_services(services)
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._cmd_import(str(tmp_path / "nope.parquet"))
-            await app.screen.workers.wait_for_complete()
-            await _pilot.pause()
+            task = await _wait_for_dataset_task(app, _pilot, TaskType.IMPORT)
+            assert task.status == TaskStatus.FAILED
             assert "Dataset not found" in mock_notify.call_args[0][0]
+    set_services(None)
+
+
+async def test_chat_slash_import_reports_embed_progress(tmp_path):
+    """The import task row ticks determinate progress off EMBED events."""
+    from lilbee.cli.tui.task_queue import TaskType
+
+    _store, services = _dataset_services(tmp_path)
+    out = tmp_path / "pages.jsonl"
+    from lilbee.app.dataset import export_to_path
+
+    set_services(services)
+    export_to_path(out, "", None)
+    set_services(None)
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        set_services(services)
+        updates: list[tuple[float, str]] = []
+        real_update = app.task_bar.queue.update_task
+
+        def _spy(task_id, progress, detail="", **kwargs):
+            updates.append((progress, detail))
+            return real_update(task_id, progress, detail, **kwargs)
+
+        with patch.object(app.task_bar.queue, "update_task", side_effect=_spy):
+            app.screen._cmd_import(str(out))
+            await _wait_for_dataset_task(app, _pilot, TaskType.IMPORT)
+        assert any("Embedding" in detail for _, detail in updates)
     set_services(None)
 
 
@@ -3790,6 +3853,20 @@ async def test_chat_completion_value_preserves_posix_directory():
         app.screen._completion_origin = "/add /var/tmp/docs/quantum_test.md"
         assert (
             app.screen._completion_value("quantum_test.md") == "/add /var/tmp/docs/quantum_test.md"
+        )
+
+
+async def test_chat_completion_value_preserves_directory_for_import_and_export():
+    """Accepting an /import or /export path completion keeps the typed directory."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        app.screen._completion_origin = "/import /var/tmp/docs/pages.parquet"
+        assert (
+            app.screen._completion_value("pages.parquet") == "/import /var/tmp/docs/pages.parquet"
+        )
+        app.screen._completion_origin = "/export /var/tmp/docs/pages.parquet"
+        assert (
+            app.screen._completion_value("pages.parquet") == "/export /var/tmp/docs/pages.parquet"
         )
 
 
@@ -7340,6 +7417,42 @@ def test_build_sync_progress_callback_routes_extract_event() -> None:
     assert "scan.pdf" in args[1]
     assert "2" in args[1] and "5" in args[1]
     assert kwargs.get("indeterminate") is True
+
+
+def test_build_import_progress_callback_routes_embed_events() -> None:
+    """``build_import_progress_callback`` ticks determinate progress on EMBED events."""
+    from unittest.mock import MagicMock
+
+    from lilbee.cli.tui.screens.chat import build_import_progress_callback
+    from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
+    from lilbee.runtime.progress import EmbedEvent, EventType
+
+    reporter = MagicMock(spec=ProgressReporter)
+    callback = build_import_progress_callback(reporter)
+    callback(EventType.EMBED, EmbedEvent(file="doc.pdf", chunk=5, total_chunks=10))
+    reporter.update.assert_called_once()
+    args, kwargs = reporter.update.call_args
+    assert args[0] == 50
+    assert "doc.pdf" in args[1]
+    assert kwargs.get("indeterminate") is False
+
+
+def test_build_import_progress_callback_throttles_and_ignores_other_events() -> None:
+    """A second EMBED inside the throttle window is dropped; non-EMBED events no-op."""
+    from unittest.mock import MagicMock
+
+    from lilbee.cli.tui.screens.chat import build_import_progress_callback
+    from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
+    from lilbee.runtime.progress import EmbedEvent, EventType, ExtractEvent
+
+    reporter = MagicMock(spec=ProgressReporter)
+    callback = build_import_progress_callback(reporter)
+    callback(EventType.EXTRACT, ExtractEvent(file="doc.pdf", page=1, total_pages=3))
+    reporter.update.assert_not_called()
+    callback(EventType.EMBED, EmbedEvent(file="doc.pdf", chunk=1, total_chunks=10))
+    callback(EventType.EMBED, EmbedEvent(file="doc.pdf", chunk=2, total_chunks=10))
+    assert reporter.update.call_count == 1
+    reporter.check_cancelled.assert_called()
 
 
 async def test_do_add_callback_routes_embed_and_extract_events(tmp_path):

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2827,6 +2827,39 @@ class TestGetCompletions:
         r = get_completions("/add ./")
         assert any("beta.txt" in x for x in r)
 
+    def test_import_arg_completions_offer_paths(self, tmp_path: object) -> None:
+        """``/import`` takes a dataset path, so Tab completes filesystem entries."""
+        from pathlib import Path as P
+
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        d = P(str(tmp_path))
+        (d / "pages.parquet").touch()
+        r = get_completions(f"/import {d}/")
+        assert any("pages.parquet" in x for x in r)
+
+    def test_export_arg_completions_offer_paths(self, tmp_path: object) -> None:
+        """``/export`` takes an output path, so Tab completes filesystem entries."""
+        from pathlib import Path as P
+
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        d = P(str(tmp_path))
+        (d / "out.parquet").touch()
+        r = get_completions(f"/export {d}/")
+        assert any("out.parquet" in x for x in r)
+
+    def test_import_complete_path_collapses_so_enter_submits(self, tmp_path: object) -> None:
+        """A fully-typed existing dataset path yields no completions so Enter submits."""
+        from pathlib import Path as P
+
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        d = P(str(tmp_path))
+        (d / "pages.parquet").touch()
+        assert get_completions(f"/import {d}/pages.parquet") == []
+        assert any("pages.parquet" in x for x in get_completions(f"/import {d}/"))
+
 
 class TestPathCompletionPrefix:
     def test_posix_path_keeps_directory(self) -> None:


### PR DESCRIPTION
## Problem

Running /import or /export in the TUI was completely invisible. Both commands ran as bare background workers: nothing appeared in the task center, no progress ever showed, there was no way to cancel, and the only signal anything happened was a toast at the very end. Import also silently dropped the embed progress events the pipeline already emits, and neither command offered path tab-completion, so /import forced typing full paths by hand while /add completed them.

## Solution

Both commands now run as standard task-center tasks, the same as sync, add, and crawl. They appear in the task bar and task center with live status, flash on completion or failure, and can be cancelled from the task center. Import reports real-time determinate progress from the embed events it was previously discarding, takes the same ingest mutex sync uses so it can't race a running sync, and refreshes the pending-documents hint when it finishes. Export runs as an indeterminate task with immediate feedback while the dataset builds. Tab completion now offers filesystem paths for /import and /export, sharing /add's behavior of keeping the typed directory prefix and collapsing once a full path is typed so Enter submits.