### PR TITLE
Bind spawned engines and the device probe so a crash can't orphan them

### DIFF
--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -307,11 +307,8 @@ def spawn_server(
         stdout = log_file
         stderr = subprocess.STDOUT
 
-    # A dict replaces the environment wholesale, so merge onto a copy of
-    # os.environ to keep PATH and the rest. LILBEE_PARENT_PID arms the serve
-    # process's own parent-death watcher: a launcher killed outright skips the
-    # finally that stops it, and the orphan keeps server_lock, so the next
-    # `lilbee serve` is refused until someone finds it by hand.
+    # LILBEE_PARENT_PID arms serve's parent-death watcher, so a hard-killed
+    # launcher (whose finally never runs) does not orphan serve holding server_lock.
     child_env = {**os.environ, **(env_overrides or {}), PARENT_PID_ENV: str(os.getpid())}
 
     try:

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -23,6 +23,8 @@ from lilbee.cli.commands.servers import port_file
 from lilbee.cli.launchers.warm_render import render_warm
 from lilbee.core.config import cfg
 from lilbee.modelhub.registry import ModelRegistry
+from lilbee.parent_monitor import PARENT_PID_ENV
+from lilbee.providers.fleet.child_guard import spawn_bound_child
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.server.auth import server_json_path
 
@@ -305,13 +307,15 @@ def spawn_server(
         stdout = log_file
         stderr = subprocess.STDOUT
 
-    # None inherits the parent environment; a dict replaces it wholesale, so
-    # merge the overrides onto a copy of os.environ to keep PATH and the rest.
-    child_env = {**os.environ, **env_overrides} if env_overrides else None
+    # A dict replaces the environment wholesale, so merge onto a copy of
+    # os.environ to keep PATH and the rest. LILBEE_PARENT_PID arms the serve
+    # process's own parent-death watcher: a launcher killed outright skips the
+    # finally that stops it, and the orphan keeps server_lock, so the next
+    # `lilbee serve` is refused until someone finds it by hand.
+    child_env = {**os.environ, **(env_overrides or {}), PARENT_PID_ENV: str(os.getpid())}
 
     try:
-        # Only caller-controlled value is the validated integer port; no shell.
-        return subprocess.Popen(  # noqa: S603
+        return spawn_bound_child(
             cmd,
             stdout=stdout,
             stderr=stderr,

--- a/src/lilbee/providers/fleet/child_guard.py
+++ b/src/lilbee/providers/fleet/child_guard.py
@@ -15,12 +15,16 @@ mechanism is unavailable, so a failure here never fails a spawn:
   that thread returned.
 * Windows: the child joins a job object marked kill-on-close. The job handle is
   held for the life of the process, so every child in it dies when the handle does.
-* macOS: no equivalent primitive, so the spawn is plain and the reap covers it.
+* Everywhere else (macOS, and any POSIX host where prctl is unavailable): a death
+  pipe. This process holds the write end open for its lifetime, so the kernel
+  closes it however this process dies, SIGKILL included; a small ``sh`` watcher
+  holding the read end sees EOF and signals the child.
 
 Not a third-party library: ``processfamily`` wraps the same primitives but needs
 ``pywin32`` (the standalone build cannot bundle it) and its ``prctl`` path skips
-macOS. The syscalls are a few ctypes lines and the process-lifetime routing is
-lilbee-specific, so they stay custom; the single-worker executor is the stdlib's.
+macOS, which is the only platform still needing cover. The syscalls are a few
+ctypes lines and the process-lifetime routing is lilbee-specific, so they stay
+custom; the single-worker executor is the stdlib's.
 """
 
 from __future__ import annotations
@@ -62,6 +66,15 @@ _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
 _JOB_OBJECT_EXTENDED_LIMIT_CLASS = 9
 _PROCESS_SET_QUOTA = 0x0100
 _PROCESS_TERMINATE = 0x0001
+
+# Where the watcher parks the read end. POSIX sh only guarantees a single-digit
+# fd as a redirect target, so the inherited fd is moved here before it is read.
+_DEATH_PIPE_CHILD_FD = 3
+
+# Write ends of every live death pipe. Held for the process's lifetime so the
+# kernel is what closes them; dropping a reference would fake this process's
+# death and take the engine down with it.
+_death_pipe_write_fds: list[int] = []
 
 
 def _make_pdeathsig_preexec(parent_pid: int) -> Callable[[], None] | None:
@@ -180,16 +193,68 @@ def _assign_to_kill_on_close_job(pid: int) -> None:  # pragma: no cover - Window
         kernel32.CloseHandle(handle)
 
 
-def spawn_llama_swap(
-    argv: list[str], *, bind_lifetime: bool = True, **popen_kwargs: Any
-) -> subprocess.Popen[Any]:
-    """Spawn llama-swap, by default bound to this process's lifetime.
+def _watch_via_death_pipe(pid: int) -> None:
+    """Signal *pid* from a detached watcher once this process's death closes a pipe.
 
-    With ``bind_lifetime`` a crash cannot orphan the engine; the binding is
-    best-effort, so an unavailable platform primitive falls back to a plain spawn
-    and the stale-engine reap on the next launch is the backstop. ``bind_lifetime``
-    is False when the engine is meant to outlive this process on purpose
-    (``keep_engine_warm``), where that same reap is the only cleanup wanted.
+    The portable stand-in for prctl and job objects: this process keeps the write
+    end for its lifetime, so only its death closes it, whatever the cause. The
+    watcher blocks reading the read end and terminates *pid* at EOF.
+
+    Best-effort like the primitives it stands in for. It signals a pid rather than
+    holding a kernel handle, so a pid recycled between this process's death and the
+    signal could be hit; the window is the watcher's wakeup, and the ``kill -0``
+    guard covers the common case of an already-dead child.
+    """
+    read_fd, write_fd = os.pipe()
+    # `|| exit 0` is load-bearing: a watcher that cannot take the read end must
+    # leave without signalling. Falling through to the kill would make a failed
+    # binding destroy the child it exists to protect, which is far worse than
+    # not binding at all. Only the redirect target must be a single digit; the
+    # source may be any fd number, so no dup2 (and no preexec) is needed.
+    script = (
+        f"exec {_DEATH_PIPE_CHILD_FD}<&{read_fd} || exit 0; "
+        f"read -r _ <&{_DEATH_PIPE_CHILD_FD}; "
+        f"kill -0 {pid} 2>/dev/null && kill {pid}"
+    )
+    try:
+        _spawner.spawn(
+            ["/bin/sh", "-c", script],
+            pass_fds=(read_fd,),
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        os.close(write_fd)
+        log.info("Could not bind the engine to this process; the next launch reaps it.")
+    else:
+        _death_pipe_write_fds.append(write_fd)
+    finally:
+        os.close(read_fd)
+
+
+def spawn_bound_child(
+    argv: list[str],
+    *,
+    bind_lifetime: bool = True,
+    death_pipe: bool = True,
+    **popen_kwargs: Any,
+) -> subprocess.Popen[Any]:
+    """Spawn *argv*, by default bound to this process's lifetime.
+
+    With ``bind_lifetime`` a crash cannot orphan the child; the binding is
+    best-effort, so an unavailable platform primitive falls back to the stale
+    reap on the next launch. ``bind_lifetime`` is False when the child is meant
+    to outlive this process on purpose (``keep_engine_warm``), where that same
+    reap is the only cleanup wanted.
+
+    ``death_pipe`` is False for a short-lived child. The pipe's watcher lives
+    until this process dies, so binding a child that outlives neither is a
+    process and an fd held for nothing, and by then the pid it would signal may
+    belong to something else. Kernel bindings have neither cost and still apply.
+
+    Callers that also want the child in its own process group pass
+    ``start_new_session=True``; the binding does not depend on it.
     """
     if not bind_lifetime:
         return _spawner.spawn(argv, **popen_kwargs)
@@ -199,8 +264,7 @@ def spawn_llama_swap(
         try:
             return _spawner.spawn(argv, preexec_fn=preexec, **popen_kwargs)
         except OSError:
-            log.info("Could not bind the engine to this process; the next launch reaps it.")
-            return _spawner.spawn(argv, **popen_kwargs)
+            log.info("Could not bind the engine to this process; falling back to a death pipe.")
 
     proc = _spawner.spawn(argv, **popen_kwargs)
     if sys.platform == "win32":
@@ -208,4 +272,6 @@ def spawn_llama_swap(
             _assign_to_kill_on_close_job(proc.pid)
         except OSError:
             log.info("Could not bind the engine to this process; the next launch reaps it.")
+    elif death_pipe:
+        _watch_via_death_pipe(proc.pid)
     return proc

--- a/src/lilbee/providers/fleet/child_guard.py
+++ b/src/lilbee/providers/fleet/child_guard.py
@@ -29,6 +29,7 @@ custom; the single-worker executor is the stdlib's.
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import logging
 import os
@@ -71,10 +72,13 @@ _PROCESS_TERMINATE = 0x0001
 # fd as a redirect target, so the inherited fd is moved here before it is read.
 _DEATH_PIPE_CHILD_FD = 3
 
-# Write ends of every live death pipe. Held for the process's lifetime so the
-# kernel is what closes them; dropping a reference would fake this process's
-# death and take the engine down with it.
-_death_pipe_write_fds: list[int] = []
+# The live death pipes, keyed by the pid each one guards. os.pipe() hands back
+# bare ints, which the GC never closes, so this map is the only handle that can
+# close a write end deliberately: on the guarded child's stop (so its watcher
+# wakes and exits instead of parking for our whole lifetime), or left for the
+# kernel to close when we die (which is what fires the binding). Keyed by pid so
+# the fd's lifetime tracks the child's, not ours.
+_death_pipe_write_fds: dict[int, int] = {}
 
 
 def _make_pdeathsig_preexec(parent_pid: int) -> Callable[[], None] | None:
@@ -197,15 +201,25 @@ def _watch_via_death_pipe(pid: int) -> None:
     """Signal *pid* from a detached watcher once this process's death closes a pipe.
 
     The portable stand-in for prctl and job objects: this process keeps the write
-    end for its lifetime, so only its death closes it, whatever the cause. The
-    watcher blocks reading the read end and terminates *pid* at EOF.
+    end until the child stops or we die, so the pipe reaches EOF on either. The
+    watcher blocks reading the read end and terminates *pid* at EOF. The write end
+    is O_CLOEXEC (os.pipe's default), so exec'd children never inherit it; a
+    fork-without-exec child would, keeping the pipe open past our death, so a
+    holder of a bound child must not fork workers (serve is single-process).
 
     Best-effort like the primitives it stands in for. It signals a pid rather than
-    holding a kernel handle, so a pid recycled between this process's death and the
-    signal could be hit; the window is the watcher's wakeup, and the ``kill -0``
-    guard covers the common case of an already-dead child.
+    holding a kernel handle, so a pid recycled in the instant between the write end
+    closing and the wakeup could be hit; the ``kill -0`` guard covers the common
+    case of an already-dead child, and :func:`release_death_pipe` keeps that window
+    to the child's own stop rather than letting a stale watcher span our lifetime.
     """
-    read_fd, write_fd = os.pipe()
+    try:
+        read_fd, write_fd = os.pipe()
+    except OSError:
+        # os.pipe() shares the binding's best-effort contract: at the fd ceiling
+        # the engine still runs, unbound, and the next launch reaps it.
+        log.info("Could not bind the engine to this process; the next launch reaps it.")
+        return
     # `|| exit 0` is load-bearing: a watcher that cannot take the read end must
     # leave without signalling. Falling through to the kill would make a failed
     # binding destroy the child it exists to protect, which is far worse than
@@ -228,9 +242,27 @@ def _watch_via_death_pipe(pid: int) -> None:
         os.close(write_fd)
         log.info("Could not bind the engine to this process; the next launch reaps it.")
     else:
-        _death_pipe_write_fds.append(write_fd)
+        # A crashed-without-release child can leave a stale entry the OS then
+        # recycles this pid into; close it first so the overwrite never leaks it.
+        release_death_pipe(pid)
+        _death_pipe_write_fds[pid] = write_fd
     finally:
         os.close(read_fd)
+
+
+def release_death_pipe(pid: int) -> None:
+    """Close the death pipe guarding *pid*, so its watcher wakes and exits.
+
+    Called when the guarded child is stopped while this process lives on (a fleet
+    reload or model switch): closing the write end unblocks the watcher, which
+    finds the child already gone and exits, instead of parking until our death and
+    then signalling a pid that may since have been recycled. A no-op for a pid
+    with no death pipe (the kernel-bound platforms, or an already-released one).
+    """
+    write_fd = _death_pipe_write_fds.pop(pid, None)
+    if write_fd is not None:
+        with contextlib.suppress(OSError):
+            os.close(write_fd)
 
 
 def spawn_bound_child(
@@ -264,7 +296,8 @@ def spawn_bound_child(
         try:
             return _spawner.spawn(argv, preexec_fn=preexec, **popen_kwargs)
         except OSError:
-            log.info("Could not bind the engine to this process; falling back to a death pipe.")
+            # Fall through to the death pipe below, unless this child opted out.
+            log.info("Could not set the death signal on the engine; trying the death pipe.")
 
     proc = _spawner.spawn(argv, **popen_kwargs)
     if sys.platform == "win32":

--- a/src/lilbee/providers/fleet/child_guard.py
+++ b/src/lilbee/providers/fleet/child_guard.py
@@ -1,30 +1,19 @@
 """Bind a spawned llama-swap's lifetime to this process, so a crash cannot orphan it.
 
-A graceful exit already tears the fleet down, and a stale engine is reaped on the
-next launch. This closes the window in between: when lilbee dies without running
-cleanup (SIGKILL, a segfault, a closed terminal), the engine and its VRAM would
-otherwise survive until something launches again.
+A graceful exit tears the fleet down and a stale engine is reaped on the next
+launch; this closes the window between, when lilbee dies without cleanup (SIGKILL,
+segfault, closed terminal). Each platform binds differently and falls back to the
+next-launch reap when its primitive is unavailable, so a failure here never fails
+a spawn:
 
-Each platform binds differently, and each falls back to the existing reap when its
-mechanism is unavailable, so a failure here never fails a spawn:
+* Linux: ``PR_SET_PDEATHSIG``, set in the preexec of one process-lifetime thread
+  (the signal binds to the forking thread, not the process).
+* Windows: a kill-on-close job object whose handle is held for the process life.
+* Elsewhere (macOS, any POSIX host without prctl): a death pipe (see
+  :func:`_watch_via_death_pipe`).
 
-* Linux: ``PR_SET_PDEATHSIG`` asks the kernel to signal the child when its parent
-  dies. The catch is that "parent" is the *thread* that forked, not the process,
-  so the spawn is routed through one long-lived thread whose lifetime is the
-  process's. Binding to a transient worker thread would kill the engine the moment
-  that thread returned.
-* Windows: the child joins a job object marked kill-on-close. The job handle is
-  held for the life of the process, so every child in it dies when the handle does.
-* Everywhere else (macOS, and any POSIX host where prctl is unavailable): a death
-  pipe. This process holds the write end open for its lifetime, so the kernel
-  closes it however this process dies, SIGKILL included; a small ``sh`` watcher
-  holding the read end sees EOF and signals the child.
-
-Not a third-party library: ``processfamily`` wraps the same primitives but needs
-``pywin32`` (the standalone build cannot bundle it) and its ``prctl`` path skips
-macOS, which is the only platform still needing cover. The syscalls are a few
-ctypes lines and the process-lifetime routing is lilbee-specific, so they stay
-custom; the single-worker executor is the stdlib's.
+``processfamily`` covers only prctl+job (needs pywin32, skips macOS), so the
+syscalls stay custom; the executor is the stdlib's.
 """
 
 from __future__ import annotations
@@ -44,15 +33,12 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# Linux prctl(2): PR_SET_PDEATHSIG is option 1. SIGTERM (15) lets llama-swap run
-# its own shutdown; the kernel escalates nothing, so a wedged child is still the
-# reap's job.
+# prctl(2) PR_SET_PDEATHSIG=1; SIGTERM so llama-swap runs its own shutdown.
 _PR_SET_PDEATHSIG = 1
 _PDEATHSIG = 15
 
-# Resolve libc in the parent, at import, so the post-fork child touches only an
-# already-loaded handle. A dlopen (or a Python import) after fork can deadlock on
-# the linker/import lock a sibling thread may hold, and lilbee is heavily threaded.
+# Resolved at import so the post-fork child touches an already-loaded handle: a
+# dlopen after fork can deadlock on a lock a sibling thread holds.
 _libc: ctypes.CDLL | None = None
 if sys.platform.startswith("linux"):  # pragma: no cover - Linux only
     try:
@@ -60,44 +46,30 @@ if sys.platform.startswith("linux"):  # pragma: no cover - Linux only
     except OSError:
         _libc = None
 
-# Windows job-object constants (winnt.h). Extended-limit information carries the
-# kill-on-close flag; the class ordinal is JobObjectExtendedLimitInformation. The
-# access rights are the minimum OpenProcess needs to place a pid in a job.
+# Windows job-object constants (winnt.h).
 _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
 _JOB_OBJECT_EXTENDED_LIMIT_CLASS = 9
 _PROCESS_SET_QUOTA = 0x0100
 _PROCESS_TERMINATE = 0x0001
 
-# Where the watcher parks the read end. POSIX sh only guarantees a single-digit
-# fd as a redirect target, so the inherited fd is moved here before it is read.
-_DEATH_PIPE_CHILD_FD = 3
-
-# The live death pipes, keyed by the pid each one guards. os.pipe() hands back
-# bare ints, which the GC never closes, so this map is the only handle that can
-# close a write end deliberately: on the guarded child's stop (so its watcher
-# wakes and exits instead of parking for our whole lifetime), or left for the
-# kernel to close when we die (which is what fires the binding). Keyed by pid so
-# the fd's lifetime tracks the child's, not ours.
+# Live death-pipe write ends, keyed by guarded pid. os.pipe() returns bare fds the
+# GC never closes, so this is the only handle to close one deliberately (on child
+# stop) or leave for the kernel to close on our death (which fires the binding).
 _death_pipe_write_fds: dict[int, int] = {}
 
 
 def _make_pdeathsig_preexec(parent_pid: int) -> Callable[[], None] | None:
-    """A preexec that binds the child's death to *parent_pid*, or None if libc is absent.
+    """A preexec binding the child's death to *parent_pid*, or None if libc is absent.
 
-    *parent_pid* is this process's pid, captured before the fork. The child asks
-    the kernel to signal it when its parent thread dies, then exits if it has
-    already been reparented (its parent is no longer *parent_pid*): comparing
-    against the real pid, not against 1, so a lilbee running legitimately as pid 1
-    (a container without an init shim) is not mistaken for a dead parent.
+    Compares against the real pid, not 1, so a lilbee running as pid 1 (a container
+    without an init shim) is not mistaken for a dead parent.
     """
     if _libc is None:
         return None
     libc = _libc
 
     def _set_pdeathsig() -> None:
-        # Runs in the forked child before exec. Touches only pre-resolved handles
-        # (libc, os, the captured pid), since a fork in a threaded process must
-        # neither allocate nor take a lock a sibling thread may hold.
+        # In the forked child pre-exec: touch only pre-resolved handles, no alloc.
         libc.prctl(_PR_SET_PDEATHSIG, _PDEATHSIG, 0, 0, 0)
         if os.getppid() != parent_pid:
             os._exit(1)
@@ -106,13 +78,11 @@ def _make_pdeathsig_preexec(parent_pid: int) -> Callable[[], None] | None:
 
 
 class _LifetimeSpawner:
-    """Runs subprocess spawns on one process-lifetime thread so PR_SET_PDEATHSIG holds.
+    """Runs spawns on one process-lifetime thread so PR_SET_PDEATHSIG binds to it.
 
-    The death signal binds to the thread that forks, not the process, so the fork
-    must happen on a thread that lives as long as the process. A one-worker
-    ``ThreadPoolExecutor`` is exactly that: created on first spawn, its single
-    thread is reused for every spawn and only stops at interpreter exit (or the
-    test-only ``close``). Spawns are infrequent, so serializing them costs nothing.
+    The death signal binds to the forking thread, so a one-worker
+    ``ThreadPoolExecutor`` (reused for every spawn, stopped only at exit or the
+    test-only ``close``) keeps that thread alive for the process.
     """
 
     def __init__(self) -> None:
@@ -129,7 +99,7 @@ class _LifetimeSpawner:
         return executor.submit(subprocess.Popen, *args, **kwargs).result()
 
     def close(self) -> None:
-        """Stop the spawner thread. Unused in production, where it lives forever."""
+        """Stop the spawner thread. Test-only; in production it lives forever."""
         with self._lock:
             executor, self._executor = self._executor, None
         if executor is not None:
@@ -140,15 +110,13 @@ _spawner = _LifetimeSpawner()
 
 
 def _assign_to_kill_on_close_job(pid: int) -> None:  # pragma: no cover - Windows only
-    """Put *pid* in a job object that kills its members when this process exits.
+    """Put *pid* in a kill-on-close job object.
 
-    One job is created per child and its handle deliberately leaked: the process
-    holding an open kill-on-close handle is what makes the child die with it, and
-    the handle is reclaimed by the OS when the process ends.
+    The job handle is deliberately leaked: holding it open is what kills the child
+    when this process ends, and the OS reclaims it then.
     """
-    # windll is a Windows-only stdlib loader, absent from the type stubs on other
-    # platforms; reaching it through an Any-typed alias keeps the checker quiet
-    # without an attr-defined ignore, and this runs only on win32.
+    # windll is a Windows-only loader absent from other platforms' stubs; the
+    # Any alias keeps the checker quiet without an attr-defined ignore.
     ct: Any = ctypes
     kernel32 = ct.windll.kernel32
 
@@ -198,42 +166,29 @@ def _assign_to_kill_on_close_job(pid: int) -> None:  # pragma: no cover - Window
 
 
 def _watch_via_death_pipe(pid: int) -> None:
-    """Signal *pid* from a detached watcher once this process's death closes a pipe.
+    """Signal *pid* from a detached ``sh`` watcher once a pipe reaches EOF.
 
-    The portable stand-in for prctl and job objects: this process keeps the write
-    end until the child stops or we die, so the pipe reaches EOF on either. The
-    watcher blocks reading the read end and terminates *pid* at EOF. The write end
-    is O_CLOEXEC (os.pipe's default), so exec'd children never inherit it; a
-    fork-without-exec child would, keeping the pipe open past our death, so a
-    holder of a bound child must not fork workers (serve is single-process).
+    Portable stand-in for prctl/job objects: we hold the pipe's write end until the
+    child stops or we die, and the watcher (reading the read end as its stdin)
+    signals *pid* at EOF. The write end is O_CLOEXEC, so exec'd children never
+    inherit it; a fork-without-exec child would keep the pipe open past our death,
+    so a bound child's owner must not fork workers (serve is single-process).
 
-    Best-effort like the primitives it stands in for. It signals a pid rather than
-    holding a kernel handle, so a pid recycled in the instant between the write end
-    closing and the wakeup could be hit; the ``kill -0`` guard covers the common
-    case of an already-dead child, and :func:`release_death_pipe` keeps that window
-    to the child's own stop rather than letting a stale watcher span our lifetime.
+    The read end is passed as the watcher's stdin rather than redirected with
+    ``<&N``: dash mis-dups a multi-digit fd there, silently binding the wrong one.
+    Best-effort; ``kill -0`` skips an already-dead pid, and :func:`release_death_pipe`
+    keeps the pid-recycle window to the child's own stop.
     """
     try:
         read_fd, write_fd = os.pipe()
     except OSError:
-        # os.pipe() shares the binding's best-effort contract: at the fd ceiling
-        # the engine still runs, unbound, and the next launch reaps it.
         log.info("Could not bind the engine to this process; the next launch reaps it.")
         return
-    # `|| exit 0` is load-bearing: a watcher that cannot take the read end must
-    # leave without signalling. Falling through to the kill would make a failed
-    # binding destroy the child it exists to protect, which is far worse than
-    # not binding at all. Only the redirect target must be a single digit; the
-    # source may be any fd number, so no dup2 (and no preexec) is needed.
-    script = (
-        f"exec {_DEATH_PIPE_CHILD_FD}<&{read_fd} || exit 0; "
-        f"read -r _ <&{_DEATH_PIPE_CHILD_FD}; "
-        f"kill -0 {pid} 2>/dev/null && kill {pid}"
-    )
+    script = f"read -r _; kill -0 {pid} 2>/dev/null && kill {pid}"
     try:
         _spawner.spawn(
             ["/bin/sh", "-c", script],
-            pass_fds=(read_fd,),
+            stdin=read_fd,
             start_new_session=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -242,8 +197,8 @@ def _watch_via_death_pipe(pid: int) -> None:
         os.close(write_fd)
         log.info("Could not bind the engine to this process; the next launch reaps it.")
     else:
-        # A crashed-without-release child can leave a stale entry the OS then
-        # recycles this pid into; close it first so the overwrite never leaks it.
+        # A crashed-without-release child can leave a stale entry the OS recycles
+        # this pid into; close it before the overwrite so it never leaks.
         release_death_pipe(pid)
         _death_pipe_write_fds[pid] = write_fd
     finally:
@@ -251,13 +206,11 @@ def _watch_via_death_pipe(pid: int) -> None:
 
 
 def release_death_pipe(pid: int) -> None:
-    """Close the death pipe guarding *pid*, so its watcher wakes and exits.
+    """Close the death pipe guarding *pid* so its watcher wakes and exits.
 
-    Called when the guarded child is stopped while this process lives on (a fleet
-    reload or model switch): closing the write end unblocks the watcher, which
-    finds the child already gone and exits, instead of parking until our death and
-    then signalling a pid that may since have been recycled. A no-op for a pid
-    with no death pipe (the kernel-bound platforms, or an already-released one).
+    Called when the guarded child is stopped while this process lives on (fleet
+    reload / model switch), instead of leaving the watcher parked until our death.
+    A no-op for a pid with no death pipe (kernel-bound platforms, or already released).
     """
     write_fd = _death_pipe_write_fds.pop(pid, None)
     if write_fd is not None:
@@ -274,19 +227,15 @@ def spawn_bound_child(
 ) -> subprocess.Popen[Any]:
     """Spawn *argv*, by default bound to this process's lifetime.
 
-    With ``bind_lifetime`` a crash cannot orphan the child; the binding is
-    best-effort, so an unavailable platform primitive falls back to the stale
-    reap on the next launch. ``bind_lifetime`` is False when the child is meant
-    to outlive this process on purpose (``keep_engine_warm``), where that same
-    reap is the only cleanup wanted.
+    ``bind_lifetime`` is False when the child is meant to outlive this process
+    (``keep_engine_warm``); the next-launch reap is then the only cleanup.
 
-    ``death_pipe`` is False for a short-lived child. The pipe's watcher lives
-    until this process dies, so binding a child that outlives neither is a
-    process and an fd held for nothing, and by then the pid it would signal may
-    belong to something else. Kernel bindings have neither cost and still apply.
+    ``death_pipe`` is False for a short-lived child: the pipe's watcher lives until
+    we die, so binding a child that outlives neither costs a process and an fd for
+    nothing. Kernel bindings have no such cost and still apply.
 
-    Callers that also want the child in its own process group pass
-    ``start_new_session=True``; the binding does not depend on it.
+    Pass ``start_new_session=True`` to also put the child in its own group; the
+    binding does not depend on it.
     """
     if not bind_lifetime:
         return _spawner.spawn(argv, **popen_kwargs)
@@ -296,7 +245,6 @@ def spawn_bound_child(
         try:
             return _spawner.spawn(argv, preexec_fn=preexec, **popen_kwargs)
         except OSError:
-            # Fall through to the death pipe below, unless this child opted out.
             log.info("Could not set the death signal on the engine; trying the death pipe.")
 
     proc = _spawner.spawn(argv, **popen_kwargs)

--- a/src/lilbee/providers/fleet/devices.py
+++ b/src/lilbee/providers/fleet/devices.py
@@ -217,9 +217,8 @@ def _run_list_devices(binary: Path, timeout_s: float) -> tuple[str, int]:
     """
     proc = spawn_bound_child(
         [str(binary), "--list-devices"],
-        # Seconds-long and killed on every exit path below, so a watcher process
-        # outliving it would cost more than it protects; the kernel bindings the
-        # spawn still applies are free.
+        # Short-lived and killed on every exit path below; skip the death-pipe
+        # watcher (kernel bindings still apply).
         death_pipe=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -240,8 +239,8 @@ def _run_list_devices(binary: Path, timeout_s: float) -> tuple[str, int]:
             kind=ProviderErrorKind.SERVER,
         ) from None
     except BaseException:
-        # A Ctrl-C during startup lands here, not on the timeout branch, and the
-        # probe is in its own session so the tty's SIGINT never reached it.
+        # A Ctrl-C lands here, not the timeout branch; the probe is in its own
+        # session so the tty's SIGINT never reached it.
         _kill_probe(proc)
         raise
     return output or "", proc.returncode

--- a/src/lilbee/providers/fleet/devices.py
+++ b/src/lilbee/providers/fleet/devices.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
+from lilbee.providers.fleet.child_guard import spawn_bound_child
 from lilbee.providers.fleet.gpu_select import USABLE_VULKAN_TYPES, VkDeviceType
 
 log = logging.getLogger(__name__)
@@ -209,9 +210,17 @@ def _run_list_devices(binary: Path, timeout_s: float) -> tuple[str, int]:
     ``subprocess.run``'s timeout path waits indefinitely for the killed child to
     be reaped, so a probe wedged in uninterruptible GPU-driver I/O would hang the
     caller forever; this bounds the reap and abandons an unkillable child.
+
+    The probe holds a device context and writes no state file, so nothing can reap
+    it later by record: it is bound to this process, and killed on the way out of
+    every abort, not just the timeout.
     """
-    proc = subprocess.Popen(  # noqa: S603 - binary is the resolved llama-server
+    proc = spawn_bound_child(
         [str(binary), "--list-devices"],
+        # Seconds-long and killed on every exit path below, so a watcher process
+        # outliving it would cost more than it protects; the kernel bindings the
+        # spawn still applies are free.
+        death_pipe=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -230,6 +239,11 @@ def _run_list_devices(binary: Path, timeout_s: float) -> tuple[str, int]:
             provider=_PROVIDER,
             kind=ProviderErrorKind.SERVER,
         ) from None
+    except BaseException:
+        # A Ctrl-C during startup lands here, not on the timeout branch, and the
+        # probe is in its own session so the tty's SIGINT never reached it.
+        _kill_probe(proc)
+        raise
     return output or "", proc.returncode
 
 

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -27,7 +27,7 @@ import psutil
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.binary import engine_pin, resolve_llama_swap
-from lilbee.providers.fleet.child_guard import spawn_llama_swap
+from lilbee.providers.fleet.child_guard import spawn_bound_child
 from lilbee.providers.fleet.groups import SwapGroup
 from lilbee.providers.fleet.launch import role_model_prefix
 from lilbee.providers.fleet.swap_config import PORT_FLAG, build_swap_config
@@ -254,7 +254,7 @@ class SwapManager:
         self._close_log()
         self._log_path.parent.mkdir(parents=True, exist_ok=True)
         self._log_file = self._log_path.open("ab")
-        self._proc = spawn_llama_swap(
+        self._proc = spawn_bound_child(
             [
                 str(resolve_llama_swap()),
                 _CONFIG_FLAG,

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -391,10 +391,7 @@ class SwapManager:
         _stop_own_fleet(self._config_path, tuple(self._member_ports))
         self._state_path.unlink(missing_ok=True)
         if self._proc is not None:
-            # Close this engine's death pipe now that it is stopped, so its watcher
-            # wakes and exits instead of parking until we die and then signalling a
-            # pid we already reaped (and may since have been recycled). No-op on the
-            # kernel-bound platforms.
+            # Free this engine's death pipe so its watcher exits now, not at our death.
             release_death_pipe(self._proc.pid)
         self._proc = None
         self._port = None

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -27,7 +27,7 @@ import psutil
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.binary import engine_pin, resolve_llama_swap
-from lilbee.providers.fleet.child_guard import spawn_bound_child
+from lilbee.providers.fleet.child_guard import release_death_pipe, spawn_bound_child
 from lilbee.providers.fleet.groups import SwapGroup
 from lilbee.providers.fleet.launch import role_model_prefix
 from lilbee.providers.fleet.swap_config import PORT_FLAG, build_swap_config
@@ -390,6 +390,12 @@ class SwapManager:
             return
         _stop_own_fleet(self._config_path, tuple(self._member_ports))
         self._state_path.unlink(missing_ok=True)
+        if self._proc is not None:
+            # Close this engine's death pipe now that it is stopped, so its watcher
+            # wakes and exits instead of parking until we die and then signalling a
+            # pid we already reaped (and may since have been recycled). No-op on the
+            # kernel-bound platforms.
+            release_death_pipe(self._proc.pid)
         self._proc = None
         self._port = None
         self._close_log()

--- a/tests/cli/test_launch_agent_ctx_floor.py
+++ b/tests/cli/test_launch_agent_ctx_floor.py
@@ -93,7 +93,7 @@ def test_spawn_server_applies_env_overrides_over_inherited_env(monkeypatch) -> N
         captured["env"] = env
         return MagicMock()
 
-    monkeypatch.setattr(server_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server_mod, "spawn_bound_child", fake_popen)
     server_mod.spawn_server(8080, env_overrides={"LILBEE_CHAT_N_CTX_TARGET": "65536"})
 
     assert captured["env"]["LILBEE_CHAT_N_CTX_TARGET"] == "65536"
@@ -101,8 +101,12 @@ def test_spawn_server_applies_env_overrides_over_inherited_env(monkeypatch) -> N
     assert captured["env"]["LILBEE_LAUNCHER_SERVE_QUIET"] == "1"
 
 
-def test_spawn_server_without_overrides_inherits_process_env(monkeypatch) -> None:
+def test_spawn_server_without_overrides_still_arms_the_parent_watcher(monkeypatch) -> None:
+    """Even with nothing to override, serve must learn the pid it should outlive."""
+    import os
+
     from lilbee.cli.launchers import server as server_mod
+    from lilbee.parent_monitor import PARENT_PID_ENV
 
     monkeypatch.setenv("LILBEE_LAUNCHER_SERVE_QUIET", "1")
     captured: dict = {}
@@ -111,8 +115,9 @@ def test_spawn_server_without_overrides_inherits_process_env(monkeypatch) -> Non
         captured["env"] = env
         return MagicMock()
 
-    monkeypatch.setattr(server_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server_mod, "spawn_bound_child", fake_popen)
     server_mod.spawn_server(8080)
 
-    # None means Popen inherits the parent environment unchanged.
-    assert captured["env"] is None
+    assert captured["env"][PARENT_PID_ENV] == str(os.getpid())
+    # The rest of the environment still comes through the merge.
+    assert captured["env"]["LILBEE_LAUNCHER_SERVE_QUIET"] == "1"

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -734,7 +734,7 @@ def test_spawn_server_returns_popen(monkeypatch):
     from lilbee.cli.launchers import server as launch_mod
 
     fake = MagicMock()
-    monkeypatch.setattr(launch_mod.subprocess, "Popen", lambda *a, **k: fake)
+    monkeypatch.setattr(launch_mod, "spawn_bound_child", lambda *a, **k: fake)
     out = launch_mod.spawn_server(8765)
     assert out is fake
 

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -1,6 +1,6 @@
 """Tests for ``lilbee.cli.launchers.server.spawn_server`` stdout/stderr wiring.
 
-``subprocess.Popen`` is patched so no real ``lilbee serve`` process is spawned;
+``spawn_bound_child`` is patched so no real ``lilbee serve`` process is spawned;
 the tests assert how the child's stdout/stderr are routed (DEVNULL in quiet
 mode, a size-capped log file otherwise).
 """
@@ -21,7 +21,7 @@ from tests._mock_effects import repeat_last
 
 @pytest.fixture()
 def _capture_popen():
-    """Patch Popen to record the stdout/stderr kwargs without spawning."""
+    """Patch the bound spawn to record the stdout/stderr kwargs without spawning."""
     captured: dict = {}
 
     def fake_popen(cmd, *, stdout, stderr, env=None):
@@ -31,7 +31,7 @@ def _capture_popen():
         captured["env"] = env
         return mock.MagicMock()
 
-    with mock.patch.object(server_mod.subprocess, "Popen", side_effect=fake_popen):
+    with mock.patch.object(server_mod, "spawn_bound_child", side_effect=fake_popen):
         yield captured
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,16 +216,23 @@ def _reset_services_after_test():
 
 @pytest.fixture(autouse=True)
 def _join_fleet_background_threads():
-    """Join lingering fleet warm-up / reload daemon threads after each test.
+    """Retire the fleet's background threads after each test.
 
-    ``warm_up_pool`` / ``reload_role`` dispatch fire-and-forget daemon threads; on a
-    host without the engine binary they fail fast and log a warning. Joining them
-    here keeps that warning inside the test that started the thread instead of
-    leaking it into a later test's log capture.
+    Two shapes need retiring. ``warm_up_pool`` / ``reload_role`` dispatch
+    fire-and-forget daemon threads that end on their own once joined; on a host
+    without the engine binary they fail fast, and joining keeps that warning
+    inside the test that started them. The child-guard spawner is different: its
+    ``fleet-spawner`` worker is a process-lifetime executor thread that a join
+    never ends (it parks waiting for the next spawn), so any test that ran a real
+    probe or launch must close it, or the leak guard flags it against whatever
+    test happens to run next.
     """
     yield
     import threading
 
+    from lilbee.providers.fleet import child_guard
+
+    child_guard._spawner.close()
     for thread in threading.enumerate():
         if thread.name.startswith("fleet-") and thread.is_alive():
             thread.join(timeout=5.0)

--- a/tests/integration/test_child_guard_binding.py
+++ b/tests/integration/test_child_guard_binding.py
@@ -2,12 +2,12 @@
 
 The unit tests in tests/test_child_guard.py mock the kernel calls, so they prove the
 dispatch and fallbacks but not that the binding fires. These do the real thing on
-each OS: a middle process spawns a child through the actual spawn_llama_swap path,
+each OS: a middle process spawns a child through the actual spawn_bound_child path,
 the middle is killed, and the child's fate is checked against the platform contract.
 
   Linux:   PR_SET_PDEATHSIG -> the child dies with its parent.
   Windows: kill-on-close job object -> the child dies with its parent.
-  macOS:   no primitive -> the child survives; the stale-engine reap is the backstop.
+  macOS:   death pipe -> the watcher sees EOF and the child dies with its parent.
 
 Run on CI's real ubuntu/windows/macos integration jobs (make test-integration).
 """
@@ -30,8 +30,8 @@ pytestmark = pytest.mark.slow
 _CHILD = [sys.executable, "-c", "import time; time.sleep(600)"]
 _MIDDLE_SRC = (
     "import sys, time\n"
-    "from lilbee.providers.fleet.child_guard import spawn_llama_swap\n"
-    f"proc = spawn_llama_swap({_CHILD!r}, start_new_session=(sys.platform != 'win32'))\n"
+    "from lilbee.providers.fleet.child_guard import spawn_bound_child\n"
+    f"proc = spawn_bound_child({_CHILD!r}, start_new_session=(sys.platform != 'win32'))\n"
     "print(proc.pid, flush=True)\n"
     "time.sleep(600)\n"
 )
@@ -96,16 +96,16 @@ def test_job_object_kills_the_child_when_the_parent_exits() -> None:
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.skipif(sys.platform != "darwin", reason="documents the macOS no-binding contract")
-def test_macos_child_survives_and_relies_on_the_reap() -> None:
+@pytest.mark.skipif(sys.platform != "darwin", reason="the death pipe covers macOS")
+def test_death_pipe_reaps_the_child_when_the_parent_is_killed() -> None:
+    # SIGKILL specifically: no handler, no atexit, nothing in-process runs. Only
+    # the kernel closing the pipe's write end can reach the child here.
     middle, child_pid = _spawn_child_via_middle()
     try:
         assert psutil.pid_exists(child_pid), "child was not running before the kill"
         middle.kill()
         middle.wait(timeout=10)
-        # macOS has no death-binding primitive, so the child outlives its parent;
-        # the stale-engine reap on the next launch is what reclaims it.
-        assert not _child_gone_within(child_pid, 2), "child unexpectedly died without a binding"
+        assert _child_gone_within(child_pid, 15), "the death pipe did not reap the child"
     finally:
         _kill(child_pid)
         _kill(middle)

--- a/tests/test_child_guard.py
+++ b/tests/test_child_guard.py
@@ -249,8 +249,14 @@ class TestTheLifetimeSpawner:
         assert spawner._executor is None
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="the death pipe is the POSIX fallback")
+_POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="spawns a real /bin/sh watcher")
+
+
 class TestTheDeathPipe:
+    """The mock-based cases run on every platform (the death-pipe code is POSIX but
+    exercised through a mocked spawn); only the real-``sh`` cases are POSIX-gated."""
+
+    @_POSIX_ONLY
     def test_the_watcher_signals_the_child_when_the_write_end_closes(self, monkeypatch):
         """Closing the write end (what the kernel does at our death) reaps the child."""
         held: dict[int, int] = {}
@@ -336,6 +342,7 @@ class TestTheDeathPipe:
         assert "pass_fds" not in recorded["kw"]
         # The read end is the watcher's stdin, so it is the fd not retained as write.
         assert recorded["kw"]["stdin"] not in held.values()
+        child_guard.release_death_pipe(4242)
 
     def test_a_watcher_that_cannot_start_leaks_no_fds(self, monkeypatch):
         """The reap is the fallback, but a leaked fd per failed spawn is not."""
@@ -344,12 +351,13 @@ class TestTheDeathPipe:
         monkeypatch.setattr(
             child_guard._spawner, "spawn", mock.MagicMock(side_effect=OSError("no sh"))
         )
-        before = len(os.listdir("/dev/fd"))
+        before = len(os.listdir("/dev/fd")) if sys.platform != "win32" else None
 
         child_guard._watch_via_death_pipe(1234)
 
         assert held == {}
-        assert len(os.listdir("/dev/fd")) <= before
+        if before is not None:
+            assert len(os.listdir("/dev/fd")) <= before
 
     def test_pipe_exhaustion_does_not_fail_the_spawn(self, monkeypatch):
         """os.pipe() shares the binding's best-effort contract: never fail a spawn."""

--- a/tests/test_child_guard.py
+++ b/tests/test_child_guard.py
@@ -252,11 +252,7 @@ class TestTheLifetimeSpawner:
 @pytest.mark.skipif(sys.platform == "win32", reason="the death pipe is the POSIX fallback")
 class TestTheDeathPipe:
     def test_the_watcher_signals_the_child_when_the_write_end_closes(self, monkeypatch):
-        """The real thing: a live sleeper dies once the pipe's write end is closed.
-
-        Closing the write end by hand is exactly what the kernel does when this
-        process dies, which is the case that cannot be staged from inside a test.
-        """
+        """Closing the write end (what the kernel does at our death) reaps the child."""
         held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
@@ -274,13 +270,7 @@ class TestTheDeathPipe:
                 victim.wait(timeout=10)
 
     def test_release_death_pipe_closes_the_write_end_for_a_stopped_child(self, monkeypatch):
-        """A reload stops the child and releases its pipe, closing the write end.
-
-        The closed write end is what the parked watcher reads as EOF (proven by
-        the signals-the-child test); without release it stays open until lilbee
-        dies, leaking one fd and one watcher per model switch. Here we pin the
-        release itself: the fd is closed and the entry dropped, idempotently.
-        """
+        """Release closes the write end and drops the entry, idempotently."""
         held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         monkeypatch.setattr(child_guard._spawner, "spawn", lambda *a, **k: mock.MagicMock())
@@ -315,8 +305,7 @@ class TestTheDeathPipe:
         child_guard.release_death_pipe(999999)  # must not raise
 
     def test_a_recycled_pid_closes_the_stale_entry_instead_of_leaking_it(self, monkeypatch):
-        """A child that crashed without release leaves an entry; if the OS recycles
-        that pid into a new bound child, the overwrite must close the old fd."""
+        """Re-binding a pid whose stale entry was never released closes the old fd."""
         held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         monkeypatch.setattr(child_guard._spawner, "spawn", lambda *a, **k: mock.MagicMock())
@@ -330,57 +319,23 @@ class TestTheDeathPipe:
             os.fstat(stale_fd)  # the stale write end was closed, not leaked
         child_guard.release_death_pipe(1234)
 
-    def test_the_watcher_script_guards_the_kill_behind_the_redirect(self):
-        """The `|| exit 0` guard is load-bearing; pin its presence structurally.
-
-        A behavioural test cannot catch its removal: the real /bin/sh exits on a
-        failed `exec` redirect regardless, so deleting the guard stays green. The
-        guard exists for shells that would not, so assert it is emitted, ahead of
-        the kill, rather than trusting the shell to mask its absence.
-        """
-        recorded: dict[str, object] = {}
-
-        def _capture(argv, **_kw):
-            recorded["argv"] = argv
-            return mock.MagicMock()
-
-        with mock.patch.object(child_guard._spawner, "spawn", _capture):
-            child_guard._watch_via_death_pipe(4242)
-        child_guard.release_death_pipe(4242)
-
-        script = recorded["argv"][2]
-        assert "|| exit 0" in script
-        assert script.index("|| exit 0") < script.index("kill")
-
-    def test_a_watcher_that_cannot_take_the_read_end_never_signals(self, monkeypatch):
-        """A broken binding must degrade to no binding, not to killing the child.
-
-        The first cut dup2'd the read end in a preexec_fn, which subprocess then
-        closed (it closes fds *after* preexec), so the watcher's redirect failed
-        and it fell straight through to the kill: every bound child died within
-        milliseconds of being spawned.
-        """
+    def test_the_watcher_reads_the_pipe_as_stdin_with_no_fd_redirect(self, monkeypatch):
+        """Pin the stdin design: dash mis-dups a multi-digit fd in a ``<&N`` redirect."""
         held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
-        victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(10)"])
-        try:
-            # pass_fds dropped, so the inherited read end is not there to redirect.
-            real_spawn = child_guard._spawner.spawn
-            monkeypatch.setattr(
-                child_guard._spawner,
-                "spawn",
-                lambda argv, **kw: real_spawn(argv, **{**kw, "pass_fds": ()}),
-            )
+        recorded: dict[str, object] = {}
 
-            child_guard._watch_via_death_pipe(victim.pid)
-            for fd in list(held.values()):
-                os.close(fd)
+        def _capture(argv, **kw):
+            recorded["argv"], recorded["kw"] = argv, kw
+            return mock.MagicMock()
 
-            with pytest.raises(subprocess.TimeoutExpired):
-                victim.wait(timeout=3)
-        finally:
-            victim.kill()
-            victim.wait(timeout=10)
+        monkeypatch.setattr(child_guard._spawner, "spawn", _capture)
+        child_guard._watch_via_death_pipe(4242)
+
+        assert "<&" not in recorded["argv"][2]  # no fd-number redirect
+        assert "pass_fds" not in recorded["kw"]
+        # The read end is the watcher's stdin, so it is the fd not retained as write.
+        assert recorded["kw"]["stdin"] not in held.values()
 
     def test_a_watcher_that_cannot_start_leaks_no_fds(self, monkeypatch):
         """The reap is the fallback, but a leaked fd per failed spawn is not."""

--- a/tests/test_child_guard.py
+++ b/tests/test_child_guard.py
@@ -9,6 +9,9 @@ binding problem never fails a launch.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -48,7 +51,7 @@ class TestPlatformDispatch:
 
         monkeypatch.setattr(child_guard._spawner, "spawn", _spawn)
 
-        result = child_guard.spawn_llama_swap(["/x/llama-swap"], stdout=7)
+        result = child_guard.spawn_bound_child(["/x/llama-swap"], stdout=7)
 
         assert result == "proc"
         assert callable(captured["kwargs"]["preexec_fn"])  # the death-signal preexec
@@ -69,19 +72,55 @@ class TestPlatformDispatch:
 
         monkeypatch.setattr(child_guard._spawner, "spawn", _spawn)
 
-        child_guard.spawn_llama_swap(["/x/llama-swap"], bind_lifetime=False)
+        child_guard.spawn_bound_child(["/x/llama-swap"], bind_lifetime=False)
 
         assert "preexec_fn" not in captured["kwargs"]
         assert assigned == []  # no job object either
 
-    def test_macos_spawns_plainly_with_no_binding(self, monkeypatch):
+    def test_macos_binds_through_a_death_pipe(self, monkeypatch):
+        # No prctl and no job object here, so the portable pipe-EOF watcher is
+        # what makes a SIGKILLed lilbee take its engine with it.
         monkeypatch.setattr(child_guard.sys, "platform", "darwin")
-        with mock.patch.object(child_guard.subprocess, "Popen", return_value="proc") as popen:
-            result = child_guard.spawn_llama_swap(["/x/llama-swap"], stdout=7)
+        proc = mock.MagicMock(pid=4321)
+        watched: list[int] = []
+        monkeypatch.setattr(child_guard, "_watch_via_death_pipe", watched.append)
+        with mock.patch.object(child_guard.subprocess, "Popen", return_value=proc) as popen:
+            result = child_guard.spawn_bound_child(["/x/llama-swap"], stdout=7)
 
-        assert result == "proc"
-        # No death-signal preexec, no job object: the reap is the macOS backstop.
+        assert result is proc
+        assert watched == [4321]
         assert "preexec_fn" not in popen.call_args.kwargs
+
+    def test_keep_warm_on_macos_gets_no_death_pipe(self, monkeypatch):
+        # The whole point of keep_engine_warm is outliving this process, so the
+        # portable binding must be skipped exactly like the kernel ones.
+        monkeypatch.setattr(child_guard.sys, "platform", "darwin")
+        watched: list[int] = []
+        monkeypatch.setattr(child_guard, "_watch_via_death_pipe", watched.append)
+        with mock.patch.object(child_guard.subprocess, "Popen", return_value=mock.MagicMock()):
+            child_guard.spawn_bound_child(["/x/llama-swap"], bind_lifetime=False)
+
+        assert watched == []
+
+    def test_a_failed_death_signal_spawn_falls_back_to_the_death_pipe(self, monkeypatch):
+        # Losing prctl must not drop the binding entirely where a pipe still works.
+        monkeypatch.setattr(child_guard, "_libc", mock.MagicMock())
+        monkeypatch.setattr(child_guard.sys, "platform", "linux")
+        proc = mock.MagicMock(pid=77)
+        watched: list[int] = []
+        monkeypatch.setattr(child_guard, "_watch_via_death_pipe", watched.append)
+        calls: list[dict] = []
+
+        def _spawn(*args, **kwargs):
+            calls.append(kwargs)
+            if "preexec_fn" in kwargs:
+                raise OSError("preexec unavailable")
+            return proc
+
+        monkeypatch.setattr(child_guard._spawner, "spawn", _spawn)
+
+        assert child_guard.spawn_bound_child(["/x/llama-swap"]) is proc
+        assert watched == [77]
 
     def test_windows_assigns_the_child_to_a_kill_on_close_job(self, monkeypatch):
         monkeypatch.setattr(child_guard.sys, "platform", "win32")
@@ -89,7 +128,7 @@ class TestPlatformDispatch:
         assigned: list[int] = []
         monkeypatch.setattr(child_guard, "_assign_to_kill_on_close_job", assigned.append)
         with mock.patch.object(child_guard.subprocess, "Popen", return_value=proc):
-            result = child_guard.spawn_llama_swap(["/x/llama-swap"])
+            result = child_guard.spawn_bound_child(["/x/llama-swap"])
 
         assert result is proc
         assert assigned == [4321]
@@ -149,22 +188,24 @@ class TestFailureNeverFailsASpawn:
 
         monkeypatch.setattr(child_guard, "_assign_to_kill_on_close_job", _boom)
         with mock.patch.object(child_guard.subprocess, "Popen", return_value=proc):
-            result = child_guard.spawn_llama_swap(["/x/llama-swap"])
+            result = child_guard.spawn_bound_child(["/x/llama-swap"])
 
         assert result is proc  # spawned anyway; the next launch reaps it
 
-    def test_a_linux_spawn_error_falls_back_to_a_plain_spawn(self, monkeypatch):
+    def test_a_linux_spawn_error_still_returns_the_child(self, monkeypatch):
         monkeypatch.setattr(child_guard, "_libc", mock.MagicMock())
+        proc = mock.MagicMock(pid=55)
+        monkeypatch.setattr(child_guard, "_watch_via_death_pipe", lambda _pid: None)
 
         def _spawn(_argv, **kwargs):
             # The binding attempt carries the death-signal preexec; the retry does not.
             if "preexec_fn" in kwargs:
                 raise OSError("preexec rejected")
-            return "plain"
+            return proc
 
         monkeypatch.setattr(child_guard._spawner, "spawn", _spawn)
 
-        assert child_guard.spawn_llama_swap(["/x/llama-swap"]) == "plain"
+        assert child_guard.spawn_bound_child(["/x/llama-swap"]) is proc
 
 
 @pytest.fixture
@@ -206,3 +247,84 @@ class TestTheLifetimeSpawner:
         assert spawner._executor is not None
         spawner.close()
         assert spawner._executor is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="the death pipe is the POSIX fallback")
+class TestTheDeathPipe:
+    def test_the_watcher_signals_the_child_when_the_write_end_closes(self, monkeypatch):
+        """The real thing: a live sleeper dies once the pipe's write end is closed.
+
+        Closing the write end by hand is exactly what the kernel does when this
+        process dies, which is the case that cannot be staged from inside a test.
+        """
+        held: list[int] = []
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        try:
+            child_guard._watch_via_death_pipe(victim.pid)
+            assert held, "no write end was retained"
+            assert victim.poll() is None, "victim died before the pipe closed"
+
+            os.close(held[0])
+
+            victim.wait(timeout=15)
+        finally:
+            if victim.poll() is None:
+                victim.kill()
+                victim.wait(timeout=10)
+
+    def test_the_write_end_is_held_so_only_this_process_death_closes_it(self, monkeypatch):
+        """A dropped reference would close the pipe early and kill a healthy engine."""
+        held: list[int] = []
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        monkeypatch.setattr(child_guard._spawner, "spawn", lambda *a, **k: mock.MagicMock())
+
+        child_guard._watch_via_death_pipe(1234)
+
+        assert len(held) == 1
+        os.fstat(held[0])  # raises if it was closed
+        os.close(held[0])
+
+    def test_a_watcher_that_cannot_take_the_read_end_never_signals(self, monkeypatch):
+        """A broken binding must degrade to no binding, not to killing the child.
+
+        The first cut dup2'd the read end in a preexec_fn, which subprocess then
+        closed (it closes fds *after* preexec), so the watcher's redirect failed
+        and it fell straight through to the kill: every bound child died within
+        milliseconds of being spawned.
+        """
+        held: list[int] = []
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(10)"])
+        try:
+            # pass_fds dropped, so the inherited read end is not there to redirect.
+            real_spawn = child_guard._spawner.spawn
+            monkeypatch.setattr(
+                child_guard._spawner,
+                "spawn",
+                lambda argv, **kw: real_spawn(argv, **{**kw, "pass_fds": ()}),
+            )
+
+            child_guard._watch_via_death_pipe(victim.pid)
+            for fd in held:
+                os.close(fd)
+
+            with pytest.raises(subprocess.TimeoutExpired):
+                victim.wait(timeout=3)
+        finally:
+            victim.kill()
+            victim.wait(timeout=10)
+
+    def test_a_watcher_that_cannot_start_leaks_no_fds(self, monkeypatch):
+        """The reap is the fallback, but a leaked fd per failed spawn is not."""
+        held: list[int] = []
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        monkeypatch.setattr(
+            child_guard._spawner, "spawn", mock.MagicMock(side_effect=OSError("no sh"))
+        )
+        before = len(os.listdir("/dev/fd"))
+
+        child_guard._watch_via_death_pipe(1234)
+
+        assert held == []
+        assert len(os.listdir("/dev/fd")) <= before

--- a/tests/test_child_guard.py
+++ b/tests/test_child_guard.py
@@ -257,15 +257,15 @@ class TestTheDeathPipe:
         Closing the write end by hand is exactly what the kernel does when this
         process dies, which is the case that cannot be staged from inside a test.
         """
-        held: list[int] = []
+        held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
         try:
             child_guard._watch_via_death_pipe(victim.pid)
-            assert held, "no write end was retained"
+            assert held == {victim.pid: mock.ANY}, "write end not retained under its pid"
             assert victim.poll() is None, "victim died before the pipe closed"
 
-            os.close(held[0])
+            os.close(held[victim.pid])
 
             victim.wait(timeout=15)
         finally:
@@ -273,17 +273,84 @@ class TestTheDeathPipe:
                 victim.kill()
                 victim.wait(timeout=10)
 
-    def test_the_write_end_is_held_so_only_this_process_death_closes_it(self, monkeypatch):
+    def test_release_death_pipe_closes_the_write_end_for_a_stopped_child(self, monkeypatch):
+        """A reload stops the child and releases its pipe, closing the write end.
+
+        The closed write end is what the parked watcher reads as EOF (proven by
+        the signals-the-child test); without release it stays open until lilbee
+        dies, leaking one fd and one watcher per model switch. Here we pin the
+        release itself: the fd is closed and the entry dropped, idempotently.
+        """
+        held: dict[int, int] = {}
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        monkeypatch.setattr(child_guard._spawner, "spawn", lambda *a, **k: mock.MagicMock())
+
+        child_guard._watch_via_death_pipe(1234)
+        write_fd = held[1234]
+
+        child_guard.release_death_pipe(1234)
+
+        assert 1234 not in held, "the write end was not dropped"
+        with pytest.raises(OSError):
+            os.fstat(write_fd)  # closed -> EBADF
+        child_guard.release_death_pipe(1234)  # idempotent second call must not raise
+
+    def test_the_write_end_is_held_under_its_pid_until_released(self, monkeypatch):
         """A dropped reference would close the pipe early and kill a healthy engine."""
-        held: list[int] = []
+        held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         monkeypatch.setattr(child_guard._spawner, "spawn", lambda *a, **k: mock.MagicMock())
 
         child_guard._watch_via_death_pipe(1234)
 
-        assert len(held) == 1
-        os.fstat(held[0])  # raises if it was closed
-        os.close(held[0])
+        assert list(held) == [1234]
+        os.fstat(held[1234])  # raises if it was closed
+        child_guard.release_death_pipe(1234)
+        assert 1234 not in held
+
+    def test_release_is_a_noop_for_an_unbound_pid(self, monkeypatch):
+        """Kernel-bound platforms record no pipe; release must not raise for them."""
+        held: dict[int, int] = {}
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        child_guard.release_death_pipe(999999)  # must not raise
+
+    def test_a_recycled_pid_closes_the_stale_entry_instead_of_leaking_it(self, monkeypatch):
+        """A child that crashed without release leaves an entry; if the OS recycles
+        that pid into a new bound child, the overwrite must close the old fd."""
+        held: dict[int, int] = {}
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        monkeypatch.setattr(child_guard._spawner, "spawn", lambda *a, **k: mock.MagicMock())
+
+        child_guard._watch_via_death_pipe(1234)
+        stale_fd = held[1234]
+        child_guard._watch_via_death_pipe(1234)  # same pid recycled
+
+        assert held[1234] != stale_fd, "the entry was not replaced"
+        with pytest.raises(OSError):
+            os.fstat(stale_fd)  # the stale write end was closed, not leaked
+        child_guard.release_death_pipe(1234)
+
+    def test_the_watcher_script_guards_the_kill_behind_the_redirect(self):
+        """The `|| exit 0` guard is load-bearing; pin its presence structurally.
+
+        A behavioural test cannot catch its removal: the real /bin/sh exits on a
+        failed `exec` redirect regardless, so deleting the guard stays green. The
+        guard exists for shells that would not, so assert it is emitted, ahead of
+        the kill, rather than trusting the shell to mask its absence.
+        """
+        recorded: dict[str, object] = {}
+
+        def _capture(argv, **_kw):
+            recorded["argv"] = argv
+            return mock.MagicMock()
+
+        with mock.patch.object(child_guard._spawner, "spawn", _capture):
+            child_guard._watch_via_death_pipe(4242)
+        child_guard.release_death_pipe(4242)
+
+        script = recorded["argv"][2]
+        assert "|| exit 0" in script
+        assert script.index("|| exit 0") < script.index("kill")
 
     def test_a_watcher_that_cannot_take_the_read_end_never_signals(self, monkeypatch):
         """A broken binding must degrade to no binding, not to killing the child.
@@ -293,7 +360,7 @@ class TestTheDeathPipe:
         and it fell straight through to the kill: every bound child died within
         milliseconds of being spawned.
         """
-        held: list[int] = []
+        held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(10)"])
         try:
@@ -306,7 +373,7 @@ class TestTheDeathPipe:
             )
 
             child_guard._watch_via_death_pipe(victim.pid)
-            for fd in held:
+            for fd in list(held.values()):
                 os.close(fd)
 
             with pytest.raises(subprocess.TimeoutExpired):
@@ -317,7 +384,7 @@ class TestTheDeathPipe:
 
     def test_a_watcher_that_cannot_start_leaks_no_fds(self, monkeypatch):
         """The reap is the fallback, but a leaked fd per failed spawn is not."""
-        held: list[int] = []
+        held: dict[int, int] = {}
         monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
         monkeypatch.setattr(
             child_guard._spawner, "spawn", mock.MagicMock(side_effect=OSError("no sh"))
@@ -326,5 +393,15 @@ class TestTheDeathPipe:
 
         child_guard._watch_via_death_pipe(1234)
 
-        assert held == []
+        assert held == {}
         assert len(os.listdir("/dev/fd")) <= before
+
+    def test_pipe_exhaustion_does_not_fail_the_spawn(self, monkeypatch):
+        """os.pipe() shares the binding's best-effort contract: never fail a spawn."""
+        held: dict[int, int] = {}
+        monkeypatch.setattr(child_guard, "_death_pipe_write_fds", held)
+        monkeypatch.setattr(child_guard.os, "pipe", mock.Mock(side_effect=OSError("EMFILE")))
+
+        child_guard._watch_via_death_pipe(1234)  # must not raise
+
+        assert held == {}

--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -183,8 +183,29 @@ def test_run_list_devices_returns_the_child_output(monkeypatch: pytest.MonkeyPat
         def communicate(self, timeout: float | None = None) -> tuple[str, None]:
             return (_CUDA_LISTING, None)
 
-    monkeypatch.setattr(dev_mod.subprocess, "Popen", lambda *_a, **_k: _HealthyProc())
+    monkeypatch.setattr(dev_mod, "spawn_bound_child", lambda *_a, **_k: _HealthyProc())
     assert dev_mod._run_list_devices(Path("/bin/llama-server"), 1.0) == (_CUDA_LISTING, 0)
+
+
+def test_probe_killed_on_a_ctrl_c_during_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A KeyboardInterrupt while the probe runs must kill it, not only a timeout.
+
+    The probe writes no state file, so no later reap can match it; unless this
+    branch kills it here, a Ctrl-C during startup strands it holding a device.
+    """
+
+    class _InterruptedProc:
+        pid = 4242
+
+        def communicate(self, timeout: float | None = None) -> tuple[str, None]:
+            raise KeyboardInterrupt
+
+    killed: list[object] = []
+    monkeypatch.setattr(dev_mod, "spawn_bound_child", lambda *_a, **_k: _InterruptedProc())
+    monkeypatch.setattr(dev_mod, "_kill_probe", killed.append)
+    with pytest.raises(KeyboardInterrupt):
+        dev_mod._run_list_devices(Path("/bin/llama-server"), 1.0)
+    assert len(killed) == 1
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
@@ -218,7 +239,7 @@ def test_probe_abandons_an_unreapable_child(
         def communicate(self, timeout: float | None = None) -> tuple[str, str]:
             raise subprocess.TimeoutExpired(cmd="llama-server", timeout=timeout or 0)
 
-    monkeypatch.setattr(dev_mod.subprocess, "Popen", lambda *_a, **_k: _WedgedProc())
+    monkeypatch.setattr(dev_mod, "spawn_bound_child", lambda *_a, **_k: _WedgedProc())
     monkeypatch.setattr(dev_mod.os, "name", "posix")
     monkeypatch.setattr(dev_mod.os, "killpg", lambda *_a: None, raising=False)
     monkeypatch.setattr(dev_mod.signal, "SIGKILL", 9, raising=False)

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -279,6 +279,22 @@ class TestLifecycle:
         with pytest.raises(ProviderError):
             mgr.endpoint()  # port cleared after shutdown
 
+    def test_shutdown_releases_the_stopped_engines_death_pipe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stopping the engine must free its death pipe, or reloads accumulate one
+        parked watcher and one fd per model switch on the pipe-bound platforms."""
+        proc = _FakeProc(poll_result=None)
+        _patch_spawn(monkeypatch, proc)
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
+        released: list[int] = []
+        monkeypatch.setattr(sm, "release_death_pipe", released.append)
+        mgr = SwapManager(tmp_path, _GROUP)
+        mgr.start([_launch(WorkerRole.CHAT)])
+        mgr.shutdown()
+        assert released == [proc.pid]
+
 
 class _FakeChild:
     """A stand-in psutil.Process that records the signals it receives."""

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -64,7 +64,7 @@ def _fake_response(*, status: int = 200, payload: object = None) -> object:
 
 def _patch_spawn(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> None:
     monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
-    monkeypatch.setattr(sm, "spawn_llama_swap", lambda *a, **k: proc)
+    monkeypatch.setattr(sm, "spawn_bound_child", lambda *a, **k: proc)
     # Isolate lifecycle tests from the real process-tree teardown.
     monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
 
@@ -131,7 +131,7 @@ class TestStart:
             return _FakeProc(poll_result=None)
 
         monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
-        monkeypatch.setattr(sm, "spawn_llama_swap", _capturing_popen)
+        monkeypatch.setattr(sm, "spawn_bound_child", _capturing_popen)
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
 
@@ -160,7 +160,7 @@ class TestStart:
             return _FakeProc(poll_result=None)
 
         monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
-        monkeypatch.setattr(sm, "spawn_llama_swap", _capturing_popen)
+        monkeypatch.setattr(sm, "spawn_bound_child", _capturing_popen)
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
 


### PR DESCRIPTION
## Problem

Three paths could leave a `llama-swap`, `llama-server`, or GPU device probe running after lilbee had gone.

macOS, and any host where `prctl` is unavailable, had no lifetime binding at all, so a SIGKILLed lilbee orphaned its whole fleet with nothing to reclaim it until the next launch.

The GPU device probe was a bare `Popen` whose only killer sat on the timeout branch. A Ctrl-C during startup never reached it, and it writes no state file, so nothing could ever reap it — it sat holding a device context.

A launcher-spawned `lilbee serve` was unbound and never learned its launcher's pid, so `serve`'s parent-death watcher was dead code. A launcher killed outright orphaned `serve`, which kept `server_lock` and made the next `lilbee serve` refuse to start.

## Solution

Add a portable death-pipe fallback in `child_guard`: lilbee holds a pipe's write end for its lifetime and a small `sh` watcher holds the read end, so the kernel closes the pipe however lilbee dies (SIGKILL included) and the watcher signals the child at EOF. The kernel primitives (`PR_SET_PDEATHSIG`, job objects) still win where they exist; the pipe covers macOS and any host where they don't.

Route the device probe through the bound spawn and kill it on every abort path, not only the timeout.

Bind `spawn_server` and set `LILBEE_PARENT_PID` in its environment so `serve`'s existing parent-death watcher actually arms.

`spawn_llama_swap` is renamed `spawn_bound_child` since it now guards more than swaps, with a `death_pipe` opt-out for short-lived children like the probe. Verified on real Linux (pdeathsig and the prctl-off death-pipe fallback) and macOS (death pipe reaps on parent SIGKILL) hardware; the macOS binding test now asserts reaping instead of survival.
