### PR TITLE
Publish every flatpak from one run and gate promotion on the channel artifacts

### DIFF
--- a/.github/actions/fanout-packaging/action.yml
+++ b/.github/actions/fanout-packaging/action.yml
@@ -1,5 +1,5 @@
 name: Fan out downstream packaging
-description: "Trigger publish-docker.yml and publish-packages.yml for a tag once the Linux + macOS-arm64 executables are attached to the GH release. Waits up to 5 hours for those to land before failing loudly. Caller needs actions:write."
+description: "Trigger publish-docker.yml, publish-packages.yml and publish-flatpak.yml for a tag once the Linux + macOS-arm64 executables are attached to the GH release. Waits up to 5 hours for those to land before failing loudly. Caller needs actions:write."
 
 inputs:
   tag:
@@ -56,5 +56,17 @@ runs:
         GH_TOKEN: ${{ github.token }}
       run: |
         gh workflow run publish-packages.yml \
+          --repo ${{ github.repository }} \
+          -f tag=${{ inputs.tag }}
+
+    # Every flatpak variant publishes from one workflow, so it is dispatched here
+    # rather than once per fan-out: the variants share the OSTree pages repo and
+    # must write one at a time. It waits for the CUDA and compat binaries itself.
+    - name: Trigger Publish Flatpak
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh workflow run publish-flatpak.yml \
           --repo ${{ github.repository }} \
           -f tag=${{ inputs.tag }}

--- a/.github/workflows/publish-compat-packages.yml
+++ b/.github/workflows/publish-compat-packages.yml
@@ -28,7 +28,6 @@ jobs:
       tag: ${{ steps.info.outputs.tag }}
       version: ${{ steps.info.outputs.version }}
       sha_linux_compat: ${{ steps.info.outputs.sha_linux_compat }}
-      size_linux_compat: ${{ steps.info.outputs.size_linux_compat }}
       sha_windows_compat: ${{ steps.info.outputs.sha_windows_compat }}
     steps:
       - name: Resolve tag and compat asset digests
@@ -47,11 +46,7 @@ jobs:
           get_sha() {
             awk -F'\t' -v name="$1" '$1 == name { print $2 }' /tmp/assets.tsv
           }
-          get_size() {
-            awk -F'\t' -v name="$1" '$1 == name { print $3 }' /tmp/assets.tsv
-          }
           sha_linux_compat=$(get_sha lilbee-compat-linux-x86_64)
-          size_linux_compat=$(get_size lilbee-compat-linux-x86_64)
           sha_windows_compat=$(get_sha lilbee-compat-windows-x86_64.exe)
 
           [ -n "$sha_linux_compat" ] || { echo "lilbee-compat-linux-x86_64 missing from release ${tag}; run release.yml (compat cell) first"; exit 1; }
@@ -60,7 +55,6 @@ jobs:
             echo "tag=$tag"
             echo "version=$version"
             echo "sha_linux_compat=$sha_linux_compat"
-            echo "size_linux_compat=$size_linux_compat"
             echo "sha_windows_compat=$sha_windows_compat"
           } >> "$GITHUB_OUTPUT"
 
@@ -160,29 +154,6 @@ jobs:
           cp "${{ steps.build.outputs.snap }}" lilbee-compat-linux-x86_64.snap
           gh release upload "$TAG" lilbee-compat-linux-x86_64.snap --repo "$GITHUB_REPOSITORY" --clobber
 
-  flatpak:
-    needs: resolve
-    # Serialized against the regular and CUDA flatpak jobs; see publish-packages.yml.
-    concurrency:
-      group: flatpak-lilbee-repo
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/publish-flatpak
-        with:
-          pages-token: ${{ secrets.FLATPAK_PAGES_TOKEN }}
-          gpg-private-key: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
-          version: ${{ needs.resolve.outputs.version }}
-          sha-linux: ${{ needs.resolve.outputs.sha_linux_compat }}
-          size-linux: ${{ needs.resolve.outputs.size_linux_compat }}
-          tag: ${{ needs.resolve.outputs.tag }}
-          app-id: io.github.tobocop2.lilbee.compat
-          manifest-path: packaging/flatpak/io.github.tobocop2.lilbee.compat.yml
-          asset-name: lilbee-compat-linux-x86_64
-          bundle-name: lilbee-compat.flatpak
 
   scoop:
     needs: resolve

--- a/.github/workflows/publish-cuda-packages.yml
+++ b/.github/workflows/publish-cuda-packages.yml
@@ -25,7 +25,6 @@ jobs:
       tag: ${{ steps.info.outputs.tag }}
       version: ${{ steps.info.outputs.version }}
       sha_linux_cuda: ${{ steps.info.outputs.sha_linux_cuda }}
-      size_linux_cuda: ${{ steps.info.outputs.size_linux_cuda }}
     steps:
       - name: Resolve tag and CUDA asset digest
         id: info
@@ -43,11 +42,7 @@ jobs:
           get_sha() {
             awk -F'\t' -v name="$1" '$1 == name { print $2 }' /tmp/assets.tsv
           }
-          get_size() {
-            awk -F'\t' -v name="$1" '$1 == name { print $3 }' /tmp/assets.tsv
-          }
           sha_linux_cuda=$(get_sha lilbee-linux-x86_64-cu125)
-          size_linux_cuda=$(get_size lilbee-linux-x86_64-cu125)
 
           [ -n "$sha_linux_cuda" ] || { echo "lilbee-linux-x86_64-cu125 missing from release ${tag}; run build-cuda-executables.yml first"; exit 1; }
 
@@ -55,7 +50,6 @@ jobs:
             echo "tag=$tag"
             echo "version=$version"
             echo "sha_linux_cuda=$sha_linux_cuda"
-            echo "size_linux_cuda=$size_linux_cuda"
           } >> "$GITHUB_OUTPUT"
 
   homebrew:
@@ -153,26 +147,3 @@ jobs:
           cp "${{ steps.build.outputs.snap }}" lilbee-linux-x86_64-cu125.snap
           gh release upload "$TAG" lilbee-linux-x86_64-cu125.snap --repo "$GITHUB_REPOSITORY" --clobber
 
-  flatpak:
-    needs: resolve
-    # Serialized against the regular and compat flatpak jobs; see publish-packages.yml.
-    concurrency:
-      group: flatpak-lilbee-repo
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/publish-flatpak
-        with:
-          pages-token: ${{ secrets.FLATPAK_PAGES_TOKEN }}
-          gpg-private-key: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
-          version: ${{ needs.resolve.outputs.version }}
-          sha-linux: ${{ needs.resolve.outputs.sha_linux_cuda }}
-          size-linux: ${{ needs.resolve.outputs.size_linux_cuda }}
-          tag: ${{ needs.resolve.outputs.tag }}
-          app-id: io.github.tobocop2.lilbee.cuda
-          manifest-path: packaging/flatpak/io.github.tobocop2.lilbee.cuda.yml
-          asset-name: lilbee-linux-x86_64-cu125
-          bundle-name: lilbee-cuda.flatpak

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -1,0 +1,127 @@
+name: Publish Flatpak
+
+run-name: Publish Flatpak ${{ inputs.tag }}
+
+# Publishes every flatpak variant -- stock, CUDA and compat -- to the shared
+# OSTree pages repo.
+#
+# All three live in one workflow because each regenerates the repo's summary and
+# static deltas wholesale, so only one may write at a time. They used to be a job
+# apiece in the three packaging fan-outs, serialized by a shared
+# `flatpak-lilbee-repo` concurrency group. That cannot express three writers: a
+# concurrency group holds a single pending run, so when the fan-outs queued
+# together the waiting one was evicted rather than queued and its bundle never
+# attached. A max-parallel-1 matrix in one run serializes them by construction.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish flatpaks for (e.g. v0.6.90b420.dev727)."
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flatpak-lilbee-repo
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+      sha_stock: ${{ steps.info.outputs.sha_stock }}
+      size_stock: ${{ steps.info.outputs.size_stock }}
+      sha_cuda: ${{ steps.info.outputs.sha_cuda }}
+      size_cuda: ${{ steps.info.outputs.size_cuda }}
+      sha_compat: ${{ steps.info.outputs.sha_compat }}
+      size_compat: ${{ steps.info.outputs.size_compat }}
+    steps:
+      # Dispatched as soon as the stock executables are attached, which can be
+      # before the CUDA and compat binaries land, so wait for them before reading
+      # their digests rather than publishing a partial set.
+      - name: Wait for the variant binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          WAIT_MINUTES: "90"
+        run: |
+          set -uo pipefail
+          deadline=$(( $(date +%s) + WAIT_MINUTES * 60 ))
+          while true; do
+            names=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+              --jq '[.assets[].name] | join(" ")' 2>/dev/null || echo "")
+            missing=""
+            for a in lilbee-linux-x86_64 lilbee-linux-x86_64-cu125 lilbee-compat-linux-x86_64; do
+              case " ${names} " in *" ${a} "*) ;; *) missing="${missing} ${a}" ;; esac
+            done
+            [ -n "${missing}" ] || break
+            [ "$(date +%s)" -lt "${deadline}" ] || {
+              echo "::error::variant binaries missing after ${WAIT_MINUTES}m:${missing}"; exit 1; }
+            echo "waiting for:${missing}"
+            sleep 60
+          done
+      - name: Resolve each variant's digest and size
+        id: info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          gh api "/repos/${REPO}/releases/tags/${TAG}" \
+            --jq '.assets[] | "\(.name)\t\(.digest|sub("sha256:"; ""))\t\(.size)"' > /tmp/assets.tsv
+          field() { awk -F'\t' -v n="$1" -v c="$2" '$1 == n { print $c }' /tmp/assets.tsv; }
+          {
+            echo "version=${TAG#v}"
+            echo "sha_stock=$(field lilbee-linux-x86_64 2)"
+            echo "size_stock=$(field lilbee-linux-x86_64 3)"
+            echo "sha_cuda=$(field lilbee-linux-x86_64-cu125 2)"
+            echo "size_cuda=$(field lilbee-linux-x86_64-cu125 3)"
+            echo "sha_compat=$(field lilbee-compat-linux-x86_64 2)"
+            echo "size_compat=$(field lilbee-compat-linux-x86_64 3)"
+          } >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      # One writer at a time: each variant rewrites the repo summary and static
+      # deltas wholesale, so a second in flight would drop the first's app.
+      max-parallel: 1
+      # A variant that fails must not stop the others from publishing.
+      fail-fast: false
+      matrix:
+        include:
+          - app-id: io.github.tobocop2.lilbee
+            asset: lilbee-linux-x86_64
+            bundle: lilbee.flatpak
+            sha: ${{ needs.resolve.outputs.sha_stock }}
+            size: ${{ needs.resolve.outputs.size_stock }}
+          - app-id: io.github.tobocop2.lilbee.cuda
+            asset: lilbee-linux-x86_64-cu125
+            bundle: lilbee-cuda.flatpak
+            sha: ${{ needs.resolve.outputs.sha_cuda }}
+            size: ${{ needs.resolve.outputs.size_cuda }}
+          - app-id: io.github.tobocop2.lilbee.compat
+            asset: lilbee-compat-linux-x86_64
+            bundle: lilbee-compat.flatpak
+            sha: ${{ needs.resolve.outputs.sha_compat }}
+            size: ${{ needs.resolve.outputs.size_compat }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/publish-flatpak
+        with:
+          pages-token: ${{ secrets.FLATPAK_PAGES_TOKEN }}
+          gpg-private-key: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
+          version: ${{ needs.resolve.outputs.version }}
+          sha-linux: ${{ matrix.sha }}
+          size-linux: ${{ matrix.size }}
+          tag: ${{ inputs.tag }}
+          app-id: ${{ matrix['app-id'] }}
+          manifest-path: packaging/flatpak/${{ matrix['app-id'] }}.yml
+          asset-name: ${{ matrix.asset }}
+          bundle-name: ${{ matrix.bundle }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -10,7 +10,9 @@ on:
         description: "Release tag to (re)publish (e.g. v0.6.66b469)."
         required: true
       channels:
-        description: "Channels to publish: 'all' or a comma list of homebrew,aur,nix,flatpak,snap."
+        # Flatpak is not here: every variant publishes from publish-flatpak.yml,
+        # which serializes them against the shared OSTree repo.
+        description: "Channels to publish: 'all' or a comma list of homebrew,aur,nix,snap,scoop."
         required: false
         default: "all"
 
@@ -32,7 +34,6 @@ jobs:
       sha_macos_x86_64: ${{ steps.info.outputs.sha_macos_x86_64 }}
       sha_windows: ${{ steps.info.outputs.sha_windows }}
       sha_windows_cu125: ${{ steps.info.outputs.sha_windows_cu125 }}
-      size_linux: ${{ steps.info.outputs.size_linux }}
     steps:
       - name: Resolve tag and asset digests
         id: info
@@ -50,11 +51,7 @@ jobs:
           get_sha() {
             awk -F'\t' -v name="$1" '$1 == name { print $2 }' /tmp/assets.tsv
           }
-          get_size() {
-            awk -F'\t' -v name="$1" '$1 == name { print $3 }' /tmp/assets.tsv
-          }
           sha_linux=$(get_sha lilbee-linux-x86_64)
-          size_linux=$(get_size lilbee-linux-x86_64)
           sha_macos_arm64=$(get_sha lilbee-macos-arm64)
           sha_macos_x86_64=$(get_sha lilbee-macos-x86_64)
           sha_windows=$(get_sha lilbee-windows-x86_64.exe)
@@ -71,7 +68,6 @@ jobs:
             echo "sha_macos_x86_64=$sha_macos_x86_64"
             echo "sha_windows=$sha_windows"
             echo "sha_windows_cu125=$sha_windows_cu125"
-            echo "size_linux=$size_linux"
           } >> "$GITHUB_OUTPUT"
 
   homebrew:
@@ -113,31 +109,6 @@ jobs:
           version: ${{ needs.resolve.outputs.version }}
           sha-linux: ${{ needs.resolve.outputs.sha_linux }}
           aur-ssh-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-
-  flatpak:
-    needs: resolve
-    if: inputs.channels == 'all' || contains(inputs.channels, 'flatpak')
-    # One writer at a time for the shared OSTree pages repo. The regular, CUDA and
-    # compat fan-outs run concurrently and each regenerates the repo's summary and
-    # static deltas wholesale, so the rebase-retry the text-file channels use would
-    # drop whichever app a sibling had just published. Group name is shared across
-    # all three workflows on purpose.
-    concurrency:
-      group: flatpak-lilbee-repo
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/publish-flatpak
-        with:
-          pages-token: ${{ secrets.FLATPAK_PAGES_TOKEN }}
-          gpg-private-key: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
-          version: ${{ needs.resolve.outputs.version }}
-          sha-linux: ${{ needs.resolve.outputs.sha_linux }}
-          size-linux: ${{ needs.resolve.outputs.size_linux }}
-          tag: ${{ needs.resolve.outputs.tag }}
 
   snap:
     needs: resolve

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -94,6 +94,52 @@ jobs:
           [ "${missing}" -eq 0 ] || { echo "a continue-on-error CUDA build cell dropped its artifact"; exit 1; }
           echo "every expected CUDA asset is present"
 
+  # The packaging fan-outs are dispatched fire-and-forget and finish after the RC
+  # run this workflow triggers on, so their artifacts are still arriving when the
+  # rest of the verification starts. Nothing else checks they arrived: dev727
+  # promoted-ready at 26 of 29 assets, missing two flatpaks and a snap, because a
+  # dropped fan-out looks exactly like one still in flight. Wait for them, then
+  # fail if any is still absent, so the promotion gate cannot green-light an
+  # incomplete release.
+  verify-channel-assets:
+    needs: [resolve]
+    timeout-minutes: 210
+    runs-on: ubuntu-latest
+    steps:
+      - name: Every channel artifact reached the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          # Generous: the flatpak variants publish one at a time against the
+          # shared repo, behind their own wait for the binaries. A false timeout
+          # here blocks promotion, which is worse than waiting.
+          WAIT_MINUTES: "180"
+        run: |
+          set -uo pipefail
+          expected="lilbee.flatpak lilbee-cuda.flatpak lilbee-compat.flatpak
+                    lilbee-linux-x86_64.snap lilbee-linux-x86_64-cu125.snap
+                    lilbee-compat-linux-x86_64.snap"
+          deadline=$(( $(date +%s) + WAIT_MINUTES * 60 ))
+          while true; do
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+              --jq '.assets[].name' > assets.txt 2>/dev/null || : > assets.txt
+            missing=""
+            for name in ${expected}; do
+              # -x: an exact line, so lilbee-linux-x86_64-cu125.snap cannot satisfy
+              # the check for lilbee-linux-x86_64.snap.
+              grep -qxF "${name}" assets.txt || missing="${missing} ${name}"
+            done
+            [ -n "${missing}" ] || { echo "every channel artifact is on the release"; exit 0; }
+            if [ "$(date +%s)" -ge "${deadline}" ]; then
+              echo "::error::channel artifacts still missing after ${WAIT_MINUTES}m:${missing}"
+              echo "a packaging fan-out dropped its artifact; re-run it before promoting"
+              exit 1
+            fi
+            echo "waiting for:${missing}"
+            sleep 60
+          done
+
   verify-executables:
     needs: [resolve]
     timeout-minutes: 45


### PR DESCRIPTION
## Problem

Two ways a release shipped incomplete with nothing going red.

The three packaging fan-outs each carried a flatpak job sharing the `flatpak-lilbee-repo` concurrency group. Sharing it is right: all three rewrite the same OSTree summary and static deltas, so they must serialize. But a concurrency group holds one pending run, so three writers queued together evict the waiter. On dev727 the compat flatpak job was cancelled six seconds in and its bundle never attached; it took a manual re-run after the other two finished.

Verify release is the promotion gate, and it fires when the release candidate finishes, before the fan-outs have attached anything. It checked only the six CUDA assets, so dev727 went green at 26 of 29 assets, missing two flatpaks and a snap.

## Solution

Every variant now publishes from `publish-flatpak.yml` over a `max-parallel: 1` matrix, so they serialize by construction rather than contending for a group that can queue only one. The dispatch lives in the shared `fanout-packaging` action so the emergency publish path gets it too.

Verify release now waits for the flatpak and snap artifacts and fails if any is missing, so the gate cannot pass an incomplete release.

Deleting the flatpak jobs left `size_linux`, `size_linux_cuda` and `size_linux_compat` with no readers; they and their `get_size` helper go too.

## Worth knowing

Workflow changes cannot run locally, so the matrix expansion, the `max-parallel: 1` ordering and the wait loops are verified by reading and YAML parse only. The first real proof is the next release.

Serializing the three flatpak builds is slower in wall clock than three racing in parallel. That is the intended behaviour rather than a regression: they were always meant to serialize, and the eviction is what made it look faster. Verify waits 180 minutes so a slow tail cannot false-fail and block promotion.