### PR TITLE
Remove the unused has_arg_completion field from SlashCommand

### DIFF
--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -18,7 +18,6 @@ class SlashCommand:
     aliases: tuple[str, ...] = ()
     args_hint: str = ""
     help_text: str = ""
-    has_arg_completion: bool = False
 
 
 COMMANDS: tuple[SlashCommand, ...] = (
@@ -28,7 +27,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="[name]",
         help_text="Switch chat model (no arg opens the catalog)",
-        has_arg_completion=True,
     ),
     SlashCommand(
         "/add",
@@ -36,7 +34,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="<path>",
         help_text="Add file or folder to the knowledge base",
-        has_arg_completion=True,
     ),
     SlashCommand(
         "/crawl",
@@ -51,7 +48,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="<name>",
         help_text="Remove a document from the index",
-        has_arg_completion=True,
     ),
     SlashCommand(
         "/set",
@@ -59,7 +55,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="<key> <value>",
         help_text="Change a setting",
-        has_arg_completion=True,
     ),
     SlashCommand(
         "/theme",
@@ -67,7 +62,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="[name]",
         help_text="Switch theme (no arg opens the theme list)",
-        has_arg_completion=True,
     ),
     SlashCommand(
         "/reset",
@@ -124,7 +118,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="<name>",
         help_text="Uninstall a downloaded model",
-        has_arg_completion=True,
     ),
     SlashCommand(
         "/login",


### PR DESCRIPTION
## Problem

`SlashCommand.has_arg_completion` was defined and set on six commands but is never read anywhere in the codebase. Argument completion is gated on `_ARG_SOURCES` membership in `autocomplete.py`, not on this flag, so the field has been dead metadata since it was first introduced.

## Solution

Drop the field and its six assignments. No behavior change: nothing consumed it. Confirmed with a repo-wide search (no attribute reads, no string/reflection references, no dataclass field iteration over `SlashCommand`); the slash-discoverability and completion test suites stay green.

Note: PR #608 (import task visibility) adds `has_arg_completion=True` to `/import` and `/export`. Those two additions should be dropped when that branch rebases on this, otherwise the constructor kwarg would reference a field that no longer exists.