### PR TITLE
Fix Windows CI: cover devices.py timeout path and stabilize focus test

### DIFF
--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 from collections.abc import Iterator
 from pathlib import Path
@@ -178,6 +179,15 @@ def test_probe_runs_the_real_binary(tmp_path: Path) -> None:
 def test_run_list_devices_returns_the_child_output(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dev_mod, "run_bounded", lambda *_a, **_k: (_CUDA_LISTING, 0))
     assert dev_mod._run_list_devices(Path("/bin/llama-server"), 1.0) == (_CUDA_LISTING, 0)
+
+
+def test_run_list_devices_timeout_raises_provider_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _timeout(*_a: object, **_k: object) -> tuple[str, int]:
+        raise subprocess.TimeoutExpired(cmd="llama-server --list-devices", timeout=1.0)
+
+    monkeypatch.setattr(dev_mod, "run_bounded", _timeout)
+    with pytest.raises(ProviderError, match="did not respond"):
+        dev_mod._run_list_devices(Path("/bin/llama-server"), 1.0)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -10341,12 +10341,12 @@ async def test_catalog_grid_leave_down_focuses_next():
             if len(grids) < 2:
                 pytest.skip("test requires at least two grids mounted")
             grids[0].focus()
-            # focus() lands over one or more refresh hops, not synchronously; a
-            # bare pause here lets LeaveDown post before grids[0] is actually the
-            # focused widget, so focus_next moves from the wrong anchor and can
-            # land back on grids[0]. Wait for the anchor to settle first, and
-            # assert it landed: without focus on grids[0] the post-condition
-            # ("focus moved off grids[0]") would pass for the wrong reason.
+            await pilot.pause()
+            grids = list(screen.query(ModelGrid))
+            grids[0].focus()
+            # Wait for focus to settle: focus() lands over one or more refresh
+            # hops, so a bare pause can leave grids[0] unfocused and LeaveDown
+            # then moves from the wrong anchor.
             assert await pump_until(pilot, lambda: screen.focused is grids[0])
             grids[0].post_message(ModelGrid.LeaveDown(grids[0]))
             await pump_until(pilot, lambda: screen.focused is not grids[0])


### PR DESCRIPTION
Two pre-existing issues causing the Windows test lane to fail:

1. **Coverage gap**: `src/lilbee/providers/fleet/devices.py` lines 226-227 (the `except subprocess.TimeoutExpired` branch in `_run_list_devices`) was only covered by a POSIX-only end-to-end test that spawns a real shell script, which is skipped on Windows. Added a monkeypatch-based unit test that covers the same path on every platform.

2. **Flaky focus test**: `test_catalog_grid_leave_down_focuses_next` failed on Windows because `grids[0].focus()` didn't settle fast enough for the widget-identity check. The sibling test already uses a double-focus + re-query pattern; applied the same fix here.