### PR TITLE
Stop disabling the only GPU driver a machine has

### DIFF
--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -78,6 +78,10 @@ class PlacementView:
     # Roles sharing one swap group: each is placed, but only one is resident at a
     # time, so their footprints do not sum against the card they name.
     co_tenants: tuple[WorkerRole, ...] = ()
+    # A saved spec this hardware no longer satisfies. The auto plan is what runs,
+    # but the spec stays in config.toml and reapplies once it fits again, so a
+    # surface has to say it is there rather than report placement as plain auto.
+    rejected_spec_json: str | None = None
 
 
 def _active_spec() -> PlacementSpec | None:
@@ -85,7 +89,13 @@ def _active_spec() -> PlacementSpec | None:
     return PlacementSpec.from_json(raw) if raw else None
 
 
-def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -> PlacementView:
+def _view(
+    resolved: ResolvedPlacement,
+    *,
+    manual: bool,
+    spec_json: str | None,
+    rejected_spec_json: str | None = None,
+) -> PlacementView:
     gpus = tuple(
         GpuInfo(
             index=d.index,
@@ -122,6 +132,7 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
             for role, ref in resolved.skipped_not_installed.items()
         ),
         co_tenants=tuple(sorted(resolved.co_tenants, key=lambda role: role.value)),
+        rejected_spec_json=rejected_spec_json,
     )
 
 
@@ -134,8 +145,10 @@ def get_placement() -> PlacementView:
     """
     spec = _active_spec()
     resolved = resolve_placement_plan(spec, fall_back_to_auto=True)
-    if spec is None or not resolved.spec_applied:
+    if spec is None:
         return _view(resolved, manual=False, spec_json=None)
+    if not resolved.spec_applied:
+        return _view(resolved, manual=False, spec_json=None, rejected_spec_json=spec.to_json())
     return _view(resolved, manual=True, spec_json=spec.to_json())
 
 

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -126,10 +126,17 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
 
 
 def get_placement() -> PlacementView:
-    """The current effective placement (manual if a spec is set, else auto)."""
+    """The current effective placement (manual if a spec is set, else auto).
+
+    A saved spec that no longer fits the hardware is not the effective placement:
+    the fleet runs the auto plan, and this reports that rather than a manual layout
+    nothing is using.
+    """
     spec = _active_spec()
-    resolved = resolve_placement_plan(spec)
-    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
+    resolved = resolve_placement_plan(spec, fall_back_to_auto=True)
+    if spec is None or not resolved.spec_applied:
+        return _view(resolved, manual=False, spec_json=None)
+    return _view(resolved, manual=True, spec_json=spec.to_json())
 
 
 def preview_placement(spec: PlacementSpec | None = None) -> PlacementView:

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -112,6 +112,12 @@ def _render_view(view: PlacementView) -> None:
             f"pull it to place it[/{theme.WARNING}]"
         )
 
+    if view.rejected_spec_json:
+        console.print(
+            f"  [{theme.WARNING}]a saved placement does not fit this hardware and is being "
+            f"ignored; run 'lilbee placement clear' or set a new one[/{theme.WARNING}]"
+        )
+
 
 @placement_app.command("show")
 def show(

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -506,6 +506,10 @@ FLEET_GPU_PROBE_FAILED = "GPU probe failed: {reason}"
 # Shown for a role that has no placement because its model isn't downloaded, so the
 # empty slot reads as a fixable state instead of "GPU placement is broken".
 FLEET_MODEL_NOT_DOWNLOADED = "{role}: {model} not downloaded, pull it to place it"
+FLEET_SAVED_PLACEMENT_IGNORED = (
+    "A saved placement does not fit this hardware and is being ignored. "
+    "Press the auto command to clear it, or set a new one."
+)
 # Shown when an Intel GPU's utilization is unreadable only because intel_gpu_top
 # lacks the CAP_PERFMON grant, so the muted "--" reads as a fixable state.
 FLEET_INTEL_UTIL_GRANT = (

--- a/src/lilbee/cli/tui/widgets/fleet_body.py
+++ b/src/lilbee/cli/tui/widgets/fleet_body.py
@@ -266,6 +266,8 @@ class FleetBody(Widget):
         if view.unplaceable:
             names = ", ".join(role.value for role in view.unplaceable)
             self.notify(f"Does not fit: {names}", severity="warning")
+        if view.rejected_spec_json:
+            self.notify(msg.FLEET_SAVED_PLACEMENT_IGNORED, severity="warning")
 
     def _render_skipped(self, view: PlacementView) -> None:
         """Show a 'not downloaded' line per role skipped for a missing model."""

--- a/src/lilbee/providers/fleet/gpu_hardware.py
+++ b/src/lilbee/providers/fleet/gpu_hardware.py
@@ -8,6 +8,9 @@ reads the PnP display-adapter class out of the registry.
 An installed ICD manifest is not evidence of hardware. Mesa ships every vendor's
 driver together on Linux (a Flatpak runtime always carries all of them), and a
 Windows manifest outlives the card it arrived with.
+
+Read directly rather than through pyudev or WMI: this is one attribute read per
+device on either platform, and neither dependency earns its place for that.
 """
 
 from __future__ import annotations

--- a/src/lilbee/providers/fleet/gpu_hardware.py
+++ b/src/lilbee/providers/fleet/gpu_hardware.py
@@ -1,0 +1,112 @@
+"""Which GPU vendors are physically installed, read from the OS device tree.
+
+The Vulkan loader cannot answer this. Creating an instance loads every installed
+ICD, which is the crash the ICD disable exists to prevent, so the answer has to
+come from the OS: Linux reads the PCI display controllers out of sysfs, Windows
+reads the PnP display-adapter class out of the registry.
+
+An installed ICD manifest is not evidence of hardware. Mesa ships every vendor's
+driver together on Linux (a Flatpak runtime always carries all of them), and a
+Windows manifest outlives the card it arrived with.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lilbee.providers.fleet.vulkan_icd_discovery import (
+    PNP_DISPLAY_ADAPTER_CLASS_GUID,
+    iter_pnp_class_subkeys,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# PCI base class 0x03 is "display controller"; sysfs writes the full 24-bit
+# class code (0x030000 for VGA), so the base class is its high byte.
+_PCI_DISPLAY_CONTROLLER_CLASS = 0x03
+_PCI_CLASS_CODE_BASE_SHIFT = 16
+_SYSFS_PCI_DEVICE_DIR = Path("/sys/bus/pci/devices")
+_SYSFS_CLASS_FILE = "class"
+_SYSFS_VENDOR_FILE = "vendor"
+
+# Windows PnP device-instance IDs carry the PCI vendor in their hardware IDs
+# ("PCI\\VEN_10DE&DEV_1F95&..."). Both value names are set by the class
+# installer; REG_SZ and REG_MULTI_SZ are both allowed.
+_PNP_HARDWARE_ID_VALUE_NAMES = ("MatchingDeviceId", "HardwareID")
+_PCI_VENDOR_ID_PATTERN = re.compile(r"ven_([0-9a-f]{4})", re.IGNORECASE)
+
+
+def installed_gpu_vendor_ids() -> frozenset[int]:
+    """PCI vendor IDs of this host's display controllers.
+
+    Empty means the device tree holds no PCI display controller or could not be
+    read at all (macOS, an ARM SoC whose GPU is not on the PCI bus, a container
+    with no ``/sys``). That is "cannot tell", not "there is no GPU", and callers
+    must not read it as proof that a vendor is absent.
+    """
+    if sys.platform == "win32":
+        return frozenset(_windows_gpu_vendor_ids())
+    if sys.platform.startswith("linux"):
+        return frozenset(_linux_gpu_vendor_ids())
+    return frozenset()
+
+
+def _linux_gpu_vendor_ids() -> Iterator[int]:
+    """Yield the vendor ID of every PCI display controller in sysfs."""
+    try:
+        devices = sorted(_SYSFS_PCI_DEVICE_DIR.iterdir())
+    except OSError:
+        return
+    for device in devices:
+        class_code = _read_sysfs_hex(device / _SYSFS_CLASS_FILE)
+        if class_code is None:
+            continue
+        if class_code >> _PCI_CLASS_CODE_BASE_SHIFT != _PCI_DISPLAY_CONTROLLER_CLASS:
+            continue
+        vendor_id = _read_sysfs_hex(device / _SYSFS_VENDOR_FILE)
+        if vendor_id is not None:
+            yield vendor_id
+
+
+def _read_sysfs_hex(path: Path) -> int | None:
+    """The ``0x``-prefixed integer in a sysfs attribute, ``None`` when unreadable."""
+    try:
+        return int(path.read_text().strip(), 16)
+    except (OSError, ValueError):
+        return None
+
+
+def _windows_gpu_vendor_ids() -> Iterator[int]:
+    """Yield the vendor ID of every registered display adapter."""
+    try:
+        import winreg
+    except ImportError:  # pragma: no cover - winreg ships with CPython on Windows
+        return
+    yield from _iter_windows_gpu_vendor_ids(winreg)
+
+
+def _iter_windows_gpu_vendor_ids(winreg: Any) -> Iterator[int]:
+    """Yield vendor IDs from the hardware IDs under the display-adapter class."""
+    for subkey in iter_pnp_class_subkeys(winreg, PNP_DISPLAY_ADAPTER_CLASS_GUID):
+        for value_name in _PNP_HARDWARE_ID_VALUE_NAMES:
+            try:
+                value, _value_type = winreg.QueryValueEx(subkey, value_name)
+            except OSError:
+                continue
+            yield from _vendor_ids_in(value)
+
+
+def _vendor_ids_in(value: object) -> Iterator[int]:
+    """Yield the PCI vendor IDs named in one registry hardware-ID value."""
+    # Registry values are untyped: REG_SZ arrives as str, REG_MULTI_SZ as list[str].
+    entries = value if isinstance(value, list) else [value]
+    for entry in entries:
+        if not isinstance(entry, str):
+            continue
+        match = _PCI_VENDOR_ID_PATTERN.search(entry)
+        if match is not None:
+            yield int(match.group(1), 16)

--- a/src/lilbee/providers/fleet/gpu_select.py
+++ b/src/lilbee/providers/fleet/gpu_select.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from functools import lru_cache
 
+from lilbee.providers.fleet.gpu_hardware import installed_gpu_vendor_ids
 from lilbee.providers.fleet.vulkan_icd_discovery import (
     iter_vulkan_manifest_paths,
 )
@@ -933,6 +934,19 @@ def _select_best_vendor(vendors: set[PCIVendorID]) -> PCIVendorID | None:
     return None
 
 
+def _vendors_with_hardware(vendors: set[PCIVendorID]) -> set[PCIVendorID]:
+    """The subset of *vendors* whose silicon is in this host's device tree.
+
+    An installed ICD proves a driver is present, not a card: Mesa ships
+    ``radeon_icd`` beside ``intel_icd`` on every Linux desktop, so an Intel-only
+    laptop reads as dual-vendor and the preference order would pick AMD and
+    disable the one ICD that drives the machine. Empty when the device tree
+    cannot be read, which leaves the choice to the manifests alone.
+    """
+    present = installed_gpu_vendor_ids()
+    return {vendor for vendor in vendors if vendor in present}
+
+
 def _platform_supports_icd_pin() -> bool:
     """True on Windows + Linux, where dual-vendor ICD crashes are documented."""
     return sys.platform == "win32" or sys.platform.startswith("linux")
@@ -962,10 +976,12 @@ def _platform_supports_icd_pin() -> bool:
 def disable_conflicting_vulkan_icds() -> str | None:
     """Manifest-filename glob list of non-preferred ICDs to disable, or ``None``.
 
-    Preferred-vendor order is NVIDIA > AMD > Intel. Returns ``None`` when the
-    user has pinned a GPU, when fewer than two vendors are present, or when the
-    platform has no documented dual-vendor crash class. Discovery reads manifests
-    from disk (registry on Windows, XDG on Linux); enumerating via
+    Preferred-vendor order is NVIDIA > AMD > Intel, applied to the vendors whose
+    hardware this host actually has, so the survivor is always a driver for a card
+    that is present. Returns ``None`` when the user has pinned a GPU, when fewer
+    than two vendors are installed, or when the platform has no documented
+    dual-vendor crash class. Discovery reads manifests from disk (registry on
+    Windows, XDG on Linux) and the device tree from the OS; enumerating via
     ``vkCreateInstance`` would pre-load every vendor's ICD before the disable lands.
     """
     from lilbee.core.config import cfg
@@ -979,7 +995,7 @@ def disable_conflicting_vulkan_icds() -> str | None:
     vendors = _vulkan_vendors_present()
     if len(vendors) < _MIN_VENDORS_FOR_CONFLICT:
         return None
-    best = _select_best_vendor(vendors)
+    best = _select_best_vendor(_vendors_with_hardware(vendors) or vendors)
     if best is None:  # pragma: no cover - invariant: vendors is non-empty here
         return None
     return ",".join(_icds_to_disable(best, vendors))

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -593,7 +593,18 @@ def _charge_devices(
     remaining: dict[int, float],
     device_capacity: dict[int, int],
 ) -> None:
-    """Subtract one instance's per-device peaks from *remaining*; fail loud if a card overflows."""
+    """Subtract one instance's per-device peaks from *remaining*; fail loud if a card overflows.
+
+    An estimate that does not cover every pinned device is a PlacementError rather
+    than a zip mismatch: gguf-parser returns no per-device breakdown for some
+    models, and the auto planner skips such a candidate (see :func:`_place_split`),
+    so the manual path must refuse in the currency callers already handle.
+    """
+    if len(per_device) != len(devices):
+        raise PlacementError(
+            f"{role.value} is pinned to {len(devices)} device(s) but its memory estimate "
+            f"covers {len(per_device)}; clear the placement to place it automatically"
+        )
     for idx, peak in zip(devices, per_device, strict=True):
         if peak > remaining[idx]:
             raise PlacementError(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -41,7 +41,7 @@ from lilbee.providers.fleet.placement import (
     placement_from_spec,
     plan_placement,
 )
-from lilbee.providers.fleet.placement_spec import PlacementSpec
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 from lilbee.providers.fleet.replicas import resolve_replica_count
 from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION, estimate_instance_footprint
 from lilbee.providers.model_ref import parse_model_ref
@@ -1584,6 +1584,43 @@ def _resolve_placement(
     )
 
 
+def _placement_or_auto(
+    placement: PlacementSpec | None,
+    inputs: list[ModelPlacementInput],
+    model_refs: dict[WorkerRole, str],
+    devices: list[FleetDevice],
+    *,
+    unified_budget: int | None,
+) -> tuple[Placement, bool]:
+    """Resolve a saved spec, falling back to auto when it no longer fits the hardware.
+
+    Returns the placement and whether the spec was the one applied. Hardware moves
+    under a saved placement: a card is removed, a driver stops enumerating a GPU, a
+    container starts without one. Refusing to plan there takes chat, embed and
+    ingest down over a pin set on hardware the host no longer has, so the fleet
+    degrades to automatic placement and logs why. An interactive apply still fails
+    loud (:func:`lilbee.app.placement.set_placement`), where the pin is what the
+    caller just asked for and a silent substitution would be the surprise.
+    """
+    if placement is None:
+        return _resolve_placement(
+            None, inputs, model_refs, devices, unified_budget=unified_budget
+        ), False
+    try:
+        return _resolve_placement(
+            placement, inputs, model_refs, devices, unified_budget=unified_budget
+        ), True
+    except PlacementError as exc:
+        log.warning(
+            "The saved GPU placement does not fit this hardware (%s); using automatic "
+            "placement instead. Set a new placement to replace it.",
+            exc,
+        )
+    return _resolve_placement(
+        None, inputs, model_refs, devices, unified_budget=unified_budget
+    ), False
+
+
 @dataclass(frozen=True)
 class ResolvedPlacement:
     """Devices + resolved instance plans + model refs for the placement view."""
@@ -1593,14 +1630,24 @@ class ResolvedPlacement:
     unplaceable_roles: tuple[WorkerRole, ...]
     model_refs: dict[WorkerRole, str]
     co_tenants: frozenset[WorkerRole] = frozenset()
+    # False when a spec was given but did not fit the hardware, so these instances
+    # are the auto planner's and a surface must not present them as the manual plan.
+    spec_applied: bool = True
     # Roles configured but skipped because their model isn't installed (role -> ref).
     # Distinct from unplaceable_roles (installed but won't fit); lets a surface show
     # "not downloaded" instead of an empty table on a fresh install.
     skipped_not_installed: dict[WorkerRole, str] = field(default_factory=dict)
 
 
-def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement:
-    """Probe devices and resolve the auto-or-manual placement, without launching."""
+def resolve_placement_plan(
+    placement: PlacementSpec | None, *, fall_back_to_auto: bool = False
+) -> ResolvedPlacement:
+    """Probe devices and resolve the auto-or-manual placement, without launching.
+
+    ``fall_back_to_auto`` reads *placement* as a saved setting rather than a
+    request: one that no longer fits the hardware resolves to the auto plan with
+    ``spec_applied`` False instead of raising.
+    """
     from lilbee.providers.fleet.cuda_runtime import apply_cuda_runtime_env
     from lilbee.providers.fleet.gpu_env import apply_fleet_gpu_env
 
@@ -1612,13 +1659,16 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
     inputs, model_refs, _, skipped_not_installed = _server_model_inputs(
         None, unified_budget=unified_budget, total_vram=sum(d.total_bytes for d in devices)
     )
-    resolved = _resolve_placement(
-        placement,
-        inputs,
-        model_refs,
-        devices,
-        unified_budget=_unified_admission_budget(devices),
-    )
+    admission_budget = _unified_admission_budget(devices)
+    if fall_back_to_auto:
+        resolved, spec_applied = _placement_or_auto(
+            placement, inputs, model_refs, devices, unified_budget=admission_budget
+        )
+    else:
+        resolved = _resolve_placement(
+            placement, inputs, model_refs, devices, unified_budget=admission_budget
+        )
+        spec_applied = placement is not None
     return ResolvedPlacement(
         devices=tuple(devices),
         instances=resolved.instances,
@@ -1626,6 +1676,7 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
         model_refs=model_refs,
         co_tenants=resolved.co_tenants,
         skipped_not_installed=skipped_not_installed,
+        spec_applied=spec_applied,
     )
 
 
@@ -1689,7 +1740,7 @@ def plan_launches(
         total_vram=sum(d.total_bytes for d in devices),
     )
     spec = PlacementSpec.from_json(cfg.placement) if cfg.placement else None
-    placement = _resolve_placement(
+    placement, _spec_applied = _placement_or_auto(
         spec,
         inputs,
         model_refs,

--- a/src/lilbee/providers/fleet/vulkan_icd_discovery.py
+++ b/src/lilbee/providers/fleet/vulkan_icd_discovery.py
@@ -41,8 +41,9 @@ def iter_vulkan_manifest_paths() -> Iterator[str]:
 # https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderDriverInterface.md#driver-discovery-on-windows
 # (the GUIDs themselves are the public Windows
 # https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors).
-_PNP_DISPLAY_ADAPTER_CLASS_GUID = "{4d36e968-e325-11ce-bfc1-08002be10318}"
+PNP_DISPLAY_ADAPTER_CLASS_GUID = "{4d36e968-e325-11ce-bfc1-08002be10318}"
 _PNP_SOFTWARE_COMPONENT_CLASS_GUID = "{5c4c3332-344d-483c-8739-259e934c9cc8}"
+_PNP_CLASS_ROOT = r"SYSTEM\CurrentControlSet\Control\Class"
 
 # Legacy software-driver paths (HKLM + WOW6432Node mirror for 32-bit ICDs).
 # Each value name is a manifest path; the DWORD value is 0=enabled.
@@ -61,7 +62,7 @@ def _iter_windows_vulkan_manifest_paths() -> Iterator[str]:
     except ImportError:  # pragma: no cover - winreg ships with CPython on Windows
         return
     yield from _iter_khronos_software_manifests(winreg)
-    yield from _iter_pnp_class_manifests(winreg, _PNP_DISPLAY_ADAPTER_CLASS_GUID)
+    yield from _iter_pnp_class_manifests(winreg, PNP_DISPLAY_ADAPTER_CLASS_GUID)
     yield from _iter_pnp_class_manifests(winreg, _PNP_SOFTWARE_COMPONENT_CLASS_GUID)
 
 
@@ -87,18 +88,16 @@ def _iter_khronos_software_manifests(winreg: Any) -> Iterator[str]:
             winreg.CloseKey(key)
 
 
-def _iter_pnp_class_manifests(winreg: Any, class_guid: str) -> Iterator[str]:
-    """Yield manifest paths from PnP keys under one device-class GUID.
+def iter_pnp_class_subkeys(winreg: Any, class_guid: str) -> Iterator[Any]:
+    """Yield each open device subkey under one PnP device-class GUID.
 
     Walks ``HKLM\\SYSTEM\\CurrentControlSet\\Control\\Class\\{GUID}\\NNNN``,
-    reading each subkey's ``VulkanDriverName`` and ``VulkanDriverNameWow``
-    values. Both ``REG_SZ`` (single path) and ``REG_MULTI_SZ`` (path list)
-    are honoured because the loader spec allows both.
+    closing every handle once the consumer has read it. A subkey that cannot be
+    opened is skipped rather than ending the walk.
     """
     hklm = winreg.HKEY_LOCAL_MACHINE
-    class_root_path = rf"SYSTEM\CurrentControlSet\Control\Class\{class_guid}"
     try:
-        class_root = winreg.OpenKey(hklm, class_root_path)
+        class_root = winreg.OpenKey(hklm, rf"{_PNP_CLASS_ROOT}\{class_guid}")
     except OSError:
         return
     try:
@@ -114,11 +113,22 @@ def _iter_pnp_class_manifests(winreg: Any, class_guid: str) -> Iterator[str]:
             except OSError:
                 continue
             try:
-                yield from _read_vulkan_driver_name_values(winreg, subkey)
+                yield subkey
             finally:
                 winreg.CloseKey(subkey)
     finally:
         winreg.CloseKey(class_root)
+
+
+def _iter_pnp_class_manifests(winreg: Any, class_guid: str) -> Iterator[str]:
+    """Yield manifest paths from PnP keys under one device-class GUID.
+
+    Reads each subkey's ``VulkanDriverName`` and ``VulkanDriverNameWow`` values.
+    Both ``REG_SZ`` (single path) and ``REG_MULTI_SZ`` (path list) are honoured
+    because the loader spec allows both.
+    """
+    for subkey in iter_pnp_class_subkeys(winreg, class_guid):
+        yield from _read_vulkan_driver_name_values(winreg, subkey)
 
 
 def _read_vulkan_driver_name_values(winreg: Any, subkey: Any) -> Iterator[str]:

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -670,6 +670,7 @@ class PlacementResponse(BaseModel):
     skipped_not_installed: list[SkippedRoleResponse] = []
     co_tenants: list[str] = []
     notice: str | None = None
+    rejected_spec_json: str | None = None
 
     @classmethod
     def from_view(cls, view: PlacementView) -> PlacementResponse:
@@ -693,6 +694,7 @@ class PlacementResponse(BaseModel):
                 SkippedRoleResponse(role=s.role, model=s.model) for s in view.skipped_not_installed
             ],
             co_tenants=[r.value for r in view.co_tenants],
+            rejected_spec_json=view.rejected_spec_json,
         )
 
 

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -116,6 +116,48 @@ def test_active_spec_parses_stored_json(monkeypatch):
     assert app_placement._active_spec() == spec
 
 
+def test_get_placement_survives_a_saved_spec_the_hardware_rejects(monkeypatch):
+    """The read path must not raise on a stale pin, driven through the real planner.
+
+    Stubbing ``resolve_placement_plan`` cannot hold this: the whole point is the
+    keyword ``get_placement`` passes it, so this reaches ``_placement_or_auto`` and
+    only the auto resolve is allowed to answer.
+    """
+    from pathlib import Path
+
+    import lilbee.providers.fleet.cuda_runtime as cuda_runtime
+    import lilbee.providers.fleet.gpu_env as gpu_env
+    from lilbee.providers.fleet import planning
+    from lilbee.providers.fleet.placement import Placement
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(1,))})
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: spec)
+    monkeypatch.setattr(planning, "resolve_llama_server", lambda: Path("/fake"))
+    monkeypatch.setattr(gpu_env, "apply_fleet_gpu_env", lambda: None)
+    monkeypatch.setattr(cuda_runtime, "apply_cuda_runtime_env", lambda: None)
+    monkeypatch.setattr(planning, "resolve_devices", lambda _b: [])
+    monkeypatch.setattr(
+        planning,
+        "_server_model_inputs",
+        lambda roles, *, unified_budget=None, total_vram=0: ([], {}, 0, {}),
+    )
+
+    def refuse(placement, *_a, **_kw):
+        if placement is None:
+            return Placement(instances=(), unplaceable_roles=())
+        raise PlacementError("embed pinned to device 1 but only 0 GPU(s) detected")
+
+    monkeypatch.setattr(planning, "_resolve_placement", refuse)
+    planning.clear_read_device_cache()
+
+    view = app_placement.get_placement()
+
+    assert view.manual is False
+    assert view.rejected_spec_json == spec.to_json()
+    planning.clear_read_device_cache()
+
+
 def test_get_placement_reports_a_saved_spec_that_did_not_apply_as_auto(monkeypatch):
     """A pin the hardware no longer satisfies is not the effective placement."""
     from dataclasses import replace

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -38,7 +38,7 @@ def test_view_surfaces_skipped_not_installed(monkeypatch):
     from lilbee.app.placement import SkippedRole
 
     monkeypatch.setattr(
-        app_placement, "resolve_placement_plan", lambda spec: _resolved_with_skipped()
+        app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved_with_skipped()
     )
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     view = app_placement.get_placement()
@@ -50,7 +50,7 @@ def test_view_surfaces_skipped_not_installed(monkeypatch):
 
 
 def test_view_has_no_skipped_when_all_installed(monkeypatch):
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     assert app_placement.get_placement().skipped_not_installed == ()
 
@@ -116,8 +116,37 @@ def test_active_spec_parses_stored_json(monkeypatch):
     assert app_placement._active_spec() == spec
 
 
+def test_get_placement_reports_a_saved_spec_that_did_not_apply_as_auto(monkeypatch):
+    """A pin the hardware no longer satisfies is not the effective placement."""
+    from dataclasses import replace
+
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    monkeypatch.setattr(
+        app_placement,
+        "resolve_placement_plan",
+        lambda _spec, **_kw: replace(_resolved(), spec_applied=False),
+    )
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: spec)
+
+    view = app_placement.get_placement()
+
+    assert view.manual is False
+    assert view.spec_json is None
+
+
+def test_get_placement_reports_an_applied_spec_as_manual(monkeypatch):
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda _spec, **_kw: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: spec)
+
+    view = app_placement.get_placement()
+
+    assert view.manual is True
+    assert view.spec_json == spec.to_json()
+
+
 def test_get_placement_renders_view(monkeypatch):
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     view = app_placement.get_placement()
     assert view.manual is False
@@ -140,7 +169,7 @@ def test_preview_passes_candidate_spec(monkeypatch):
 
 
 def test_preview_has_no_side_effects(monkeypatch):
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     peeked = {"called": False}
     monkeypatch.setattr(app_placement, "peek_services", lambda: peeked.__setitem__("called", True))
@@ -165,7 +194,7 @@ class _FakeProviderServices:
 def test_set_persists_and_reloads_live_fleet(monkeypatch):
     writes = {}
     services = _FakeProviderServices()
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: writes.update(d))
     monkeypatch.setattr(app_placement, "peek_services", lambda: services)
@@ -184,7 +213,7 @@ def test_set_persists_and_reloads_live_fleet(monkeypatch):
 def test_set_clears_read_device_cache_when_nothing_runs(monkeypatch):
     """With no services built, the next boot should probe devices fresh."""
     cleared = {"called": False}
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: None)
     monkeypatch.setattr(app_placement, "peek_services", lambda: None)
@@ -203,7 +232,7 @@ def test_set_keeps_device_probe_on_the_live_path(monkeypatch):
     """The surgical reload diffs plans against the same clean-box probe (bb-a8f):
     re-probing under a loaded fleet would poison the chat context sizing."""
     cleared = {"called": False}
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: None)
     monkeypatch.setattr(app_placement, "peek_services", _FakeProviderServices)
@@ -220,7 +249,7 @@ def test_set_keeps_device_probe_on_the_live_path(monkeypatch):
 
 def test_set_none_clears(monkeypatch):
     deletes = {}
-    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec, **_kw: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(
         app_placement.settings, "delete_values", lambda root, keys: deletes.setdefault("keys", keys)

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -58,6 +58,35 @@ def test_show_renders_not_downloaded_note(monkeypatch: object) -> None:
     assert "not downloaded" in result.stdout
 
 
+def _view_with_rejected_spec() -> PlacementView:
+    return PlacementView(
+        gpus=(GpuInfo(0, "Vulkan", "Vulkan0", "Intel Iris Xe", 8 * _GIB, 6 * _GIB),),
+        roles=(RolePlacementView(WorkerRole.EMBED, "org/embed.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=False,
+        spec_json=None,
+        rejected_spec_json='{"embed": {"devices": [1]}}',
+    )
+
+
+def test_show_reports_a_saved_placement_that_is_being_ignored(monkeypatch: object) -> None:
+    """A stale pin is named on the surface, not only in the server log."""
+    monkeypatch.setattr(cli_placement, "get_placement", _view_with_rejected_spec)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "does not fit this hardware" in result.stdout
+    assert "placement clear" in result.stdout
+
+
+def test_show_json_includes_the_rejected_spec(monkeypatch: object) -> None:
+    """HTTP, MCP and CLI all read the rejected pin off the same canonical JSON."""
+    monkeypatch.setattr(cli_placement, "get_placement", _view_with_rejected_spec)
+    monkeypatch.setattr(cfg, "json_mode", True)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["rejected_spec_json"] == '{"embed": {"devices": [1]}}'
+
+
 def test_show_json_includes_skipped_not_installed(monkeypatch: object) -> None:
     """The canonical JSON surfaces skipped-not-installed roles for HTTP/MCP/CLI parity."""
     monkeypatch.setattr(cli_placement, "get_placement", _view_with_skipped)

--- a/tests/providers/fleet/test_gpu_hardware.py
+++ b/tests/providers/fleet/test_gpu_hardware.py
@@ -14,6 +14,9 @@ NVIDIA = 0x10DE
 AMD = 0x1002
 INTEL = 0x8086
 VGA_CONTROLLER_CLASS = "0x030000"
+# What an NVIDIA Optimus dGPU and every datacenter card report: the display base
+# class with the 3D-controller subclass, never the VGA one.
+THREE_D_CONTROLLER_CLASS = "0x030200"
 DISPLAY_CONTROLLER_CLASS = "0x038000"
 NETWORK_CONTROLLER_CLASS = "0x020000"
 
@@ -53,13 +56,24 @@ class TestLinuxSysfs:
 
         assert gpu_hardware.installed_gpu_vendor_ids() == frozenset()
 
-    def test_non_vga_display_controllers_count(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize(
+        "class_code",
+        [
+            pytest.param(VGA_CONTROLLER_CLASS, id="vga"),
+            pytest.param(THREE_D_CONTROLLER_CLASS, id="3d-controller"),
+            pytest.param(DISPLAY_CONTROLLER_CLASS, id="other-display"),
+        ],
+    )
+    def test_every_display_subclass_counts(
+        self, class_code: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Class 0x03 covers every display controller, not only the VGA subclass."""
-        _write_pci_device(
-            tmp_path, "0000:01:00.0", class_code=DISPLAY_CONTROLLER_CLASS, vendor="0x1002"
-        )
+        """The whole 0x03 base class is a GPU, not just the VGA subclass.
+
+        An Optimus laptop's discrete card and every datacenter card enumerate as
+        3D controllers, so narrowing this to VGA would report them as absent and
+        disable the driver they need.
+        """
+        _write_pci_device(tmp_path, "0000:01:00.0", class_code=class_code, vendor="0x1002")
         monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
         monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
 

--- a/tests/providers/fleet/test_gpu_hardware.py
+++ b/tests/providers/fleet/test_gpu_hardware.py
@@ -1,0 +1,152 @@
+"""``installed_gpu_vendor_ids`` reads GPUs out of the OS device tree, not Vulkan."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from lilbee.providers.fleet import gpu_hardware
+
+NVIDIA = 0x10DE
+AMD = 0x1002
+INTEL = 0x8086
+VGA_CONTROLLER_CLASS = "0x030000"
+DISPLAY_CONTROLLER_CLASS = "0x038000"
+NETWORK_CONTROLLER_CLASS = "0x020000"
+
+
+def _write_pci_device(root: Path, slot: str, *, class_code: str, vendor: str) -> None:
+    device = root / slot
+    device.mkdir(parents=True)
+    (device / "class").write_text(f"{class_code}\n")
+    (device / "vendor").write_text(f"{vendor}\n")
+
+
+class TestLinuxSysfs:
+    def test_reports_display_controller_vendors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An Intel iGPU beside a discrete NVIDIA card reports both vendors."""
+        _write_pci_device(
+            tmp_path, "0000:00:02.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x8086"
+        )
+        _write_pci_device(
+            tmp_path, "0000:01:00.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x10de"
+        )
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset({INTEL, NVIDIA})
+
+    def test_non_display_devices_are_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An Intel network card is not an Intel GPU."""
+        _write_pci_device(
+            tmp_path, "0000:00:1f.6", class_code=NETWORK_CONTROLLER_CLASS, vendor="0x8086"
+        )
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset()
+
+    def test_non_vga_display_controllers_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Class 0x03 covers every display controller, not only the VGA subclass."""
+        _write_pci_device(
+            tmp_path, "0000:01:00.0", class_code=DISPLAY_CONTROLLER_CLASS, vendor="0x1002"
+        )
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset({AMD})
+
+    def test_unreadable_attributes_are_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A device missing class or vendor drops out instead of failing the probe."""
+        (tmp_path / "0000:00:02.0").mkdir()  # no class file at all
+        no_vendor = tmp_path / "0000:01:00.0"
+        no_vendor.mkdir()
+        (no_vendor / "class").write_text(VGA_CONTROLLER_CLASS)
+        _write_pci_device(
+            tmp_path, "0000:02:00.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x10de"
+        )
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset({NVIDIA})
+
+    def test_garbage_attribute_value_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-hex class code cannot raise out of the probe."""
+        _write_pci_device(tmp_path, "0000:00:02.0", class_code="not-a-number", vendor="0x8086")
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset()
+
+    def test_missing_sysfs_reports_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No /sys (a stripped container) is "cannot tell", not a crash."""
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", Path("/nonexistent/pci"))
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset()
+
+
+class TestWindowsRegistry:
+    def test_reads_vendors_from_display_adapter_hardware_ids(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """MatchingDeviceId (REG_SZ) and HardwareID (REG_MULTI_SZ) both carry VEN_xxxx."""
+        winreg = mock.MagicMock(name="winreg")
+        winreg.HKEY_LOCAL_MACHINE = 0
+        class_root = mock.MagicMock(name="class_root")
+        subkey0 = mock.MagicMock(name="0000")
+        subkey1 = mock.MagicMock(name="0001")
+        winreg.OpenKey.side_effect = [class_root, subkey0, subkey1]
+        winreg.EnumKey.side_effect = ["0000", "0001", OSError("end")]
+
+        def _query(key: mock.MagicMock, name: str) -> tuple[object, int]:
+            if key is subkey0 and name == "MatchingDeviceId":
+                return (r"PCI\VEN_10DE&DEV_1F95", 1)
+            if key is subkey1 and name == "HardwareID":
+                return ([r"PCI\VEN_8086&DEV_9A49&SUBSYS_22C317AA", ""], 7)
+            raise OSError("missing value")
+
+        winreg.QueryValueEx.side_effect = _query
+        monkeypatch.setitem(sys.modules, "winreg", winreg)
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "win32")
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset({NVIDIA, INTEL})
+
+    def test_non_pci_hardware_id_yields_nothing(self) -> None:
+        """A hardware ID with no VEN_ field (a virtual adapter) names no vendor."""
+        assert list(gpu_hardware._vendor_ids_in(r"ROOT\BasicDisplay")) == []
+
+    def test_non_string_registry_value_is_skipped(self) -> None:
+        """A REG_BINARY or REG_DWORD value cannot raise out of the parse."""
+        assert list(gpu_hardware._vendor_ids_in(b"\x00")) == []
+        assert list(gpu_hardware._vendor_ids_in([b"\x00", r"PCI\VEN_1002&DEV_73FF"])) == [AMD]
+
+    def test_unreadable_class_root_reports_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing display-adapter class key is "cannot tell", not a crash."""
+        winreg = mock.MagicMock(name="winreg")
+        winreg.HKEY_LOCAL_MACHINE = 0
+        winreg.OpenKey.side_effect = OSError("class GUID has no key")
+        monkeypatch.setitem(sys.modules, "winreg", winreg)
+        monkeypatch.setattr(gpu_hardware.sys, "platform", "win32")
+
+        assert gpu_hardware.installed_gpu_vendor_ids() == frozenset()
+
+
+def test_darwin_reports_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """macOS has no PCI device tree to read and runs Metal anyway."""
+    monkeypatch.setattr(gpu_hardware.sys, "platform", "darwin")
+
+    assert gpu_hardware.installed_gpu_vendor_ids() == frozenset()

--- a/tests/providers/fleet/test_gpu_hardware.py
+++ b/tests/providers/fleet/test_gpu_hardware.py
@@ -22,6 +22,11 @@ NETWORK_CONTROLLER_CLASS = "0x020000"
 
 
 def _write_pci_device(root: Path, slot: str, *, class_code: str, vendor: str) -> None:
+    """Write one sysfs PCI device directory.
+
+    Real slot names are ``0000:00:02.0``; the colons are illegal in Windows paths
+    and the probe never parses the name, so the fixture uses a portable stand-in.
+    """
     device = root / slot
     device.mkdir(parents=True)
     (device / "class").write_text(f"{class_code}\n")
@@ -34,10 +39,10 @@ class TestLinuxSysfs:
     ) -> None:
         """An Intel iGPU beside a discrete NVIDIA card reports both vendors."""
         _write_pci_device(
-            tmp_path, "0000:00:02.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x8086"
+            tmp_path, "0000-00-02.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x8086"
         )
         _write_pci_device(
-            tmp_path, "0000:01:00.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x10de"
+            tmp_path, "0000-01-00.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x10de"
         )
         monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
         monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
@@ -49,7 +54,7 @@ class TestLinuxSysfs:
     ) -> None:
         """An Intel network card is not an Intel GPU."""
         _write_pci_device(
-            tmp_path, "0000:00:1f.6", class_code=NETWORK_CONTROLLER_CLASS, vendor="0x8086"
+            tmp_path, "0000-00-1f.6", class_code=NETWORK_CONTROLLER_CLASS, vendor="0x8086"
         )
         monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
         monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
@@ -73,7 +78,7 @@ class TestLinuxSysfs:
         3D controllers, so narrowing this to VGA would report them as absent and
         disable the driver they need.
         """
-        _write_pci_device(tmp_path, "0000:01:00.0", class_code=class_code, vendor="0x1002")
+        _write_pci_device(tmp_path, "0000-01-00.0", class_code=class_code, vendor="0x1002")
         monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
         monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
 
@@ -83,12 +88,12 @@ class TestLinuxSysfs:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A device missing class or vendor drops out instead of failing the probe."""
-        (tmp_path / "0000:00:02.0").mkdir()  # no class file at all
-        no_vendor = tmp_path / "0000:01:00.0"
+        (tmp_path / "0000-00-02.0").mkdir()  # no class file at all
+        no_vendor = tmp_path / "0000-01-00.0"
         no_vendor.mkdir()
         (no_vendor / "class").write_text(VGA_CONTROLLER_CLASS)
         _write_pci_device(
-            tmp_path, "0000:02:00.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x10de"
+            tmp_path, "0000-02-00.0", class_code=VGA_CONTROLLER_CLASS, vendor="0x10de"
         )
         monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
         monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
@@ -99,7 +104,7 @@ class TestLinuxSysfs:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A non-hex class code cannot raise out of the probe."""
-        _write_pci_device(tmp_path, "0000:00:02.0", class_code="not-a-number", vendor="0x8086")
+        _write_pci_device(tmp_path, "0000-00-02.0", class_code="not-a-number", vendor="0x8086")
         monkeypatch.setattr(gpu_hardware.sys, "platform", "linux")
         monkeypatch.setattr(gpu_hardware, "_SYSFS_PCI_DEVICE_DIR", tmp_path)
 

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -56,6 +56,21 @@ def test_errors_on_nonexistent_device():
         )
 
 
+def test_errors_as_placement_error_when_the_estimate_has_no_per_device_split():
+    """An estimate that does not break down per device is a PlacementError, not a raw zip error.
+
+    gguf-parser returns no ``vrams[]`` breakdown for some models, leaving the
+    per-device vector empty. The auto planner already skips such a candidate; the
+    manual path must refuse in the same currency, so a saved pin degrades to
+    automatic placement instead of taking the fleet down.
+    """
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    with pytest.raises(PlacementError, match="chat is pinned to 1 device"):
+        placement_from_spec(
+            spec, (WorkerRole.CHAT,), {0: 80 * GIB}, estimate_peak=lambda role, ratio: ()
+        )
+
+
 def test_errors_when_does_not_fit_naming_card():
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
     est = _peak({WorkerRole.CHAT: [70]})

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -1,9 +1,12 @@
+import logging
 from pathlib import Path
+
+import pytest
 
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.devices import FleetDevice
 from lilbee.providers.fleet.placement import InstancePlan, Placement
-from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
 from lilbee.providers.roles import WorkerRole
 
 GIB = 1024**3
@@ -121,6 +124,119 @@ def test_auto_planner_charged_against_total_capacity(monkeypatch):
     monkeypatch.setattr(planning, "plan_placement", fake_plan)
     planning._resolve_placement(None, [], {}, devices, unified_budget=None)
     assert captured["devs"] == [(0, 80 * GIB)]  # total, not the 5 GiB free
+
+
+def test_saved_spec_that_no_longer_fits_falls_back_to_auto(monkeypatch, caplog):
+    """A pin naming a GPU this host no longer has must not take the fleet down."""
+    devices = [FleetDevice("Vulkan", 0, "Iris Xe", 8 * GIB, 8 * GIB)]
+    auto = Placement(
+        instances=(InstancePlan(role=WorkerRole.EMBED, devices=(0,)),), unplaceable_roles=()
+    )
+
+    def refuse(spec, *_a, **_kw):
+        if spec is None:
+            return auto
+        raise PlacementError("embed pinned to device 1 but only 1 GPU(s) detected")
+
+    monkeypatch.setattr(planning, "_resolve_placement", refuse)
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(1,))})
+
+    with caplog.at_level(logging.WARNING):
+        placement, spec_applied = planning._placement_or_auto(
+            spec, [], {WorkerRole.EMBED: "ref"}, devices, unified_budget=None
+        )
+
+    assert placement is auto
+    assert spec_applied is False
+    assert "does not fit this hardware" in caplog.text
+
+
+def test_saved_spec_that_fits_is_applied(monkeypatch):
+    """A pin the hardware still satisfies is used, and reports itself as applied."""
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    manual = Placement(
+        instances=(InstancePlan(role=WorkerRole.CHAT, devices=(0,)),), unplaceable_roles=()
+    )
+    monkeypatch.setattr(planning, "_resolve_placement", lambda spec, *_a, **_kw: manual)
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+
+    placement, spec_applied = planning._placement_or_auto(
+        spec, [], {WorkerRole.CHAT: "ref"}, devices, unified_budget=None
+    )
+
+    assert placement is manual
+    assert spec_applied is True
+
+
+def test_no_saved_spec_is_not_reported_as_applied(monkeypatch):
+    """With nothing saved the plan is the auto planner's, so spec_applied is False."""
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    auto = Placement(instances=(), unplaceable_roles=())
+    monkeypatch.setattr(planning, "_resolve_placement", lambda *_a, **_kw: auto)
+
+    placement, spec_applied = planning._placement_or_auto(
+        None, [], {}, devices, unified_budget=None
+    )
+
+    assert placement is auto
+    assert spec_applied is False
+
+
+def test_interactive_resolve_still_raises(monkeypatch):
+    """Without the fallback opt-in an unfittable spec raises, so an apply fails loud."""
+    import lilbee.providers.fleet.cuda_runtime as cuda_runtime
+    import lilbee.providers.fleet.gpu_env as gpu_env
+
+    planning.clear_read_device_cache()
+    monkeypatch.setattr(planning, "resolve_llama_server", lambda: Path("/fake"))
+    monkeypatch.setattr(gpu_env, "apply_fleet_gpu_env", lambda: None)
+    monkeypatch.setattr(cuda_runtime, "apply_cuda_runtime_env", lambda: None)
+    monkeypatch.setattr(planning, "resolve_devices", lambda _b: [])
+    monkeypatch.setattr(
+        planning,
+        "_server_model_inputs",
+        lambda roles, *, unified_budget=None, total_vram=0: ([], {}, 0, {}),
+    )
+
+    def refuse(*_a, **_kw):
+        raise PlacementError("embed pinned to device 0 but only 0 GPU(s) detected")
+
+    monkeypatch.setattr(planning, "_resolve_placement", refuse)
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
+
+    with pytest.raises(PlacementError):
+        planning.resolve_placement_plan(spec)
+    planning.clear_read_device_cache()
+
+
+def test_read_path_reports_the_plan_it_fell_back_to(monkeypatch):
+    """The view path opts into the fallback and marks the spec as not applied."""
+    import lilbee.providers.fleet.cuda_runtime as cuda_runtime
+    import lilbee.providers.fleet.gpu_env as gpu_env
+
+    planning.clear_read_device_cache()
+    monkeypatch.setattr(planning, "resolve_llama_server", lambda: Path("/fake"))
+    monkeypatch.setattr(gpu_env, "apply_fleet_gpu_env", lambda: None)
+    monkeypatch.setattr(cuda_runtime, "apply_cuda_runtime_env", lambda: None)
+    monkeypatch.setattr(planning, "resolve_devices", lambda _b: [])
+    monkeypatch.setattr(
+        planning,
+        "_server_model_inputs",
+        lambda roles, *, unified_budget=None, total_vram=0: ([], {}, 0, {}),
+    )
+
+    def refuse(spec, *_a, **_kw):
+        if spec is None:
+            return Placement(instances=(), unplaceable_roles=())
+        raise PlacementError("embed pinned to device 0 but only 0 GPU(s) detected")
+
+    monkeypatch.setattr(planning, "_resolve_placement", refuse)
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
+
+    resolved = planning.resolve_placement_plan(spec, fall_back_to_auto=True)
+
+    assert resolved.spec_applied is False
+    planning.clear_read_device_cache()
 
 
 def test_no_spec_uses_auto_planner(monkeypatch):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1827,7 +1827,7 @@ class TestIterWindowsVulkanManifestPaths:
         assert r"C:\soft\nv-vk64.json" in result
         assert any("amdvlk64.json" in path for path in result)
         # Both PnP class GUIDs (display adapter + software component) must be walked.
-        assert vulkan_icd_discovery._PNP_DISPLAY_ADAPTER_CLASS_GUID in pnp_calls
+        assert vulkan_icd_discovery.PNP_DISPLAY_ADAPTER_CLASS_GUID in pnp_calls
         assert vulkan_icd_discovery._PNP_SOFTWARE_COMPONENT_CLASS_GUID in pnp_calls
 
 
@@ -2109,7 +2109,7 @@ class TestIterPnpClassManifests:
 
         result = list(
             vulkan_icd_discovery._iter_pnp_class_manifests(
-                winreg, vulkan_icd_discovery._PNP_DISPLAY_ADAPTER_CLASS_GUID
+                winreg, vulkan_icd_discovery.PNP_DISPLAY_ADAPTER_CLASS_GUID
             )
         )
         assert r"C:\nv-vk64.json" in result
@@ -2128,7 +2128,7 @@ class TestIterPnpClassManifests:
         assert (
             list(
                 vulkan_icd_discovery._iter_pnp_class_manifests(
-                    winreg, vulkan_icd_discovery._PNP_DISPLAY_ADAPTER_CLASS_GUID
+                    winreg, vulkan_icd_discovery.PNP_DISPLAY_ADAPTER_CLASS_GUID
                 )
             )
             == []
@@ -2157,7 +2157,7 @@ class TestIterPnpClassManifests:
 
         result = list(
             vulkan_icd_discovery._iter_pnp_class_manifests(
-                winreg, vulkan_icd_discovery._PNP_DISPLAY_ADAPTER_CLASS_GUID
+                winreg, vulkan_icd_discovery.PNP_DISPLAY_ADAPTER_CLASS_GUID
             )
         )
         assert result == [r"C:\nv-vk64.json"]
@@ -2169,7 +2169,70 @@ class TestDisableConflictingVulkanIcds:
     Detection is registry-only: no Vulkan call runs while the disable env var
     is still unset, so the buggy vendor's ICD never gets pre-loaded into
     the process before we ask the loader to skip it.
+
+    Tests that don't name the host's GPUs leave ``installed_gpu_vendor_ids`` empty
+    (the "device tree says nothing" case) so the choice falls to the manifests.
     """
+
+    @pytest.fixture(autouse=True)
+    def _no_hardware_signal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.providers.fleet import gpu_select
+
+        monkeypatch.setattr(gpu_select, "installed_gpu_vendor_ids", frozenset)
+
+    def test_keeps_the_only_vendor_whose_gpu_is_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mesa ships radeon_icd on an Intel-only laptop; Intel must survive.
+
+        The Flatpak freedesktop runtime carries every Mesa driver, so the manifests
+        alone read as AMD + Intel. Disabling Intel there leaves the host with no
+        working ICD at all and the engine reports zero GPUs.
+        """
+        from lilbee.providers.fleet import gpu_select
+        from lilbee.providers.fleet.gpu_select import PCIVendorID
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_vulkan_vendors_present",
+            lambda: {PCIVendorID.AMD, PCIVendorID.INTEL},
+        )
+        monkeypatch.setattr(
+            gpu_select, "installed_gpu_vendor_ids", lambda: frozenset({PCIVendorID.INTEL})
+        )
+
+        result = gpu_select.disable_conflicting_vulkan_icds()
+        assert result is not None
+        assert "radeon*" in result
+        assert "intel*" not in result
+        assert "igvk*" not in result
+
+    def test_preference_order_applies_among_installed_gpus(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With NVIDIA and Intel both really present, NVIDIA still wins."""
+        from lilbee.providers.fleet import gpu_select
+        from lilbee.providers.fleet.gpu_select import PCIVendorID
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "linux")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_vulkan_vendors_present",
+            lambda: {PCIVendorID.NVIDIA, PCIVendorID.INTEL},
+        )
+        monkeypatch.setattr(
+            gpu_select,
+            "installed_gpu_vendor_ids",
+            lambda: frozenset({PCIVendorID.NVIDIA, PCIVendorID.INTEL}),
+        )
+
+        result = gpu_select.disable_conflicting_vulkan_icds()
+        assert result is not None
+        assert "intel*" in result
+        assert "nv*" not in result
 
     def test_pins_nvidia_when_amd_also_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """NVIDIA + AMD installed on Windows -> disable AMD ICD globs, keep NVIDIA."""

--- a/tests/test_tui_fleet.py
+++ b/tests/test_tui_fleet.py
@@ -18,7 +18,12 @@ GIB = 1024**3
 
 
 def _make_view(  # type: ignore[type-arg]
-    *, manual: bool = False, unplaceable: tuple = (), spec_json=None, co_tenants: tuple = ()
+    *,
+    manual: bool = False,
+    unplaceable: tuple = (),
+    spec_json=None,
+    co_tenants: tuple = (),
+    rejected_spec_json=None,
 ):
     from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
     from lilbee.providers.roles import WorkerRole
@@ -35,6 +40,7 @@ def _make_view(  # type: ignore[type-arg]
         manual=manual,
         spec_json=spec_json,
         co_tenants=co_tenants,
+        rejected_spec_json=rejected_spec_json,
     )
 
 
@@ -452,6 +458,26 @@ async def test_unplaceable_warns(monkeypatch):
         await pilot.pause()
 
     assert any("vision" in n.lower() for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_ignored_saved_placement_warns(monkeypatch):
+    """A stale pin reaches the surface the user is looking at, not just the log."""
+    from lilbee.cli.tui.widgets import fleet_body as fbm
+
+    view = _make_view(rejected_spec_json='{"embed": {"devices": [7]}}')
+    monkeypatch.setattr(fbm, "get_placement", lambda: view)
+
+    notes: list[str] = []
+    app = FleetTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        body = app.screen.query_one("FleetBody")
+        body.notify = lambda msg, **k: notes.append(msg)  # type: ignore[method-assign]
+        body._load_worker()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert any("does not fit this hardware" in n for n in notes)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

On a laptop whose only GPU is Intel, every chat and every ingest failed with `lilbee: embed pinned to device 0 but only 0 GPU(s) detected`.

Two things had to go wrong together:

- lilbee decides which GPU vendors a machine has by looking at which Vulkan driver files are installed. Mesa ships every vendor's driver together, so the AMD driver file sits next to the Intel one whether or not there is an AMD card in the box, and a Flatpak runtime always carries the full set. So an Intel-only laptop looked like an AMD + Intel machine.
- AMD wins that tie, so lilbee disabled the Intel driver: the only driver the machine actually had. From then on the engine reported zero GPUs.
- The GPU placement saved in `config.toml` pinned roles to devices 0 and 1. With zero GPUs those pins are impossible, and that error was fatal. Chat, embed and ingest all stopped working, with no way back except editing the config by hand.

## Solution

- Which vendors a host has now comes from the hardware itself (PCI display controllers in sysfs on Linux, the display-adapter class in the registry on Windows), matched against the installed driver files, so the driver left enabled always drives a card that is really there. Where the hardware can't be read, the old behaviour still applies.
- A saved placement that no longer matches the hardware falls back to automatic placement instead of taking the server down. Applying a placement by hand still fails loudly, so a pin you just typed that doesn't fit is still reported as an error.
- The CLI, the TUI and the JSON surfaces all say when a saved placement is being ignored, so it isn't a silent fallback: the pin stays in `config.toml` and would otherwise reapply the next time the hardware happens to fit it.
- One more way a saved placement could kill the server: when the memory estimator returns no per-device breakdown for a model, charging a pinned card raised a bare `ValueError` that the fallback above could not catch. It now refuses the same way every other bad pin does.

Anyone already stuck in this state recovers on upgrade: the Intel driver comes back, and the stale pins no longer block startup.