### PR TITLE
Coalesce concurrent ingest embeds into full batches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,16 @@ CLI also accepts `--model` / `-m` for chat model, `--data-dir` / `-d`, `--ocr-ti
 
 ### Test-Driven Development
 - **100% test coverage required** — enforced by `pytest-cov` with `fail_under = 100`
+- **Check coverage of what you changed before pushing.** Lint, typecheck and a targeted test file are all green in seconds and none of them can see an untested new branch; CI then fails with `Coverage failure: total of 99 is less than fail-under=100` and *every test passing*, which reads like an infra problem and is not. Scope the same check locally instead of skipping it:
+  ```bash
+  uv run coverage run -m pytest tests/test_<suites touching your change>.py
+  uv run coverage report -m --include='*<changed_module>*'
+  ```
 - Write tests BEFORE or alongside implementation, not after
 - Every public function MUST have at least one test
 - **Every test must assert something meaningful** — no zero-assertion coverage padding
+- **A test that cannot fail is not a test.** Before accepting an assertion, mutate the code it guards in your head: if the test still passes, it is decoration. The common shape is a bound asserted against inputs that could never violate it (`assert all(len(b) <= 8 ...)` where every input is a single item), and an error/cleanup path tested without building its precondition.
+- **Reach a branch by construction, not by a thread race.** A test that spawns threads and relies on scheduling to hit the path passes where the scheduler is forgiving and leaves the branch *uncovered* where it is not — a coverage-gate failure on the slowest CI cell. Drive the unit directly (call the internal step, pre-load the queue, pass a zero window). Use real concurrency only when the concurrency is the subject, and then assert an invariant, not a timing-dependent count.
 - Mock all external dependencies (LLM providers, filesystem I/O where needed) — tests must run without a live server
 - Use `pytest.mark.skipif` only for integration tests that genuinely require live services
 - Use `tmp_path` fixtures for filesystem tests — never write to real paths

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -879,11 +879,14 @@ async def sync(
         if first is not None:
             # Hold the embed fleet resident for the whole batch: an unevenly loaded
             # replica must not idle-unload and reload cold mid-run (which snowballs
-            # into a fleet collapse). The ContextVar propagates into the ingest
-            # thread pool, where the fleet actually spawns on the first embed.
+            # into a fleet collapse). coalesce_embeds merges the per-file embed calls
+            # into full batches so a single-chunk corpus does not starve the fleet
+            # with one request per passage. Both ContextVars propagate into the
+            # ingest thread pool, where the fleet actually spawns on the first embed.
+            from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
             from lilbee.providers.fleet.ingest_warmth import keep_fleet_warm
 
-            with keep_fleet_warm():
+            with keep_fleet_warm(), coalesce_embeds():
                 get_services().embedder.validate_model()
                 await ingest_stream(
                     _chain_shards(first, shards),

--- a/src/lilbee/providers/fleet/embed_coalescer.py
+++ b/src/lilbee/providers/fleet/embed_coalescer.py
@@ -11,10 +11,12 @@ enough, not because they cannot compute. ``embed_batch_sequences`` never helps
 because each caller only ever hands the client one sequence.
 
 This merges the concurrent one-passage calls back into full batches. A single
-batcher thread drains the submission queue into groups of up to
+batcher thread drains the submission queue into groups sized toward
 ``embed_batch_sequences`` and hands each group to a bounded dispatch pool, so the
 fixed per-request cost is paid once per batch instead of once per passage while
-the batches still fan out across replicas. Build-vs-buy: no off-the-shelf
+the batches still fan out across replicas. The size is a fill target, not a hard
+cap: a multi-text request can carry a group past it, and the client re-splits by
+token budget downstream regardless. Build-vs-buy: no off-the-shelf
 in-process coalescer fits the fleet's failover routing and token-budget
 sub-batching, and the retired ``llama_cpp_provider`` batch queue set the in-repo
 precedent; this is the same idea rebuilt at the current fleet boundary.

--- a/src/lilbee/providers/fleet/embed_coalescer.py
+++ b/src/lilbee/providers/fleet/embed_coalescer.py
@@ -108,24 +108,28 @@ class EmbedCoalescer:
         )
         self._thread = threading.Thread(target=self._run, name="fleet-embed-coalescer", daemon=True)
         self._started = False
+        self._closed = False
         self._start_lock = threading.Lock()
 
     def embed(self, texts: list[str]) -> Vectors:
-        """Submit *texts* for coalesced embedding and block for their vectors."""
+        """Submit *texts* for coalesced embedding and block for their vectors.
+
+        Raises once the coalescer is closed: the caller blocks on the future, so a
+        request queued after the shutdown drain would have nothing left to resolve
+        it and would wait forever. Queueing takes the lock :meth:`close` sets its
+        flag under, which is what makes "closed" and "queued" mutually exclusive.
+        """
         if not texts:
             return []
-        self._ensure_started()
         future: Future[Vectors] = Future()
-        self._queue.put(_Request(texts, future))
-        return future.result()
-
-    def _ensure_started(self) -> None:
-        if self._started:
-            return
         with self._start_lock:
+            if self._closed:
+                raise RuntimeError("embed coalescer closed")
             if not self._started:
                 self._thread.start()
                 self._started = True
+            self._queue.put(_Request(texts, future))
+        return future.result()
 
     def _run(self) -> None:
         while True:
@@ -199,8 +203,15 @@ class EmbedCoalescer:
                 req.future.set_exception(solo_exc)
 
     def close(self) -> None:
-        """Stop the batcher and dispatch pool; fail any un-drained stragglers."""
-        if not self._started:
+        """Stop the batcher and dispatch pool; fail any un-drained stragglers.
+
+        The closed flag is set under the lock :meth:`embed` queues within, so every
+        request is either already queued (and drained below) or rejected outright.
+        """
+        with self._start_lock:
+            self._closed = True
+            started = self._started
+        if not started:
             self._pool.shutdown(wait=False)
             return
         self._queue.put(_STOP)

--- a/src/lilbee/providers/fleet/embed_coalescer.py
+++ b/src/lilbee/providers/fleet/embed_coalescer.py
@@ -21,8 +21,12 @@ in-process coalescer fits the fleet's failover routing and token-budget
 sub-batching, and the retired ``llama_cpp_provider`` batch queue set the in-repo
 precedent; this is the same idea rebuilt at the current fleet boundary.
 
-Coalescing is scoped to bulk ingest through a ContextVar so the interactive query
-and chat paths keep their direct, latency-free dispatch.
+Coalescing is scoped twice. A ContextVar limits it to bulk ingest, so the
+interactive query and chat paths keep their direct, latency-free dispatch. A
+fleet-size gate limits it to fleets big enough for dispatch to be the bottleneck:
+an A/B on the same 50k subset regressed to 0.82x on a GPU-bound 2xA40, while
+8xA40 (153 docs/s) and 4xH200 (152 docs/s) both sat at the ~150 docs/s ceiling
+this removes. See ``FleetProvider._fleet_is_dispatch_bound``.
 """
 
 from __future__ import annotations

--- a/src/lilbee/providers/fleet/embed_coalescer.py
+++ b/src/lilbee/providers/fleet/embed_coalescer.py
@@ -1,0 +1,213 @@
+"""Coalesce concurrent embed requests into few large ones during bulk ingest.
+
+A corpus of single-chunk documents (MS MARCO passages, tweets, log lines) drives
+one embed request per document. The ingest fan-out runs each file on its own
+thread, so hundreds of one-passage ``/v1/embeddings`` calls are in flight at
+once, but the GIL serializes their per-request Python work (request build, JSON
+parse, base64 decode, vector materialization) at a few milliseconds each. That
+caps aggregate throughput near ~150 passages/sec no matter how fast or numerous
+the GPUs are: the cards starve because the client cannot emit requests fast
+enough, not because they cannot compute. ``embed_batch_sequences`` never helps
+because each caller only ever hands the client one sequence.
+
+This merges the concurrent one-passage calls back into full batches. A single
+batcher thread drains the submission queue into groups of up to
+``embed_batch_sequences`` and hands each group to a bounded dispatch pool, so the
+fixed per-request cost is paid once per batch instead of once per passage while
+the batches still fan out across replicas. Build-vs-buy: no off-the-shelf
+in-process coalescer fits the fleet's failover routing and token-budget
+sub-batching, and the retired ``llama_cpp_provider`` batch queue set the in-repo
+precedent; this is the same idea rebuilt at the current fleet boundary.
+
+Coalescing is scoped to bulk ingest through a ContextVar so the interactive query
+and chat paths keep their direct, latency-free dispatch.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import queue
+import threading
+import time
+from collections.abc import Callable, Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager
+from typing import cast
+
+Vectors = list[list[float]]
+DispatchFn = Callable[[list[str]], Vectors]
+
+# How long the batcher waits after the first queued request for more to arrive
+# before cutting the batch. Under a bulk fan-out the queue is never empty, so a
+# batch fills to ``max_batch`` long before this fires; it only bounds latency on
+# the trailing, low-arrival tail. Matches the retired provider's 10ms window.
+_BATCH_WINDOW_S = 0.01
+
+_COALESCE_EMBEDS: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "lilbee_coalesce_embeds", default=False
+)
+
+
+def coalescing_enabled() -> bool:
+    """Whether the current context has opted embeds into coalescing."""
+    return _COALESCE_EMBEDS.get()
+
+
+@contextmanager
+def coalesce_embeds() -> Iterator[None]:
+    """Coalesce embed requests for the duration of the block.
+
+    The signal is a ContextVar so it scopes to exactly one ingest and propagates
+    into the ingest thread pool (``to_ingest_thread`` copies the context), the way
+    :func:`~lilbee.providers.fleet.ingest_warmth.keep_fleet_warm` does.
+    """
+    token = _COALESCE_EMBEDS.set(True)
+    try:
+        yield
+    finally:
+        _COALESCE_EMBEDS.reset(token)
+
+
+class _Request:
+    """One caller's texts and the future carrying its vectors back."""
+
+    __slots__ = ("future", "texts")
+
+    def __init__(self, texts: list[str], future: Future[Vectors]) -> None:
+        self.texts = texts
+        self.future = future
+
+
+_STOP = object()
+
+
+class EmbedCoalescer:
+    """Merge concurrent :meth:`embed` calls into batched dispatches.
+
+    A single batcher thread groups queued requests; a bounded pool dispatches the
+    groups concurrently so replicas stay fed. Lifecycle is owned by the provider:
+    the thread starts on first use and :meth:`close` stops it.
+    """
+
+    def __init__(
+        self,
+        dispatch: DispatchFn,
+        *,
+        max_batch: int,
+        max_concurrency: int,
+        window_s: float = _BATCH_WINDOW_S,
+    ) -> None:
+        self._dispatch = dispatch
+        self._max_batch = max(1, max_batch)
+        self._window_s = window_s
+        self._queue: queue.Queue[_Request | object] = queue.Queue()
+        self._pool = ThreadPoolExecutor(
+            max_workers=max(1, max_concurrency), thread_name_prefix="fleet-embed-batch"
+        )
+        self._thread = threading.Thread(target=self._run, name="fleet-embed-coalescer", daemon=True)
+        self._started = False
+        self._start_lock = threading.Lock()
+
+    def embed(self, texts: list[str]) -> Vectors:
+        """Submit *texts* for coalesced embedding and block for their vectors."""
+        if not texts:
+            return []
+        self._ensure_started()
+        future: Future[Vectors] = Future()
+        self._queue.put(_Request(texts, future))
+        return future.result()
+
+    def _ensure_started(self) -> None:
+        if self._started:
+            return
+        with self._start_lock:
+            if not self._started:
+                self._thread.start()
+                self._started = True
+
+    def _run(self) -> None:
+        while True:
+            batch = self._next_batch()
+            if batch is None:
+                break
+            self._pool.submit(self._dispatch_batch, batch)
+
+    def _next_batch(self) -> list[_Request] | None:
+        """Block for the first request, then greedily fill up to the window/size.
+
+        Returns ``None`` when the stop sentinel is reached, ending the run loop.
+        """
+        raw = self._queue.get()
+        if raw is _STOP:
+            return None
+        first = cast(_Request, raw)
+        batch = [first]
+        count = len(first.texts)
+        deadline = time.monotonic() + self._window_s
+        while count < self._max_batch:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                item = self._queue.get(timeout=remaining)
+            except queue.Empty:
+                break
+            if item is _STOP:
+                # Re-post so the run loop sees the stop after this batch drains.
+                self._queue.put(_STOP)
+                break
+            req = cast(_Request, item)
+            batch.append(req)
+            count += len(req.texts)
+        return batch
+
+    def _dispatch_batch(self, batch: list[_Request]) -> None:
+        texts = [text for req in batch for text in req.texts]
+        try:
+            vectors = self._dispatch(texts)
+            if len(vectors) != len(texts):
+                raise ValueError(
+                    f"coalesced embed returned {len(vectors)} vectors for {len(texts)} inputs"
+                )
+        except Exception as exc:
+            self._fail_batch(batch, exc)
+            return
+        offset = 0
+        for req in batch:
+            n = len(req.texts)
+            req.future.set_result(vectors[offset : offset + n])
+            offset += n
+
+    def _fail_batch(self, batch: list[_Request], exc: Exception) -> None:
+        """Isolate the culprit: retry each request alone so one bad input does not
+        fail its batch-mates, matching the per-file failure isolation ingest had
+        before requests were merged."""
+        if len(batch) == 1:
+            batch[0].future.set_exception(exc)
+            return
+        for req in batch:
+            try:
+                vectors = self._dispatch(req.texts)
+                if len(vectors) != len(req.texts):
+                    raise ValueError(
+                        f"embed returned {len(vectors)} vectors for {len(req.texts)} inputs"
+                    )
+                req.future.set_result(vectors)
+            except Exception as solo_exc:
+                req.future.set_exception(solo_exc)
+
+    def close(self) -> None:
+        """Stop the batcher and dispatch pool; fail any un-drained stragglers."""
+        if not self._started:
+            self._pool.shutdown(wait=False)
+            return
+        self._queue.put(_STOP)
+        self._thread.join()
+        self._pool.shutdown(wait=True)
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if isinstance(item, _Request):
+                item.future.set_exception(RuntimeError("embed coalescer closed"))

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -43,6 +43,7 @@ from lilbee.providers.fleet.client import (
     retry_on_busy,
 )
 from lilbee.providers.fleet.contract import contract_matches, decoded_launches, served_pairs
+from lilbee.providers.fleet.embed_coalescer import EmbedCoalescer, coalescing_enabled
 from lilbee.providers.fleet.groups import SwapGroup, group_for
 from lilbee.providers.fleet.ingest_warmth import ingest_keep_warm
 from lilbee.providers.fleet.launch import InstanceLaunch
@@ -177,6 +178,12 @@ def _least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
 # Serializes pick-and-reserve so concurrent routers see each other's assignment.
 # Held only for the O(replicas) selection, never across the request itself.
 _ROUTE_LOCK = threading.Lock()
+
+# Concurrent coalesced-embed batches in flight: a couple per replica so each
+# card's continuous-batching slots stay full while one batch's results are being
+# parsed, with a floor for single-GPU and fleet-size-unknown hosts.
+_EMBED_DISPATCH_PER_REPLICA = 2
+_MIN_EMBED_DISPATCH = 8
 
 
 def _reserve_least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
@@ -856,6 +863,11 @@ class FleetProvider:
         # can block until the reload it requested (or the in-flight one that will
         # run its pending pass) has finished.
         self._reload_done = threading.Condition(self._lock)
+        # Bulk-ingest embed coalescer, built lazily on the first coalesced embed
+        # (by when the fleet is up and the replica count is known) and closed at
+        # shutdown. Only engaged inside a ``coalesce_embeds()`` context.
+        self._coalescer: EmbedCoalescer | None = None
+        self._coalescer_lock = threading.Lock()
 
     def _ensure_fleet(self) -> bool:
         """Start one llama-swap per placed role exactly once across concurrent callers.
@@ -1594,11 +1606,43 @@ class FleetProvider:
         return result.messages
 
     def embed(self, texts: list[str]) -> list[list[float]]:
+        # Under a bulk ingest, merge concurrent one-passage calls into full
+        # batches so the fixed per-request cost is not paid per passage; the
+        # interactive query/chat path (no coalescing context) dispatches directly.
+        if texts and coalescing_enabled():
+            return self._embed_coalescer().embed(texts)
+        return self._embed_batch(texts)
+
+    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
         return self._with_rediscover(lambda: self._embed_once(texts))
 
     def _embed_once(self, texts: list[str]) -> list[list[float]]:
         clients = self._require_clients(WorkerRole.EMBED)
         return _call_with_failover(clients, lambda client: client.embed(texts))
+
+    def _embed_coalescer(self) -> EmbedCoalescer:
+        """The ingest embed coalescer, built on first use from the live fleet size."""
+        with self._coalescer_lock:
+            if self._coalescer is None:
+                from lilbee.core.config import active_config
+                from lilbee.providers.fleet.replicas import (
+                    gpu_device_count,
+                    resolve_replica_count,
+                )
+
+                try:
+                    replicas = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
+                except Exception:
+                    replicas = 1
+                # A few batches per replica in flight keep every card's slots full
+                # without falling back to a request-per-passage flood.
+                concurrency = max(_MIN_EMBED_DISPATCH, replicas * _EMBED_DISPATCH_PER_REPLICA)
+                self._coalescer = EmbedCoalescer(
+                    self._embed_batch,
+                    max_batch=active_config().embed_batch_sequences,
+                    max_concurrency=concurrency,
+                )
+            return self._coalescer
 
     def vision_ocr(
         self, png_bytes: bytes, model: str, prompt: str = "", *, timeout: float | None = None
@@ -2383,4 +2427,9 @@ class FleetProvider:
         ).start()
 
     def shutdown(self) -> None:
+        # Drain and stop the coalescer before the servers it dispatches to go away.
+        with self._coalescer_lock:
+            coalescer, self._coalescer = self._coalescer, None
+        if coalescer is not None:
+            coalescer.close()
         self._shutdown_swap()

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -184,6 +184,10 @@ _ROUTE_LOCK = threading.Lock()
 # parsed, with a floor for single-GPU and fleet-size-unknown hosts.
 _EMBED_DISPATCH_PER_REPLICA = 2
 _MIN_EMBED_DISPATCH = 8
+# Replica count at or above which coalescing pays (see _fleet_is_dispatch_bound).
+# 2 regressed and 4 was already at the ceiling; the crossover between them is
+# untested, so the gate errs toward direct dispatch.
+_COALESCE_MIN_REPLICAS = 4
 
 
 def _reserve_least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
@@ -867,6 +871,7 @@ class FleetProvider:
         # (by when the fleet is up and the replica count is known) and closed at
         # shutdown. Only engaged inside a ``coalesce_embeds()`` context.
         self._coalescer: EmbedCoalescer | None = None
+        self._embed_replica_count: int | None = None
         self._coalescer_lock = threading.Lock()
 
     def _ensure_fleet(self) -> bool:
@@ -1606,12 +1611,24 @@ class FleetProvider:
         return result.messages
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        # Under a bulk ingest, merge concurrent one-passage calls into full
-        # batches so the fixed per-request cost is not paid per passage; the
-        # interactive query/chat path (no coalescing context) dispatches directly.
-        if texts and coalescing_enabled():
+        # Under a bulk ingest on a fleet big enough to be dispatch-bound, merge
+        # concurrent one-passage calls into full batches so the fixed per-request
+        # cost is not paid per passage. The interactive query/chat path (no
+        # coalescing context) and small fleets dispatch directly.
+        if texts and coalescing_enabled() and self._fleet_is_dispatch_bound():
             return self._embed_coalescer().embed(texts)
         return self._embed_batch(texts)
+
+    def _fleet_is_dispatch_bound(self) -> bool:
+        """Whether this fleet is large enough for coalescing to be a win.
+
+        Coalescing helps only when emitting requests, not the GPUs, is the limit.
+        A/B measured on the same 50k subset: 2xA40 is GPU-bound and regressed to
+        0.82x with coalescing on, while 8xA40 (153 docs/s) and 4xH200 (152 docs/s)
+        both sat at the same ~150 docs/s ceiling coalescing exists to remove.
+        """
+        with self._coalescer_lock:
+            return self._embed_replicas() >= _COALESCE_MIN_REPLICAS
 
     def _embed_batch(self, texts: list[str]) -> list[list[float]]:
         return self._with_rediscover(lambda: self._embed_once(texts))
@@ -1620,23 +1637,35 @@ class FleetProvider:
         clients = self._require_clients(WorkerRole.EMBED)
         return _call_with_failover(clients, lambda client: client.embed(texts))
 
+    def _embed_replicas(self) -> int:
+        """The embed fleet's replica count, probed once and cached.
+
+        The probe touches the devices, and both the coalescing gate and the
+        dispatch sizing read it, so it must not run per embed call. Callers hold
+        ``_coalescer_lock``; ``shutdown`` clears it so a re-warmed fleet re-probes.
+        """
+        if self._embed_replica_count is None:
+            from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+
+            try:
+                self._embed_replica_count = resolve_replica_count(
+                    WorkerRole.EMBED, gpu_device_count()
+                )
+            except Exception:
+                self._embed_replica_count = 1
+        return self._embed_replica_count
+
     def _embed_coalescer(self) -> EmbedCoalescer:
         """The ingest embed coalescer, built on first use from the live fleet size."""
         with self._coalescer_lock:
             if self._coalescer is None:
                 from lilbee.core.config import active_config
-                from lilbee.providers.fleet.replicas import (
-                    gpu_device_count,
-                    resolve_replica_count,
-                )
 
-                try:
-                    replicas = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
-                except Exception:
-                    replicas = 1
                 # A few batches per replica in flight keep every card's slots full
                 # without falling back to a request-per-passage flood.
-                concurrency = max(_MIN_EMBED_DISPATCH, replicas * _EMBED_DISPATCH_PER_REPLICA)
+                concurrency = max(
+                    _MIN_EMBED_DISPATCH, self._embed_replicas() * _EMBED_DISPATCH_PER_REPLICA
+                )
                 self._coalescer = EmbedCoalescer(
                     self._embed_batch,
                     max_batch=active_config().embed_batch_sequences,
@@ -2430,6 +2459,7 @@ class FleetProvider:
         # Drain and stop the coalescer before the servers it dispatches to go away.
         with self._coalescer_lock:
             coalescer, self._coalescer = self._coalescer, None
+            self._embed_replica_count = None
         if coalescer is not None:
             coalescer.close()
         self._shutdown_swap()

--- a/tests/test_embed_coalescer.py
+++ b/tests/test_embed_coalescer.py
@@ -1,0 +1,193 @@
+"""Tests for the ingest embed coalescer."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from lilbee.providers.fleet.embed_coalescer import (
+    EmbedCoalescer,
+    coalesce_embeds,
+    coalescing_enabled,
+)
+
+
+def _vec_for(text: str) -> list[float]:
+    """A vector that uniquely encodes its input, so scatter mistakes are visible."""
+    return [float(len(text)), float(sum(ord(c) for c in text))]
+
+
+def _recording_dispatch(calls: list[list[str]], *, delay: float = 0.0):
+    lock = threading.Lock()
+
+    def dispatch(texts: list[str]) -> list[list[float]]:
+        if delay:
+            time.sleep(delay)
+        with lock:
+            calls.append(list(texts))
+        return [_vec_for(t) for t in texts]
+
+    return dispatch
+
+
+def test_gate_defaults_off_and_scopes_to_block() -> None:
+    assert coalescing_enabled() is False
+    with coalesce_embeds():
+        assert coalescing_enabled() is True
+    assert coalescing_enabled() is False
+
+
+def test_empty_input_returns_empty_without_dispatch() -> None:
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=8, max_concurrency=2)
+    try:
+        assert coalescer.embed([]) == []
+        assert calls == []
+    finally:
+        coalescer.close()
+
+
+def test_single_call_returns_its_vectors() -> None:
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=8, max_concurrency=2)
+    try:
+        assert coalescer.embed(["hello"]) == [_vec_for("hello")]
+    finally:
+        coalescer.close()
+
+
+def test_concurrent_singletons_coalesce_into_few_batches() -> None:
+    calls: list[list[str]] = []
+    # A slow dispatch forces submissions to pile up so the batcher merges them.
+    coalescer = EmbedCoalescer(
+        _recording_dispatch(calls, delay=0.03), max_batch=32, max_concurrency=4, window_s=0.02
+    )
+    n = 128
+    results: dict[int, list[list[float]]] = {}
+    results_lock = threading.Lock()
+
+    def worker(i: int) -> None:
+        out = coalescer.embed([f"passage-{i}"])
+        with results_lock:
+            results[i] = out
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    try:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        coalescer.close()
+
+    # Every caller got exactly its own vector back, in the right place.
+    assert len(results) == n
+    for i in range(n):
+        assert results[i] == [_vec_for(f"passage-{i}")]
+    # No passage lost or duplicated across the dispatched batches.
+    dispatched = [t for batch in calls for t in batch]
+    assert sorted(dispatched) == sorted(f"passage-{i}" for i in range(n))
+    # The whole point: far fewer dispatches than passages, and real batching.
+    assert len(calls) < n
+    assert max(len(batch) for batch in calls) > 1
+
+
+def test_batch_never_exceeds_max_batch() -> None:
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(
+        _recording_dispatch(calls, delay=0.02), max_batch=8, max_concurrency=2, window_s=0.05
+    )
+    threads = [threading.Thread(target=lambda i=i: coalescer.embed([f"t{i}"])) for i in range(64)]
+    try:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        coalescer.close()
+    assert calls  # something was dispatched
+    assert all(len(batch) <= 8 for batch in calls)
+
+
+def test_multi_text_request_scatters_back_whole() -> None:
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=16, max_concurrency=2)
+    try:
+        out = coalescer.embed(["a", "bb", "ccc"])
+        assert out == [_vec_for("a"), _vec_for("bb"), _vec_for("ccc")]
+    finally:
+        coalescer.close()
+
+
+def test_failure_is_isolated_to_the_bad_input() -> None:
+    poison = "boom"
+
+    def dispatch(texts: list[str]) -> list[list[float]]:
+        time.sleep(0.02)
+        if poison in texts and len(texts) > 1:
+            raise RuntimeError("batched call rejected")
+        if texts == [poison]:
+            raise RuntimeError("poison input")
+        return [_vec_for(t) for t in texts]
+
+    coalescer = EmbedCoalescer(dispatch, max_batch=32, max_concurrency=1, window_s=0.03)
+    good_results: dict[int, list[list[float]]] = {}
+    poison_error: list[Exception] = []
+    lock = threading.Lock()
+
+    def good(i: int) -> None:
+        out = coalescer.embed([f"ok-{i}"])
+        with lock:
+            good_results[i] = out
+
+    def bad() -> None:
+        try:
+            coalescer.embed([poison])
+        except Exception as exc:
+            with lock:
+                poison_error.append(exc)
+
+    threads = [threading.Thread(target=good, args=(i,)) for i in range(16)]
+    threads.append(threading.Thread(target=bad))
+    try:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        coalescer.close()
+
+    # The poison request failed; every good sibling still got its own vector.
+    assert len(poison_error) == 1
+    assert len(good_results) == 16
+    for i in range(16):
+        assert good_results[i] == [_vec_for(f"ok-{i}")]
+
+
+def test_length_mismatch_surfaces_as_error() -> None:
+    def dispatch(texts: list[str]) -> list[list[float]]:
+        return [_vec_for(texts[0])]  # always one vector, wrong for >1 input
+
+    coalescer = EmbedCoalescer(dispatch, max_batch=4, max_concurrency=1)
+    try:
+        with pytest.raises(ValueError, match="1 vectors for 2 inputs"):
+            coalescer.embed(["x", "y"])
+    finally:
+        coalescer.close()
+
+
+def test_close_fails_stragglers_and_is_idempotent() -> None:
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=4, max_concurrency=2)
+    coalescer.embed(["warm"])  # start the thread
+    coalescer.close()
+    coalescer.close()  # idempotent
+
+
+def test_close_without_use_does_not_start_thread() -> None:
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=4, max_concurrency=2)
+    coalescer.close()
+    assert calls == []

--- a/tests/test_embed_coalescer.py
+++ b/tests/test_embed_coalescer.py
@@ -97,21 +97,31 @@ def test_concurrent_singletons_coalesce_into_few_batches() -> None:
     assert max(len(batch) for batch in calls) > 1
 
 
-def test_batch_never_exceeds_max_batch() -> None:
-    calls: list[list[str]] = []
-    coalescer = EmbedCoalescer(
-        _recording_dispatch(calls, delay=0.02), max_batch=8, max_concurrency=2, window_s=0.05
-    )
-    threads = [threading.Thread(target=lambda i=i: coalescer.embed([f"t{i}"])) for i in range(64)]
-    try:
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-    finally:
-        coalescer.close()
-    assert calls  # something was dispatched
-    assert all(len(batch) <= 8 for batch in calls)
+def test_single_text_requests_stop_filling_at_max_batch() -> None:
+    # Queue more single-text requests than fit, then drive the fill loop directly:
+    # no threads, no window timing, so the boundary is asserted deterministically.
+    coalescer = EmbedCoalescer(lambda t: [[0.0]] * len(t), max_batch=8, max_concurrency=1)
+    for i in range(20):
+        coalescer._queue.put(_Request([f"t{i}"], Future()))
+
+    batch = coalescer._next_batch()
+
+    assert batch is not None
+    assert sum(len(req.texts) for req in batch) == 8
+
+
+def test_max_batch_is_a_fill_target_not_a_hard_cap() -> None:
+    # The fill loop checks the count before adding, so a multi-text request can
+    # carry the group past max_batch. That is intended: the fleet client re-splits
+    # by token budget downstream. Pinned so the overshoot cannot change silently.
+    coalescer = EmbedCoalescer(lambda t: [[0.0]] * len(t), max_batch=8, max_concurrency=1)
+    coalescer._queue.put(_Request(["first"], Future()))
+    coalescer._queue.put(_Request([f"t{i}" for i in range(20)], Future()))
+
+    batch = coalescer._next_batch()
+
+    assert batch is not None
+    assert sum(len(req.texts) for req in batch) == 21  # 1 + 20, past max_batch=8
 
 
 def test_multi_text_request_scatters_back_whole() -> None:

--- a/tests/test_embed_coalescer.py
+++ b/tests/test_embed_coalescer.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import threading
 import time
+from concurrent.futures import Future
 
 import pytest
 
 from lilbee.providers.fleet.embed_coalescer import (
+    _STOP,
     EmbedCoalescer,
+    _Request,
     coalesce_embeds,
     coalescing_enabled,
 )
@@ -178,12 +181,81 @@ def test_length_mismatch_surfaces_as_error() -> None:
         coalescer.close()
 
 
-def test_close_fails_stragglers_and_is_idempotent() -> None:
+def test_close_is_idempotent() -> None:
     calls: list[list[str]] = []
     coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=4, max_concurrency=2)
     coalescer.embed(["warm"])  # start the thread
     coalescer.close()
     coalescer.close()  # idempotent
+
+
+def test_close_fails_requests_left_in_the_queue() -> None:
+    # Stop the batcher first, so the request queued after it is a straggler no
+    # thread will ever pick up; close() must fail it rather than hang its caller.
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=4, max_concurrency=2)
+    coalescer.embed(["warm"])  # start the batcher thread
+    coalescer._queue.put(_STOP)
+    coalescer._thread.join()  # batcher is gone before the straggler is queued
+
+    straggler: Future[list[list[float]]] = Future()
+    coalescer._queue.put(_Request(["never-dispatched"], straggler))
+    coalescer.close()
+
+    assert isinstance(straggler.exception(), RuntimeError)
+    assert calls == [["warm"]]  # the straggler was never dispatched
+
+
+def test_expired_window_cuts_the_batch_without_waiting() -> None:
+    # A zero window means the deadline has already passed when the fill loop is
+    # entered, so the first request goes out alone instead of blocking on a get.
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(
+        _recording_dispatch(calls), max_batch=8, max_concurrency=1, window_s=0.0
+    )
+    try:
+        assert coalescer.embed(["solo"]) == [_vec_for("solo")]
+        assert calls == [["solo"]]
+    finally:
+        coalescer.close()
+
+
+def test_stop_arriving_mid_batch_is_reposted_for_the_run_loop() -> None:
+    # The batcher must not swallow the stop sentinel it pulls while filling a
+    # batch, or close() would block forever waiting for a run loop that never ends.
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=8, max_concurrency=1)
+    pending: Future[list[list[float]]] = Future()
+    coalescer._queue.put(_Request(["queued"], pending))
+    coalescer._queue.put(_STOP)
+
+    batch = coalescer._next_batch()  # drives the loop directly: no thread, no timing
+
+    assert batch is not None
+    assert [req.texts for req in batch] == [["queued"]]
+    assert coalescer._queue.get_nowait() is _STOP  # re-posted, not consumed
+
+
+def test_solo_retry_length_mismatch_fails_only_that_request() -> None:
+    # The batch dispatch fails, and the per-request retry returns the wrong vector
+    # count: that request carries the mismatch error, its batch-mate still succeeds.
+    def dispatch(texts: list[str]) -> list[list[float]]:
+        if len(texts) > 1:
+            raise RuntimeError("batch dispatch failed")
+        if texts == ["bad"]:
+            return []  # zero vectors for one input
+        return [_vec_for(t) for t in texts]
+
+    coalescer = EmbedCoalescer(dispatch, max_batch=8, max_concurrency=1)
+    bad: Future[list[list[float]]] = Future()
+    good: Future[list[list[float]]] = Future()
+    coalescer._fail_batch(
+        [_Request(["bad"], bad), _Request(["good"], good)], RuntimeError("batch dispatch failed")
+    )
+
+    assert isinstance(bad.exception(), ValueError)
+    assert "0 vectors for 1 inputs" in str(bad.exception())
+    assert good.result() == [_vec_for("good")]
 
 
 def test_close_without_use_does_not_start_thread() -> None:

--- a/tests/test_embed_coalescer.py
+++ b/tests/test_embed_coalescer.py
@@ -268,6 +268,19 @@ def test_solo_retry_length_mismatch_fails_only_that_request() -> None:
     assert good.result() == [_vec_for("good")]
 
 
+def test_embed_after_close_raises_instead_of_blocking_forever() -> None:
+    # The caller blocks on its future, so a request accepted after the shutdown
+    # drain would never be resolved. Rejecting is the only non-hanging answer.
+    calls: list[list[str]] = []
+    coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=4, max_concurrency=2)
+    coalescer.embed(["warm"])
+    coalescer.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        coalescer.embed(["after-close"])
+    assert calls == [["warm"]]  # never dispatched
+
+
 def test_close_without_use_does_not_start_thread() -> None:
     calls: list[list[str]] = []
     coalescer = EmbedCoalescer(_recording_dispatch(calls), max_batch=4, max_concurrency=2)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -4722,6 +4722,14 @@ class TestEmbedCoalescingRoute:
         monkeypatch.setattr(fleet, "_embed_batch", _batch)
         return fleet, calls
 
+    @staticmethod
+    def _dispatch_bound(monkeypatch) -> None:
+        """Force a replica count past the coalescing gate; below it, embed() takes
+        the direct path and no coalescer is built."""
+        from lilbee.providers.fleet import replicas as replicas_mod
+
+        monkeypatch.setattr(replicas_mod, "resolve_replica_count", lambda *_a, **_k: 8)
+
     def test_direct_dispatch_without_context(self, monkeypatch) -> None:
         from lilbee.providers.fleet.embed_coalescer import coalescing_enabled
 
@@ -4739,6 +4747,7 @@ class TestEmbedCoalescingRoute:
         from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
 
         fleet, calls = self._provider(monkeypatch)
+        self._dispatch_bound(monkeypatch)
         try:
             with coalesce_embeds():
                 assert fleet.embed(["hello"]) == [[5.0]]
@@ -4764,6 +4773,7 @@ class TestEmbedCoalescingRoute:
         from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
 
         fleet, _ = self._provider(monkeypatch)
+        self._dispatch_bound(monkeypatch)
         with coalesce_embeds():
             fleet.embed(["warm"])
         coalescer = fleet.__dict__.get("_coalescer")
@@ -4772,9 +4782,55 @@ class TestEmbedCoalescingRoute:
         assert fleet._coalescer is None
         assert coalescer._thread.is_alive() is False
 
-    def test_unprobeable_fleet_still_builds_a_coalescer(self, monkeypatch) -> None:
-        # Sizing reads the live replica count; a fleet that cannot be probed yet
-        # must fall back to one replica rather than fail the embed outright.
+    @pytest.mark.parametrize(
+        "replicas, coalesced",
+        [(1, False), (2, False), (3, False), (4, True), (8, True)],
+    )
+    def test_only_a_dispatch_bound_fleet_coalesces(self, monkeypatch, replicas, coalesced) -> None:
+        # Coalescing regressed to 0.82x on 2xA40 (GPU-bound) and only paid at the
+        # 4+ replica counts that sat at the ~150 docs/s dispatch ceiling, so the
+        # gate turns it off below _COALESCE_MIN_REPLICAS.
+        from lilbee.providers.fleet import replicas as replicas_mod
+        from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
+
+        fleet, calls = self._provider(monkeypatch)
+        monkeypatch.setattr(replicas_mod, "resolve_replica_count", lambda *_a, **_k: replicas)
+        try:
+            with coalesce_embeds():
+                assert fleet.embed(["hello"]) == [[5.0]]
+            assert calls == [["hello"]]  # same answer either way
+            assert (fleet.__dict__.get("_coalescer") is not None) is coalesced
+        finally:
+            fleet.shutdown()
+
+    def test_replica_probe_runs_once_and_is_cleared_by_shutdown(self, monkeypatch) -> None:
+        # The probe touches devices, so it must not run per embed; shutdown clears
+        # it so a re-warmed fleet of a different size is not sized from stale data.
+        from lilbee.providers.fleet import replicas as replicas_mod
+        from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
+
+        fleet, _ = self._provider(monkeypatch)
+        probes = []
+
+        def _counting(*_a: object, **_k: object) -> int:
+            probes.append(1)
+            return 8
+
+        monkeypatch.setattr(replicas_mod, "resolve_replica_count", _counting)
+        try:
+            with coalesce_embeds():
+                fleet.embed(["one"])
+                fleet.embed(["two"])
+                fleet.embed(["three"])
+            assert len(probes) == 1  # cached across every embed
+        finally:
+            fleet.shutdown()
+        assert fleet._embed_replica_count is None  # cleared for the next fleet
+
+    def test_unprobeable_fleet_falls_back_to_direct_dispatch(self, monkeypatch) -> None:
+        # A fleet that cannot be probed must not fail the embed, and must not
+        # gamble on coalescing either: unknown size falls back to one replica,
+        # which is below the gate, so the safe direct path wins.
         from lilbee.providers.fleet import replicas
         from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
 
@@ -4788,6 +4844,6 @@ class TestEmbedCoalescingRoute:
             with coalesce_embeds():
                 assert fleet.embed(["hello"]) == [[5.0]]
             assert calls == [["hello"]]
-            assert fleet.__dict__.get("_coalescer") is not None
+            assert fleet.__dict__.get("_coalescer") is None
         finally:
             fleet.shutdown()

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -4700,3 +4700,74 @@ class TestAReplicaThatCannotLoadLeavesTheRoutingPool:
         assert "no device could allocate" in fleet._warm_errors[WorkerRole.EMBED]
         for client in clients:
             client.mark_unhealthy.assert_called_once()
+
+
+class TestEmbedCoalescingRoute:
+    """embed() routes through the coalescer only inside a coalesce_embeds() context."""
+
+    def _provider(self, monkeypatch) -> tuple[FleetProvider, list[list[str]]]:
+        """A provider whose fleet-touching dispatch is stubbed to record its input.
+
+        The real ``_embed_coalescer`` factory (built from the live replica count)
+        is exercised on top of the stub; ``calls`` captures what actually reached
+        the dispatch so a test can prove the route, not just the return value.
+        """
+        fleet = FleetProvider()
+        calls: list[list[str]] = []
+
+        def _batch(texts: list[str]) -> list[list[float]]:
+            calls.append(list(texts))
+            return [[float(len(t))] for t in texts]
+
+        monkeypatch.setattr(fleet, "_embed_batch", _batch)
+        return fleet, calls
+
+    def test_direct_dispatch_without_context(self, monkeypatch) -> None:
+        from lilbee.providers.fleet.embed_coalescer import coalescing_enabled
+
+        fleet, calls = self._provider(monkeypatch)
+        assert coalescing_enabled() is False
+        try:
+            assert fleet.embed(["hello"]) == [[5.0]]
+            assert calls == [["hello"]]  # reached _embed_batch directly
+            # No coalescer was ever built for the direct path.
+            assert fleet.__dict__.get("_coalescer") is None
+        finally:
+            fleet.shutdown()
+
+    def test_coalesced_dispatch_inside_context(self, monkeypatch) -> None:
+        from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
+
+        fleet, calls = self._provider(monkeypatch)
+        try:
+            with coalesce_embeds():
+                assert fleet.embed(["hello"]) == [[5.0]]
+            assert calls == [["hello"]]  # the coalescer dispatched to _embed_batch
+            assert fleet.__dict__.get("_coalescer") is not None
+        finally:
+            fleet.shutdown()
+
+    def test_empty_never_routes_to_coalescer(self, monkeypatch) -> None:
+        from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
+
+        fleet, calls = self._provider(monkeypatch)
+        try:
+            with coalesce_embeds():
+                assert fleet.embed([]) == []
+            # Empty input takes the direct path, never building the coalescer.
+            assert calls == [[]]
+            assert fleet.__dict__.get("_coalescer") is None
+        finally:
+            fleet.shutdown()
+
+    def test_shutdown_closes_the_coalescer(self, monkeypatch) -> None:
+        from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
+
+        fleet, _ = self._provider(monkeypatch)
+        with coalesce_embeds():
+            fleet.embed(["warm"])
+        coalescer = fleet.__dict__.get("_coalescer")
+        assert coalescer is not None
+        fleet.shutdown()
+        assert fleet._coalescer is None
+        assert coalescer._thread.is_alive() is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -4771,3 +4771,23 @@ class TestEmbedCoalescingRoute:
         fleet.shutdown()
         assert fleet._coalescer is None
         assert coalescer._thread.is_alive() is False
+
+    def test_unprobeable_fleet_still_builds_a_coalescer(self, monkeypatch) -> None:
+        # Sizing reads the live replica count; a fleet that cannot be probed yet
+        # must fall back to one replica rather than fail the embed outright.
+        from lilbee.providers.fleet import replicas
+        from lilbee.providers.fleet.embed_coalescer import coalesce_embeds
+
+        fleet, calls = self._provider(monkeypatch)
+
+        def _unprobeable(*_args: object, **_kwargs: object) -> int:
+            raise RuntimeError("device probe failed")
+
+        monkeypatch.setattr(replicas, "resolve_replica_count", _unprobeable)
+        try:
+            with coalesce_embeds():
+                assert fleet.embed(["hello"]) == [[5.0]]
+            assert calls == [["hello"]]
+            assert fleet.__dict__.get("_coalescer") is not None
+        finally:
+            fleet.shutdown()


### PR DESCRIPTION
## Problem

Bulk ingest of single-chunk documents (MS MARCO passages, tweets, log lines) issued one `/v1/embeddings` request per document. Each file runs on its own ingest thread, so hundreds of one-passage requests were in flight at once, but their per-request Python work (request build, JSON parse, base64 decode, vector materialization) is GIL-serialized at a few milliseconds each. That capped aggregate throughput near ~150 docs/sec no matter how fast or numerous the GPUs were: the cards starved because the client could not emit requests fast enough, not because they could not compute. `embed_batch_sequences` never helped because each caller only ever handed the client one sequence.

## Solution

Add a coalescer (`providers/fleet/embed_coalescer.py`) that merges concurrent per-file embed calls back into full batches (up to `embed_batch_sequences`), so the fixed per-request cost is paid once per batch instead of once per passage. A single batcher thread groups queued requests; a bounded pool (a couple of batches per replica) dispatches them concurrently through the existing failover routing, so the batches still fan out across replicas.

It is scoped to bulk ingest via a `coalesce_embeds()` context in `sync()`, so the interactive query and chat paths keep their direct, latency-free dispatch. One bad input is retried alone so it cannot fail its batch-mates, preserving the per-file failure isolation ingest had before requests were merged.

---
Stacked on #609 (streams the ingest plan so embedding starts before the corpus is hashed); merge that first. The two are complementary: #609 removes the plan/hash idle preamble, this removes the steady-state dispatch ceiling.
