### PR TITLE
Run exit-time teardown where a second Ctrl-C cannot abandon it

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -312,8 +312,8 @@ def peek_services() -> Services | None:
     return _state.singleton
 
 
-# Serializes the singleton swap in reset_services: the hard-exit teardown
-# thread and the atexit hook can race, and both tearing down the same container
+# Serializes the singleton swap in reset_services: a signal's teardown thread
+# and an exiting caller's can race, and both tearing down the same container
 # would double-close the store.
 _reset_swap_lock = threading.Lock()
 
@@ -323,10 +323,10 @@ def reset_services() -> None:
 
     Swap the module reference to ``None`` *before* tearing the old instances
     down, so a new caller never observes a half-closed container. The swap is
-    locked so concurrent callers (the hard-exit teardown thread plus atexit)
-    tear the container down exactly once. On the shared HTTP daemon every entry
-    point that would call this mid-flight is refused, so it only ever runs
-    single-client (CLI, TUI, stdio MCP).
+    locked so concurrent callers (a signal's teardown thread plus an exiting
+    one) tear the container down exactly once. On the shared HTTP daemon every
+    entry point that would call this mid-flight is refused, so it only ever
+    runs single-client (CLI, TUI, stdio MCP).
     """
     with _reset_swap_lock:
         old = _state.singleton
@@ -418,7 +418,7 @@ class _EngineLifecycle:
 
 
 def wait_for_hard_exit_teardown() -> None:
-    """Block until a signal-driven teardown thread (if any) finishes.
+    """Block until any teardown thread (signal-driven or exit-driven) finishes.
 
     Lets ``serve`` hold its OS locks through the fleet stop, so a successor
     cannot acquire them while this server's models still occupy memory.
@@ -426,6 +426,20 @@ def wait_for_hard_exit_teardown() -> None:
     for thread in threading.enumerate():
         if thread.name == _HARD_EXIT_THREAD_NAME:
             thread.join()
+
+
+def reset_services_on_exit() -> None:
+    """Tear the container down on a thread no signal reaches, and wait for it.
+
+    Engine release waits on the fleet build lock before it releases anything, so
+    a Ctrl-C on the main thread skips the release, and atexit cannot retry: the
+    singleton is already cleared. The teardown thread is non-daemon and takes no
+    signals, so an interrupt breaks only the join here.
+    """
+    if peek_services() is None:
+        return
+    threading.Thread(target=reset_services, name=_HARD_EXIT_THREAD_NAME).start()
+    wait_for_hard_exit_teardown()
 
 
 def _teardown_for_signal(signum: int) -> None:
@@ -444,4 +458,4 @@ def install_engine_lifecycle_hooks() -> None:
     _lifecycle.install()
 
 
-atexit.register(reset_services)
+atexit.register(reset_services_on_exit)

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -9,7 +9,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from lilbee.app.services import reset_services
+from lilbee.app.services import reset_services_on_exit
 from lilbee.cli.tui.log_routing import setup_tui_log_file
 
 
@@ -112,4 +112,4 @@ def run_tui(*, initial_view: str | None = None) -> None:
     finally:
         _restore_native_stderr(stderr_redirect)
         shutdown_executor()
-        reset_services()
+        reset_services_on_exit()

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -778,7 +778,12 @@ def _is_live_llama_swap(state: SwapState) -> bool:
 
 
 def _stop_stale_swap(state: SwapState) -> None:
-    """TERM-then-KILL a stale llama-swap's group and reap the servers it spawned."""
+    """TERM-then-KILL a stale llama-swap's group and reap the servers it spawned.
+
+    Swept as wide as ``_stop_own_fleet``: a reparented or respawned server is no
+    longer a descendant, and every caller unlinks the record next, so the member
+    ports are the last thing that can match it.
+    """
     children = _live_children(state.pid)
     try:
         proc = psutil.Process(state.pid)
@@ -791,7 +796,7 @@ def _stop_stale_swap(state: SwapState) -> None:
         except psutil.TimeoutExpired:
             _signal_stale(state, _SIGKILL)
             _await_killed([proc])
-    _reap_survivors(children)
+    _reap_survivors(children + _find_orphan_servers(state.member_ports))
 
 
 def _signal_stale(state: SwapState, sig: int) -> None:

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -850,6 +850,28 @@ class TestStopStaleSwap:
         sm._stop_stale_swap(sm.SwapState(pid=7777, pgid=None))
         assert survivor.terminated is True
 
+    def test_reaps_member_port_servers_the_descendant_snapshot_missed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A server that was reparented away from the swap, or respawned after
+        # the snapshot, is no longer a descendant; only the recorded member
+        # ports find it. Every caller unlinks the record straight after, so a
+        # miss here strands it with nothing left to match it against.
+        port_server = _FakeChild(running=True)
+        stale = _FakePsProcess(7777, cmdline=["/opt/llama-swap"])
+        _patch_psutil_process(monkeypatch, {7777: stale})
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
+        swept: list[tuple[int, ...]] = []
+        monkeypatch.setattr(
+            sm,
+            "_find_orphan_servers",
+            lambda ports: swept.append(ports) or [port_server],
+        )
+        monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: ([], []))
+        sm._stop_stale_swap(sm.SwapState(pid=7777, pgid=None, member_ports=(9101, 9102)))
+        assert swept == [(9101, 9102)]
+        assert port_server.terminated is True
+
 
 class TestAtomicStateWrite:
     def test_config_and_state_both_land_via_replace_with_no_tmp_leftovers(

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -14,6 +14,7 @@ from lilbee.app.services import (
     install_engine_lifecycle_hooks,
     peek_services,
     reset_services,
+    reset_services_on_exit,
     set_services,
     wait_for_hard_exit_teardown,
 )
@@ -193,3 +194,47 @@ def test_wait_for_hard_exit_teardown_joins_the_running_thread():
 
 def test_wait_for_hard_exit_teardown_without_a_teardown_is_a_noop():
     wait_for_hard_exit_teardown()
+
+
+def test_exit_teardown_runs_off_the_main_thread():
+    """Only the main thread takes signals, so an exit teardown must leave it."""
+    provider = _install_stub_services()
+    runners: list[threading.Thread] = []
+    provider.shutdown.side_effect = lambda: runners.append(threading.current_thread())
+
+    reset_services_on_exit()
+
+    assert runners
+    assert runners[0] is not threading.main_thread()
+    assert runners[0].daemon is False
+    assert peek_services() is None
+
+
+def test_exit_teardown_finishes_after_the_wait_is_interrupted(monkeypatch):
+    """A second Ctrl-C must abandon only the wait, never the fleet stop."""
+    provider = _install_stub_services()
+    release = threading.Event()
+    provider.shutdown.side_effect = lambda: release.wait(timeout=5)
+    monkeypatch.setattr(
+        services_mod,
+        "wait_for_hard_exit_teardown",
+        MagicMock(side_effect=KeyboardInterrupt),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        reset_services_on_exit()
+
+    release.set()
+    _join_teardown()
+    provider.shutdown.assert_called_once()
+
+
+def test_exit_teardown_without_services_starts_no_thread(monkeypatch):
+    """Every process exit runs this hook; an unused container costs no thread."""
+    reset_services()
+    spawned = MagicMock()
+    monkeypatch.setattr(services_mod.threading, "Thread", spawned)
+
+    reset_services_on_exit()
+
+    spawned.assert_not_called()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -11502,7 +11502,7 @@ def test_run_tui_keyboard_interrupt_during_shutdown_propagates():
     with (
         patch("lilbee.cli.tui.app.LilbeeApp", return_value=mock_app),
         patch("lilbee.cli.sync.shutdown_executor", side_effect=KeyboardInterrupt),
-        patch("lilbee.cli.tui.reset_services") as mock_reset,
+        patch("lilbee.cli.tui.reset_services_on_exit") as mock_reset,
         pytest.raises(KeyboardInterrupt),
     ):
         run_tui()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -3777,7 +3777,7 @@ class TestRunTuiKeyboardInterrupt:
             MockApp.return_value.run.side_effect = KeyboardInterrupt
             with (
                 mock.patch("lilbee.cli.sync.shutdown_executor"),
-                mock.patch("lilbee.cli.tui.reset_services"),
+                mock.patch("lilbee.cli.tui.reset_services_on_exit"),
             ):
                 from lilbee.cli.tui import run_tui
 
@@ -3789,7 +3789,7 @@ class TestRunTuiKeyboardInterrupt:
             MockApp.return_value.run.side_effect = KeyboardInterrupt
             with (
                 mock.patch("lilbee.cli.sync.shutdown_executor") as mock_shutdown,
-                mock.patch("lilbee.cli.tui.reset_services") as mock_reset,
+                mock.patch("lilbee.cli.tui.reset_services_on_exit") as mock_reset,
             ):
                 from lilbee.cli.tui import run_tui
 


### PR DESCRIPTION
## Problem

Exit-time teardown ran inline on the main thread. Engine release waits on the fleet build lock before it releases anything, so a Ctrl-C landing in that wait skipped the release entirely, and atexit could not retry because `reset_services` clears the singleton first. On macOS, where no OS binding backs teardown up, the fleet keeps running.

`_stop_stale_swap` reaped only the swap's descendants, and its callers unlink the record holding the member ports right after — leaving a reparented or respawned llama-server with nothing that could match it.

## Solution

Run both exit paths on the non-daemon teardown thread the SIGTERM path already uses, and join it. Signals only reach the main thread, so an interrupt breaks the join instead of the teardown. The build-lock timeout is unchanged.

`_stop_stale_swap` now also sweeps `_find_orphan_servers(state.member_ports)`, matching `_stop_own_fleet`.
