### PR TITLE
Let a user withdraw its keep-warm opt-in when the setting goes off

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -71,6 +71,7 @@ from lilbee.runtime.engine_lock import (
     machine_engine_dir,
     private_engine_dir,
     request_keep_warm,
+    withdraw_keep_warm,
 )
 
 log = logging.getLogger(__name__)
@@ -1036,7 +1037,7 @@ class FleetProvider:
         if engine_dir not in self._engine_holds:
             self._engine_holds[engine_dir] = hold_user_lock(engine_dir)
         if cfg.keep_engine_warm:
-            request_keep_warm(engine_dir)
+            request_keep_warm(engine_dir, cfg.data_root)
 
     def _plan_and_spawn(self, data_dir: Path) -> bool:
         """Plan placement against the clean box and start one swap per group.
@@ -1365,13 +1366,15 @@ class FleetProvider:
         for engine_dir, hold in list(self._engine_holds.items()):
             with build_lock(engine_dir, best_effort=True):
                 last = hold.release_and_check_last()
-                # Any user's opt-in keeps the engine: the mark left by a peer, or
-                # this process's own setting, which it may have flipped after
-                # binding (the setting doesn't affect the load, so a flip never
-                # re-acquires and never reaches the mark).
-                keep = not config_changed and (
-                    keep_warm_requested(engine_dir) or cfg.keep_engine_warm
-                )
+                # A flip after binding never re-acquires, so reconcile our own mark
+                # here. Skipped on a config change, which stops and clears regardless.
+                if not config_changed:
+                    if cfg.keep_engine_warm:
+                        request_keep_warm(engine_dir, cfg.data_root)
+                    else:
+                        withdraw_keep_warm(engine_dir, cfg.data_root)
+                # Any remaining opt-in keeps the engine, including a peer's.
+                keep = not config_changed and keep_warm_requested(engine_dir)
                 if last and not keep:
                     stop_engine(engine_dir)
                     log.info("Engine stopped at %s (last user out)", engine_dir)

--- a/src/lilbee/runtime/engine_lock.py
+++ b/src/lilbee/runtime/engine_lock.py
@@ -8,6 +8,7 @@ The mechanics are agnostic to what they front.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from contextlib import contextmanager
@@ -33,9 +34,10 @@ _BUILD_LOCK_NAME = "engine.lock"
 _BUILD_LOCK_TIMEOUT_S = 90.0
 _USERS_DIRNAME = "engine-users"
 _USER_LOCK_SUFFIX = ".lock"
-# Marks an engine whose users asked it to outlive them. A plain file, not a
-# lock: it outlives every process by design.
-_KEEP_WARM_NAME = "keep-warm"
+# One opt-in file per installation, keyed by config root (not pid, which changes
+# every run). Plain files, not locks: an opt-in outlives its process. Per-install
+# so a restart reclaims its own prior mark while a peer's stays distinct.
+_KEEP_WARM_SUFFIX = ".keep-warm"
 # Throwaway per-process file used to ask whether flock really works here.
 _FLOCK_PROBE_PREFIX = ".flock-probe."
 # Non-blocking probe: a live peer refuses instantly.
@@ -140,29 +142,47 @@ def _users_dir(engine_dir: Path) -> Path:
     return engine_dir / _USERS_DIRNAME
 
 
-def request_keep_warm(engine_dir: Path) -> None:
-    """Record that a user of *engine_dir* wants the engine to outlive it.
+def _keep_warm_path(engine_dir: Path, config_root: Path) -> Path:
+    token = hashlib.blake2b(str(config_root).encode(), digest_size=8).hexdigest()
+    return _users_dir(engine_dir) / f"{token}{_KEEP_WARM_SUFFIX}"
 
-    The opt-in belongs to the engine, not to a process: the machine slot is
-    shared across installations whose configs differ, so reading the setting
-    from whichever process happens to exit last hands the decision to an
-    arbitrary sibling. Any user that opts in marks the engine, and the mark
-    lasts exactly as long as the engine instance it describes -- ``stop_engine``
-    clears it, so a rebuilt engine starts from whoever opts in next.
+
+def request_keep_warm(engine_dir: Path, config_root: Path) -> None:
+    """Record that the installation at *config_root* wants *engine_dir*'s engine warm.
+
+    The slot is shared across installations whose configs differ, so any one's
+    opt-in keeps the engine warm even when a default-config sibling is last out.
+    Keyed by config root, not pid: a restart of the same installation reclaims
+    its own mark. ``stop_engine`` clears the set, so a rebuilt engine starts
+    unmarked.
     """
-    marker = engine_dir / _KEEP_WARM_NAME
+    marker = _keep_warm_path(engine_dir, config_root)
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.touch()
 
 
+def withdraw_keep_warm(engine_dir: Path, config_root: Path) -> None:
+    """Drop this installation's opt-in for *engine_dir*, leaving every peer's intact.
+
+    Reclaims the mark this installation left, so flipping the setting off (even
+    across a restart) lets the engine stop instead of staying warm forever.
+    """
+    _keep_warm_path(engine_dir, config_root).unlink(missing_ok=True)
+
+
 def keep_warm_requested(engine_dir: Path) -> bool:
-    """Whether any user of *engine_dir* asked for the engine to stay resident."""
-    return (engine_dir / _KEEP_WARM_NAME).exists()
+    """Whether any user of *engine_dir* asked for the engine to stay resident.
+
+    Not gated on liveness: an opt-in means "outlive me", so an exited user's
+    marker is the case it exists for.
+    """
+    return any(_users_dir(engine_dir).glob(f"*{_KEEP_WARM_SUFFIX}"))
 
 
 def clear_keep_warm(engine_dir: Path) -> None:
-    """Forget *engine_dir*'s persistence opt-in; the engine it applied to is gone."""
-    (engine_dir / _KEEP_WARM_NAME).unlink(missing_ok=True)
+    """Forget every persistence opt-in for *engine_dir*; the engine they applied to is gone."""
+    for marker in _users_dir(engine_dir).glob(f"*{_KEEP_WARM_SUFFIX}"):
+        marker.unlink(missing_ok=True)
 
 
 def _user_lock_path(engine_dir: Path, pid: int) -> Path:

--- a/tests/test_engine_lock.py
+++ b/tests/test_engine_lock.py
@@ -1,5 +1,6 @@
 """The engine's cross-process lifecycle primitives: dirs, build lock, user locks."""
 
+import os
 import subprocess
 import sys
 import threading
@@ -294,3 +295,49 @@ def test_kernel_arbitrates_locks_assumes_support_when_the_probe_is_unusable(
         assert el.kernel_arbitrates_locks(tmp_path / "engine") is True
     finally:
         el.kernel_arbitrates_locks.cache_clear()
+
+
+def test_a_restart_reclaims_its_own_prior_keep_warm(monkeypatch, tmp_path: Path) -> None:
+    """Keyed by config root, not pid: a later run (new pid) of the same install
+
+    reclaims the mark an earlier run left, which a pid key could not.
+    """
+    from lilbee.runtime.engine_lock import (
+        keep_warm_requested,
+        request_keep_warm,
+        withdraw_keep_warm,
+    )
+
+    engine, root = tmp_path / "engine", tmp_path / "cfgroot"
+    request_keep_warm(engine, root)  # run 1: warm on
+    assert keep_warm_requested(engine) is True
+    restarted_pid = os.getpid() + 4242
+    monkeypatch.setattr(os, "getpid", lambda: restarted_pid)  # run 2 is a new process
+    withdraw_keep_warm(engine, root)  # same install, warm now off
+    assert keep_warm_requested(engine) is False
+
+
+def test_withdrawing_leaves_another_installs_optin_intact(tmp_path: Path) -> None:
+    """Each opt-in is one installation's, so withdrawing ours must not revoke a peer's."""
+    from lilbee.runtime.engine_lock import (
+        keep_warm_requested,
+        request_keep_warm,
+        withdraw_keep_warm,
+    )
+
+    engine = tmp_path / "engine"
+    request_keep_warm(engine, tmp_path / "mine")
+    request_keep_warm(engine, tmp_path / "peer")
+    withdraw_keep_warm(engine, tmp_path / "mine")
+    assert keep_warm_requested(engine) is True
+    withdraw_keep_warm(engine, tmp_path / "peer")
+    assert keep_warm_requested(engine) is False
+
+
+def test_withdrawing_an_absent_keep_warm_is_a_noop(tmp_path: Path) -> None:
+    """Teardown withdraws unconditionally, so an install that never opted in must not raise."""
+    from lilbee.runtime.engine_lock import keep_warm_requested, withdraw_keep_warm
+
+    engine = tmp_path / "engine"
+    withdraw_keep_warm(engine, tmp_path / "cfgroot")
+    assert keep_warm_requested(engine) is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -3782,25 +3782,27 @@ def test_a_default_config_peer_leaving_last_keeps_a_warm_users_engine(
     monkeypatch, tmp_path: Path
 ) -> None:
     """The machine slot is shared; whose config decides must not be exit order."""
+    from lilbee.runtime.engine_lock import request_keep_warm
+
     swap, _machine = _bindable_machine(monkeypatch, tmp_path)
     stopped: list[Path] = []
     monkeypatch.setattr(prov_mod, "stop_engine", lambda d: stopped.append(Path(d)))
 
-    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", True, raising=False)
-    warm = FleetProvider()
-    assert warm._ensure_fleet() is True
+    # The warm user is a sibling installation, seeded under its own config root.
+    request_keep_warm(_machine, tmp_path / "peer-install")
     monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
     plain = FleetProvider()
     assert plain._ensure_fleet() is True
-    assert swap.started == []  # both bound the one machine engine
+    assert swap.started == []  # bound the one machine engine
 
-    warm.shutdown()
     plain.shutdown()  # last out, and its own config says stop
     assert stopped == []
 
 
 def test_a_warm_peer_leaving_first_still_keeps_the_engine(monkeypatch, tmp_path: Path) -> None:
     """The opt-in belongs to the engine, so it outlives the process that made it."""
+    from lilbee.runtime.engine_lock import request_keep_warm
+
     _swap, _machine = _bindable_machine(monkeypatch, tmp_path)
     stopped: list[Path] = []
     monkeypatch.setattr(prov_mod, "stop_engine", lambda d: stopped.append(Path(d)))
@@ -3808,12 +3810,10 @@ def test_a_warm_peer_leaving_first_still_keeps_the_engine(monkeypatch, tmp_path:
     monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
     plain = FleetProvider()
     assert plain._ensure_fleet() is True
-    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", True, raising=False)
-    warm = FleetProvider()
-    assert warm._ensure_fleet() is True
+    # A sibling installation opted in and has already left: only its mark
+    # remains, which is exactly what "outlive me" means.
+    request_keep_warm(_machine, tmp_path / "peer-install")
 
-    warm.shutdown()  # the opt-in user leaves first
-    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
     plain.shutdown()  # last out, reading a config that says stop
     assert stopped == []
 
@@ -3873,7 +3873,7 @@ def test_stopping_an_engine_forgets_its_keep_warm_optin(tmp_path: Path) -> None:
     from lilbee.providers.fleet.swap_manager import stop_engine
     from lilbee.runtime.engine_lock import keep_warm_requested, request_keep_warm
 
-    request_keep_warm(tmp_path)
+    request_keep_warm(tmp_path, tmp_path / "cfgroot")
     assert keep_warm_requested(tmp_path) is True
     stop_engine(tmp_path)
     assert keep_warm_requested(tmp_path) is False
@@ -3888,6 +3888,49 @@ def test_warm_leaves_the_engine_even_when_last(monkeypatch, tmp_path: Path) -> N
     assert p._ensure_fleet() is True
     p.shutdown()
     assert stopped == []
+
+
+def test_turning_warm_off_mid_session_stops_the_engine(monkeypatch, tmp_path: Path) -> None:
+    """A withdrawn opt-in must not keep the engine: the mark is this user's, not the engine's.
+
+    Without withdrawal the mark outlives the setting, and because the mark is
+    what suppresses ``stop_engine`` -- the only thing that clears it -- the
+    engine stays resident on every later run too.
+    """
+    _swap, machine, _built = _install_ladder(monkeypatch, tmp_path, launches=[_chat_launch()])
+    stopped: list[Path] = []
+    monkeypatch.setattr(prov_mod, "stop_engine", lambda d: stopped.append(Path(d)))
+    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", True, raising=False)
+    p = FleetProvider()
+    assert p._ensure_fleet() is True
+    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
+    p.shutdown()
+    assert stopped == [machine]
+
+
+def test_a_prior_runs_keep_warm_is_reclaimed_when_the_setting_goes_off(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A mark left by an earlier run of this install (new pid, same config root)
+
+    is reclaimed on a later warm-off run, so the engine stops rather than staying
+    warm forever. The opt-in is keyed by config root precisely so a restart can
+    reach its own prior mark.
+    """
+    from lilbee.runtime.engine_lock import request_keep_warm
+
+    _swap, machine, _built = _install_ladder(monkeypatch, tmp_path, launches=[_chat_launch()])
+    stopped: list[Path] = []
+    monkeypatch.setattr(prov_mod, "stop_engine", lambda d: stopped.append(Path(d)))
+    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
+    # An earlier run of this same installation opted in, then exited.
+    request_keep_warm(machine, prov_mod.cfg.data_root)
+    p = FleetProvider()
+    assert p._ensure_fleet() is True
+    restarted_pid = os.getpid() + 4242
+    monkeypatch.setattr(os, "getpid", lambda: restarted_pid)  # this run is a new process
+    p.shutdown()
+    assert stopped == [machine]
 
 
 def test_warm_on_pins_weights_resident(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

Turning `keep_engine_warm` off had no effect once an engine was bound with it on.

The opt-in was a single anonymous file per engine dir, so a process could not tell which mark was its own, and could not take it back. `stop_engine` is the only thing that clears the mark, and the mark is what suppresses `stop_engine` — so it kept itself alive on every later run.

keep-warm also spawns with `bind_lifetime=False`, so there is no PDEATHSIG or job object to fall back on. The weights stay in VRAM until the user finds `lilbee engine stop`.

## Solution

Record the opt-in per user, beside that user's lock in `engine-users/`.

At teardown a user reconciles only its own mark against its own setting: a flip to off withdraws it and the engine stops, while a sibling installation's opt-in still keeps it warm. Reading is not gated on liveness, since an opt-in means "outlive me".

## Tests

Two peer tests simulated two installations as two providers in one process. Per-user marks cannot distinguish that — one process has one pid and one config — so they now seed the sibling under a foreign pid, asserting the same invariant: exit order must not decide whose config wins.