### PR TITLE
Return float32 arrays from the embed provider contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ The full rules follow; this block is the part that gets skipped under time
 pressure, so it leads.
 
 ## Project
-The whole local AI stack in one executable: a model manager plus a search engine you can talk to. Python 3.11+, pluggable LLM providers (a managed local `llama-server` fleet by default, Ollama/OpenAI via litellm), LanceDB for vectors. Managed with `uv`. Task tracking with `beads` (`bd`). Learned behaviors with `floop`.
+The whole local AI stack in one executable: a model manager plus a search engine you can talk to. Python 3.11+, pluggable LLM providers (a managed local `llama-server` fleet by default, Ollama/OpenAI via litellm), LanceDB for vectors. Managed with `uv`. Task tracking with `beads` (`bd`).
 
 **Framing:** Lead with "the whole local AI stack in one executable". Two pillars, always both: it runs and manages the models (its own model manager, no Ollama or LM Studio needed, works with both), and it is a search engine you can talk to (cited answers). "RAG" and "local-first" are properties, not the identity. lilbee is both a standalone multipurpose tool AND an AI agent backend.
 
@@ -410,14 +410,6 @@ Run this mentally or explicitly before claiming work is done:
 10. **No new test-aware production branches** — `grep -rnE "isinstance\(self\.app, LilbeeApp\)\|test apps aren't" src/` must return zero new sites in your diff. The escape hatch was rip-and-replaced; new occurrences are regressions.
 11. **No new owned-attribute reflection** — `git diff` for added `getattr(self, "X"` and `# type: ignore[attr-defined]` lines. Each must have a written justification in the PR body or be removed.
 12. **Run the Code-Smell Triggers section grep set** — every entry above. Compare counts vs `main`. The number must not increase.
-
-### Behavior Learning (floop)
-- `floop` captures corrections and learned behaviors across sessions
-- Hooks run automatically via `~/.claude/settings.json` (session-start, dynamic-context, detect-correction)
-- `floop active` — show behaviors active in current context
-- `floop learn` — manually capture a correction/behavior
-- `floop list` — list all learned behaviors
-- `floop prompt` — generate prompt section from active behaviors
 
 ### Build & Release Artifacts
 The release ships standalone executables (Nuitka onefile) and pip wheels, each

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,10 +279,33 @@ measured 12% slower, to guard against corruption that loopback HTTP already excl
 wrong buffer length, a wrong response shape, and a wrong vector dimension are each still
 caught, the last by the store on write.
 
-**What headroom is left?** Returning numpy arrays instead of `list[float]` measures
-40 ms per 1k vectors, but it changes the embedding contract across every provider
-backend. GPUs saturate well before decode does at current fleet sizes, so that trade is
-not worth its blast radius yet.
+**Vectors stay numpy to the store.** Most of what was left after base64 was not the wire
+at all. `numpy.frombuffer` gives a float32 array, and the client then called `.tolist()`
+on it, building 4096 Python float objects per vector to satisfy a `list[list[float]]`
+signature. Nothing downstream wanted them: pyarrow and LanceDB take float32 arrays
+directly, and the vector column is float32 either way. So `LLMProvider.embed` returns
+`list[NDArray[float32]]` (`Vector` in `core/vectors.py`) and the conversion is gone.
+
+Measured end to end through `LlamaServerClient.embed` against a mock transport, so the
+figure includes envelope parse, base64 decode, and the client's own batching, not decode
+alone. 4096-dimensional, 64 per batch, median of 7 reps:
+
+| | base64 + `tolist` | base64, numpy |
+|---|---|---|
+| CPU per 1k vectors | 128 ms | **70 ms** |
+
+Base measured against itself across runs varies about 1.5%, so the 46% drop is signal.
+Isolating the decode alone puts the remaining cost near 40 ms per 1k and the one-core
+ceiling around 25,000 vectors/sec, up from roughly 9,000.
+
+Batching the conversion was not the alternative. One contiguous 2D `tolist` measured
+101 ms per 1k against 96 ms per vector: the cost is allocating float objects, not call
+overhead, so only not allocating them helps.
+
+The SDK backends (Ollama, OpenAI via litellm) receive JSON float lists from their SDK
+and convert once at the provider boundary. They are network-bound, so the conversion
+does not show up. Two places still need Python lists and say so: `MemoryRow` serializes
+to JSON on write, and LanceDB read rows (`SearchChunk.vector`) come back as lists.
 
 ---
 

--- a/src/lilbee/app/memory.py
+++ b/src/lilbee/app/memory.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
+from lilbee.core.vectors import Vector
 from lilbee.data.store import (
     LOCAL_OWNER,
     MemoryKind,
@@ -28,7 +29,7 @@ from lilbee.data.store import (
 
 def make_memory_row(
     text: str,
-    embed: Callable[[str], list[float]],
+    embed: Callable[[str], Vector],
     *,
     owner: str = LOCAL_OWNER,
     kind: MemoryKind = MemoryKind.FACT,
@@ -47,7 +48,8 @@ def make_memory_row(
         kind=kind,
         source=source,
         text=text,
-        vector=embed(text),
+        # MemoryRow serializes to JSON on write, which has no ndarray encoding.
+        vector=embed(text).tolist(),
         created_at=now,
         updated_at=now,
     )

--- a/src/lilbee/core/vectors.py
+++ b/src/lilbee/core/vectors.py
@@ -1,0 +1,9 @@
+"""The embedding vector type shared by providers, retrieval, and the store."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+Vector = npt.NDArray[np.float32]
+"""A single embedding, float32 to match the store's vector column."""

--- a/src/lilbee/data/ingest/types.py
+++ b/src/lilbee/data/ingest/types.py
@@ -9,6 +9,7 @@ from typing import NamedTuple, TypedDict
 
 from pydantic import BaseModel
 
+from lilbee.core.vectors import Vector
 from lilbee.data.store import (
     ChunkType,
     ConceptRecords,
@@ -71,7 +72,7 @@ class ChunkRecord(TypedDict):
     line_end: int
     chunk: str
     chunk_index: int
-    vector: list[float]
+    vector: Vector
 
 
 class SyncResult(BaseModel):

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -24,6 +24,7 @@ from lilbee.core.config import (
     SOURCES_TABLE,
     Config,
 )
+from lilbee.core.vectors import Vector
 from lilbee.runtime.lock import LOCK_TIMEOUT, write_lock
 
 from .fusion import fuse_arms, normalized_bm25, vector_similarity
@@ -515,7 +516,7 @@ class Store:
 
     def search(
         self,
-        query_vector: list[float],
+        query_vector: Vector,
         top_k: int | None = None,
         max_distance: float | None = None,
         query_text: str | None = None,
@@ -576,7 +577,7 @@ class Store:
     def _vector_arm(
         self,
         table: lancedb.table.Table,
-        query_vector: list[float],
+        query_vector: Vector,
         limit: int,
         chunk_type: ChunkType | None,
     ) -> list[SearchChunk]:
@@ -613,7 +614,7 @@ class Store:
         self,
         table: lancedb.table.Table,
         query_text: str,
-        query_vector: list[float],
+        query_vector: Vector,
         top_k: int,
         max_distance: float,
         chunk_type: ChunkType | None = None,
@@ -642,7 +643,7 @@ class Store:
     def _filter_and_rerank(
         self,
         results: list[SearchChunk],
-        query_vector: list[float],
+        query_vector: Vector,
         top_k: int,
         max_distance: float,
     ) -> list[SearchChunk]:
@@ -1343,7 +1344,7 @@ class Store:
 
     def search_memories(
         self,
-        query_vector: list[float],
+        query_vector: Vector,
         *,
         owner_predicate: str,
         top_k: int,
@@ -1404,7 +1405,7 @@ class Store:
         """SQL predicate matching a single memory id within *owner*'s namespace."""
         return f"id = '{escape_sql_string(memory_id)}' AND owner = '{escape_sql_string(owner)}'"
 
-    def rebuild_memory_embeddings(self, embed: Callable[[list[str]], list[list[float]]]) -> int:
+    def rebuild_memory_embeddings(self, embed: Callable[[list[str]], list[Vector]]) -> int:
         """Re-embed every memory under the current model, recreating the table.
 
         The vector column dimension is immutable, so a different-dim model needs a
@@ -1426,7 +1427,8 @@ class Store:
             memories = [MemoryRow(**r) for r in rows]
             vectors = embed([m.text for m in memories])
             for memory, vector in zip(memories, vectors, strict=True):
-                memory.vector = vector
+                # MemoryRow serializes to JSON on write, which has no ndarray encoding.
+                memory.vector = vector.tolist()
             db = self.get_db()
             db.drop_table(MEMORIES_TABLE)
             new_table = ensure_table(db, MEMORIES_TABLE, self._memories_schema())

--- a/src/lilbee/data/store/ranking.py
+++ b/src/lilbee/data/store/ranking.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 
 from lilbee.core.config import cfg
+from lilbee.core.vectors import Vector
 
 from .types import SearchChunk
 
 
-def cosine_sim(a: list[float], b: list[float]) -> float:
+def cosine_sim(a: Vector | Sequence[float], b: Vector | Sequence[float]) -> float:
     """Cosine similarity between two vectors."""
     arr_a = np.asarray(a, dtype=np.float64)
     arr_b = np.asarray(b, dtype=np.float64)
@@ -21,7 +24,7 @@ def cosine_sim(a: list[float], b: list[float]) -> float:
 
 
 def mmr_rerank(
-    query_vector: list[float],
+    query_vector: Vector,
     results: list[SearchChunk],
     top_k: int,
     mmr_lambda: float | None = None,

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, overload, run
 
 from pydantic import BaseModel
 
+from lilbee.core.vectors import Vector
+
 if TYPE_CHECKING:
     from lilbee.providers.roles import OcrBackend, WorkerRole
     from lilbee.providers.warm_progress import WarmProgress
@@ -258,7 +260,7 @@ last, when the backend reports them)."""
 class LLMProvider(Protocol):
     """Protocol for pluggable LLM backends."""
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, texts: list[str]) -> list[Vector]:
         """Embed a batch of texts, return list of vectors."""
         ...
 

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -19,6 +19,7 @@ import numpy as np
 import numpy.typing as npt
 
 from lilbee.core.config import cfg
+from lilbee.core.vectors import Vector
 from lilbee.providers.base import (
     THINK_CLOSE_TAG,
     THINK_OPEN_TAG,
@@ -850,15 +851,15 @@ class LlamaServerClient:
             return None if _is_transient_probe_failure(exc) else False
         return True
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, texts: list[str]) -> list[Vector]:
         """Embed a batch via ``/v1/embeddings``."""
         if not texts:
             # Match the in-process embedder; the server rejects an empty input.
             return []
-        vectors: list[list[float]] = []
+        vectors: list[Vector] = []
         for sub_batch in self._truncate_and_subbatch(texts, estimate=True):
             data = self._embed_subbatch(sub_batch)
-            vectors.extend(_embedding_vector(item).tolist() for item in data)
+            vectors.extend(_embedding_vector(item) for item in data)
         return vectors
 
     def _embed_subbatch(self, sub_batch: list[str]) -> list[dict[str, Any]]:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -27,6 +27,7 @@ import httpx
 
 from lilbee.catalog import clean_display_name
 from lilbee.core.config import cfg
+from lilbee.core.vectors import Vector
 from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import (
     GENERATION_RESERVE_TOKENS,
@@ -1593,10 +1594,10 @@ class FleetProvider:
             )
         return result.messages
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, texts: list[str]) -> list[Vector]:
         return self._with_rediscover(lambda: self._embed_once(texts))
 
-    def _embed_once(self, texts: list[str]) -> list[list[float]]:
+    def _embed_once(self, texts: list[str]) -> list[Vector]:
         clients = self._require_clients(WorkerRole.EMBED)
         return _call_with_failover(clients, lambda client: client.embed(texts))
 

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 from lilbee.catalog import is_rerank_ref
 from lilbee.core.config import cfg
+from lilbee.core.vectors import Vector
 from lilbee.providers.base import (
     ChatResult,
     ChatStreamItem,
@@ -82,7 +83,7 @@ class RoutingProvider(LLMProvider):
             return self._get_sdk_provider()
         return self._get_local()
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, texts: list[str]) -> list[Vector]:
         ref = parse_model_ref(cfg.embedding_model)
         return self._pick_backend(ref).embed(texts)
 

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -19,7 +19,10 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal, overload
 
+import numpy as np
+
 from lilbee.core.config import cfg
+from lilbee.core.vectors import Vector
 from lilbee.providers.base import (
     ChatMessage,
     ChatResult,
@@ -105,8 +108,8 @@ class SdkLLMProvider(LLMProvider):
         inject_provider_keys()
         self._initialized = True
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
-        """Embed texts via the configured backend."""
+    def embed(self, texts: list[str]) -> list[Vector]:
+        """Embed texts via the configured backend, converting its JSON floats to float32."""
         self._ensure_initialized()
         ref = parse_model_ref(cfg.embedding_model)
         request = EmbeddingRequest(
@@ -123,7 +126,7 @@ class SdkLLMProvider(LLMProvider):
             raise ProviderError(
                 f"Embedding failed: {exc}", provider=self._backend.provider_name
             ) from exc
-        return result.vectors
+        return [np.asarray(vec, dtype=np.float32) for vec in result.vectors]
 
     @overload
     def chat(

--- a/src/lilbee/retrieval/embedder.py
+++ b/src/lilbee/retrieval/embedder.py
@@ -6,6 +6,7 @@ import threading
 import numpy as np
 
 from lilbee.core.config import Config
+from lilbee.core.vectors import Vector
 from lilbee.data.chunk import CHARS_PER_TOKEN
 from lilbee.providers.base import LLMProvider
 from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref
@@ -101,7 +102,7 @@ class Embedder:
             self._truncated_total += 1
         return text[:budget]
 
-    def validate_vector(self, vector: list[float]) -> None:
+    def validate_vector(self, vector: Vector) -> None:
         """Validate embedding vector dimension and values."""
         if len(vector) != self._config.embedding_dim:
             raise ValueError(
@@ -130,11 +131,11 @@ class Embedder:
         """Instruction profile for the configured embedder (symmetric if unrecognized)."""
         return resolve_embedding_profile(self._config.embedding_model)
 
-    def embed(self, text: str) -> list[float]:
+    def embed(self, text: str) -> Vector:
         """Embed a single document string, return vector."""
         return self._embed_with([text], self._profile().doc_prefix)[0]
 
-    def embed_query(self, text: str) -> list[float]:
+    def embed_query(self, text: str) -> Vector:
         """Embed a single query string, applying the model's query instruction if any."""
         return self._embed_with([text], self._profile().query_instruction)[0]
 
@@ -144,7 +145,7 @@ class Embedder:
         *,
         source: str = "",
         on_progress: DetailedProgressCallback = noop_callback,
-    ) -> list[list[float]]:
+    ) -> list[Vector]:
         """Embed document texts with adaptive batching, return list of vectors."""
         return self._embed_with(
             texts, self._profile().doc_prefix, source=source, on_progress=on_progress
@@ -156,7 +157,7 @@ class Embedder:
         *,
         source: str = "",
         on_progress: DetailedProgressCallback = noop_callback,
-    ) -> list[list[float]]:
+    ) -> list[Vector]:
         """Embed query texts (query instruction applied), adaptive batching."""
         return self._embed_with(
             texts, self._profile().query_instruction, source=source, on_progress=on_progress
@@ -169,7 +170,7 @@ class Embedder:
         *,
         source: str = "",
         on_progress: DetailedProgressCallback = noop_callback,
-    ) -> list[list[float]]:
+    ) -> list[Vector]:
         """Adaptive-batched embed of *texts*, each prefixed (query/document instruction).
 
         Fires ``embed`` progress events per batch when *on_progress* is provided.
@@ -180,7 +181,7 @@ class Embedder:
         truncated_before = self.truncated_total
         total_chunks = len(texts)
         max_batch_chars = self.batch_char_budget
-        vectors: list[list[float]] = []
+        vectors: list[Vector] = []
         batch: list[str] = []
         batch_chars = 0
         for text in texts:

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -14,6 +14,7 @@ from typing_extensions import TypedDict
 
 from lilbee.core.config import Config
 from lilbee.core.config.enums import ChatMode
+from lilbee.core.vectors import Vector
 from lilbee.data.store import (
     ChunkType,
     MemoryKind,
@@ -281,9 +282,9 @@ class Searcher:
 
     def _apply_guardrails(
         self,
-        variants: list[tuple[str, list[float]]],
-        question_vec: list[float],
-    ) -> list[tuple[str, list[float]]]:
+        variants: list[tuple[str, Vector]],
+        question_vec: Vector,
+    ) -> list[tuple[str, Vector]]:
         """Drop expansion variants whose embedding drifts too far from the question."""
         if not self._config.expansion_guardrails:
             return variants
@@ -321,9 +322,7 @@ class Searcher:
         log.info("Query expansion produced %d variants", len(kept))
         return kept
 
-    def _expand_query(
-        self, question: str, question_vec: list[float]
-    ) -> list[tuple[str, list[float]]]:
+    def _expand_query(self, question: str, question_vec: Vector) -> list[tuple[str, Vector]]:
         """Return ``(variant, variant_vec)`` pairs for downstream search.
 
         LLM variants run through ``_apply_guardrails``; concept-graph
@@ -339,7 +338,7 @@ class Searcher:
         short_threshold = self._config.expansion_short_query_tokens
         skip_llm = short_threshold > 0 and len(_tokenize(question)) <= short_threshold
         try:
-            llm_variants: list[tuple[str, list[float]]] = []
+            llm_variants: list[tuple[str, Vector]] = []
             if count > 0 and not skip_llm:
                 llm_texts = list(self._llm_expand(question, count))
                 if llm_texts:
@@ -515,7 +514,7 @@ class Searcher:
     def _merge_variant_results(
         self,
         question: str,
-        query_vec: list[float],
+        query_vec: Vector,
         results: list[SearchChunk],
         seen: set[tuple[str, int]],
         top_k: int,

--- a/src/lilbee/wiki/quality.py
+++ b/src/lilbee/wiki/quality.py
@@ -16,6 +16,7 @@ import numpy as np
 from lilbee.app.services import get_services
 from lilbee.core.config import Config
 from lilbee.core.text import clean_label_for_display, is_valid_label
+from lilbee.core.vectors import Vector
 from lilbee.data.store import SearchChunk
 from lilbee.wiki.citation import strip_citation_block
 
@@ -110,7 +111,7 @@ def _mean_vector(vectors: list[list[float]]) -> list[float]:
 
 
 def _embedding_faithfulness_score(
-    body_vec: list[float],
+    body_vec: Vector,
     source_vectors: list[list[float]],
 ) -> float:
     """Cosine-similarity score between the body and the mean source vector.
@@ -132,7 +133,7 @@ def _embedding_faithfulness_score(
     from lilbee.data.store import cosine_sim
 
     mean_vec = _mean_vector(source_vectors)
-    if not mean_vec or not body_vec:
+    if len(mean_vec) == 0 or len(body_vec) == 0:
         return 0.0
     if len(mean_vec) != len(body_vec):
         log.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import warnings
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 # Opt tests out of the per-role catalog-task validator at import time so
@@ -436,10 +437,14 @@ def _default_store_mock():
 
 def _default_embedder_mock():
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1] * 768
-    embedder.embed_query.return_value = [0.1] * 768
-    embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
-    embedder.embed_query_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
+    embedder.embed_query.return_value = np.full(768, 0.1, dtype=np.float32)
+    embedder.embed_batch.side_effect = lambda texts, **kw: [
+        np.full(768, 0.1, dtype=np.float32) for _ in texts
+    ]
+    embedder.embed_query_batch.side_effect = lambda texts, **kw: [
+        np.full(768, 0.1, dtype=np.float32) for _ in texts
+    ]
     # Production reads embedder.truncated_total to compute the per-sync delta; the
     # mock never truncates, so it must report a real 0 rather than a MagicMock.
     embedder.truncated_total = 0

--- a/tests/integration/test_fleet_integration.py
+++ b/tests/integration/test_fleet_integration.py
@@ -15,6 +15,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import httpx
+import numpy as np
 import pytest
 
 from lilbee.providers.fleet.client import LlamaServerClient
@@ -57,4 +58,5 @@ def test_client_chat_plain_stream_and_tools(stub_client: LlamaServerClient) -> N
 def test_client_embeds_over_real_http(stub_client: LlamaServerClient) -> None:
     embeds = stub_client.embed(["a", "b"])
     assert len(embeds) == 2
-    assert embeds[0] == [0.5, 0.5]
+    assert embeds[0].dtype == np.float32
+    assert embeds[0].tolist() == [0.5, 0.5]

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 
+import numpy as np
 import pytest
 
 litellm = pytest.importorskip("litellm")
@@ -65,7 +66,7 @@ class TestSdkEmbed:
 
         assert len(result) == 1
         assert len(result[0]) > 0
-        assert all(isinstance(v, float) for v in result[0])
+        assert result[0].dtype == np.float32
 
     def test_embed_batch(self) -> None:
         """Batch embedding returns one vector per input."""

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -7,6 +7,7 @@ Run with:
     uv run pytest tests/integration/test_pipeline_integration.py -v
 """
 
+import numpy as np
 import pytest
 
 from lilbee.core.config import cfg
@@ -44,9 +45,10 @@ class TestEmbedder:
         from lilbee.app.services import get_services
 
         vec = get_services().embedder.embed("test sentence")
-        assert isinstance(vec, list)
+        assert isinstance(vec, np.ndarray)
+        assert vec.dtype == np.float32
         assert len(vec) > 0
-        assert all(isinstance(v, float) for v in vec)
+        assert np.isfinite(vec).all()
 
     def test_embed_batch_returns_matching_count(self):
         from lilbee.app.services import get_services

--- a/tests/providers/test_sdk_llm_provider.py
+++ b/tests/providers/test_sdk_llm_provider.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from unittest import mock
 
+import numpy as np
 import pytest
 
 from lilbee.core.config import cfg
@@ -482,7 +483,7 @@ class TestEmbed:
     def test_returns_vectors(self) -> None:
         backend = FakeBackend(embed_result=EmbeddingResult(vectors=[[0.0, 1.0]]))
         provider = SdkLLMProvider(backend)
-        assert provider.embed(["hi"]) == [[0.0, 1.0]]
+        assert [v.tolist() for v in provider.embed(["hi"])] == [[0.0, 1.0]]
 
     def test_request_includes_api_base_for_ollama(self) -> None:
         backend = FakeBackend()
@@ -510,6 +511,17 @@ class TestEmbed:
         assert req.ref.name == "org/Custom-Embed-GGUF/custom-Q4_K_M.gguf"
         assert req.ref.provider == "local"
         assert req.api_base is None
+
+    def test_converts_sdk_float_lists_to_float32_arrays(self) -> None:
+        # The SDK hands back JSON floats; the provider contract is float32 arrays.
+        backend = FakeBackend(embed_result=EmbeddingResult(vectors=[[0.25, -0.5], [1.0, 0.0]]))
+        vectors = SdkLLMProvider(backend).embed(["a", "b"])
+        assert all(isinstance(v, np.ndarray) and v.dtype == np.float32 for v in vectors)
+        assert [v.tolist() for v in vectors] == [[0.25, -0.5], [1.0, 0.0]]
+
+    def test_embed_of_no_texts_returns_no_vectors(self) -> None:
+        backend = FakeBackend(embed_result=EmbeddingResult(vectors=[]))
+        assert SdkLLMProvider(backend).embed([]) == []
 
     def test_wraps_backend_errors(self) -> None:
         backend = FakeBackend(raise_embed=RuntimeError("oops"))

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 from litestar.testing import AsyncTestClient
 
@@ -43,7 +44,7 @@ def mock_svc():
     from tests.conftest import make_mock_services
 
     embedder = mock.MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
     embedder.validate_model.return_value = None
     services = make_mock_services(embedder=embedder)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,17 +3,18 @@
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pytest
 
 from lilbee.core.config import cfg
 
 
 def _fake_embed(text):
-    return [0.1] * 768
+    return np.full(768, 0.1, dtype=np.float32)
 
 
 def _fake_embed_batch(texts, **kwargs):
-    return [[0.1] * 768 for _ in texts]
+    return [np.full(768, 0.1, dtype=np.float32) for _ in texts]
 
 
 @pytest.fixture(autouse=True)
@@ -104,7 +105,9 @@ class TestCreate:
         from lilbee import Lilbee
 
         custom_provider = mock.MagicMock(
-            embed=mock.MagicMock(side_effect=lambda texts: [[0.5] * 768 for _ in texts]),
+            embed=mock.MagicMock(
+                side_effect=lambda texts: [np.full(768, 0.5, dtype=np.float32) for _ in texts]
+            ),
             pull_model=mock.MagicMock(),
             shutdown=mock.MagicMock(),
         )

--- a/tests/test_app_memory.py
+++ b/tests/test_app_memory.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from lilbee.app import memory as app_memory
@@ -26,7 +27,7 @@ def svc():
     store.add_memory.return_value = "stored-id"
     store.update_memory.return_value = True
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1, 0.2]
+    embedder.embed.return_value = np.asarray([0.1, 0.2], dtype=np.float32)
     services = make_mock_services(
         store=store,
         embedder=embedder,
@@ -76,7 +77,7 @@ class TestRemember:
         assert record.kind is MemoryKind.PREFERENCE
         assert record.owner == LOCAL_OWNER
         assert record.shared is True
-        assert record.vector == [0.1, 0.2]
+        assert record.vector == pytest.approx([0.1, 0.2])
         assert len(record.id) == 32  # uuid4 hex
 
     def test_agent_owner_extracted_memory_defaults(self, svc):

--- a/tests/test_chat_memory_commands.py
+++ b/tests/test_chat_memory_commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 from textual.app import ComposeResult
 
@@ -33,7 +34,7 @@ def mock_svc():
     store = MagicMock()
     store.add_memory.return_value = "id123"
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     embedder.embedding_available.return_value = True
     services = make_mock_services(store=store, embedder=embedder)
     set_services(services)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
+import numpy as np
 import pytest
 from typer.testing import CliRunner
 
@@ -58,7 +59,7 @@ def mock_svc():
     # No entity schema induced unless a test persists one.
     store.entity_schema_state.return_value = None
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     embedder.embed_batch.return_value = []
     services = make_mock_services(searcher=searcher, store=store, embedder=embedder)
     svc_mod.set_services(services)

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from typer.testing import CliRunner
 
@@ -38,7 +39,7 @@ def mock_svc():
     store.search_memories.return_value = []
     store.delete_memory.return_value = True
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     services = make_mock_services(store=store, embedder=embedder)
     svc_mod.set_services(services)
     yield services

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -3,6 +3,7 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from lilbee.core.config import cfg
@@ -107,9 +108,31 @@ class TestEmbedBatch:
         assert len(call_input[1]) == embedder.embed_char_budget
 
 
+class TestVectorType:
+    def test_embed_returns_the_provider_array_unconverted(self, embedder, mock_provider):
+        vector = np.full(768, 0.1, dtype=np.float32)
+        mock_provider.embed.return_value = [vector]
+        assert embedder.embed("test") is vector
+
+    def test_embed_batch_elements_stay_float32_arrays(self, embedder, mock_provider):
+        mock_provider.embed.return_value = [np.zeros(768, dtype=np.float32) for _ in range(2)]
+        vectors = embedder.embed_batch(["a", "b"])
+        assert all(isinstance(v, np.ndarray) and v.dtype == np.float32 for v in vectors)
+
+
 class TestValidateVector:
     def test_valid_vector_passes(self, embedder):
-        embedder.validate_vector([0.1] * 768)
+        embedder.validate_vector(np.full(768, 0.1, dtype=np.float32))
+
+    def test_array_wrong_dim_raises(self, embedder):
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            embedder.validate_vector(np.zeros(2, dtype=np.float32))
+
+    def test_array_invalid_value_raises(self, embedder):
+        vector = np.zeros(768, dtype=np.float32)
+        vector[5] = np.nan
+        with pytest.raises(ValueError, match="invalid value at index 5"):
+            embedder.validate_vector(vector)
 
     def test_embed_wrong_dim_raises(self, embedder, mock_provider):
         mock_provider.embed.return_value = [[0.1, 0.2]]

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -8,6 +8,7 @@ from itertools import pairwise
 
 import httpx
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from lilbee.providers.base import ProviderError
@@ -35,6 +36,11 @@ def _embed_body(vectors: list[list[float]]) -> dict[str, object]:
             for index, vec in enumerate(vectors)
         ]
     }
+
+
+def _as_lists(vectors: list[npt.NDArray[np.float32]]) -> list[list[float]]:
+    """The float32 vectors ``embed`` returns, as plain lists for value comparison."""
+    return [vec.tolist() for vec in vectors]
 
 
 _STREAM_BODY = (
@@ -138,7 +144,7 @@ def test_embed_retries_transient_gateway_error_then_succeeds(monkeypatch) -> Non
             return httpx.Response(502, text="Bad Gateway")
         return httpx.Response(200, json=_embed_body([[0.25, 0.5]]))
 
-    assert _client(handler).embed(["hello"]) == [[0.25, 0.5]]
+    assert _as_lists(_client(handler).embed(["hello"])) == [[0.25, 0.5]]
     assert calls["n"] == 3
 
 
@@ -173,7 +179,7 @@ def test_embed_retries_on_busy_then_succeeds(monkeypatch) -> None:
             return httpx.Response(429, json={"error": "Too many requests"})
         return httpx.Response(200, json=_embed_body([[0.25, 0.5]]))
 
-    assert _client(handler).embed(["hello"]) == [[0.25, 0.5]]
+    assert _as_lists(_client(handler).embed(["hello"])) == [[0.25, 0.5]]
     assert calls["n"] == 3  # two 429s retried, third succeeds
 
 
@@ -211,7 +217,7 @@ def test_embed_rides_out_cold_start_past_interactive_budget(monkeypatch) -> None
             return httpx.Response(429, json={"error": "warming"})
         return httpx.Response(200, json=_embed_body([[0.75]]))
 
-    assert _client(handler).embed(["x"]) == [[0.75]]
+    assert _as_lists(_client(handler).embed(["x"])) == [[0.75]]
     assert calls["n"] == warmup + 1
 
 
@@ -238,7 +244,7 @@ def test_embed_with_cold_load_deadline_rides_out_more_429s_than_attempt_cap(monk
     http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://gpu0")
     client = LlamaServerClient("http://gpu0", "test-model", http=http, embed_busy_deadline_s=600.0)
     client._needs_alternation = False
-    assert client.embed(["x"]) == [[0.75]]
+    assert _as_lists(client.embed(["x"])) == [[0.75]]
     assert calls["n"] == warmup + 1
 
 
@@ -681,7 +687,13 @@ def test_chat_stream_items_requests_include_usage() -> None:
 
 
 def test_embed_returns_vectors() -> None:
-    assert _client().embed(["a", "b"]) == [[0.25, 0.5], [0.75]]
+    got = _client().embed(["a", "b"])
+    assert [vec.tolist() for vec in got] == [[0.25, 0.5], [0.75]]
+
+
+def test_embed_returns_float32_arrays_not_python_float_lists() -> None:
+    got = _client().embed(["a", "b"])
+    assert all(isinstance(vec, np.ndarray) and vec.dtype == np.float32 for vec in got)
 
 
 def test_embed_requests_base64_encoded_vectors() -> None:
@@ -692,7 +704,8 @@ def test_embed_requests_base64_encoded_vectors() -> None:
         seen["encoding_format"] = body.get("encoding_format")
         return httpx.Response(200, json=_embed_body([[0.25, -0.5]]))
 
-    assert _client(handler).embed(["a"]) == [[0.25, -0.5]]
+    got = _client(handler).embed(["a"])
+    assert [vec.tolist() for vec in got] == [[0.25, -0.5]]
     assert seen["encoding_format"] == "base64"
 
 
@@ -703,8 +716,8 @@ def test_embed_decodes_base64_vectors_exactly() -> None:
         return httpx.Response(200, json=_embed_body(vectors))
 
     decoded = _client(handler).embed(["a", "b"])
-    expected = np.asarray(vectors, dtype="<f4").tolist()
-    assert decoded == expected
+    expected = np.asarray(vectors, dtype="<f4")
+    assert all(np.array_equal(got, want) for got, want in zip(decoded, expected, strict=True))
 
 
 @pytest.mark.parametrize(
@@ -769,7 +782,7 @@ def test_embed_truncates_oversize_input_via_server_tokenizer() -> None:
         return httpx.Response(200, json=_embed_body([[0.5]]))
 
     out = _capped_client(handler, cap=3).embed(["a very long input"])
-    assert out == [[0.5]]
+    assert _as_lists(out) == [[0.5]]
     assert seen["detok_tokens"] == [10, 11, 12]  # first cap tokens
     assert seen["embedded"] == ["trunc"]
 
@@ -785,7 +798,7 @@ def test_embed_keeps_input_within_cap_unchanged() -> None:
         seen["embedded"] = json.loads(request.content)["input"]
         return httpx.Response(200, json=_embed_body([[0.5]]))
 
-    assert _capped_client(handler, cap=3).embed(["short"]) == [[0.5]]
+    assert _as_lists(_capped_client(handler, cap=3).embed(["short"])) == [[0.5]]
     assert seen["embedded"] == ["short"]  # original text passed through
 
 
@@ -1860,7 +1873,7 @@ def test_embed_retries_with_exact_tokenize_on_context_overflow() -> None:
 
     # cap=10 so "dense" (est 2) is trusted and sent untruncated on the first try.
     out = _capped_client(handler, 10).embed(["dense"])
-    assert out == [[0.5]]
+    assert _as_lists(out) == [[0.5]]
     assert calls["embed"] == 2  # first overflowed, retry succeeded
     assert calls["tokenize"] >= 1  # retry used exact tokenization
 
@@ -1887,7 +1900,7 @@ def test_embed_retries_exact_on_batch_overflow_500() -> None:
             return httpx.Response(200, json=_embed_body([[0.5]]))
         return httpx.Response(404)
 
-    assert _capped_client(handler, 10).embed(["dense"]) == [[0.5]]
+    assert _as_lists(_capped_client(handler, 10).embed(["dense"])) == [[0.5]]
     assert calls["embed"] == 2
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest import mock
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 
 from lilbee.app.services import set_services
@@ -41,7 +42,7 @@ def mock_svc():
     from tests.conftest import make_mock_services
 
     embedder = mock.MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
     embedder.validate_model.return_value = None
     services = make_mock_services(embedder=embedder)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock, Mock
 
+import numpy as np
 import pytest
 
 import lilbee.app.services as svc_mod
@@ -79,7 +80,7 @@ def mock_svc():
     store.drop_all.side_effect = lambda: _sources.clear()
     store.ensure_fts_index.return_value = None
     embedder = MagicMock()
-    embedder.embed.side_effect = lambda text, **kw: [0.1] * 768
+    embedder.embed.side_effect = lambda text, **kw: np.full(768, 0.1, dtype=np.float32)
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
     # Real int so sync()'s truncated_total delta is 0, not a coerced MagicMock.
     embedder.truncated_total = 0

--- a/tests/test_memory_rebuild_sync.py
+++ b/tests/test_memory_rebuild_sync.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import numpy as np
+
 from lilbee.app.services import set_services
 from lilbee.core.config import cfg
 from lilbee.data.ingest import sync
@@ -20,7 +22,7 @@ async def test_force_rebuild_preserves_and_reembeds_memory(tmp_path):
     cfg.lancedb_dir = tmp_path / "lancedb"
     cfg.documents_dir = tmp_path / "docs"
     store = Store(cfg)
-    new_vector = [0.5] * cfg.embedding_dim
+    new_vector = np.full(cfg.embedding_dim, 0.5, dtype=np.float32)
     embedder = MagicMock()
     embedder.embedding_available.return_value = True
     embedder.embed_batch.return_value = [new_vector]
@@ -50,7 +52,7 @@ async def test_force_rebuild_preserves_and_reembeds_memory(tmp_path):
         await sync(force_rebuild=True, quiet=True)
         memories = store.get_memories(owner_predicate=local_owner_predicate())
         assert [m.text for m in memories] == ["kept"]
-        assert memories[0].vector == new_vector
+        assert memories[0].vector == new_vector.tolist()
         embedder.embed_batch.assert_called_once_with(["kept"])
     finally:
         set_services(None)

--- a/tests/test_memory_recall.py
+++ b/tests/test_memory_recall.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import numpy as np
+
 from lilbee.core.config import cfg
 from lilbee.data.store import LOCAL_OWNER, MemoryKind, MemoryRow, MemorySource
 from lilbee.retrieval.query import Searcher
@@ -91,7 +93,7 @@ class TestSearcherMemoryBlock:
         store.search_memories.return_value = [_mem("uses rust")]
         embedder = MagicMock()
         embedder.embedding_available.return_value = True
-        embedder.embed_query.return_value = [0.1, 0.2]
+        embedder.embed_query.return_value = np.asarray([0.1, 0.2], dtype=np.float32)
         block = _searcher(store, embedder)._memory_block("q")
         assert "uses rust" in block
         embedder.embed_query.assert_called_once_with("q")
@@ -108,7 +110,7 @@ class TestSearcherMemoryBlock:
         store.search_memories.return_value = []
         embedder = MagicMock()
         embedder.embedding_available.return_value = True
-        embedder.embed_query.return_value = [0.1, 0.2]
+        embedder.embed_query.return_value = np.asarray([0.1, 0.2], dtype=np.float32)
         _searcher(store, embedder)._memory_block("q")
         assert store.get_memories.call_args.kwargs["owner_predicate"] == human_recall_predicate()
         assert store.search_memories.call_args.kwargs["owner_predicate"] == human_recall_predicate()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,6 +3,7 @@
 from typing import ClassVar
 from unittest import mock
 
+import numpy as np
 import pytest
 
 from lilbee.app.services import get_services, set_services
@@ -510,7 +511,7 @@ class TestSearchContext:
         original = _make_result(source="a.md", chunk_index=0)
         expanded = _make_result(source="b.md", chunk_index=0)
         mock_svc.store.search.side_effect = [[original], [expanded]]
-        mock_svc.embedder.embed.return_value = [0.1] * 768
+        mock_svc.embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
         mock_svc.provider.chat.return_value = _text_result("kubernetes deployment internals")
         results = get_services().searcher.search("kubernetes deployment internals")
         assert len(results) == 2
@@ -521,7 +522,7 @@ class TestSearchContext:
     def test_expansion_deduplicates(self, mock_svc):
         same = _make_result(source="a.md", chunk_index=0)
         mock_svc.store.search.side_effect = [[same], [same]]
-        mock_svc.embedder.embed.return_value = [0.1] * 768
+        mock_svc.embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
         mock_svc.provider.chat.return_value = _text_result("kubernetes deployment internals")
         results = get_services().searcher.search("kubernetes deployment internals")
         assert len(results) == 1

--- a/tests/test_server_memory.py
+++ b/tests/test_server_memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from litestar.testing import TestClient
 
@@ -47,7 +48,7 @@ def store():
     store.update_memory.return_value = True
     store.delete_memory.return_value = True
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     svc_mod.set_services(make_mock_services(store=store, embedder=embedder))
     yield store
     svc_mod.set_services(None)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,9 +3,10 @@
 from contextlib import contextmanager
 from unittest import mock
 
+import numpy as np
 import pytest
 
-from lilbee.core.config import META_TABLE, cfg
+from lilbee.core.config import CHUNKS_TABLE, META_TABLE, cfg
 from lilbee.data.store import (
     ChunkType,
     CitationRecord,
@@ -52,6 +53,49 @@ def _make_records(n=3, dim=None, chunk_type="raw"):
         }
         for i in range(n)
     ]
+
+
+def _axis_record(source, axis, dim):
+    """A chunk record whose vector is the float32 array the embedder now returns."""
+    vector = np.zeros(dim, dtype=np.float32)
+    vector[axis] = 1.0
+    return {
+        "source": source,
+        "content_type": "text",
+        "chunk_type": "raw",
+        "page_start": 0,
+        "page_end": 0,
+        "line_start": 0,
+        "line_end": 0,
+        "chunk": f"{source} body",
+        "chunk_index": 0,
+        "vector": vector,
+    }
+
+
+class TestNumpyVectorRoundTrip:
+    """Embedder vectors reach LanceDB as float32 arrays, never as Python float lists."""
+
+    def test_stores_array_vectors_bit_identically(self, store):
+        dim = cfg.embedding_dim
+        vector = np.linspace(-1.0, 1.0, dim, dtype=np.float32)
+        record = _axis_record("exact.md", 0, dim) | {"vector": vector}
+        store.add_chunks([record])
+        row = store.open_table(CHUNKS_TABLE).search().to_list()[0]
+        assert np.array_equal(np.asarray(row["vector"], dtype=np.float32), vector)
+
+    def test_array_query_vector_finds_its_own_row(self, store):
+        dim = cfg.embedding_dim
+        store.add_chunks([_axis_record("a.md", 0, dim), _axis_record("b.md", 1, dim)])
+        query = np.zeros(dim, dtype=np.float32)
+        query[1] = 1.0
+        hits = store.search(query, top_k=1, max_distance=0, query_text=None)
+        assert [h.source for h in hits] == ["b.md"]
+
+    def test_array_dim_mismatch_is_rejected(self, store):
+        record = _axis_record("wrong.md", 0, cfg.embedding_dim - 1)
+        with pytest.raises(ValueError, match="Vector dimension mismatch"):
+            store.add_chunks([record])
 
 
 class TestWriteLockDir:

--- a/tests/test_store_memory.py
+++ b/tests/test_store_memory.py
@@ -2,6 +2,8 @@
 
 from datetime import UTC, datetime
 
+import numpy as np
+import numpy.typing as npt
 import pytest
 
 from lilbee.core.config import MEMORIES_TABLE, cfg
@@ -45,6 +47,13 @@ def store(test_config):
 def _unit_vector(dim: int, axis: int) -> list[float]:
     """A unit vector along *axis* so cosine distance between distinct axes is 1.0."""
     vec = [0.0] * dim
+    vec[axis] = 1.0
+    return vec
+
+
+def _unit_array(dim: int, axis: int) -> npt.NDArray[np.float32]:
+    """:func:`_unit_vector` as the float32 array the embedder hands the store."""
+    vec = np.zeros(dim, dtype=np.float32)
     vec[axis] = 1.0
     return vec
 
@@ -340,8 +349,8 @@ class TestRebuildEmbeddings:
         new_dim = 4
         store._config.embedding_dim = new_dim
 
-        def embed(texts: list[str]) -> list[list[float]]:
-            return [[0.5] * new_dim for _ in texts]
+        def embed(texts: list[str]) -> list[npt.NDArray[np.float32]]:
+            return [np.full(new_dim, 0.5, dtype=np.float32) for _ in texts]
 
         count = store.rebuild_memory_embeddings(embed)
         assert count == 1
@@ -353,12 +362,13 @@ class TestRebuildEmbeddings:
         store.add_memory(_memory(store, text="x", axis=0))
         dim = store._config.embedding_dim
 
-        def embed(texts: list[str]) -> list[list[float]]:
-            return [_unit_vector(dim, 3) for _ in texts]
+        def embed(texts: list[str]) -> list[npt.NDArray[np.float32]]:
+            return [_unit_array(dim, 3) for _ in texts]
 
         store.rebuild_memory_embeddings(embed)
         got = store.get_memories(owner_predicate=LOCAL_PREDICATE)[0]
         assert got.vector[3] == 1.0
+        assert isinstance(got.vector, list)  # the row serializes as JSON, never as an ndarray
 
     def test_snapshot_and_embed_run_under_write_lock(self, store):
         # The read+embed must hold the lock, or a concurrent add_memory
@@ -369,9 +379,9 @@ class TestRebuildEmbeddings:
         dim = store._config.embedding_dim
         locked_during: list[bool] = []
 
-        def embed(texts: list[str]) -> list[list[float]]:
+        def embed(texts: list[str]) -> list[npt.NDArray[np.float32]]:
             locked_during.append(_write_mutex.locked())
-            return [_unit_vector(dim, 3) for _ in texts]
+            return [_unit_array(dim, 3) for _ in texts]
 
         store.rebuild_memory_embeddings(embed)
         assert locked_during == [True]  # embed ran while the write lock was held

--- a/tests/test_tui_remember_helper.py
+++ b/tests/test_tui_remember_helper.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from lilbee.app import services as svc_mod
@@ -24,7 +25,7 @@ def mock_svc():
     store = MagicMock()
     store.add_memory.return_value = "id123"
     embedder = MagicMock()
-    embedder.embed.return_value = [0.1] * 768
+    embedder.embed.return_value = np.full(768, 0.1, dtype=np.float32)
     embedder.embedding_available.return_value = True
     services = make_mock_services(store=store, embedder=embedder)
     svc_mod.set_services(services)

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from lilbee.core.config import CHUNKS_TABLE, cfg
@@ -58,7 +59,7 @@ def _stub_wiki_index_services(monkeypatch):
     """
     svc = MagicMock()
     svc.embedder.embed_batch.side_effect = lambda texts, **kw: [
-        [0.1] * cfg.embedding_dim for _ in texts
+        np.full(cfg.embedding_dim, 0.1, dtype=np.float32) for _ in texts
     ]
     monkeypatch.setattr("lilbee.wiki.page.get_services", lambda: svc)
     monkeypatch.setattr("lilbee.wiki.quality.get_services", lambda: svc)
@@ -193,6 +194,15 @@ class TestEmbeddingFaithfulness:
     def test_score_zero_for_missing_inputs(self):
         assert _embedding_faithfulness_score([], [[1.0]]) == 0.0
         assert _embedding_faithfulness_score([1.0], []) == 0.0
+
+    def test_scores_the_float32_array_the_embedder_returns(self):
+        # The body vector arrives from embed_batch as an ndarray; the source
+        # vectors stay lancedb lists.
+        body = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+        assert _embedding_faithfulness_score(body, [[1.0, 0.0, 0.0]]) == pytest.approx(1.0)
+
+    def test_score_zero_for_empty_body_array(self):
+        assert _embedding_faithfulness_score(np.zeros(0, dtype=np.float32), [[1.0]]) == 0.0
 
     def test_score_zero_on_dim_mismatch_and_warns(self, caplog: pytest.LogCaptureFixture):
         """Off-shape body vector vs source-mean vector returns 0.0 with a warning."""


### PR DESCRIPTION
## Problem

`LLMProvider.embed` was typed `list[list[float]]`. The fleet client decoded each base64 vector into a float32 numpy array and then called `.tolist()` on it, allocating 4096 Python float objects per vector under the GIL. Nothing downstream wanted them: pyarrow and LanceDB take float32 arrays directly, and the chunks vector column is float32 either way.

## Solution

The contract is now `list[Vector]`, where `Vector = NDArray[np.float32]` lives in a new `core/vectors.py` (layer 0, the only layer `providers`, `retrieval` and `data/store` all import from). The fleet client drops the `.tolist()`. The SDK backends convert their SDK's JSON floats once at the provider boundary, where they are network bound and it does not show.

### Measured

End to end through `LlamaServerClient.embed` against a mock transport, so the figure carries envelope parse, base64 decode and the client's own batching, not decode alone. 4096-dim, 64 per batch, median of 7 reps:

| | base64 + `tolist` | base64, numpy |
|---|---|---|
| CPU per 1k vectors | 128 ms | **70 ms** |

Interleaved runs, with a null experiment to establish the noise floor:

| run | vector element | median CPU ms per 1k |
|---|---|---|
| base (null 1) | `list` | 127.6 |
| base (null 2) | `list` | 129.5 |
| head | `ndarray` | 69.6 |
| base | `list` | 129.5 |
| head | `ndarray` | 69.8 |

Base against itself varies about 1.5%, so the 46% drop is signal rather than drift. Isolating the decode alone puts the remaining cost near 40 ms per 1k and the one-core ceiling around 25,000 vectors/sec, up from roughly 9,000. Against the original JSON-float wire that ceiling was about 1,300.

Batching the conversion was not an alternative: one contiguous 2D `tolist` measures 101 ms per 1k against 96 ms per vector, because the cost is allocating the float objects, not call overhead.

### Details worth knowing

- `SearchChunk.vector` and `MemoryRow.vector` stay `list[float]`. Those are LanceDB read rows, which always come back as lists. Only query params and write records carry numpy.
- The two places that write a vector into a JSON-serialized pydantic row (`make_memory_row`, `rebuild_memory_embeddings`) convert at their own boundary. Without that, `model_dump(mode="json")` raises `PydanticSerializationError` on an ndarray.
- Fixes a latent crash the new contract would otherwise have introduced in the wiki faithfulness scorer, which tested a body vector for emptiness with `not body_vec`. That raises on an ndarray, and it sits outside the scorer's `except` block.
- `EmbeddingResult.vectors` on the SDK adapter Protocol deliberately stays `list[list[float]]`. That seam carries SDK-shaped data, so the conversion happens once above it rather than in every adapter.

Also carries one unrelated commit: AGENTS.md still documented `floop`, which is no longer part of the workflow.
