### PR TITLE
Stream the ingest plan so embedding starts before the whole corpus is hashed

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,6 +153,8 @@ flowchart LR
 
 Correctness is unchanged because shards are contiguous slices of one sorted list consumed in order: the streamed plan is byte-for-byte the single-pass plan, only delivered in pieces. Cross-shard bookkeeping (added/updated sets, one-to-one move detection for relocated files, skip markers) accumulates across shards to the same result. The planner runs on its own thread rather than the shared ingest pool, which extraction saturates once ingest is under way.
 
+**Why the list is sorted.** `os.walk` yields files in arbitrary filesystem order, so the corpus is sorted by key first. That fixed order is what makes the plan deterministic: classification fans out across a thread pool and completes out of order, but the plan is reassembled in sorted order, so it matches what a single serial pass would produce regardless of thread scheduling (a test asserts `parallel == serial`). It also makes move detection deterministic — when several deleted sources share a content hash, a reappeared file pairs with exactly one old key — and makes the shard boundaries stable, so a killed-and-restarted run re-shards the same corpus the same way.
+
 ### Ingest concurrency: keeping the GPUs fed
 
 A full-corpus OCR ingest is a producer/consumer pipeline: CPU-side work (rasterizing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ the full pipeline over HTTP via `/api/search`.
 
 Documents are chunked, embedded, and stored as vectors for later retrieval.
 
-- **File discovery.** Recursive walk of `documents/` with SHA-256 hash-based change detection so only modified files are re-indexed. Each source row also stores the file's size and mtime, so an unchanged file is skipped on a stat alone; the hash runs only when the stat pair drifts. Stores created before these columns re-hash once and backfill.
+- **File discovery.** Recursive walk of `documents/` with SHA-256 hash-based change detection so only modified files are re-indexed. Each source row also stores the file's size and mtime, so an unchanged file is skipped on a stat alone; the hash runs only when the stat pair drifts. Stores created before these columns re-hash once and backfill. This diff is streamed shard by shard so embedding starts before the whole corpus is hashed — see [Streaming the plan](#streaming-the-plan-start-embedding-before-the-corpus-is-hashed).
 - **Markdown.** Heading-aware chunking via kreuzberg's `chunker_type="markdown"` with `prepend_heading_context=True`. Splits at heading boundaries and prepends the full hierarchy path (e.g., `# Setup > ## Install`) so each chunk's section context travels with it. Inspired by Anthropic's Contextual Retrieval (2024), which showed adding context to chunks reduces retrieval failures by 49%.
 - **Code.** tree-sitter AST splitting via tree-sitter-language-pack for 150+ languages, with symbol name, type, and line range in chunk headers.
 - **PDF.** kreuzberg text extraction with an OCR fallback chain (text extraction → Tesseract OCR → GGUF vision model on `llama-server`). PDF page rasterization is delegated to kreuzberg's `PdfPageIterator`.
@@ -112,6 +112,46 @@ Documents are chunked, embedded, and stored as vectors for later retrieval.
 - **Concept extraction (opt-in).** With `pip install lilbee[graph]`, spaCy noun phrases are extracted per chunk, a co-occurrence graph is built with PPMI weights, and Leiden clustering assigns concepts to communities.
 - **Wiki generation (experimental).** If wiki is enabled, `lilbee wiki build` and the incremental `_incremental_wiki_update` hook inside `lilbee sync` issue one LLM call per source that jointly identifies 3–5 concepts worth their own page and drafts a section for each. Sections are citation-verified and embedding-faithfulness-scored before landing in `concepts/`, `entities/`, or `drafts/`. See the [Wiki Layer](#wiki-layer) section.
 - **Storage.** LanceDB tables: chunks (with FTS index for hybrid retrieval), sources, citations, wiki chunks, concept graph nodes/edges, and chunk-to-concept mappings.
+
+### Planning: which files to ingest
+
+Before any embedding, sync diffs the corpus against the store to decide which files to process. That diff is a **stat-gated hash**, per file.
+
+```mermaid
+flowchart TD
+    F["file on disk"] --> ST{"stored size + mtime<br/>match, and predate<br/>the recorded capture?"}
+    ST -->|yes| U["unchanged — bytes never read"]
+    ST -->|no| H["SHA-256 the bytes"]
+    H --> HC{"hash matches<br/>the stored row?"}
+    HC -->|yes| BF["unchanged —<br/>backfill the fresh stat"]
+    HC -->|no| SK{"hash matches a<br/>failed-file skip marker?"}
+    SK -->|yes| SKIP["skip — failed here last sync"]
+    SK -->|no| PR["process:<br/>extract → chunk → embed,<br/>store chunks keyed by this hash"]
+```
+
+The hash is doing two jobs at once, which is why it stays in this pass and cannot move to write time:
+
+- **Change key.** The stored hash is what the next sync diffs against. A stat match alone skips the read; the hash runs only when the stat pair drifts.
+- **Content identity.** The chunks written for a file are keyed by the hash of the *same bytes* they were extracted from. Deferring the hash to flush time would let a file edited mid-run store stale chunks under the new content's hash — the next sync would then see a matching stat, match the stored hash, and never re-process, serving stale chunks forever.
+
+### Streaming the plan: start embedding before the corpus is hashed
+
+Planning the whole corpus first, then embedding, means the GPU fleet sits idle for the entire diff. On a multi-million-file corpus that walk-plus-hash pass is tens of minutes of paid idle before the first passage is embedded.
+
+Instead, the plan is **sharded and overlapped** with ingest. Files are sorted, sliced into contiguous shards (ramping 256 → 8192), and each shard is handed to ingest as it lands. The next shard is planned on a dedicated thread while the current one is being extracted and embedded.
+
+```mermaid
+flowchart LR
+    W["walk + sort corpus"] --> SL["slice into shards<br/>256 → 8192 files"]
+    SL --> P1["plan shard 1"]
+    P1 -->|"fleet starts in ~1s"| I1["extract + embed shard 1"]
+    P1 -.->|"plan next while<br/>shard 1 ingests"| P2["plan shard 2"]
+    P2 --> I2["extract + embed shard 2"]
+    P2 -.-> P3["plan shard 3 …"]
+    P3 --> I3["…"]
+```
+
+Correctness is unchanged because shards are contiguous slices of one sorted list consumed in order: the streamed plan is byte-for-byte the single-pass plan, only delivered in pieces. Cross-shard bookkeeping (added/updated sets, one-to-one move detection for relocated files, skip markers) accumulates across shards to the same result. The planner runs on its own thread rather than the shared ingest pool, which extraction saturates once ingest is under way.
 
 ### Ingest concurrency: keeping the GPUs fed
 

--- a/src/lilbee/cli/tui/screens/chat_helpers.py
+++ b/src/lilbee/cli/tui/screens/chat_helpers.py
@@ -204,7 +204,7 @@ def build_sync_progress_callback(
         # cancelled mid-batch stops at the next progress tick instead of
         # finishing the current file. update() also checks, but events
         # without a reporter.update call (e.g. BATCH_PROGRESS in the
-        # ingest_batch path) would otherwise miss the cooperative checkpoint.
+        # ingest_stream path) would otherwise miss the cooperative checkpoint.
         reporter.check_cancelled()
         if event_type == EventType.FILE_START and isinstance(data, FileStartEvent):
             pct = int((data.current_file - 1) * 100 / data.total_files)

--- a/src/lilbee/data/ingest/__init__.py
+++ b/src/lilbee/data/ingest/__init__.py
@@ -10,7 +10,7 @@ from lilbee.data.ingest.extract import (
     ingest_document,
     ingest_markdown,
 )
-from lilbee.data.ingest.pipeline import detect_pending, ingest_batch, sync
+from lilbee.data.ingest.pipeline import detect_pending, ingest_stream, sync
 from lilbee.data.ingest.types import ExtractMode, SyncResult
 
 __all__ = [
@@ -22,9 +22,9 @@ __all__ = [
     "discover_files",
     "extraction_config",
     "file_hash",
-    "ingest_batch",
     "ingest_code_sync",
     "ingest_document",
     "ingest_markdown",
+    "ingest_stream",
     "sync",
 ]

--- a/src/lilbee/data/ingest/offload.py
+++ b/src/lilbee/data/ingest/offload.py
@@ -14,7 +14,7 @@ import functools
 import logging
 import os
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Executor, ThreadPoolExecutor
 from typing import ParamSpec, TypeVar
 
 log = logging.getLogger(__name__)
@@ -105,14 +105,21 @@ def _ingest_executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=_max_workers(), thread_name_prefix="lilbee-ingest")
 
 
-async def to_ingest_thread(fn: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-    """``asyncio.to_thread`` on the ingest executor, contextvars preserved.
+async def to_executor(
+    executor: Executor, fn: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs
+) -> _R:
+    """``asyncio.to_thread`` on *executor*, contextvars preserved.
 
-    Extraction relies on contextvar propagation into its workers (cancel and
-    progress context), which ``run_in_executor`` alone would drop; copy the
+    Extraction relies on contextvar propagation into its workers (cancel, config
+    and progress context), which ``run_in_executor`` alone would drop; copy the
     context exactly like ``asyncio.to_thread`` does.
     """
     loop = asyncio.get_running_loop()
     ctx = contextvars.copy_context()
     call = functools.partial(ctx.run, fn, *args, **kwargs)
-    return await loop.run_in_executor(_ingest_executor(), call)
+    return await loop.run_in_executor(executor, call)
+
+
+async def to_ingest_thread(fn: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+    """Run *fn* on the shared ingest executor."""
+    return await to_executor(_ingest_executor(), fn, *args, **kwargs)

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -374,6 +374,8 @@ class _StreamStop:
     """Stop signal for a streamed plan: the caller's cancel, or the stream closing.
 
     Closing the stream has to reach the shard in flight, not just the next one.
+    Build-vs-buy: the hashers run in a thread pool, so the flag must be a
+    thread-visible ``threading.Event``; ``anyio.CancelScope`` is async-only.
     """
 
     def __init__(self, cancel: _CancelSignal | None) -> None:
@@ -608,7 +610,11 @@ _PLAN_SHARD_MAX_FILES = 8192
 
 
 def _shard_bounds(total: int) -> Iterator[tuple[int, int]]:
-    """(start, stop) slices covering *total* files, doubling up to the cap."""
+    """(start, stop) slices covering *total* files, doubling up to the cap.
+
+    Build-vs-buy: ``itertools.batched`` is the stock slicer but is 3.12+ (floor is
+    3.11) and fixed-size, so it cannot ramp the shard size.
+    """
     start = 0
     size = _PLAN_SHARD_MIN_FILES
     while start < total:

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -373,9 +373,7 @@ class _CancelSignal(Protocol):
 class _StreamStop:
     """Stop signal for a streamed plan: the caller's cancel, or the stream closing.
 
-    The streamed planner outlives a single ``_plan_items`` call, so closing the
-    stream has to reach the in-flight shard as well; polling both here keeps a
-    mid-shard stop as prompt as a user cancel.
+    Closing the stream has to reach the shard in flight, not just the next one.
     """
 
     def __init__(self, cancel: _CancelSignal | None) -> None:
@@ -603,10 +601,8 @@ def _absent_sources(sources: list[SourceRecord], disk_files: dict[str, Path]) ->
     ]
 
 
-# Plan shards ramp from _PLAN_SHARD_MIN_FILES up to _PLAN_SHARD_MAX_FILES. The
-# first shard is small so the embed fleet has work within a second of sync
-# starting; the ramp then amortizes each shard's barrier (a shard is only done
-# when its slowest hash is) over larger batches once the fleet is busy.
+# A shard is only done when its slowest hash is, so the first one is small (work
+# reaches the fleet within a second) and later ones amortize that barrier.
 _PLAN_SHARD_MIN_FILES = 256
 _PLAN_SHARD_MAX_FILES = 8192
 
@@ -626,15 +622,12 @@ def _shard_bounds(total: int) -> Iterator[tuple[int, int]]:
 class _StreamedPlan:
     """Bookkeeping a streamed plan accumulates across its shards.
 
-    ``added`` and ``updated`` are the same dicts the ingest pass mutates as files
-    land, so a file planned in a late shard is tracked exactly like one planned
-    in the first.
+    ``added`` and ``updated`` are the dicts the ingest pass mutates as files land.
     """
 
     added: dict[str, None] = field(default_factory=dict)
     updated: dict[str, None] = field(default_factory=dict)
-    # Each processed file's content hash (name -> hash), for the skip markers
-    # written once the run is over.
+    # Processed files' content hashes, for the skip markers written after the run.
     pending_hashes: dict[str, str] = field(default_factory=dict)
     relocated: list[str] = field(default_factory=list)
     unchanged: int = 0
@@ -646,11 +639,8 @@ async def _absorb_shard(
 ) -> list[FileToProcess]:
     """Fold one shard's plan into *state* and return the files it queues for ingest.
 
-    Relocations and stat backfills are applied per shard rather than saved for the
-    end: they are small store writes, and applying them as they are found keeps
-    the shard's plan from being held for the rest of the run. Unlike the
-    plan-everything pass, these now land while ingest is flushing, so they take
-    the same one-shot lock retry the flush does.
+    Relocations and stat backfills are written per shard, so they contend with the
+    batch flushes and take the same one-shot lock retry.
     """
     store = get_services().store
     entries = plan.files_to_process
@@ -689,16 +679,11 @@ async def _plan_shards(
 ) -> AsyncGenerator[list[FileToProcess]]:
     """Plan the corpus shard by shard, yielding each shard's files to ingest.
 
-    The next shard is planned on its own thread while the current one is being
-    extracted and embedded, so a large corpus starts feeding the fleet after its
-    first few hundred files instead of after the last one. Shards are contiguous
-    slices of the same sorted item list, consumed in order, so the plan this
-    produces is the single-pass plan of :func:`_plan_items`, delivered in pieces.
-
-    Planning runs on a dedicated thread rather than the shared ingest pool: that
-    pool is saturated by extraction once ingest is under way, and a planner
-    queued behind it would stall the stream it is feeding. Empty shards are not
-    yielded, so a caller can treat the first yield as "there is work to do".
+    Shards are contiguous slices of one sorted item list consumed in order, so
+    this delivers the single-pass plan of :func:`_plan_items` in pieces. The next
+    shard is planned while the current one ingests, on a dedicated thread: the
+    shared ingest pool is saturated by extraction and would stall the stream it
+    feeds. Empty shards are not yielded, so the first yield means there is work.
     """
     items = sorted(disk_files.items())
     moves = _MovePool(absent, existing_sources)
@@ -875,12 +860,10 @@ async def sync(
     # reappeared identical file to its old key below.
     absent = _absent_sources(sources, disk_files)
 
-    # The planning pass stats (and where needed hashes) every file on disk. It runs
-    # shard by shard off the event loop, overlapped with ingest: on a large corpus
-    # the embed fleet starts on the first few hundred files rather than idling
-    # through a hash of all of them. A brand-new file whose content hash matches an
-    # absent source is folded in per shard as a move, not an add: repointed in place
-    # so its chunks and embeddings are reused rather than rebuilt.
+    # The planning pass stats (and where needed hashes) every file on disk, shard by
+    # shard off the event loop and overlapped with ingest. A brand-new file whose
+    # content hash matches an absent source is folded in per shard as a move, not an
+    # add: repointed in place so its chunks and embeddings are reused, not rebuilt.
     state = _StreamedPlan()
     added, updated, pending_hashes = state.added, state.updated, state.pending_hashes
     shards = _plan_shards(disk_files, existing_sources, skip_markers, absent, state, cancel)
@@ -889,8 +872,8 @@ async def sync(
     # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
     truncated_before = get_services().embedder.truncated_total
 
-    # Ingest files (with optional progress bar). The stream yields only non-empty
-    # shards, so the first one arriving is what proves there is work to do.
+    # Ingest files (with optional progress bar). Only non-empty shards are yielded,
+    # so the first one arriving is what proves there is work to do.
     try:
         first = await anext(shards, None)
         if first is not None:
@@ -915,15 +898,12 @@ async def sync(
                     reasons=reasons,
                 )
             if cancel is not None and cancel.is_set():
-                # The plan stream stops feeding the moment cancel is set, so the
-                # ingest pass can drain its admitted files and return without
-                # raising. Completed work was flushed on the way out; the run is
-                # still a cancelled one to the caller, and must not go on to
-                # write skip markers or reconcile a corpus it never planned.
+                # The stream stops feeding on cancel, so ingest can drain its
+                # admitted files and return without raising. A cancelled run must
+                # not go on to write skip markers or reconcile an unplanned corpus.
                 raise asyncio.CancelledError
     finally:
-        # Idempotent, and the only close on the paths that never reach the stream
-        # (no work at all, or a failure before ingest starts).
+        # Idempotent, and the only close when the stream is never consumed.
         await shards.aclose()
     relocated = state.relocated
 
@@ -1064,39 +1044,6 @@ async def _chain_shards(
         yield shard
 
 
-async def _one_shard(files: list[FileToProcess]) -> AsyncGenerator[list[FileToProcess]]:
-    """Present a known file list as a single-shard stream."""
-    yield files
-
-
-async def ingest_batch(
-    files_to_process: list[FileToProcess],
-    added: dict[str, None],
-    updated: dict[str, None],
-    failed: dict[str, None],
-    skipped: dict[str, None],
-    *,
-    quiet: bool = False,
-    on_progress: DetailedProgressCallback = noop_callback,
-    cancel: threading.Event | None = None,
-    flush_failed: set[str] | None = None,
-    reasons: dict[str, str] | None = None,
-) -> None:
-    """Ingest a known list of files as one shard (see :func:`ingest_stream`)."""
-    await ingest_stream(
-        _one_shard(files_to_process),
-        added,
-        updated,
-        failed,
-        skipped,
-        quiet=quiet,
-        on_progress=on_progress,
-        cancel=cancel,
-        flush_failed=flush_failed,
-        reasons=reasons,
-    )
-
-
 async def ingest_stream(
     shards: AsyncGenerator[list[FileToProcess]],
     added: dict[str, None],
@@ -1234,11 +1181,11 @@ _WRITE_FLUSH_CHUNKS = 2000
 class _ResultFeed:
     """Pull-based source of per-file ingest coroutines over a streamed plan.
 
-    Bridges the plan stream to the bounded task window: ``take(wait=False)`` hands
-    back an already-planned file without blocking, so the collector waits on the
-    planner only when it has nothing left to run. ``planned`` is the file count
-    seen so far -- the run's total once the stream is drained, and the best
-    estimate of it before that.
+    ``take(wait=False)`` hands back an already-planned file without blocking, so
+    the collector waits on the planner only when it has nothing left to run --
+    the reason this is a buffer over ``anext`` rather than an ``asyncio.Queue``,
+    which cannot be polled without also owning a producer task. ``planned`` is
+    the file count seen so far: the run's total once the stream is drained.
     """
 
     def __init__(self, shards: AsyncGenerator[list[Coroutine[Any, Any, _IngestResult]]]) -> None:
@@ -1295,15 +1242,36 @@ async def _refill_window(
 ) -> None:
     """Top up the in-flight task set from *feed*, capped at *window* tasks.
 
-    Waits on the planner only when nothing is running: with work in flight the
-    window refills from what is already planned and the collector goes straight
-    back to collecting, so a slow shard never stalls files that are ready.
+    Waits on the planner only when nothing is running, so a slow shard never
+    stalls files that are already planned.
     """
     while len(in_flight) < window:
         coro = await feed.take(wait=not in_flight)
         if coro is None:
             return
         in_flight.add(asyncio.ensure_future(coro))
+
+
+async def _next_completions(
+    in_flight: set[asyncio.Task[_IngestResult]], prefetch: asyncio.Future[Any] | None
+) -> tuple[Iterable[asyncio.Future[Any]], set[asyncio.Task[_IngestResult]]]:
+    """Wait for the next file to finish, returning (completed, still running).
+
+    The feed's shard prefetch waits alongside the running files, so work is
+    admitted as soon as it is planned rather than on the next file completion,
+    and it is filtered out of the still-running set here since it is not a file.
+    """
+    waiting: set[asyncio.Future[Any]] = set(in_flight)
+    if prefetch is not None:
+        waiting.add(prefetch)
+    done, still_running = await asyncio.wait(waiting, return_when=asyncio.FIRST_COMPLETED)
+    # Explicit loop, like _cancel_in_flight: Nuitka miscompiled the comprehension
+    # form of this task-set filtering.
+    remaining: set[asyncio.Task[_IngestResult]] = set()
+    for task in still_running:
+        if task is not prefetch:
+            remaining.add(cast("asyncio.Task[_IngestResult]", task))
+    return done, remaining
 
 
 async def _collect_results(
@@ -1323,15 +1291,13 @@ async def _collect_results(
     """Run *feed* through a bounded task window, batching writes and progress.
 
     At most *window* tasks exist at once: results are consumed as they complete
-    and the window is refilled from the feed, so memory stays flat however
-    many files a sync covers. The feed's in-flight shard prefetch is waited on
-    alongside the running files, so newly planned work is admitted as soon as it
-    lands instead of on the next file completion. Successful files are buffered
-    and flushed to LanceDB in batches (one locked transaction per batch) rather
-    than one write per file. The buffer is flushed on the way out too -- even on
-    cancel -- so completed-but-unwritten work is persisted. On exception
-    (typically asyncio.CancelledError from a user cancel), cancel every in-flight
-    sibling and await them with ``return_exceptions=True`` so their pending
+    and the window is refilled from the feed, so memory stays flat however many
+    files a sync covers. Successful files are buffered and flushed to LanceDB in
+    batches (one locked transaction per batch) rather than one write per file.
+    The buffer is flushed on the way out too -- even on cancel -- so
+    completed-but-unwritten work is persisted. On exception (typically
+    asyncio.CancelledError from a user cancel), cancel every in-flight sibling
+    and await them with ``return_exceptions=True`` so their pending
     CancelledErrors don't surface as "Task exception was never retrieved".
     """
     buffer: list[_IngestResult] = []
@@ -1343,12 +1309,7 @@ async def _collect_results(
         await _refill_window(in_flight, feed, window)
         while in_flight:
             prefetch = feed.pull()
-            waiting: set[asyncio.Future[Any]] = {*in_flight, *([prefetch] if prefetch else [])}
-            done, still_running = await asyncio.wait(waiting, return_when=asyncio.FIRST_COMPLETED)
-            in_flight = cast(
-                "set[asyncio.Task[_IngestResult]]",
-                {t for t in still_running if t is not prefetch},
-            )
+            done, in_flight = await _next_completions(in_flight, prefetch)
             saw_cancel = False
             for fut in done:
                 if fut is prefetch:

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -7,11 +7,13 @@ import contextlib
 import logging
 import threading
 import time
-from collections.abc import Callable, Coroutine, Iterable, Iterator, Mapping
+from collections import deque
+from collections.abc import AsyncGenerator, Callable, Coroutine, Iterable, Iterator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from itertools import count
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from rich.progress import (
     BarColumn,
@@ -35,7 +37,12 @@ from lilbee.data.ingest.adaptive import (
 from lilbee.data.ingest.code import ingest_code_sync
 from lilbee.data.ingest.discovery import classify_file, discover_files, file_hash
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
-from lilbee.data.ingest.offload import embed_inflight_target, max_workers, to_ingest_thread
+from lilbee.data.ingest.offload import (
+    embed_inflight_target,
+    max_workers,
+    to_executor,
+    to_ingest_thread,
+)
 from lilbee.data.ingest.skip_marker import (
     clear_skip_markers,
     load_skip_markers,
@@ -357,11 +364,64 @@ class _PlanProgress:
         )
 
 
+class _CancelSignal(Protocol):
+    """Anything the plan pass polls to stop early (a :class:`threading.Event`)."""
+
+    def is_set(self) -> bool: ...
+
+
+class _StreamStop:
+    """Stop signal for a streamed plan: the caller's cancel, or the stream closing.
+
+    The streamed planner outlives a single ``_plan_items`` call, so closing the
+    stream has to reach the in-flight shard as well; polling both here keeps a
+    mid-shard stop as prompt as a user cancel.
+    """
+
+    def __init__(self, cancel: _CancelSignal | None) -> None:
+        self._cancel = cancel
+        self._closed = threading.Event()
+
+    def close(self) -> None:
+        self._closed.set()
+
+    def is_set(self) -> bool:
+        return self._closed.is_set() or (self._cancel is not None and self._cancel.is_set())
+
+
+def _classify_pooled(
+    pool: ThreadPoolExecutor,
+    items: list[tuple[str, Path]],
+    classify: Callable[[str, Path], _FileChangeVerdict],
+    cancel: _CancelSignal | None,
+    progress: _PlanProgress,
+) -> dict[str, _FileChangeVerdict]:
+    """Fan *items* across *pool*, returning name -> verdict for what completed."""
+    verdicts: dict[str, _FileChangeVerdict] = {}
+    futures: dict[Future[_FileChangeVerdict], str] = {}
+    for name, path in items:
+        if cancel and cancel.is_set():
+            break
+        futures[pool.submit(classify, name, path)] = name
+    for future in as_completed(futures):
+        if cancel and cancel.is_set():
+            # Drop queued-but-unstarted work; running tasks drain on their own.
+            for pending in futures:
+                pending.cancel()
+            break
+        verdicts[futures[future]] = future.result()
+        progress.tick()
+    return verdicts
+
+
 def _classify_changes(
     items: list[tuple[str, Path]],
     existing_sources: dict[str, SourceRecord],
     skip_markers: dict[str, str],
-    cancel: threading.Event | None,
+    cancel: _CancelSignal | None,
+    *,
+    progress: _PlanProgress | None = None,
+    pool: ThreadPoolExecutor | None = None,
 ) -> dict[str, _FileChangeVerdict]:
     """Classify each file (stat + hash) by name, fanning across a thread pool.
 
@@ -369,38 +429,29 @@ def _classify_changes(
     serial pass; ``hashlib`` releases the GIL during digest, giving real speedup
     on a large corpus. Returns name -> verdict. A set ``cancel`` stops promptly:
     submission halts and queued-but-unstarted work is cancelled, so a mid-pass
-    cancel over a huge corpus does not hash every remaining file.
+    cancel over a huge corpus does not hash every remaining file. A *pool* and
+    *progress* passed in are shared across the shards of a streamed plan, so the
+    ETA covers the whole corpus and the workers are spun up once.
     """
 
     def _classify(name: str, path: Path) -> _FileChangeVerdict:
         return _classify_file_change(name, path, existing_sources.get(name), skip_markers)
 
-    verdicts: dict[str, _FileChangeVerdict] = {}
     total = len(items)
-    progress = _PlanProgress(total)
+    progress = progress or _PlanProgress(total)
+    if pool is not None:
+        return _classify_pooled(pool, items, _classify, cancel, progress)
     workers = _plan_workers()
     if workers <= 1 or total <= 1:
+        verdicts: dict[str, _FileChangeVerdict] = {}
         for name, path in items:
             if cancel and cancel.is_set():
                 break
             verdicts[name] = _classify(name, path)
             progress.tick()
         return verdicts
-    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="lilbee-plan") as pool:
-        futures: dict[Future[_FileChangeVerdict], str] = {}
-        for name, path in items:
-            if cancel and cancel.is_set():
-                break
-            futures[pool.submit(_classify, name, path)] = name
-        for future in as_completed(futures):
-            if cancel and cancel.is_set():
-                # Drop queued-but-unstarted work; running tasks drain on exit.
-                for pending in futures:
-                    pending.cancel()
-                break
-            verdicts[futures[future]] = future.result()
-            progress.tick()
-    return verdicts
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="lilbee-plan") as owned:
+        return _classify_pooled(owned, items, _classify, cancel, progress)
 
 
 def _plan_file_changes(
@@ -409,7 +460,20 @@ def _plan_file_changes(
     cancel: threading.Event | None,
     skip_markers: dict[str, str] | None = None,
 ) -> FileChangePlan:
-    """Diff disk against the store, hashing only files whose size/mtime drifted.
+    """Diff every disk file against the store in one pass (see :func:`_plan_items`)."""
+    return _plan_items(sorted(disk_files.items()), existing_sources, cancel, skip_markers or {})
+
+
+def _plan_items(
+    items: list[tuple[str, Path]],
+    existing_sources: dict[str, SourceRecord],
+    cancel: _CancelSignal | None,
+    skip_markers: dict[str, str],
+    *,
+    progress: _PlanProgress | None = None,
+    pool: ThreadPoolExecutor | None = None,
+) -> FileChangePlan:
+    """Diff *items* (sorted name -> path) against the store, hashing only drifted files.
 
     A tracked file whose stored (size, mtime) matches the disk stat, and whose
     mtime predates the stat capture (see :func:`_stat_unchanged`), is unchanged
@@ -423,9 +487,9 @@ def _plan_file_changes(
     or reordered completion never yields a wrong or reordered plan -- only a
     shorter one when cancelled mid-pass.
     """
-    skip_markers = skip_markers or {}
-    items = sorted(disk_files.items())
-    verdicts = _classify_changes(items, existing_sources, skip_markers, cancel)
+    verdicts = _classify_changes(
+        items, existing_sources, skip_markers, cancel, progress=progress, pool=pool
+    )
 
     files_to_process: list[FileToProcess] = []
     added: dict[str, None] = {}
@@ -460,11 +524,34 @@ class _Move:
     stat: SourceStat | None
 
 
+class _MovePool:
+    """Absent sources indexed by content hash, consumed as moves are paired.
+
+    Built once per sync and drained across the streamed plan's shards, so a file
+    that moved matches exactly the one old key it would have matched in a
+    single-pass plan however the corpus is sharded.
+    """
+
+    def __init__(self, absent: list[str], existing_sources: dict[str, SourceRecord]) -> None:
+        by_hash: dict[str, list[str]] = {}
+        for name in absent:
+            record = existing_sources.get(name)
+            if record is not None:
+                by_hash.setdefault(record["file_hash"], []).append(name)
+        for candidates in by_hash.values():
+            candidates.sort()
+        self._by_hash = by_hash
+
+    def take(self, file_hash: str) -> str | None:
+        """The next absent source with this content hash, or None."""
+        matches = self._by_hash.get(file_hash)
+        return matches.pop(0) if matches else None
+
+
 def _detect_moves(
     files_to_process: list[FileToProcess],
     added: dict[str, None],
-    absent: list[str],
-    existing_sources: dict[str, SourceRecord],
+    pool: _MovePool,
 ) -> list[_Move]:
     """Pair brand-new files with absent sources of the same content hash.
 
@@ -473,20 +560,13 @@ def _detect_moves(
     and one-to-one, so a duplicated file that moved matches exactly one old key
     and any leftovers stay indexed under their old key.
     """
-    removed_by_hash: dict[str, list[str]] = {}
-    for name in absent:
-        record = existing_sources.get(name)
-        if record is not None:
-            removed_by_hash.setdefault(record["file_hash"], []).append(name)
-    for candidates in removed_by_hash.values():
-        candidates.sort()
     moves: list[_Move] = []
     for entry in files_to_process:
         if entry.name not in added:
             continue
-        matches = removed_by_hash.get(entry.file_hash)
-        if matches:
-            moves.append(_Move(matches.pop(0), entry.name, entry.stat))
+        old = pool.take(entry.file_hash)
+        if old is not None:
+            moves.append(_Move(old, entry.name, entry.stat))
     return moves
 
 
@@ -521,6 +601,142 @@ def _absent_sources(sources: list[SourceRecord], disk_files: dict[str, Path]) ->
         for s in sources
         if s["filename"] not in disk_files and s["source_type"] != SourceType.IMPORTED
     ]
+
+
+# Plan shards ramp from _PLAN_SHARD_MIN_FILES up to _PLAN_SHARD_MAX_FILES. The
+# first shard is small so the embed fleet has work within a second of sync
+# starting; the ramp then amortizes each shard's barrier (a shard is only done
+# when its slowest hash is) over larger batches once the fleet is busy.
+_PLAN_SHARD_MIN_FILES = 256
+_PLAN_SHARD_MAX_FILES = 8192
+
+
+def _shard_bounds(total: int) -> Iterator[tuple[int, int]]:
+    """(start, stop) slices covering *total* files, doubling up to the cap."""
+    start = 0
+    size = _PLAN_SHARD_MIN_FILES
+    while start < total:
+        stop = min(start + size, total)
+        yield start, stop
+        start = stop
+        size = min(size * 2, _PLAN_SHARD_MAX_FILES)
+
+
+@dataclass
+class _StreamedPlan:
+    """Bookkeeping a streamed plan accumulates across its shards.
+
+    ``added`` and ``updated`` are the same dicts the ingest pass mutates as files
+    land, so a file planned in a late shard is tracked exactly like one planned
+    in the first.
+    """
+
+    added: dict[str, None] = field(default_factory=dict)
+    updated: dict[str, None] = field(default_factory=dict)
+    # Each processed file's content hash (name -> hash), for the skip markers
+    # written once the run is over.
+    pending_hashes: dict[str, str] = field(default_factory=dict)
+    relocated: list[str] = field(default_factory=list)
+    unchanged: int = 0
+    planned: int = 0
+
+
+async def _absorb_shard(
+    plan: FileChangePlan, state: _StreamedPlan, moves: _MovePool
+) -> list[FileToProcess]:
+    """Fold one shard's plan into *state* and return the files it queues for ingest.
+
+    Relocations and stat backfills are applied per shard rather than saved for the
+    end: they are small store writes, and applying them as they are found keeps
+    the shard's plan from being held for the rest of the run.
+    """
+    store = get_services().store
+    entries = plan.files_to_process
+    state.unchanged += plan.unchanged
+    state.added.update(plan.added)
+    state.updated.update(plan.updated)
+
+    detected = _detect_moves(entries, plan.added, moves)
+    if detected:
+        await to_ingest_thread(store.relocate_sources, [(m.old, m.new, m.stat) for m in detected])
+        entries, relocated = _apply_moves(detected, entries, plan.added)
+        for name in relocated:
+            state.added.pop(name, None)
+        state.relocated.extend(relocated)
+    if plan.stat_backfills:
+        await to_ingest_thread(store.update_source_stats, plan.stat_backfills)
+
+    state.pending_hashes.update((entry.name, entry.file_hash) for entry in entries)
+    state.planned += len(entries)
+    return entries
+
+
+async def _plan_shards(
+    disk_files: dict[str, Path],
+    existing_sources: dict[str, SourceRecord],
+    skip_markers: dict[str, str],
+    absent: list[str],
+    state: _StreamedPlan,
+    cancel: threading.Event | None,
+) -> AsyncGenerator[list[FileToProcess]]:
+    """Plan the corpus shard by shard, yielding each shard's files to ingest.
+
+    The next shard is planned on its own thread while the current one is being
+    extracted and embedded, so a large corpus starts feeding the fleet after its
+    first few hundred files instead of after the last one. Shards are contiguous
+    slices of the same sorted item list, consumed in order, so the plan this
+    produces is the single-pass plan of :func:`_plan_items`, delivered in pieces.
+
+    Planning runs on a dedicated thread rather than the shared ingest pool: that
+    pool is saturated by extraction once ingest is under way, and a planner
+    queued behind it would stall the stream it is feeding. Empty shards are not
+    yielded, so a caller can treat the first yield as "there is work to do".
+    """
+    items = sorted(disk_files.items())
+    moves = _MovePool(absent, existing_sources)
+    progress = _PlanProgress(len(items))
+    stop = _StreamStop(cancel)
+    workers = _plan_workers()
+    hashers = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="lilbee-plan")
+    driver = ThreadPoolExecutor(max_workers=1, thread_name_prefix="lilbee-plan-driver")
+
+    def _plan(lo: int, hi: int) -> FileChangePlan:
+        return _plan_items(
+            items[lo:hi],
+            existing_sources,
+            stop,
+            skip_markers,
+            progress=progress,
+            pool=hashers if workers > 1 else None,
+        )
+
+    bounds = list(_shard_bounds(len(items)))
+    try:
+        ahead = asyncio.ensure_future(to_executor(driver, _plan, *bounds[0])) if bounds else None
+        for index, _bound in enumerate(bounds):
+            if ahead is None:
+                break
+            plan = await ahead
+            ahead = (
+                asyncio.ensure_future(to_executor(driver, _plan, *bounds[index + 1]))
+                if index + 1 < len(bounds) and not stop.is_set()
+                else None
+            )
+            entries = await _absorb_shard(plan, state, moves)
+            if entries:
+                yield entries
+    finally:
+        stop.close()
+        if ahead is not None:
+            ahead.cancel()
+            # Retrieve the outcome: a prefetch that had already failed would
+            # otherwise surface as an unretrieved task exception.
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await ahead
+        # No wait: the running shard notices the stop and exits on its own, and a
+        # generator being closed must not block the event loop on a hash in flight.
+        hashers.shutdown(wait=False)
+        driver.shutdown(wait=False)
 
 
 def detect_pending() -> int:
@@ -649,53 +865,50 @@ async def sync(
     # reappeared identical file to its old key below.
     absent = _absent_sources(sources, disk_files)
 
-    # The planning pass stats (and where needed hashes) every file on disk;
-    # off the event loop so a large corpus doesn't freeze the TUI.
-    plan = await to_ingest_thread(
-        _plan_file_changes, disk_files, existing_sources, cancel, skip_markers
-    )
-    files_to_process, added, updated = plan.files_to_process, plan.added, plan.updated
-
-    # A brand-new file whose content hash matches an absent source is that source
-    # moved, not an add: repoint it in place so its chunks and embeddings are
-    # reused rather than rebuilt, and the old key drops out of the index.
-    moves = _detect_moves(files_to_process, added, absent, existing_sources)
-    relocated: list[str] = []
-    if moves:
-        await to_ingest_thread(_store.relocate_sources, [(m.old, m.new, m.stat) for m in moves])
-        files_to_process, relocated = _apply_moves(moves, files_to_process, added)
-
-    if plan.stat_backfills:
-        await to_ingest_thread(_store.update_source_stats, plan.stat_backfills)
-    # Track skip markers for files processed this run, keyed by name → hash.
-    pending_hashes = {entry.name: entry.file_hash for entry in files_to_process}
+    # The planning pass stats (and where needed hashes) every file on disk. It runs
+    # shard by shard off the event loop, overlapped with ingest: on a large corpus
+    # the embed fleet starts on the first few hundred files rather than idling
+    # through a hash of all of them. A brand-new file whose content hash matches an
+    # absent source is folded in per shard as a move, not an add: repointed in place
+    # so its chunks and embeddings are reused rather than rebuilt.
+    state = _StreamedPlan()
+    added, updated, pending_hashes = state.added, state.updated, state.pending_hashes
+    shards = _plan_shards(disk_files, existing_sources, skip_markers, absent, state, cancel)
 
     # Snapshot the cumulative truncation counter so the delta over this sync can
     # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
     truncated_before = get_services().embedder.truncated_total
 
-    # Ingest files (with optional progress bar)
-    if files_to_process:
-        # Hold the embed fleet resident for the whole batch: an unevenly loaded
-        # replica must not idle-unload and reload cold mid-run (which snowballs
-        # into a fleet collapse). The ContextVar propagates into the ingest
-        # thread pool, where the fleet actually spawns on the first embed.
-        from lilbee.providers.fleet.ingest_warmth import keep_fleet_warm
+    # Ingest files (with optional progress bar). The stream yields only non-empty
+    # shards, so the first one arriving is what proves there is work to do.
+    try:
+        first = await anext(shards, None)
+        if first is not None:
+            # Hold the embed fleet resident for the whole batch: an unevenly loaded
+            # replica must not idle-unload and reload cold mid-run (which snowballs
+            # into a fleet collapse). The ContextVar propagates into the ingest
+            # thread pool, where the fleet actually spawns on the first embed.
+            from lilbee.providers.fleet.ingest_warmth import keep_fleet_warm
 
-        with keep_fleet_warm():
-            get_services().embedder.validate_model()
-            await ingest_batch(
-                files_to_process,
-                added,
-                updated,
-                failed,
-                skipped,
-                quiet=quiet,
-                on_progress=on_progress,
-                cancel=cancel,
-                flush_failed=flush_failed,
-                reasons=reasons,
-            )
+            with keep_fleet_warm():
+                get_services().embedder.validate_model()
+                await ingest_stream(
+                    _chain_shards(first, shards),
+                    added,
+                    updated,
+                    failed,
+                    skipped,
+                    quiet=quiet,
+                    on_progress=on_progress,
+                    cancel=cancel,
+                    flush_failed=flush_failed,
+                    reasons=reasons,
+                )
+    finally:
+        # Idempotent, and the only close on the paths that never reach the stream
+        # (no work at all, or a failure before ingest starts).
+        await shards.aclose()
+    relocated = state.relocated
 
     # A flush failure is a transient store-side problem, not a verdict on the
     # file: leaving it unmarked re-plans it next sync instead of skipping it.
@@ -708,7 +921,7 @@ async def sync(
     # so a transient flush failure doesn't leave a stale reason behind.
     write_skip_reasons(config.data_root, {n: reasons[n] for n in marker_failed if n in reasons})
 
-    if files_to_process or relocated:
+    if state.planned or relocated:
         _store.ensure_fts_index()
         _store.ensure_vector_index()
         _store.optimize_sources()
@@ -742,7 +955,7 @@ async def sync(
         added=list(added),
         updated=list(updated),
         removed=[],
-        unchanged=plan.unchanged,
+        unchanged=state.unchanged,
         relocated=relocated,
         failed=list(failed),
         skipped=list(skipped),
@@ -825,6 +1038,20 @@ def _build_admission(
     return gate, permit_max * _TASK_WINDOW_MULTIPLIER, task
 
 
+async def _chain_shards(
+    first: list[FileToProcess], rest: AsyncGenerator[list[FileToProcess]]
+) -> AsyncGenerator[list[FileToProcess]]:
+    """Yield an already-pulled shard, then the remainder of its stream."""
+    yield first
+    async for shard in rest:
+        yield shard
+
+
+async def _one_shard(files: list[FileToProcess]) -> AsyncGenerator[list[FileToProcess]]:
+    """Present a known file list as a single-shard stream."""
+    yield files
+
+
 async def ingest_batch(
     files_to_process: list[FileToProcess],
     added: dict[str, None],
@@ -838,17 +1065,46 @@ async def ingest_batch(
     flush_failed: set[str] | None = None,
     reasons: dict[str, str] | None = None,
 ) -> None:
-    """Ingest a batch of files, optionally showing a Rich progress bar.
-    When *needs_cleanup* is True, old chunks are deleted immediately before
-    ingesting new ones so the two operations are atomic per file.
-    When *cancel* is set, pending files raise CancelledError before starting.
+    """Ingest a known list of files as one shard (see :func:`ingest_stream`)."""
+    await ingest_stream(
+        _one_shard(files_to_process),
+        added,
+        updated,
+        failed,
+        skipped,
+        quiet=quiet,
+        on_progress=on_progress,
+        cancel=cancel,
+        flush_failed=flush_failed,
+        reasons=reasons,
+    )
+
+
+async def ingest_stream(
+    shards: AsyncGenerator[list[FileToProcess]],
+    added: dict[str, None],
+    updated: dict[str, None],
+    failed: dict[str, None],
+    skipped: dict[str, None],
+    *,
+    quiet: bool = False,
+    on_progress: DetailedProgressCallback = noop_callback,
+    cancel: threading.Event | None = None,
+    flush_failed: set[str] | None = None,
+    reasons: dict[str, str] | None = None,
+) -> None:
+    """Ingest a stream of planned file shards, optionally showing a Rich progress bar.
+
+    Files are admitted as their shard is planned, so ingest starts on the first
+    shard instead of waiting for the whole corpus to be diffed. Old chunks are
+    deleted in the same transaction as the new write, so the two are atomic per
+    file. When *cancel* is set, pending files raise CancelledError before starting.
     """
     # Throughput is measured in OCR pages, not documents: a document's cost scales
     # with its page count (a 500-page scan is 500x a memo), so pages are the unbiased
     # unit of GPU-feeding work for the adaptive controller to hill-climb on.
     pages_done = [0]
     admission, window, controller_task = _build_admission(_max_concurrent(), pages_done)
-    total_files = len(files_to_process)
 
     async def _process_one(entry: FileToProcess, file_index: int) -> _IngestResult:
         name = entry.name
@@ -859,7 +1115,7 @@ async def ingest_batch(
             try:
                 on_progress(
                     EventType.FILE_START,
-                    FileStartEvent(file=name, total_files=total_files, current_file=file_index),
+                    FileStartEvent(file=name, total_files=feed.planned, current_file=file_index),
                 )
             except TaskCancelledError as exc:
                 # FILE_START itself can raise the cooperative cancel signal;
@@ -924,51 +1180,25 @@ async def ingest_batch(
                 pages_done[0] += 1  # cleared the gate (as a failure); still a throughput tick
                 return _IngestResult(name, entry.path, 0, error=exc)
 
-    pending = (_process_one(entry, idx) for idx, entry in enumerate(files_to_process, 1))
+    async def _tasks() -> AsyncGenerator[list[Coroutine[Any, Any, _IngestResult]]]:
+        index = count(1)
+        async for shard in shards:
+            yield [_process_one(entry, next(index)) for entry in shard]
+
+    feed = _ResultFeed(_tasks())
+    collect = _collect_results if quiet else _collect_under_bar
     try:
-        if quiet:
-            await _collect_results(
-                pending,
-                total_files,
-                added,
-                updated,
-                failed,
-                skipped,
-                window=window,
-                on_progress=on_progress,
-                flush_failed=flush_failed,
-                reasons=reasons,
-            )
-        else:
-            with Progress(
-                SpinnerColumn(),
-                TextColumn("{task.description}"),
-                BarColumn(),
-                MofNCompleteColumn(),
-                TimeElapsedColumn(),
-                transient=True,
-            ) as progress:
-                ptask = progress.add_task("Ingesting documents...", total=total_files)
-                # The bar advances once per file (in _collect_results), so a single
-                # multi-page scanned PDF would freeze at "0/1" through its whole
-                # OCR + embed phase. Drive the spinner's description off the same
-                # EXTRACT (OCR page i/N) and EMBED (chunk i/N) events the TUI uses
-                # so the row visibly moves while one file is being worked.
-                phase_progress = _phase_progress_callback(progress, ptask, on_progress)
-                await _collect_results(
-                    pending,
-                    total_files,
-                    added,
-                    updated,
-                    failed,
-                    skipped,
-                    window=window,
-                    on_progress=phase_progress,
-                    progress=progress,
-                    ptask=ptask,
-                    flush_failed=flush_failed,
-                    reasons=reasons,
-                )
+        await collect(
+            feed,
+            added,
+            updated,
+            failed,
+            skipped,
+            window=window,
+            on_progress=on_progress,
+            flush_failed=flush_failed,
+            reasons=reasons,
+        )
     finally:
         # Stop the adaptive controller (if any) before returning: its background
         # loop must not outlive the batch it was tuning.
@@ -984,22 +1214,83 @@ async def ingest_batch(
 _WRITE_FLUSH_CHUNKS = 2000
 
 
-def _refill_window(
+class _ResultFeed:
+    """Pull-based source of per-file ingest coroutines over a streamed plan.
+
+    Bridges the plan stream to the bounded task window: ``take(wait=False)`` hands
+    back an already-planned file without blocking, so the collector waits on the
+    planner only when it has nothing left to run. ``planned`` is the file count
+    seen so far -- the run's total once the stream is drained, and the best
+    estimate of it before that.
+    """
+
+    def __init__(self, shards: AsyncGenerator[list[Coroutine[Any, Any, _IngestResult]]]) -> None:
+        self._shards = shards
+        self._buffer: deque[Coroutine[Any, Any, _IngestResult]] = deque()
+        self._pull: asyncio.Task[list[Coroutine[Any, Any, _IngestResult]] | None] | None = None
+        self._drained = False
+        self.planned = 0
+
+    def pull(self) -> asyncio.Task[list[Coroutine[Any, Any, _IngestResult]] | None] | None:
+        """The in-flight shard prefetch, so a waiting collector wakes when it lands."""
+        return self._pull
+
+    async def take(self, *, wait: bool) -> Coroutine[Any, Any, _IngestResult] | None:
+        """The next planned file, or None when the stream is drained (or, with
+        *wait* False, when the next shard is not planned yet)."""
+        while not self._buffer:
+            if self._drained:
+                return None
+            if self._pull is None:
+                self._pull = asyncio.ensure_future(anext(self._shards, None))
+            if not wait and not self._pull.done():
+                return None
+            shard = await self._pull
+            self._pull = None
+            if shard is None:
+                self._drained = True
+                return None
+            self._buffer.extend(shard)
+            self.planned += len(shard)
+        return self._buffer.popleft()
+
+    async def aclose(self) -> None:
+        """Close the plan stream and discard files that were never started."""
+        if self._pull is not None:
+            self._pull.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                # A shard that landed before the cancel took effect still owns
+                # coroutines; recover it so they are closed rather than leaked.
+                shard = await self._pull
+                if shard:
+                    self._buffer.extend(shard)
+            self._pull = None
+        for coro in self._buffer:
+            coro.close()
+        self._buffer.clear()
+        await self._shards.aclose()
+
+
+async def _refill_window(
     in_flight: set[asyncio.Task[_IngestResult]],
-    pending: Iterator[Coroutine[Any, Any, _IngestResult]],
+    feed: _ResultFeed,
     window: int,
 ) -> None:
-    """Top up the in-flight task set from *pending*, capped at *window* tasks."""
+    """Top up the in-flight task set from *feed*, capped at *window* tasks.
+
+    Waits on the planner only when nothing is running: with work in flight the
+    window refills from what is already planned and the collector goes straight
+    back to collecting, so a slow shard never stalls files that are ready.
+    """
     while len(in_flight) < window:
-        coro = next(pending, None)
+        coro = await feed.take(wait=not in_flight)
         if coro is None:
             return
         in_flight.add(asyncio.ensure_future(coro))
 
 
 async def _collect_results(
-    pending: Iterator[Coroutine[Any, Any, _IngestResult]],
-    total: int,
+    feed: _ResultFeed,
     added: dict[str, None],
     updated: dict[str, None],
     failed: dict[str, None],
@@ -1012,16 +1303,18 @@ async def _collect_results(
     flush_failed: set[str] | None = None,
     reasons: dict[str, str] | None = None,
 ) -> None:
-    """Run *pending* through a bounded task window, batching writes and progress.
+    """Run *feed* through a bounded task window, batching writes and progress.
 
     At most *window* tasks exist at once: results are consumed as they complete
-    and the window is refilled from the iterator, so memory stays flat however
-    many files a sync covers. Successful files are buffered and flushed to
-    LanceDB in batches (one locked transaction per batch) rather than one write
-    per file. The buffer is flushed on the way out too -- even on cancel -- so
-    completed-but-unwritten work is persisted. On exception (typically
-    asyncio.CancelledError from a user cancel), cancel every in-flight sibling
-    and await them with ``return_exceptions=True`` so their pending
+    and the window is refilled from the feed, so memory stays flat however
+    many files a sync covers. The feed's in-flight shard prefetch is waited on
+    alongside the running files, so newly planned work is admitted as soon as it
+    lands instead of on the next file completion. Successful files are buffered
+    and flushed to LanceDB in batches (one locked transaction per batch) rather
+    than one write per file. The buffer is flushed on the way out too -- even on
+    cancel -- so completed-but-unwritten work is persisted. On exception
+    (typically asyncio.CancelledError from a user cancel), cancel every in-flight
+    sibling and await them with ``return_exceptions=True`` so their pending
     CancelledErrors don't surface as "Task exception was never retrieved".
     """
     buffer: list[_IngestResult] = []
@@ -1030,12 +1323,19 @@ async def _collect_results(
     to_purge: list[str] = []
     in_flight: set[asyncio.Task[_IngestResult]] = set()
     try:
-        _refill_window(in_flight, pending, window)
+        await _refill_window(in_flight, feed, window)
         while in_flight:
-            done, still_running = await asyncio.wait(in_flight, return_when=asyncio.FIRST_COMPLETED)
-            in_flight = set(still_running)
+            prefetch = feed.pull()
+            waiting: set[asyncio.Future[Any]] = {*in_flight, *([prefetch] if prefetch else [])}
+            done, still_running = await asyncio.wait(waiting, return_when=asyncio.FIRST_COMPLETED)
+            in_flight = cast(
+                "set[asyncio.Task[_IngestResult]]",
+                {t for t in still_running if t is not prefetch},
+            )
             saw_cancel = False
             for fut in done:
+                if fut is prefetch:
+                    continue  # a planned shard landing, not a file result
                 try:
                     result = fut.result()
                 except asyncio.CancelledError:
@@ -1065,13 +1365,13 @@ async def _collect_results(
                     # purge pass (see _purge_emptied_sources).
                     to_purge.append(result.name)
                 _report_file_progress(
-                    result, status, completed_count, total, on_progress, progress, ptask
+                    result, status, completed_count, feed.planned, on_progress, progress, ptask
                 )
             if saw_cancel:
                 # Completed siblings in this batch are now buffered; propagate the
                 # cancel so the finally flushes them and cancels still-running work.
                 raise asyncio.CancelledError
-            _refill_window(in_flight, pending, window)
+            await _refill_window(in_flight, feed, window)
     finally:
         # The inner finally guarantees the sibling cancel even if the flush
         # itself raises (e.g. a cancellation landing on the to_thread await).
@@ -1081,7 +1381,56 @@ async def _collect_results(
             )
             await to_ingest_thread(_purge_emptied_sources, to_purge)
         finally:
-            await _cancel_in_flight(in_flight)
+            try:
+                await _cancel_in_flight(in_flight)
+            finally:
+                # Closing the feed stops the planner behind it, so a cancelled
+                # sync does not keep hashing the rest of the corpus.
+                await feed.aclose()
+
+
+async def _collect_under_bar(
+    feed: _ResultFeed,
+    added: dict[str, None],
+    updated: dict[str, None],
+    failed: dict[str, None],
+    skipped: dict[str, None],
+    *,
+    window: int,
+    on_progress: DetailedProgressCallback = noop_callback,
+    flush_failed: set[str] | None = None,
+    reasons: dict[str, str] | None = None,
+) -> None:
+    """Run :func:`_collect_results` under a transient Rich progress bar."""
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        transient=True,
+    ) as progress:
+        # No total yet: the corpus is still being planned, so the bar's total is
+        # filled in (and grows) as shards land.
+        ptask = progress.add_task("Ingesting documents...", total=None)
+        # The bar advances once per file (in _collect_results), so a single
+        # multi-page scanned PDF would freeze at "0/1" through its whole
+        # OCR + embed phase. Drive the spinner's description off the same
+        # EXTRACT (OCR page i/N) and EMBED (chunk i/N) events the TUI uses
+        # so the row visibly moves while one file is being worked.
+        await _collect_results(
+            feed,
+            added,
+            updated,
+            failed,
+            skipped,
+            window=window,
+            on_progress=_phase_progress_callback(progress, ptask, on_progress),
+            progress=progress,
+            ptask=ptask,
+            flush_failed=flush_failed,
+            reasons=reasons,
+        )
 
 
 async def _cancel_in_flight(in_flight: set[asyncio.Task[_IngestResult]]) -> None:
@@ -1126,10 +1475,14 @@ def _report_file_progress(
     progress: Progress | None,
     ptask: Any,
 ) -> None:
-    """Advance the Rich bar (when present) and emit one BATCH_PROGRESS event."""
+    """Advance the Rich bar (when present) and emit one BATCH_PROGRESS event.
+
+    *total* is what the plan has produced so far, which grows while the corpus is
+    still being planned, so the bar's total is refreshed on every file.
+    """
     if progress is not None and ptask is not None:
         desc = f"Ingested {result.name}" if result.error is None else f"Failed {result.name}"
-        progress.update(ptask, description=desc)
+        progress.update(ptask, description=desc, total=total)
         progress.advance(ptask)
     with contextlib.suppress(TaskCancelledError):
         on_progress(

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -1182,10 +1182,12 @@ class _ResultFeed:
     """Pull-based source of per-file ingest coroutines over a streamed plan.
 
     ``take(wait=False)`` hands back an already-planned file without blocking, so
-    the collector waits on the planner only when it has nothing left to run --
-    the reason this is a buffer over ``anext`` rather than an ``asyncio.Queue``,
-    which cannot be polled without also owning a producer task. ``planned`` is
-    the file count seen so far: the run's total once the stream is drained.
+    the collector waits on the planner only when it has nothing left to run.
+    Build-vs-buy: an ``asyncio.Queue`` is the stock bounded channel, but it would
+    need a separate producer task to pump the shard generator into it and a
+    sentinel to close it; pulling ``anext`` on demand keeps the plan stream the
+    single driver and needs neither. ``planned`` is the file count seen so far:
+    the run's total once the stream is drained.
     """
 
     def __init__(self, shards: AsyncGenerator[list[Coroutine[Any, Any, _IngestResult]]]) -> None:

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -904,6 +904,13 @@ async def sync(
                     flush_failed=flush_failed,
                     reasons=reasons,
                 )
+            if cancel is not None and cancel.is_set():
+                # The plan stream stops feeding the moment cancel is set, so the
+                # ingest pass can drain its admitted files and return without
+                # raising. Completed work was flushed on the way out; the run is
+                # still a cancelled one to the caller, and must not go on to
+                # write skip markers or reconcile a corpus it never planned.
+                raise asyncio.CancelledError
     finally:
         # Idempotent, and the only close on the paths that never reach the stream
         # (no work at all, or a failure before ingest starts).

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -843,7 +843,9 @@ async def sync(
     """Sync documents/ with the vector store.
     Returns a SyncResult with the added/updated/removed/unchanged/failed/skipped lists.
     When *quiet* is True, the Rich progress bar is suppressed (for JSON output).
-    When *cancel* is set, processing stops between files without data loss.
+    When *cancel* is set mid-run, planning and processing stop between files
+    without data loss (completed work is flushed) and CancelledError is raised;
+    a cancel already set on entry returns an empty result instead.
     When *retry_skipped* (or *force_rebuild*) is set, the failed-file skip
     markers are cleared so this sync attempts every file.
     """

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -648,7 +648,9 @@ async def _absorb_shard(
 
     Relocations and stat backfills are applied per shard rather than saved for the
     end: they are small store writes, and applying them as they are found keeps
-    the shard's plan from being held for the rest of the run.
+    the shard's plan from being held for the rest of the run. Unlike the
+    plan-everything pass, these now land while ingest is flushing, so they take
+    the same one-shot lock retry the flush does.
     """
     store = get_services().store
     entries = plan.files_to_process
@@ -658,13 +660,19 @@ async def _absorb_shard(
 
     detected = _detect_moves(entries, plan.added, moves)
     if detected:
-        await to_ingest_thread(store.relocate_sources, [(m.old, m.new, m.stat) for m in detected])
+        relocations = [(m.old, m.new, m.stat) for m in detected]
+        await to_ingest_thread(
+            _retry_after_lock_timeout, lambda: store.relocate_sources(relocations)
+        )
         entries, relocated = _apply_moves(detected, entries, plan.added)
         for name in relocated:
             state.added.pop(name, None)
         state.relocated.extend(relocated)
     if plan.stat_backfills:
-        await to_ingest_thread(store.update_source_stats, plan.stat_backfills)
+        backfills = plan.stat_backfills
+        await to_ingest_thread(
+            _retry_after_lock_timeout, lambda: store.update_source_stats(backfills)
+        )
 
     state.pending_hashes.update((entry.name, entry.file_hash) for entry in entries)
     state.planned += len(entries)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -654,3 +654,8 @@ def install_fake_model(hf_repo: str, gguf_filename: str, task: str) -> str:
         ),
     )
     return format_native_gguf_ref(hf_repo, gguf_filename)
+
+
+async def one_shard(files):
+    """Present a known file list to ``ingest_stream`` as a single-shard stream."""
+    yield list(files)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2352,8 +2352,9 @@ class TestIngestShutdownError:
         import asyncio
         from pathlib import Path
 
-        from lilbee.data.ingest import ingest_batch
+        from lilbee.data.ingest import ingest_stream
         from lilbee.data.ingest.types import FileToProcess
+        from tests.conftest import one_shard
 
         shutdown_err = RuntimeError("cannot schedule new futures after shutdown")
 
@@ -2368,8 +2369,10 @@ class TestIngestShutdownError:
                 ),
                 pytest.raises(asyncio.CancelledError),
             ):
-                await ingest_batch(
-                    [FileToProcess("test.txt", Path("test.txt"), "text", "abc123", False)],
+                await ingest_stream(
+                    one_shard(
+                        [FileToProcess("test.txt", Path("test.txt"), "text", "abc123", False)]
+                    ),
                     added,
                     updated,
                     failed,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -842,12 +842,13 @@ class TestSyncCancellation:
         assert result.added == []
         assert result.unchanged == 0
 
-    async def test_cancel_during_ingest_batch(self, mock_extract_file, isolated_env, mock_svc):
+    async def test_cancel_during_ingest_stream(self, mock_extract_file, isolated_env, mock_svc):
         """Cancel set mid-batch raises CancelledError for pending files."""
         import asyncio
         import threading
 
-        from lilbee.data.ingest import ingest_batch
+        from lilbee.data.ingest import ingest_stream
+        from tests.conftest import one_shard
 
         (isolated_env / "a.txt").write_text("file a")
         (isolated_env / "b.txt").write_text("file b")
@@ -863,7 +864,7 @@ class TestSyncCancellation:
             FileToProcess("b.txt", isolated_env / "b.txt", "text", "hash_b", False),
         ]
         with pytest.raises(asyncio.CancelledError):
-            await ingest_batch(files, added, {}, {}, {}, quiet=True, cancel=cancel)
+            await ingest_stream(one_shard(files), added, {}, {}, {}, quiet=True, cancel=cancel)
 
     async def test_cancel_in_batch_still_flushes_completed_sibling(self, isolated_env, mock_svc):
         """A cancel landing in the same done-batch as a genuinely completed file must
@@ -1048,15 +1049,16 @@ class TestCancellation:
             raise asyncio.CancelledError()
 
         with mock.patch("lilbee.data.ingest.pipeline._produce_records", side_effect=_cancel):
-            from lilbee.data.ingest import ingest_batch
+            from lilbee.data.ingest import ingest_stream
             from lilbee.data.ingest.types import FileToProcess
+            from tests.conftest import one_shard
 
             added = {"cancel.txt": None}
             entry = FileToProcess(
                 "cancel.txt", isolated_env / "cancel.txt", "text", "abc123", False
             )
             with pytest.raises(asyncio.CancelledError):
-                await ingest_batch([entry], added, {}, {}, {}, quiet=True)
+                await ingest_stream(one_shard([entry]), added, {}, {}, {}, quiet=True)
 
     @mock.patch(
         "kreuzberg.extract_file_sync", new_callable=Mock, return_value=_make_kreuzberg_result()
@@ -1076,8 +1078,9 @@ class TestCancellation:
         """
         import asyncio
 
-        from lilbee.data.ingest import ingest_batch
+        from lilbee.data.ingest import ingest_stream
         from lilbee.runtime.cancellation import TaskCancelledError
+        from tests.conftest import one_shard
 
         # The callback flips on the second invocation so the first file makes
         # progress (which exercises the FILE_DONE re-entry path inside the error
@@ -1106,8 +1109,8 @@ class TestCancellation:
         # Should raise asyncio.CancelledError (not TaskCancelledError) so the
         # surrounding try/except in _do_sync catches it cleanly.
         with pytest.raises(asyncio.CancelledError):
-            await ingest_batch(
-                files, added, {}, failed, skipped, quiet=True, on_progress=on_progress
+            await ingest_stream(
+                one_shard(files), added, {}, failed, skipped, quiet=True, on_progress=on_progress
             )
 
 
@@ -2221,6 +2224,52 @@ class TestStreamedPlan:
             await asyncio.wait_for(sync(quiet=True, cancel=cancel), timeout=60)
         assert len(classified) < len(names)
 
+    async def test_cancel_with_nothing_left_to_admit_still_raises(self, isolated_env, mock_svc):
+        # The last admitted file finishes and the planner has stopped, so ingest
+        # returns without any file raising; sync still reports the run cancelled.
+        import threading
+
+        from lilbee.data.ingest import sync
+
+        (isolated_env / "only.txt").write_text("the one file in this corpus")
+        cancel = threading.Event()
+
+        def _extract(*_args, **_kwargs):
+            cancel.set()
+            return _make_kreuzberg_result()
+
+        with (
+            mock.patch("kreuzberg.extract_file_sync", new=Mock(side_effect=_extract)),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await sync(quiet=True, cancel=cancel)
+        # Cancelled before the marker pass: the file is not skip-marked.
+        from lilbee.data.ingest.skip_marker import load_skip_markers
+
+        assert load_skip_markers(cfg.data_root) == {}
+
+    async def test_feed_close_discards_a_shard_that_landed_late(self):
+        # A shard landing between the prefetch and the close still owns unstarted
+        # coroutines; closing the feed has to close them, not leak them.
+        from lilbee.data.ingest.pipeline import _ResultFeed
+        from lilbee.data.ingest.types import _IngestResult
+
+        planned: list = []
+
+        async def _file(name) -> _IngestResult:
+            raise AssertionError("an unstarted file must never run")
+
+        async def _shards():
+            coro = _file("a.txt")
+            planned.append(coro)
+            yield [coro]
+
+        feed = _ResultFeed(_shards())
+        assert await feed.take(wait=False) is None  # starts the prefetch
+        await asyncio.sleep(0)  # let the shard land while nothing is consuming
+        await feed.aclose()
+        assert planned[0].cr_frame is None  # closed, not leaked
+
     async def test_feed_does_not_wait_on_a_shard_that_is_not_ready(self):
         from lilbee.data.ingest.pipeline import _ResultFeed
         from lilbee.data.ingest.types import _IngestResult
@@ -2250,7 +2299,7 @@ class TestStreamedPlan:
         assert feed.planned == 2
         await feed.aclose()
 
-    async def test_collector_does_not_spin_on_a_ready_shard(self, monkeypatch, mock_svc):
+    async def test_collector_wakeups_stay_bounded_per_file(self, monkeypatch, mock_svc):
         # With every window slot busy, an already-planned shard must not wake the
         # collector on every pass: it has nothing to admit until a file finishes.
         from lilbee.data.ingest import pipeline

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2230,6 +2230,33 @@ class TestStreamedPlan:
         assert feed.planned == 2
         await feed.aclose()
 
+    async def test_collector_does_not_spin_on_a_ready_shard(self, monkeypatch, mock_svc):
+        # With every window slot busy, an already-planned shard must not wake the
+        # collector on every pass: it has nothing to admit until a file finishes.
+        from lilbee.data.ingest import pipeline
+        from lilbee.data.ingest.types import _IngestResult
+
+        async def _slow(name) -> _IngestResult:
+            await asyncio.sleep(0.05)
+            return _IngestResult(name, Path(name), chunk_count=0, error=None)
+
+        async def _shards():
+            yield [_slow("a.txt")]
+            yield [_slow("b.txt")]
+
+        waits = 0
+        real_wait = pipeline.asyncio.wait
+
+        async def _counting_wait(fs, **kwargs):
+            nonlocal waits
+            waits += 1
+            return await real_wait(fs, **kwargs)
+
+        monkeypatch.setattr(pipeline.asyncio, "wait", _counting_wait)
+        await pipeline._collect_results(pipeline._ResultFeed(_shards()), {}, {}, {}, {}, window=1)
+        # One wait per file, plus at most a couple for the shard landings.
+        assert waits <= 6
+
 
 class TestTaskWindow:
     """The ingest pump keeps at most ``window`` tasks alive at once."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2051,6 +2051,186 @@ class TestCollectResultsSkipped:
         assert sibling_cancelled.is_set()
 
 
+class TestStreamedPlan:
+    """The plan pass is sharded and overlapped with ingest, not a barrier before it."""
+
+    @staticmethod
+    def _small_shards(monkeypatch, size=2):
+        from lilbee.data.ingest import pipeline
+
+        monkeypatch.setattr(pipeline, "_PLAN_SHARD_MIN_FILES", size)
+        monkeypatch.setattr(pipeline, "_PLAN_SHARD_MAX_FILES", size)
+
+    @staticmethod
+    async def _sync_with_extraction():
+        from lilbee.data.ingest import sync
+
+        with mock.patch(
+            "kreuzberg.extract_file_sync", new_callable=Mock, return_value=_make_kreuzberg_result()
+        ):
+            return await sync(quiet=True)
+
+    def test_shard_bounds_ramp_and_cover_every_file(self):
+        from lilbee.data.ingest.pipeline import (
+            _PLAN_SHARD_MAX_FILES,
+            _PLAN_SHARD_MIN_FILES,
+            _shard_bounds,
+        )
+
+        assert list(_shard_bounds(0)) == []
+        total = _PLAN_SHARD_MAX_FILES * 4
+        bounds = list(_shard_bounds(total))
+        # Small first shard, doubling, capped -- and contiguous over the corpus.
+        assert bounds[0] == (0, _PLAN_SHARD_MIN_FILES)
+        assert bounds[1][1] - bounds[1][0] == 2 * _PLAN_SHARD_MIN_FILES
+        assert max(hi - lo for lo, hi in bounds) == _PLAN_SHARD_MAX_FILES
+        assert [lo for lo, _ in bounds[1:]] == [hi for _, hi in bounds[:-1]]
+        assert bounds[-1][1] == total
+
+    async def test_ingest_starts_before_the_corpus_is_planned(
+        self, isolated_env, monkeypatch, mock_svc
+    ):
+        # Planning the last file blocks until a file from the first shard has been
+        # extracted. A plan-everything-then-ingest pass can never satisfy that, so
+        # this deadlocks (and fails on the wait) unless planning overlaps ingest.
+        import threading
+
+        from lilbee.data.ingest import pipeline, sync
+
+        names = [f"doc{i}.txt" for i in range(6)]
+        for name in names:
+            (isolated_env / name).write_text(f"content of {name}")
+        self._small_shards(monkeypatch)
+
+        extracted = threading.Event()
+        real_hash = pipeline.file_hash
+
+        def _blocking_hash(path):
+            if path.name == names[-1]:
+                assert extracted.wait(timeout=10), "planning never overlapped ingest"
+            return real_hash(path)
+
+        def _extract(*_args, **_kwargs):
+            extracted.set()
+            return _make_kreuzberg_result()
+
+        monkeypatch.setattr(pipeline, "file_hash", _blocking_hash)
+        with mock.patch("kreuzberg.extract_file_sync", new=Mock(side_effect=_extract)):
+            result = await asyncio.wait_for(sync(quiet=True), timeout=60)
+        assert sorted(result.added) == sorted(names)
+
+    async def test_sharded_plan_accumulates_unchanged_and_backfills(
+        self, isolated_env, monkeypatch, mock_svc
+    ):
+        # Counts and stat backfills are per shard, so they have to add up across
+        # the whole run: four legacy rows over two shards, all unchanged.
+        from lilbee.data.ingest import file_hash
+
+        names = [f"legacy{i}.txt" for i in range(4)]
+        for name in names:
+            path = isolated_env / name
+            path.write_text(f"legacy content of {name}")
+            # Tracked at the right hash but with no stat columns, so each file
+            # hashes clean and queues a backfill.
+            mock_svc.store.upsert_source(name, file_hash(path), 1, source_type="document")
+        self._small_shards(monkeypatch)
+
+        result = await self._sync_with_extraction()
+        assert result.unchanged == 4
+        assert result.added == []
+        backfilled = [
+            b.record["filename"]
+            for call in mock_svc.store.update_source_stats.call_args_list
+            for b in call.args[0]
+        ]
+        assert sorted(backfilled) == names
+        assert mock_svc.store.update_source_stats.call_count == 2
+
+    async def test_move_pairs_across_shard_boundaries(self, isolated_env, monkeypatch, mock_svc):
+        # The absent-source pool is built once for the run, so a file that moved
+        # still pairs with its old key when the two land in different shards.
+        from lilbee.data.ingest import file_hash
+
+        for i in range(4):
+            (isolated_env / f"doc{i}.txt").write_text(f"content of doc{i}")
+        moved = isolated_env / "zmoved.txt"
+        moved.write_text("the relocated document")
+        mock_svc.store.upsert_source("old/moved.txt", file_hash(moved), 1, source_type="document")
+        self._small_shards(monkeypatch)
+
+        result = await self._sync_with_extraction()
+        assert result.relocated == ["zmoved.txt"]
+        assert "zmoved.txt" not in result.added
+        mock_svc.store.relocate_sources.assert_called_once()
+        assert mock_svc.store.relocate_sources.call_args.args[0][0][:2] == (
+            "old/moved.txt",
+            "zmoved.txt",
+        )
+
+    async def test_cancel_stops_planning_the_rest_of_the_corpus(
+        self, isolated_env, monkeypatch, mock_svc
+    ):
+        # A cancel during ingest stops the planner feeding it, instead of hashing
+        # every remaining file first.
+        import threading
+
+        from lilbee.data.ingest import pipeline, sync
+
+        names = [f"doc{i:02d}.txt" for i in range(40)]
+        for name in names:
+            (isolated_env / name).write_text(f"content of {name}")
+        self._small_shards(monkeypatch)
+
+        cancel = threading.Event()
+        classified: list[str] = []
+        real_classify = pipeline._classify_file_change
+
+        def _spy_classify(name, path, record, markers):
+            classified.append(name)
+            return real_classify(name, path, record, markers)
+
+        def _extract(*_args, **_kwargs):
+            cancel.set()
+            return _make_kreuzberg_result()
+
+        monkeypatch.setattr(pipeline, "_classify_file_change", _spy_classify)
+        with (
+            mock.patch("kreuzberg.extract_file_sync", new=Mock(side_effect=_extract)),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await asyncio.wait_for(sync(quiet=True, cancel=cancel), timeout=60)
+        assert len(classified) < len(names)
+
+    async def test_feed_does_not_wait_on_a_shard_that_is_not_ready(self):
+        from lilbee.data.ingest.pipeline import _ResultFeed
+        from lilbee.data.ingest.types import _IngestResult
+
+        gate = asyncio.Event()
+
+        async def _file(name) -> _IngestResult:
+            return _IngestResult(name, Path(name), chunk_count=0, error=None)
+
+        async def _shards():
+            yield [_file("a.txt")]
+            await gate.wait()
+            yield [_file("b.txt")]
+
+        feed = _ResultFeed(_shards())
+        first = await feed.take(wait=True)
+        assert first is not None
+        first.close()
+        assert feed.planned == 1
+        # The second shard is still being planned: the collector is handed None
+        # rather than being blocked behind it.
+        assert await feed.take(wait=False) is None
+        gate.set()
+        second = await feed.take(wait=True)
+        assert second is not None
+        second.close()
+        assert feed.planned == 2
+        await feed.aclose()
+
+
 class TestTaskWindow:
     """The ingest pump keeps at most ``window`` tasks alive at once."""
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1458,7 +1458,10 @@ class TestStatShortCircuit:
         assert list(parallel.added) == list(serial.added) == names
         assert parallel.unchanged == serial.unchanged == 0
 
-    def test_cancelled_parallel_plan_returns_partial(self, isolated_env, monkeypatch):
+    @pytest.mark.parametrize("workers", [1, 4])
+    def test_cancelled_plan_returns_partial(self, isolated_env, monkeypatch, workers):
+        # Both planning paths stop on a set cancel: the serial one (single CPU,
+        # and what detect_pending falls back to) and the pooled one.
         import threading
 
         from lilbee.data.ingest import pipeline
@@ -1471,7 +1474,7 @@ class TestStatShortCircuit:
 
         cancel = threading.Event()
         cancel.set()
-        monkeypatch.setattr(pipeline, "_plan_workers", lambda: 4)
+        monkeypatch.setattr(pipeline, "_plan_workers", lambda: workers)
         plan = pipeline._plan_file_changes(disk, {}, cancel=cancel)
         assert plan.files_to_process == []
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -100,6 +100,27 @@ def _install_real_store():
     return store
 
 
+def _feed(coros):
+    """A _ResultFeed over one already-planned shard of file coroutines."""
+    from lilbee.data.ingest.pipeline import _ResultFeed
+
+    async def _shards():
+        yield list(coros)
+
+    return _ResultFeed(_shards())
+
+
+def _lazy_feed(coros):
+    """A _ResultFeed that plans one file at a time, as a live plan stream does."""
+    from lilbee.data.ingest.pipeline import _ResultFeed
+
+    async def _shards():
+        for coro in coros:
+            yield [coro]
+
+    return _ResultFeed(_shards())
+
+
 def _real_ingest_result(name, *, file_hash, page_text="page one of a.pdf", stat=None):
     """A store-schema _IngestResult with one chunk and one page-text row."""
     from lilbee.data.ingest.types import _IngestResult
@@ -277,7 +298,7 @@ class TestSync:
         async def _noop_ingest(*_a, **_k):
             return None
 
-        monkeypatch.setattr(pipeline, "ingest_batch", _noop_ingest)
+        monkeypatch.setattr(pipeline, "ingest_stream", _noop_ingest)
         with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"):
             await sync(quiet=True)
         assert any(
@@ -886,8 +907,7 @@ class TestSyncCancellation:
             pytest.raises(asyncio.CancelledError),
         ):
             await pipeline._collect_results(
-                iter([_ok(), _cancelled()]),
-                total=2,
+                _feed([_ok(), _cancelled()]),
                 added=added,
                 updated={},
                 failed={},
@@ -1583,13 +1603,13 @@ class TestStatShortCircuit:
         (isolated_env / "doc.txt").write_text("content")
         loop_thread = threading.get_ident()
         plan_threads: list[int] = []
-        real_plan = pipeline._plan_file_changes
+        real_plan = pipeline._plan_items
 
         def _spy_plan(*args, **kwargs):
             plan_threads.append(threading.get_ident())
             return real_plan(*args, **kwargs)
 
-        monkeypatch.setattr(pipeline, "_plan_file_changes", _spy_plan)
+        monkeypatch.setattr(pipeline, "_plan_items", _spy_plan)
         with mock.patch(
             "kreuzberg.extract_file_sync", new_callable=Mock, return_value=_make_kreuzberg_result()
         ):
@@ -1921,8 +1941,7 @@ class TestCollectResultsSkipped:
         failed: dict[str, None] = {}
         skipped: dict[str, None] = {}
         await _collect_results(
-            iter([_zero_chunk_result()]),
-            1,
+            _feed([_zero_chunk_result()]),
             added,
             updated,
             failed,
@@ -1945,7 +1964,7 @@ class TestCollectResultsSkipped:
                 "notes.md", Path("notes.md"), chunk_count=0, error=None, needs_cleanup=True
             )
 
-        await _collect_results(iter([_emptied()]), 1, {}, {}, {}, {}, window=2)
+        await _collect_results(_feed([_emptied()]), {}, {}, {}, {}, window=2)
         mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
 
     async def test_zero_text_without_cleanup_does_not_purge(self, mock_svc):
@@ -1957,7 +1976,7 @@ class TestCollectResultsSkipped:
                 "fresh.md", Path("fresh.md"), chunk_count=0, error=None, needs_cleanup=False
             )
 
-        await _collect_results(iter([_emptied()]), 1, {}, {}, {}, {}, window=2)
+        await _collect_results(_feed([_emptied()]), {}, {}, {}, {}, window=2)
         mock_svc.store.remove_documents.assert_not_called()
 
     def test_purge_emptied_sources_noop_on_empty(self, mock_svc):
@@ -1994,7 +2013,7 @@ class TestCollectResultsSkipped:
         skipped: dict[str, None] = {}
         with pytest.raises(RuntimeError, match="ingest blew up"):
             await _collect_results(
-                iter([_boom(), _never_finishes()]), 2, added, {}, failed, skipped, window=2
+                _feed([_boom(), _never_finishes()]), added, {}, failed, skipped, window=2
             )
         assert sibling_cancelled.is_set()
 
@@ -2027,7 +2046,7 @@ class TestCollectResultsSkipped:
         monkeypatch.setattr(pipeline, "_flush_writes", _exploding_flush)
         with pytest.raises(RuntimeError, match="flush blew up"):
             await pipeline._collect_results(
-                iter([_boom(), _never_finishes()]), 2, {}, {}, {}, {}, window=2
+                _feed([_boom(), _never_finishes()]), {}, {}, {}, {}, window=2
             )
         assert sibling_cancelled.is_set()
 
@@ -2059,7 +2078,7 @@ class TestTaskWindow:
                 yield _one(i)
 
         skipped: dict[str, None] = {}
-        await _collect_results(_pending(), total, {}, {}, {}, skipped, window=window)
+        await _collect_results(_lazy_feed(_pending()), {}, {}, {}, skipped, window=window)
         assert len(skipped) == total
         assert high_water <= window
         assert created == total
@@ -2092,7 +2111,7 @@ class TestTaskWindow:
 
         added: dict[str, None] = {"f0.txt": None}
         with pytest.raises(asyncio.CancelledError):
-            await _collect_results(_pending(), 10, added, {}, {}, {}, window=1)
+            await _collect_results(_lazy_feed(_pending()), added, {}, {}, {}, window=1)
         # The window kept task creation bounded: only f0 and the cancelling f1 started.
         assert created == [0, 1]
         # The completed file's chunks were flushed on the way out.
@@ -3446,7 +3465,7 @@ class TestDetectMoves:
         to_remove = ["old/a.txt"]
         existing = {"old/a.txt": self._record("old/a.txt", "h1")}
 
-        moves = pipeline._detect_moves(files, added, to_remove, existing)
+        moves = pipeline._detect_moves(files, added, pipeline._MovePool(to_remove, existing))
         assert len(moves) == 1
         assert moves[0].old == "old/a.txt"
         assert moves[0].new == "new/a.txt"
@@ -3458,7 +3477,7 @@ class TestDetectMoves:
         added = {"new/a.txt": None}
         existing = {"old/a.txt": self._record("old/a.txt", "h1")}
 
-        moves = pipeline._detect_moves(files, added, ["old/a.txt"], existing)
+        moves = pipeline._detect_moves(files, added, pipeline._MovePool(["old/a.txt"], existing))
         assert moves == []
 
     def test_update_is_not_a_move(self):
@@ -3467,7 +3486,7 @@ class TestDetectMoves:
         # Same name (an update, not in `added`) is never a move even on hash match.
         files = [self._entry("a.txt", "h1")]
         existing = {"a.txt": self._record("a.txt", "h1")}
-        moves = pipeline._detect_moves(files, {}, [], existing)
+        moves = pipeline._detect_moves(files, {}, pipeline._MovePool([], existing))
         assert moves == []
 
     def test_duplicate_hash_pairs_one_to_one(self):
@@ -3479,7 +3498,9 @@ class TestDetectMoves:
             "old/a.txt": self._record("old/a.txt", "h1"),
             "old/b.txt": self._record("old/b.txt", "h1"),
         }
-        moves = pipeline._detect_moves(files, added, ["old/a.txt", "old/b.txt"], existing)
+        moves = pipeline._detect_moves(
+            files, added, pipeline._MovePool(["old/a.txt", "old/b.txt"], existing)
+        )
         assert {m.new for m in moves} == {"new/a.txt", "new/b.txt"}
         assert {m.old for m in moves} == {"old/a.txt", "old/b.txt"}
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2146,6 +2146,26 @@ class TestStreamedPlan:
         assert sorted(backfilled) == names
         assert mock_svc.store.update_source_stats.call_count == 2
 
+    async def test_shard_backfill_retries_once_on_lock_timeout(
+        self, isolated_env, monkeypatch, mock_svc
+    ):
+        # A shard's backfill now lands while ingest is flushing, so it can lose the
+        # store lock to a flush; it takes the same one-shot retry the flush does.
+        from lilbee.data.ingest import file_hash, pipeline
+        from lilbee.runtime.lock import LockTimeoutError
+
+        path = isolated_env / "legacy.txt"
+        path.write_text("legacy content")
+        mock_svc.store.upsert_source("legacy.txt", file_hash(path), 1, source_type="document")
+        sleeps: list[float] = []
+        monkeypatch.setattr(pipeline.time, "sleep", sleeps.append)
+        mock_svc.store.update_source_stats.side_effect = [LockTimeoutError("busy"), None]
+
+        result = await self._sync_with_extraction()
+        assert result.unchanged == 1
+        assert mock_svc.store.update_source_stats.call_count == 2
+        assert sleeps == [pipeline._FLUSH_RETRY_DELAY_SECONDS]
+
     async def test_move_pairs_across_shard_boundaries(self, isolated_env, monkeypatch, mock_svc):
         # The absent-source pool is built once for the run, so a file that moved
         # still pairs with its old key when the two land in different shards.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -103,11 +103,9 @@ def _install_real_store():
 def _feed(coros):
     """A _ResultFeed over one already-planned shard of file coroutines."""
     from lilbee.data.ingest.pipeline import _ResultFeed
+    from tests.conftest import one_shard
 
-    async def _shards():
-        yield list(coros)
-
-    return _ResultFeed(_shards())
+    return _ResultFeed(one_shard(coros))
 
 
 def _lazy_feed(coros):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2225,6 +2225,32 @@ class TestStreamedPlan:
             await asyncio.wait_for(sync(quiet=True, cancel=cancel), timeout=60)
         assert len(classified) < len(names)
 
+    async def test_plan_shards_break_between_shards_is_deterministic(
+        self, isolated_env, monkeypatch, mock_svc
+    ):
+        # The shard loop's break fires when a cancel is observed between shards.
+        # Driving it through sync relies on a cancel-during-extract race that is
+        # not portable across platforms; drive _plan_shards directly with a cancel
+        # already set, over >1 shard, so the break is hit without any timing.
+        import threading
+
+        from lilbee.data.ingest import pipeline
+        from lilbee.data.ingest.pipeline import _plan_shards, _StreamedPlan
+
+        disk = {f"doc{i}.txt": isolated_env / f"doc{i}.txt" for i in range(4)}
+        for path in disk.values():
+            path.write_text("content")
+        monkeypatch.setattr(pipeline, "_PLAN_SHARD_MIN_FILES", 1)
+        monkeypatch.setattr(pipeline, "_PLAN_SHARD_MAX_FILES", 1)
+
+        cancel = threading.Event()
+        cancel.set()  # shard 0 plans nothing, ahead drops to None, shard 1 breaks
+        state = _StreamedPlan()
+        shards = _plan_shards(disk, {}, {}, [], state, cancel)
+        yielded = [shard async for shard in shards]
+        assert yielded == []  # the break stopped planning the remaining shards
+        assert state.planned == 0
+
     async def test_cancel_with_nothing_left_to_admit_still_raises(self, isolated_env, mock_svc):
         # The last admitted file finishes and the planner has stopped, so ingest
         # returns without any file raising; sync still reports the run cancelled.


### PR DESCRIPTION
## Problem

`sync()` planned the whole corpus before embedding anything: walk `documents/`, stat every file, SHA-256 every changed one, hold the plan in memory. Nothing was extracted or embedded until the last file was hashed.

On the 8.8M-file MS MARCO ingest that was ~30 minutes of eight idle observed per run, repeated on every restart.

## Solution

Plan in contiguous shards and hand each to ingest as it lands. The next shard is planned on a dedicated thread while the current one is extracted and embedded, so the fleet has work within a second of sync starting.

```mermaid
flowchart LR
    W["walk + sort corpus"] --> SL["slice into shards<br/>256 → 8192 files"]
    SL --> P1["plan shard 1"]
    P1 -->|"fleet starts in ~1s"| I1["extract + embed shard 1"]
    P1 -.->|"plan next while<br/>shard 1 ingests"| P2["plan shard 2"]
    P2 --> I2["extract + embed shard 2"]
    P2 -.-> P3["plan shard 3 …"]
    P3 --> I3["…"]
```

Shards are contiguous slices of one sorted list consumed in order, so the streamed plan is the single-pass plan delivered in pieces. Added/updated sets, one-to-one move pairing and skip markers accumulate across shards to the same result.

The corpus is sorted by key first because `os.walk` order is arbitrary. That fixed order is what makes the plan deterministic under parallel classification (it is reassembled in sorted order, so it matches a serial pass regardless of thread scheduling), makes duplicate-hash move pairing one-to-one, and keeps shard boundaries stable so a restarted run re-shards identically.

## Hashing stays in the plan pass

The hash is both the change key (what the next sync diffs against) and the content identity (chunks are stored keyed by the hash of the bytes they were extracted from). It cannot move to write time: a file edited mid-run would store stale chunks under the new hash, and the next sync — matching stat, then matching hash — would never re-process. This is why the earlier deferred-hash attempt was reverted; this PR does not touch where the hash runs.

## Measured

10-core laptop, tiny-file corpus, extraction mocked. Time to the first file reaching ingest:

| corpus | before | after |
|---|---|---|
| 20k files | 3.20s | 1.26s |
| 60k files | 7.38s | 2.88s |

What remains is the directory walk, which this does not touch.

Total wall clock in that synthetic goes the other way (60k: 19.1s → 21.6s) because hashing and ingest now share a saturated CPU instead of running back to back. That trade only appears where the plan pass is a large share of total work; with real extraction and embedding it is a small fraction, and on the multi-GPU box it buys back the idle half hour. Narrowing the planner's width to free cores was measured *worse* (26.0s) by starving the ingest window, so it was reverted.

## Caller-visible changes

- **Progress totals grow while planning continues.** The run's file count is not known up front, so `FileStartEvent.total_files` and the Rich bar fill in as shards land.
- **Cancel mid-drain is raised by `sync()` itself.** The planner stops feeding rather than a queued file raising; completed work is still flushed first.
- **`ingest_batch` is removed.** `sync` streams, so nothing called it; `ingest_stream` is the export.
- **Per-shard relocate/backfill writes** now contend with batch flushes for the store lock, so they take the same one-shot retry.

Architecture doc updated (`docs/architecture.md`, "Planning" and "Streaming the plan").

Draft: fleet validation on a large corpus is still pending.
