### PR TITLE
Bound the reap of short-lived fleet subprocesses

### DIFF
--- a/src/lilbee/providers/fleet/devices.py
+++ b/src/lilbee/providers/fleet/devices.py
@@ -9,17 +9,16 @@ fallback when the binary can't enumerate. See docs/architecture.md.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
 import re
-import signal
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.gpu_select import USABLE_VULKAN_TYPES, VkDeviceType
+from lilbee.providers.fleet.proc import run_bounded
 
 log = logging.getLogger(__name__)
 
@@ -148,16 +147,15 @@ def host_lacks_nvlink() -> bool:
     single-card host stays silent rather than warning wrongly.
     """
     try:
-        proc = subprocess.run(
-            ["nvidia-smi", "topo", "-m"],  # noqa: S607
-            capture_output=True,
-            text=True,
-            timeout=_TOPO_TIMEOUT_S,
-            check=False,
+        stdout, _ = run_bounded(
+            ["nvidia-smi", "topo", "-m"],
+            timeout_s=_TOPO_TIMEOUT_S,
+            kill_wait_s=_PROBE_KILL_WAIT_S,
+            label="nvidia-smi topo",
         )
     except (OSError, subprocess.SubprocessError):
         return False
-    gpu_rows, pairs = _parse_topo_matrix(proc.stdout)
+    gpu_rows, pairs = _parse_topo_matrix(stdout)
     return len(gpu_rows) >= _TOPO_MIN_GPUS and not pairs
 
 
@@ -204,24 +202,22 @@ def probe_devices(binary: Path, *, timeout_s: float = _LIST_DEVICES_TIMEOUT_S) -
 
 
 def _run_list_devices(binary: Path, timeout_s: float) -> tuple[str, int]:
-    """Run the probe in its own process group; kill the group and raise on timeout.
+    """Run the probe with a bounded reap; raise on timeout.
 
-    ``subprocess.run``'s timeout path waits indefinitely for the killed child to
-    be reaped, so a probe wedged in uninterruptible GPU-driver I/O would hang the
-    caller forever; this bounds the reap and abandons an unkillable child.
+    A probe wedged in uninterruptible GPU-driver I/O would otherwise hang the
+    caller forever, since ``subprocess.run``'s timeout waits unbounded for the
+    reap; ``run_bounded`` abandons an unkillable child after a short wait.
     """
-    proc = subprocess.Popen(  # noqa: S603 - binary is the resolved llama-server
-        [str(binary), "--list-devices"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=_probe_env(),
-        start_new_session=True,
-    )
     try:
-        output, _ = proc.communicate(timeout=timeout_s)
+        return run_bounded(
+            [str(binary), "--list-devices"],
+            timeout_s=timeout_s,
+            kill_wait_s=_PROBE_KILL_WAIT_S,
+            env=_probe_env(),
+            merge_stderr=True,
+            label=f"{binary.name} --list-devices",
+        )
     except subprocess.TimeoutExpired:
-        _kill_probe(proc)
         raise ProviderError(
             f"The GPU device probe ({binary.name} --list-devices) did not respond "
             f"within {timeout_s:.0f}s, so the engine cannot start. The GPU driver "
@@ -230,25 +226,6 @@ def _run_list_devices(binary: Path, timeout_s: float) -> tuple[str, int]:
             provider=_PROVIDER,
             kind=ProviderErrorKind.SERVER,
         ) from None
-    return output or "", proc.returncode
-
-
-def _kill_probe(proc: subprocess.Popen[str]) -> None:
-    """SIGKILL the timed-out probe's process group; abandon it if it cannot be reaped."""
-    if os.name == "posix":
-        # start_new_session made the probe its own group leader.
-        with contextlib.suppress(OSError):
-            os.killpg(proc.pid, signal.SIGKILL)
-    else:  # pragma: no cover - Windows has no process groups to kill
-        proc.kill()
-    try:
-        proc.communicate(timeout=_PROBE_KILL_WAIT_S)
-    except subprocess.TimeoutExpired:
-        log.warning(
-            "The GPU device probe (pid %d) ignored SIGKILL and was abandoned; "
-            "it is likely stuck in the GPU driver.",
-            proc.pid,
-        )
 
 
 def _parse_devices(text: str) -> list[FleetDevice]:

--- a/src/lilbee/providers/fleet/gpu_backends/base.py
+++ b/src/lilbee/providers/fleet/gpu_backends/base.py
@@ -9,7 +9,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
+from lilbee.providers.fleet.proc import run_bounded
+
 _SMI_TIMEOUT_S = 5.0
+# Bounded wait for a timed-out smi tool to die before abandoning it: a driver-
+# wedged sampler must not hang the util-sampling thread (it holds a lock).
+_SMI_KILL_WAIT_S = 5.0
 
 
 @dataclass(frozen=True)
@@ -38,16 +43,12 @@ def run_smi(tool: str, args: Sequence[str], timeout: float = _SMI_TIMEOUT_S) -> 
     """
     binary = shutil.which(tool) or tool
     try:
-        proc = subprocess.run(  # noqa: S603 - caller supplies fixed args from named constants
-            [binary, *args],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
+        stdout, returncode = run_bounded(
+            [binary, *args], timeout_s=timeout, kill_wait_s=_SMI_KILL_WAIT_S, label=tool
         )
     except (OSError, subprocess.SubprocessError):
         return ""
-    return proc.stdout if proc.returncode == 0 else ""
+    return stdout if returncode == 0 else ""
 
 
 def extract_int(obj: object, keys: tuple[str, ...]) -> int | None:

--- a/src/lilbee/providers/fleet/proc.py
+++ b/src/lilbee/providers/fleet/proc.py
@@ -1,0 +1,69 @@
+"""Run a short-lived subprocess with a bounded reap.
+
+``subprocess.run``'s timeout path waits indefinitely for the killed child to be
+reaped, so a process wedged in uninterruptible I/O (a GPU driver, a stuck
+parser) hangs the caller forever. This kills the child's process group and
+abandons it after a bounded wait if it will not die, so a wedged child costs a
+bounded wait rather than a permanent hang.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import signal
+import subprocess
+
+log = logging.getLogger(__name__)
+
+
+def run_bounded(
+    argv: list[str],
+    *,
+    timeout_s: float,
+    kill_wait_s: float,
+    env: dict[str, str] | None = None,
+    merge_stderr: bool = False,
+    label: str | None = None,
+) -> tuple[str, int]:
+    """Run *argv*, returning ``(stdout, returncode)``.
+
+    The child runs in its own session so its whole group can be killed. With
+    *merge_stderr* stderr is folded into the returned stdout; otherwise it is
+    discarded (the caller wants clean stdout, e.g. JSON). On timeout the group
+    is SIGKILLed and awaited for at most *kill_wait_s*, then ``TimeoutExpired``
+    is re-raised -- an unkillable child is abandoned rather than waited on.
+    """
+    proc = subprocess.Popen(  # noqa: S603 - argv is trusted: a resolved binary or a fixed literal
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.DEVNULL,
+        text=True,
+        env=env,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        stdout, _ = proc.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        _abandon_group(proc, kill_wait_s, label or argv[0])
+        raise
+    return stdout or "", proc.returncode
+
+
+def _abandon_group(proc: subprocess.Popen[str], kill_wait_s: float, label: str) -> None:
+    """SIGKILL the child's group; log and give up if it cannot be reaped in time."""
+    if os.name == "posix":
+        # start_new_session made the child its own group leader.
+        with contextlib.suppress(OSError):
+            os.killpg(proc.pid, signal.SIGKILL)
+    else:  # pragma: no cover - Windows has no process groups to kill
+        proc.kill()
+    try:
+        proc.communicate(timeout=kill_wait_s)
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "%s (pid %d) ignored SIGKILL and was abandoned; it is likely wedged in a driver.",
+            label,
+            proc.pid,
+        )

--- a/src/lilbee/providers/fleet/vram.py
+++ b/src/lilbee/providers/fleet/vram.py
@@ -16,6 +16,7 @@ from lilbee.core.config.enums import KvCacheType
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.adapters import FLAG_BATCH_SIZE, FLAG_UBATCH_SIZE
 from lilbee.providers.fleet.binary import resolve_gguf_parser
+from lilbee.providers.fleet.proc import run_bounded
 
 # gguf-parser CLI flags (the batch flags are shared with the llama-server argv builder).
 _FLAG_PATH = "--path"
@@ -46,6 +47,9 @@ _KEY_NONUMA = "nonuma"
 
 _PROVIDER = "llama-server"
 _PARSE_TIMEOUT_S = 60
+# Bounded wait for a timed-out parser to die before abandoning it (matches the
+# device probe): a parser wedged in driver I/O must not hang the warm-up thread.
+_PARSE_KILL_WAIT_S = 5.0
 _CACHE_SIZE = 64
 
 # Mirrors vLLM's gpu_memory_utilization default: never charge a GPU past 90% of
@@ -258,17 +262,20 @@ def estimator_argv(
 
 def _run_parser(argv: list[str], path_str: str) -> str:
     """Run gguf-parser, returning its JSON stdout or a user-facing error."""
+    failed = ProviderError(
+        f"Could not size the model {path_str!r}: the memory estimator failed to run.",
+        provider=_PROVIDER,
+        kind=ProviderErrorKind.SERVER,
+    )
     try:
-        proc = subprocess.run(  # noqa: S603 - argv[0] is the resolved gguf-parser
-            argv, capture_output=True, text=True, timeout=_PARSE_TIMEOUT_S, check=True
+        stdout, returncode = run_bounded(
+            argv, timeout_s=_PARSE_TIMEOUT_S, kill_wait_s=_PARSE_KILL_WAIT_S, label="gguf-parser"
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        raise ProviderError(
-            f"Could not size the model {path_str!r}: the memory estimator failed to run.",
-            provider=_PROVIDER,
-            kind=ProviderErrorKind.SERVER,
-        ) from exc
-    return proc.stdout
+        raise failed from exc
+    if returncode != 0:
+        raise failed
+    return stdout
 
 
 def _parse_estimate(stdout: str, path_str: str) -> GgufVramEstimate:

--- a/tests/providers/fleet/gpu_backends/test_base.py
+++ b/tests/providers/fleet/gpu_backends/test_base.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
-
 import pytest
 
 from lilbee.providers.fleet.gpu_backends import base as base_mod
@@ -83,28 +81,28 @@ def test_parse_device_index_no_digit_returns_none() -> None:
 
 
 def test_run_smi_returns_stdout_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_run(*_a: object, **_k: object) -> subprocess.CompletedProcess:
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout="output\n", stderr="")
+    def _fake_run(*_a: object, **_k: object) -> tuple[str, int]:
+        return "output\n", 0
 
-    monkeypatch.setattr(base_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(base_mod, "run_bounded", _fake_run)
     monkeypatch.setattr(base_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
     assert run_smi("nvidia-smi", ["--version"]) == "output\n"
 
 
 def test_run_smi_returns_empty_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_run(*_a: object, **_k: object) -> subprocess.CompletedProcess:
-        return subprocess.CompletedProcess(args=[], returncode=1, stdout="output\n", stderr="")
+    def _fake_run(*_a: object, **_k: object) -> tuple[str, int]:
+        return "output\n", 1
 
-    monkeypatch.setattr(base_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(base_mod, "run_bounded", _fake_run)
     monkeypatch.setattr(base_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
     assert run_smi("nvidia-smi", []) == ""
 
 
 def test_run_smi_returns_empty_on_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _boom(*_a: object, **_k: object) -> subprocess.CompletedProcess:
+    def _boom(*_a: object, **_k: object) -> tuple[str, int]:
         raise OSError("no such file")
 
-    monkeypatch.setattr(base_mod.subprocess, "run", _boom)
+    monkeypatch.setattr(base_mod, "run_bounded", _boom)
     monkeypatch.setattr(base_mod.shutil, "which", lambda _: None)
     assert run_smi("missing-tool", []) == ""
 
@@ -117,11 +115,7 @@ def test_run_smi_resolves_which_at_call_time(monkeypatch: pytest.MonkeyPatch) ->
         return f"/custom/{name}"
 
     monkeypatch.setattr(base_mod.shutil, "which", _fake_which)
-    monkeypatch.setattr(
-        base_mod.subprocess,
-        "run",
-        lambda *_a, **_k: subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
-    )
+    monkeypatch.setattr(base_mod, "run_bounded", lambda *_a, **_k: ("", 0))
     run_smi("my-tool", [])
     assert "my-tool" in resolved
 
@@ -130,12 +124,12 @@ def test_run_smi_falls_back_to_tool_name_when_which_fails(monkeypatch: pytest.Mo
     """When shutil.which returns None the tool name itself is used as binary."""
     called_with: list[list[str]] = []
 
-    def _fake_run(*args: object, **_k: object) -> subprocess.CompletedProcess:
+    def _fake_run(*args: object, **_k: object) -> tuple[str, int]:
         called_with.append(list(args[0]))  # type: ignore[arg-type]
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        return "", 0
 
     monkeypatch.setattr(base_mod.shutil, "which", lambda _: None)
-    monkeypatch.setattr(base_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(base_mod, "run_bounded", _fake_run)
     run_smi("my-tool", ["--flag"])
     assert called_with[0][0] == "my-tool"
 

--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -27,8 +26,8 @@ _MIB = 1024 * 1024
 
 
 def _fake_run(stdout: str):
-    def _run(*_a: object, **_k: object) -> subprocess.CompletedProcess:
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+    def _run(*_a: object, **_k: object) -> tuple[str, int]:
+        return stdout, 0
 
     return _run
 
@@ -66,7 +65,7 @@ class TestNvlinkTopology:
         assert pairs == {frozenset({0, 1}), frozenset({0, 2}), frozenset({1, 2})}
 
     def test_real_h100_host_has_nvlink(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(_TOPO_REAL_H100))
+        monkeypatch.setattr(dev_mod, "run_bounded", _fake_run(_TOPO_REAL_H100))
         assert dev_mod.host_lacks_nvlink() is False
 
     def test_parse_finds_nvlink_pair(self) -> None:
@@ -80,28 +79,28 @@ class TestNvlinkTopology:
         assert pairs == set()
 
     def test_lacks_nvlink_true_for_pcie_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(_TOPO_PCIE))
+        monkeypatch.setattr(dev_mod, "run_bounded", _fake_run(_TOPO_PCIE))
         assert dev_mod.host_lacks_nvlink() is True
 
     def test_lacks_nvlink_false_when_linked(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(_TOPO_NVLINK))
+        monkeypatch.setattr(dev_mod, "run_bounded", _fake_run(_TOPO_NVLINK))
         assert dev_mod.host_lacks_nvlink() is False
 
     def test_unparseable_topo_makes_no_claim(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Garbage output parses zero GPU rows: stay silent rather than mis-warn.
-        monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run("some unrelated output\n"))
+        monkeypatch.setattr(dev_mod, "run_bounded", _fake_run("some unrelated output\n"))
         assert dev_mod.host_lacks_nvlink() is False
 
     def test_single_gpu_host_is_not_flagged(self, monkeypatch: pytest.MonkeyPatch) -> None:
         single = "\tGPU0\tCPU Affinity\nGPU0\t X \t0-31\n"
-        monkeypatch.setattr(dev_mod.subprocess, "run", _fake_run(single))
+        monkeypatch.setattr(dev_mod, "run_bounded", _fake_run(single))
         assert dev_mod.host_lacks_nvlink() is False
 
     def test_probe_failure_is_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom(*_a: object, **_k: object) -> object:
             raise OSError("no nvidia-smi")
 
-        monkeypatch.setattr(dev_mod.subprocess, "run", _boom)
+        monkeypatch.setattr(dev_mod, "run_bounded", _boom)
         assert dev_mod.host_lacks_nvlink() is False
 
 
@@ -200,32 +199,6 @@ def test_probe_timeout_raises_and_kills_the_child(tmp_path: Path) -> None:
     script.chmod(0o755)
     with pytest.raises(ProviderError, match="did not respond"):
         probe_devices(script, timeout_s=0.2)
-
-
-def test_probe_abandons_an_unreapable_child(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A child that survives SIGKILL (uninterruptible driver I/O) is abandoned
-    after a bounded reap instead of blocking the caller forever.
-
-    The POSIX group-kill path is forced (repo pattern: simulate the platform)
-    so the same lines are exercised on every CI host, Windows included.
-    """
-
-    class _WedgedProc:
-        pid = 12345
-
-        def communicate(self, timeout: float | None = None) -> tuple[str, str]:
-            raise subprocess.TimeoutExpired(cmd="llama-server", timeout=timeout or 0)
-
-    monkeypatch.setattr(dev_mod.subprocess, "Popen", lambda *_a, **_k: _WedgedProc())
-    monkeypatch.setattr(dev_mod.os, "name", "posix")
-    monkeypatch.setattr(dev_mod.os, "killpg", lambda *_a: None, raising=False)
-    monkeypatch.setattr(dev_mod.signal, "SIGKILL", 9, raising=False)
-    monkeypatch.setattr(dev_mod, "_PROBE_KILL_WAIT_S", 0.01)
-    with caplog.at_level("WARNING"), pytest.raises(ProviderError, match="did not respond"):
-        probe_devices(Path("/bin/llama-server"), timeout_s=0.01)
-    assert "abandoned" in caplog.text
 
 
 def test_probe_env_sets_pci_bus_order() -> None:

--- a/tests/test_fleet_proc.py
+++ b/tests/test_fleet_proc.py
@@ -1,0 +1,57 @@
+"""The bounded-reap subprocess runner shared by the device probe and gguf-parser."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.providers.fleet import proc
+
+
+def test_returns_stdout_and_returncode() -> None:
+    out, rc = proc.run_bounded([sys.executable, "-c", "print('hi')"], timeout_s=10, kill_wait_s=2)
+    assert out == "hi\n"
+    assert rc == 0
+
+
+def test_default_discards_stderr_but_merge_folds_it() -> None:
+    argv = [sys.executable, "-c", "import sys; sys.stderr.write('err'); print('out')"]
+    out, _ = proc.run_bounded(argv, timeout_s=10, kill_wait_s=2)
+    assert out == "out\n"  # stderr discarded
+    merged, _ = proc.run_bounded(argv, timeout_s=10, kill_wait_s=2, merge_stderr=True)
+    assert "err" in merged and "out" in merged
+
+
+@pytest.mark.timeout(10)
+def test_a_timed_out_child_is_killed_and_raises() -> None:
+    """A sleeping child is killed on timeout, so the call returns instead of hanging.
+
+    The @timeout guard fails the test if the reap were unbounded (the 30s sleep).
+    """
+    argv = [sys.executable, "-c", "import time; time.sleep(30)"]
+    with pytest.raises(subprocess.TimeoutExpired):
+        proc.run_bounded(argv, timeout_s=0.5, kill_wait_s=3)
+
+
+def test_an_unkillable_child_is_abandoned_with_a_warning(monkeypatch, caplog) -> None:
+    """If the killed child never exits, run_bounded gives up after kill_wait_s."""
+    fake = MagicMock()
+    fake.pid = 424242
+    # The run times out; the post-kill reap also times out, standing in for a child
+    # wedged in uninterruptible I/O that ignores SIGKILL.
+    fake.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="x", timeout=0.1),
+        subprocess.TimeoutExpired(cmd="x", timeout=0.1),
+    ]
+    monkeypatch.setattr(proc.subprocess, "Popen", lambda *a, **k: fake)
+    # Force the POSIX group-kill path so the same lines run on every OS. os.killpg
+    # and signal.SIGKILL are absent on Windows, so seed them with raising=False.
+    monkeypatch.setattr(proc.os, "name", "posix")
+    monkeypatch.setattr(proc.os, "killpg", lambda *a: None, raising=False)
+    monkeypatch.setattr(proc.signal, "SIGKILL", 9, raising=False)
+    with pytest.raises(subprocess.TimeoutExpired), caplog.at_level("WARNING"):
+        proc.run_bounded(["stuck"], timeout_s=0.1, kill_wait_s=0.1, label="stuck")
+    assert any("abandoned" in r.message for r in caplog.records)

--- a/tests/test_fleet_vram.py
+++ b/tests/test_fleet_vram.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -53,12 +51,12 @@ def _patch_parser(
     """Stub out the gguf-parser binary path and its subprocess invocation."""
     monkeypatch.setattr(vram_mod, "resolve_gguf_parser", lambda: Path("/fake/gguf-parser"))
 
-    def fake_run(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+    def fake_run(argv: list[str], **_kwargs: object) -> tuple[str, int]:
         if recorder is not None:
             recorder.append(argv)
-        return SimpleNamespace(stdout=stdout)
+        return stdout, 0
 
-    monkeypatch.setattr(vram_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(vram_mod, "run_bounded", fake_run)
 
 
 class TestFootprint:
@@ -228,24 +226,35 @@ class TestEstimateInstanceFootprint:
         estimate_instance_footprint(model_file, **kwargs)
         assert len(calls) == 2
 
-    def test_run_failure_raises_provider_error(
+    def _estimate(self, model_file: Path) -> None:
+        estimate_instance_footprint(
+            model_file,
+            ctx=2048,
+            slots=1,
+            gpu_layers=-1,
+            flash_attn=True,
+            kv_cache_type=KvCacheType.F16,
+        )
+
+    def test_a_nonzero_exit_raises_provider_error(
+        self, model_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vram_mod, "resolve_gguf_parser", lambda: Path("/fake/gguf-parser"))
+        monkeypatch.setattr(vram_mod, "run_bounded", lambda *a, **k: ("", 1))
+        with pytest.raises(ProviderError, match="failed to run"):
+            self._estimate(model_file)
+
+    def test_a_spawn_or_timeout_failure_raises_provider_error(
         self, model_file: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(vram_mod, "resolve_gguf_parser", lambda: Path("/fake/gguf-parser"))
 
-        def boom(argv: list[str], **_kwargs: object) -> SimpleNamespace:
-            raise subprocess.CalledProcessError(1, argv)
+        def boom(*_a: object, **_k: object) -> tuple[str, int]:
+            raise OSError("no such binary")
 
-        monkeypatch.setattr(vram_mod.subprocess, "run", boom)
+        monkeypatch.setattr(vram_mod, "run_bounded", boom)
         with pytest.raises(ProviderError, match="failed to run"):
-            estimate_instance_footprint(
-                model_file,
-                ctx=2048,
-                slots=1,
-                gpu_layers=-1,
-                flash_attn=True,
-                kv_cache_type=KvCacheType.F16,
-            )
+            self._estimate(model_file)
 
     def test_unparseable_output_raises_provider_error_with_cause(
         self, model_file: Path, monkeypatch: pytest.MonkeyPatch
@@ -367,12 +376,12 @@ class TestProjectorCorrection:
     ) -> None:
         monkeypatch.setattr(vram_mod, "resolve_gguf_parser", lambda: Path("/fake/gguf-parser"))
 
-        def fake_run(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+        def fake_run(argv: list[str], **_kwargs: object) -> tuple[str, int]:
             if recorder is not None:
                 recorder.append(argv)
-            return SimpleNamespace(stdout=mmproj_json if "--mmproj-path" in argv else base_json)
+            return (mmproj_json if "--mmproj-path" in argv else base_json), 0
 
-        monkeypatch.setattr(vram_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(vram_mod, "run_bounded", fake_run)
 
     def _estimate(self, model_file: Path, mmproj: Path) -> GgufVramEstimate:
         return estimate_instance_footprint(


### PR DESCRIPTION
## Problem

`subprocess.run` with a timeout kills the child on expiry, then waits for it to be reaped **unbounded**. A process wedged in uninterruptible driver I/O ignores even SIGKILL, so that wait never returns and the caller hangs.

The GPU device probe already worked around this by hand. Three siblings did not: the gguf-parser memory estimator (`vram._run_parser`), the `nvidia-smi topo` NVLink probe (`devices.host_lacks_nvlink`), and the live nvidia-smi/rocm-smi util sampler (`gpu_backends.base.run_smi`, which runs under a lock, so a wedge also serializes other samplers behind it).

## Solution

Extract the probe's kill-and-bounded-reap into `fleet/proc.py:run_bounded` and route the short-lived spawns through it. The child runs in its own session; on timeout its whole group is SIGKILLed and awaited for at most `kill_wait_s`, then `TimeoutExpired` is re-raised, abandoning an unkillable child instead of blocking. `merge_stderr` folds stderr into stdout for the device/topo probes, while the estimator and sampler keep clean stdout.

The bespoke `_kill_probe` is deleted rather than duplicated. The Intel smi calls stay on `subprocess.run`: they read partial stdout off the `TimeoutExpired`, which the bounded runner does not surface.

## Cross-platform

Reviewed on Windows/macOS/Linux: `os.killpg`/`signal.SIGKILL` are referenced only inside the `os.name == "posix"` branch, so Windows never evaluates them and takes `proc.kill()` (the short-lived children spawn no grandchildren); `start_new_session` is a no-op on Windows exactly as before. All call sites preserve their prior error mapping.