### PR TITLE
Let ingest workers write their own chunks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,7 @@ The codebase has a small set of `try: import X except ImportError:` patterns for
 | `litellm` | `lilbee.providers.litellm_sdk.litellm_available()` | `lilbee[litellm]` | SDK provider, settings TUI |
 | `crawl4ai` | `lilbee.crawler.crawler_available()` | `lilbee[crawler]` | Web crawler |
 | `graspologic_native` | `lilbee.retrieval.concepts.nlp.concepts_available()` | `lilbee[graph]` | Concept-graph clustering |
+| `pylance` (`lance`) | `lilbee.data.ingest.fragment_writer.fragments_available()` | `lilbee[bulk-ingest]` | Worker fragment writes in bulk multiprocess ingest |
 | `lilbee_engine` | resolved in `lilbee.providers.fleet.binary.resolve_engine_tool()` | bundled wheel | The local inference engine binaries (llama-server + llama-swap + gguf-parser) |
 
 Any other `try: import X` should be either added to this table or refactored. CLI command bodies that branch on extras dispatch through these `*_available()` helpers, not via `importlib.import_module(name)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ dependencies = [
 litellm = ["litellm>=1.84.0,<1.92"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.9.0"]
+# Server-side bulk multiprocess ingest writes each worker's chunk vectors as lance
+# fragments instead of draining them through the parent process. Needs pylance (the
+# fragment API), lazily imported only in that path, so the query/interactive paths
+# and the pre-Haswell +compat standalone never pull it in. Validated against the
+# stock lancedb 0.33 pin: fragments round-trip and ANN/FTS indexes build on them.
+bulk-ingest = ["pylance>=9.0.0"]
 # A fallback source of the CUDA 12 runtime, from NVIDIA's official PyPI wheels;
 # fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH. The engine
 # wheel now ships cudart/cublas/cublasLt beside llama-server on both Linux and Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,10 @@ crawler = ["crawl4ai>=0.9.0"]
 # fragment API), lazily imported only in that path, so the query/interactive paths
 # and the pre-Haswell +compat standalone never pull it in. Validated against the
 # stock lancedb 0.33 pin: fragments round-trip and ANN/FTS indexes build on them.
-bulk-ingest = ["pylance>=9.0.0"]
+# lance-namespace>=0.8.6 is pylance 9's runtime floor (it imports symbols absent
+# from the 0.5.x lancedb resolves otherwise); lancedb 0.33 only reads the stable
+# namespace API and works unchanged against the bump.
+bulk-ingest = ["pylance>=9.0.0", "lance-namespace>=0.8.6"]
 # A fallback source of the CUDA 12 runtime, from NVIDIA's official PyPI wheels;
 # fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH. The engine
 # wheel now ships cudart/cublas/cublasLt beside llama-server on both Linux and Windows

--- a/src/lilbee/data/ingest/fragment_writer.py
+++ b/src/lilbee/data/ingest/fragment_writer.py
@@ -1,0 +1,68 @@
+"""Append a worker's chunk batch straight to the shared LanceDB as a fragment.
+
+Bulk multiprocess ingest embeds in parallel across worker processes, but in the
+worker-pool-plus-parent-writes design every chunk (a ~16KB vector) is pickled
+back to one parent that builds Arrow and writes single-threaded. That collect
+loop is GIL-bound and caps aggregate throughput near ~220 records/sec regardless
+of how many or how fast the GPUs are -- an 8xH200 measurement sat at ~220 with
+the cards only ~50% utilised, identical to 8xA40, because the drain, not the
+fleet, is the limit.
+
+This lets each worker write its own chunk batch: ``write_fragments`` lays down
+the fragment's data files in the worker process, and an ``Append`` commit adds
+them to the dataset. Concurrent ``Append`` commits do not conflict -- lance
+merges disjoint fragments into the manifest -- so the vectors never cross IPC and
+the Arrow build parallelises across workers instead of serialising in the parent.
+
+Optional by construction. It needs ``lance`` (pylance), which is installed only
+for server-side bulk ingest; the single-process and interactive paths never
+import it, so the pre-Haswell standalone (which ships only the +compat lancedb)
+never pulls in a pylance whose AVX2 kernels it could not run. When lance is
+absent the caller falls back to the parent-writes path.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+
+# lance's own commit retries a losing optimistic-concurrency race this many times
+# before raising, rebasing the operation on the winning version each attempt.
+# Concurrent Appends are non-conflicting by design, so this almost never fires; it
+# is a correctness backstop for the rare manifest race, not the hot path.
+_COMMIT_MAX_RETRIES = 20
+
+
+def fragments_available() -> bool:
+    """True when pylance is importable, so the fragment-write path can be used."""
+    try:
+        import lance  # noqa: F401
+        from lance.fragment import write_fragments  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def append_chunk_fragment(dataset_uri: str, records: list[dict], schema: pa.Schema) -> int:
+    """Write *records* as a fragment and commit it to the dataset. Returns rows written.
+
+    The dataset must already exist with *schema* (the parent creates the chunks
+    table before spawning workers). ``write_fragments`` runs in the calling worker
+    and writes only this batch's data files; the ``Append`` commit adds them under
+    lance's own retry so a lost commit race rebases rather than corrupts. A failure
+    raises, isolating to this worker's batch rather than the whole run.
+    """
+    if not records:
+        return 0
+    import lance
+    from lance.fragment import write_fragments
+
+    table = pa.Table.from_pylist(records, schema=schema)
+    fragments = write_fragments(table, dataset_uri)
+    dataset = lance.dataset(dataset_uri)
+    lance.LanceDataset.commit(
+        dataset_uri,
+        lance.LanceOperation.Append(fragments),
+        read_version=dataset.version,
+        max_retries=_COMMIT_MAX_RETRIES,
+    )
+    return len(records)

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -36,6 +36,7 @@ from lilbee.data.ingest.adaptive import (
 from lilbee.data.ingest.code import ingest_code_sync
 from lilbee.data.ingest.discovery import classify_file, discover_files, file_hash
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
+from lilbee.data.ingest.fragment_writer import fragments_available
 from lilbee.data.ingest.offload import embed_inflight_target, max_workers, to_ingest_thread
 from lilbee.data.ingest.skip_marker import (
     clear_skip_markers,
@@ -60,6 +61,7 @@ from lilbee.data.ingest.workers import (
 )
 from lilbee.data.store import (
     SOURCE_STAT_UNKNOWN,
+    ChunksDataset,
     ChunkWrite,
     ConceptRecords,
     PageTextRecord,
@@ -891,13 +893,15 @@ async def _collect_from_worker(
         pages_done[0] += 1  # cleared the gate (as a failure); still a throughput tick
         return _IngestResult(name, entry.path, 0, error=outcome.error)
     records = outcome.records or []
+    # Fragment mode strips records after the worker commits them; the count still travels.
+    chunk_count = outcome.chunks_written if outcome.chunks_written is not None else len(records)
     page_texts = outcome.page_texts or []
-    on_progress(EventType.FILE_DONE, FileDoneEvent(file=name, status="ok", chunks=len(records)))
+    on_progress(EventType.FILE_DONE, FileDoneEvent(file=name, status="ok", chunks=chunk_count))
     pages_done[0] += max(1, len(page_texts))
     return _IngestResult(
         name,
         entry.path,
-        len(records),
+        chunk_count,
         error=None,
         file_hash=entry.file_hash,
         records=records,
@@ -924,11 +928,27 @@ async def _warm_engine_for_workers(processes: int) -> None:
         await to_ingest_thread(warm_parent_engine)
 
 
+async def _prepare_fragment_writes(processes: int) -> ChunksDataset | None:
+    """The shared chunks dataset workers append fragments to; None keeps parent-writes.
+
+    Only bulk multiprocess runs qualify (one process keeps the atomic
+    single-writer path) and only when pylance is installed (the bulk-ingest
+    extra; servers). The embedding gate runs up front because a worker's
+    fragment commit bypasses the per-flush gate in ``write_chunks_batch``.
+    """
+    if processes <= 1 or not fragments_available():
+        return None
+    store = get_services().store
+    await to_ingest_thread(store.assert_embedding_compatible)
+    return await to_ingest_thread(store.ensure_chunks_dataset)
+
+
 def _dispatch_plan(
     files_to_process: list[FileToProcess],
     processes: int,
     in_process: Callable[[FileToProcess, int], Coroutine[Any, Any, _IngestResult]],
     *,
+    chunks_uri: str | None = None,
     pages_done: list[int],
     on_progress: DetailedProgressCallback,
     cancel: threading.Event | None,
@@ -937,7 +957,7 @@ def _dispatch_plan(
     total_files = len(files_to_process)
     if processes <= 1:
         return None, (in_process(entry, idx) for idx, entry in enumerate(files_to_process, 1))
-    pool = build_pool(processes, active_config(), _max_concurrent())
+    pool = build_pool(processes, active_config(), _max_concurrent(), chunks_uri)
     log.warning("Ingesting %d files across %d worker processes", total_files, processes)
     dispatcher = BatchDispatcher(pool, files_to_process)
     return pool, (
@@ -979,6 +999,7 @@ async def ingest_batch(
     pages_done = [0]
     total_files = len(files_to_process)
     processes = resolve_process_count(total_files)
+    fragment = await _prepare_fragment_writes(processes)
     admission, window, controller_task = _admission_for(processes, pages_done)
 
     async def _process_one(entry: FileToProcess, file_index: int) -> _IngestResult:
@@ -1060,10 +1081,12 @@ async def ingest_batch(
         files_to_process,
         processes,
         _process_one,
+        chunks_uri=fragment.uri if fragment is not None else None,
         pages_done=pages_done,
         on_progress=on_progress,
         cancel=cancel,
     )
+    rowid_ceiling = fragment.rowid_ceiling if fragment is not None else None
     try:
         if quiet:
             await _collect_results(
@@ -1077,6 +1100,7 @@ async def ingest_batch(
                 on_progress=on_progress,
                 flush_failed=flush_failed,
                 reasons=reasons,
+                rowid_ceiling=rowid_ceiling,
             )
         else:
             with Progress(
@@ -1107,6 +1131,7 @@ async def ingest_batch(
                     ptask=ptask,
                     flush_failed=flush_failed,
                     reasons=reasons,
+                    rowid_ceiling=rowid_ceiling,
                 )
     finally:
         # Stop the adaptive controller (if any) before returning: its background
@@ -1154,6 +1179,7 @@ async def _collect_results(
     ptask: Any = None,
     flush_failed: set[str] | None = None,
     reasons: dict[str, str] | None = None,
+    rowid_ceiling: int | None = None,
 ) -> None:
     """Run *pending* through a bounded task window, batching writes and progress.
 
@@ -1202,6 +1228,7 @@ async def _collect_results(
                         failed,
                         skipped,
                         flush_failed,
+                        rowid_ceiling,
                     )
                 elif status is BatchStatus.SKIPPED and result.needs_cleanup:
                     # Zero-text result is never buffered; collect it for the
@@ -1220,7 +1247,7 @@ async def _collect_results(
         # itself raises (e.g. a cancellation landing on the to_thread await).
         try:
             await to_ingest_thread(
-                _flush_writes, buffer, added, updated, failed, skipped, flush_failed
+                _flush_writes, buffer, added, updated, failed, skipped, flush_failed, rowid_ceiling
             )
             await to_ingest_thread(_purge_emptied_sources, to_purge)
         finally:
@@ -1249,13 +1276,16 @@ async def _buffer_and_maybe_flush(
     failed: dict[str, None],
     skipped: dict[str, None],
     flush_failed: set[str] | None,
+    rowid_ceiling: int | None,
 ) -> int:
     """Buffer one ingested file, flushing at the chunk threshold; returns the new count."""
     buffer.append(result)
     # Zero-chunk files count one unit so the buffer stays bounded.
     buffered_chunks += max(result.chunk_count, 1)
     if buffered_chunks >= _WRITE_FLUSH_CHUNKS:
-        await to_ingest_thread(_flush_writes, buffer, added, updated, failed, skipped, flush_failed)
+        await to_ingest_thread(
+            _flush_writes, buffer, added, updated, failed, skipped, flush_failed, rowid_ceiling
+        )
         buffered_chunks = 0
     return buffered_chunks
 
@@ -1346,7 +1376,7 @@ def _retry_after_lock_timeout(write: Callable[[], object]) -> None:
         write()
 
 
-def _flush_batch(buffer: list[_IngestResult]) -> None:
+def _flush_batch(buffer: list[_IngestResult], rowid_ceiling: int | None = None) -> None:
     """Persist one flush unit in a single locked ``write_chunks_batch`` transaction.
 
     Page texts travel inside each :class:`ChunkWrite` so the store writes them
@@ -1367,7 +1397,9 @@ def _flush_batch(buffer: list[_IngestResult]) -> None:
         )
         for r in buffer
     ]
-    _retry_after_lock_timeout(lambda: store.write_chunks_batch(items))
+    _retry_after_lock_timeout(
+        lambda: store.write_chunks_batch(items, rowid_ceiling=rowid_ceiling)
+    )
     _flush_concept_records(buffer)
     _flush_entity_rows(buffer)
 
@@ -1426,6 +1458,7 @@ def _flush_writes(
     failed: dict[str, None],
     skipped: dict[str, None],
     flush_failed: set[str] | None = None,
+    rowid_ceiling: int | None = None,
 ) -> None:
     """Flush the buffered documents to the store; track a write failure.
 
@@ -1439,7 +1472,7 @@ def _flush_writes(
     if not buffer:
         return
     try:
-        _flush_batch(buffer)
+        _flush_batch(buffer, rowid_ceiling)
     except Exception as exc:
         for r in buffer:
             log.warning("Failed to write %s: %s", r.name, exc)

--- a/src/lilbee/data/ingest/workers.py
+++ b/src/lilbee/data/ingest/workers.py
@@ -9,9 +9,14 @@ concurrency: an 8-worker A/B that kept the total in flight unchanged measured
 1.00x with the GPUs still at 63%, so the process count alone buys nothing.
 
 Only per-file production (extract, chunk, embed) runs here. The parent keeps
-the plan, the single LanceDB writer, skip markers, move detection,
+the plan, skip markers, move detection, sources/side-table writes,
 reconciliation, progress and cancellation, so the one-index invariant holds by
-construction rather than by a merge step.
+construction rather than by a merge step. Chunk vectors are the exception:
+when pylance is installed the parent hands each worker the shared chunks
+dataset URI and the worker commits its batch's chunks as its own lance
+fragment (see :mod:`lilbee.data.ingest.fragment_writer`), so vectors never
+cross IPC and the Arrow build parallelises; without pylance the parent stays
+the single chunk writer.
 
 Workers never build an engine; they attach to the parent's (see
 ``SwapManager.bind``), because a second fleet would double-book the GPUs. That
@@ -30,9 +35,12 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from contextlib import ExitStack
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from lilbee.core.config import active_config
+from lilbee.data.ingest.fragment_writer import append_chunk_fragment
+from lilbee.data.ingest.offload import to_ingest_thread
+from lilbee.data.store import chunks_schema
 from lilbee.runtime.cpu import cpu_quota
 
 if TYPE_CHECKING:
@@ -120,13 +128,19 @@ def resolve_process_count(file_count: int) -> int:
 
 @dataclass
 class WorkerOutcome:
-    """What a worker produced for one file; ``error`` set means it failed."""
+    """What a worker produced for one file; ``error`` set means it failed.
+
+    ``chunks_written`` is set when the worker committed the file's chunks to
+    the shared dataset itself (fragment mode): ``records`` is then ``None``
+    because the vectors never cross IPC.
+    """
 
     name: str
     records: list[ChunkRecord] | None = None
     page_texts: list[PageTextRecord] | None = None
     concept_records: ConceptRecords | None = None
     entity_rows: list[dict] | None = None
+    chunks_written: int | None = None
     error: WorkerIngestError | None = None
 
 
@@ -136,8 +150,9 @@ class _WorkerBindings:
     def __init__(self) -> None:
         self._stack: ExitStack | None = None
         self.inflight = 1
+        self.chunks_uri: str | None = None
 
-    def enter(self, config: Config, cpu_share: int, inflight: int) -> None:
+    def enter(self, config: Config, cpu_share: int, inflight: int, chunks_uri: str | None) -> None:
         """Bind *config* and this worker's budgets; replaces any previous binding."""
         from lilbee.core.config.context import config_scope
         from lilbee.providers.fleet.guest import bind_only_engine
@@ -155,10 +170,12 @@ class _WorkerBindings:
         # to the parent's engine, so its teardown drops the binding and stops nothing.
         stack.enter_context(keep_fleet_warm())
         self.inflight = max(1, inflight)
+        self.chunks_uri = chunks_uri
         self._stack = stack
 
     def close(self) -> None:
         """Release the bindings. Normally only tests call this; workers exit instead."""
+        self.chunks_uri = None
         if self._stack is not None:
             self._stack.close()
             self._stack = None
@@ -167,15 +184,17 @@ class _WorkerBindings:
 _bindings = _WorkerBindings()
 
 
-def init_worker(config: Config, cpu_share: int, inflight: int) -> None:
+def init_worker(config: Config, cpu_share: int, inflight: int, chunks_uri: str | None = None) -> None:
     """Bind the parent's config and this worker's budgets, once per process.
 
     Both are the box's budget divided by the worker count: *cpu_share* because
     cores are shared, *inflight* because the embed fleet is shared and has a knee
     past which more concurrent requests lower its throughput. What N processes buy
     is the CPU headroom to sustain that aggregate, not a larger aggregate.
+    *chunks_uri* is the shared chunks dataset the worker appends fragments to;
+    None keeps the parent as the single chunk writer.
     """
-    _bindings.enter(config, cpu_share, inflight)
+    _bindings.enter(config, cpu_share, inflight, chunks_uri)
 
 
 def run_batch(files: list[FileToProcess]) -> list[WorkerOutcome]:
@@ -195,7 +214,34 @@ async def _produce_batch(files: list[FileToProcess]) -> list[WorkerOutcome]:
         async with limit:
             return await _produce_one(entry)
 
-    return await asyncio.gather(*(one(entry) for entry in files))
+    outcomes = await asyncio.gather(*(one(entry) for entry in files))
+    if _bindings.chunks_uri is not None:
+        await _flush_fragment(_bindings.chunks_uri, outcomes)
+    return outcomes
+
+
+async def _flush_fragment(dataset_uri: str, outcomes: list[WorkerOutcome]) -> None:
+    """Append the batch's chunks as one lance fragment; strip them from the outcomes.
+
+    One commit per batch keeps the manifest small (per-file commits would be
+    millions on a corpus-scale run). The Arrow table build enforces the schema,
+    including the fixed vector width. A failure fails every produced file in
+    the batch, matching the parent flush's all-or-nothing semantics; rows a
+    lost commit race may have landed are pre-run rows to the next sync, whose
+    cleanup ceiling deletes them before the re-ingest appends again.
+    """
+    produced = [o for o in outcomes if o.error is None]
+    records = [record for o in produced for record in (o.records or [])]
+    if records:
+        schema = chunks_schema(active_config().embedding_dim)
+        try:
+            await to_ingest_thread(append_chunk_fragment, dataset_uri, cast("list[dict]", records), schema)
+        except Exception as exc:
+            for outcome in produced:
+                outcome.error = WorkerIngestError(error_reason(exc))
+    for outcome in produced:
+        outcome.chunks_written = len(outcome.records or []) if outcome.error is None else 0
+        outcome.records = None
 
 
 async def _produce_one(entry: FileToProcess) -> WorkerOutcome:
@@ -240,7 +286,9 @@ def warm_parent_engine() -> None:
     get_services().embedder.embed(_ENGINE_PROBE)
 
 
-def build_pool(processes: int, config: Config, inflight: int) -> ProcessPoolExecutor:
+def build_pool(
+    processes: int, config: Config, inflight: int, chunks_uri: str | None = None
+) -> ProcessPoolExecutor:
     """A pool of *processes* workers bound to *config*, the CPU share, and *inflight*.
 
     Both budgets are divided, for different reasons. Cores are shared. In-flight
@@ -258,13 +306,16 @@ def build_pool(processes: int, config: Config, inflight: int) -> ProcessPoolExec
     threads that would release them, so a child can deadlock on its first embed.
     A fresh interpreter per worker is the cost, which is part of why the pool is
     gated to plans big enough to amortise it.
+
+    *chunks_uri* is handed to each worker untouched: when set, workers commit
+    their batches as fragments of that dataset instead of returning vectors.
     """
     cpu_share = max(1, cpu_quota() // processes)
     return ProcessPoolExecutor(
         max_workers=processes,
         mp_context=multiprocessing.get_context("spawn"),
         initializer=init_worker,
-        initargs=(config, cpu_share, max(1, inflight // processes)),
+        initargs=(config, cpu_share, max(1, inflight // processes), chunks_uri),
     )
 
 

--- a/src/lilbee/data/store/__init__.py
+++ b/src/lilbee/data/store/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .core import Store
+from .core import ChunksDataset, Store, chunks_schema
 from .lance_helpers import (
     agent_recall_predicate,
     ensure_table,
@@ -43,6 +43,7 @@ __all__ = [
     "SOURCE_STAT_UNKNOWN",
     "ChunkType",
     "ChunkWrite",
+    "ChunksDataset",
     "CitationRecord",
     "ConceptRecords",
     "EmbeddingModelMismatchError",
@@ -60,6 +61,7 @@ __all__ = [
     "Store",
     "agent_owner",
     "agent_recall_predicate",
+    "chunks_schema",
     "cosine_sim",
     "ensure_table",
     "escape_sql_string",

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -1076,6 +1076,25 @@ class Store:
         self._invalidate_source_cache()
         return len(all_records)
 
+    def ensure_chunks_dataset(self) -> str:
+        """Create the empty chunks table and meta up front; return its lance dataset URI.
+
+        The parent calls this before spawning ingest workers so a worker's first
+        ``write_fragments`` has a dataset to append to. Idempotent: an existing
+        table and meta are left as they are. The return is the on-disk lance
+        dataset path, not a lancedb handle, because workers commit fragments
+        through pylance rather than the table ``add`` API.
+        """
+        with self._write_lock():
+            db = self.get_db()
+            ensure_table(db, CHUNKS_TABLE, self._chunks_schema())
+            if self.get_meta() is None:
+                self._write_meta_unlocked(
+                    embedding_model=self._config.embedding_model,
+                    embedding_dim=self._config.embedding_dim,
+                )
+        return str(self._config.lancedb_dir / f"{CHUNKS_TABLE}.lance")
+
     def _cleanup_batch_unlocked(self, items: list[ChunkWrite]) -> None:
         """One ``IN`` delete per table for the flagged documents. Caller holds ``write_lock()``."""
         cleanup_sources = [it.source for it in items if it.needs_cleanup]

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -7,7 +7,7 @@ import math
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -141,6 +141,40 @@ _SOURCE_STAT_BATCH_ROWS = 2000
 # bounds the decoded-text working set while the scan stays columnar.
 _TERM_SCAN_BATCH_ROWS = 20_000
 
+# A lance rowid packs its fragment id into the high bits: (fragment_id << 32) | offset.
+_ROWID_FRAGMENT_SHIFT = 32
+
+
+class ChunksDataset(NamedTuple):
+    """The on-disk chunks dataset, and the rowid ceiling below which its rows predate now.
+
+    ``uri`` is the dataset path workers commit fragments to. ``rowid_ceiling``
+    is the first rowid no existing row reaches: appends made after the capture
+    land at or above it, so a cleanup delete bounded by it removes a source's
+    older rows without touching rows this run appended.
+    """
+
+    uri: str
+    rowid_ceiling: int
+
+
+def chunks_schema(embedding_dim: int) -> pa.Schema:
+    """The chunks table schema for *embedding_dim*-wide vectors."""
+    return pa.schema(
+        [
+            pa.field("source", pa.utf8()),
+            pa.field("content_type", pa.utf8()),
+            pa.field("chunk_type", pa.utf8()),
+            pa.field("page_start", pa.int32()),
+            pa.field("page_end", pa.int32()),
+            pa.field("line_start", pa.int32()),
+            pa.field("line_end", pa.int32()),
+            pa.field("chunk", pa.utf8()),
+            pa.field("chunk_index", pa.int32()),
+            pa.field("vector", pa.list_(pa.float32(), embedding_dim)),
+        ]
+    )
+
 
 def _ann_nprobes(row_count: int) -> int:
     """Partitions to probe: a fixed fraction of the IVF partition count (~sqrt(N)), floored."""
@@ -211,20 +245,7 @@ class Store:
         return mapping
 
     def _chunks_schema(self) -> pa.Schema:
-        return pa.schema(
-            [
-                pa.field("source", pa.utf8()),
-                pa.field("content_type", pa.utf8()),
-                pa.field("chunk_type", pa.utf8()),
-                pa.field("page_start", pa.int32()),
-                pa.field("page_end", pa.int32()),
-                pa.field("line_start", pa.int32()),
-                pa.field("line_end", pa.int32()),
-                pa.field("chunk", pa.utf8()),
-                pa.field("chunk_index", pa.int32()),
-                pa.field("vector", pa.list_(pa.float32(), self._config.embedding_dim)),
-            ]
-        )
+        return chunks_schema(self._config.embedding_dim)
 
     def get_meta(self) -> StoreMeta | None:
         """Return the persisted store metadata row, or ``None`` if unset."""
@@ -863,20 +884,29 @@ class Store:
             rows = filtered.to_pylist()
         return [SearchChunk(**r) for r in rows]
 
-    def _delete_by_sources_unlocked(self, sources: list[str]) -> None:
+    def _delete_by_sources_unlocked(
+        self, sources: list[str], *, rowid_ceiling: int | None = None
+    ) -> None:
         """Delete the sources' chunks, page texts, and chunk-concept rows.
 
         Caller must hold ``write_lock()``. One ``IN`` delete per table covers
         every source, so a batched flush pays a constant number of predicate
         deletes instead of one set per document. A delete failure propagates:
         swallowed, it would leave every flushed file silently stale; raised,
-        the flush fails and the files replan on the next sync.
+        the flush fails and the files replan on the next sync. With
+        *rowid_ceiling* the chunks-table delete spares rows at or above it
+        (appended by this run's workers); the side tables keep no such bound
+        because the parent writes their new rows after the delete.
         """
         quoted = ", ".join(f"'{escape_sql_string(source)}'" for source in sources)
         for name, column in _PER_SOURCE_TABLES:
             table = self.open_table(name)
-            if table is not None:
-                table.delete(f"{column} IN ({quoted})")
+            if table is None:
+                continue
+            predicate = f"{column} IN ({quoted})"
+            if rowid_ceiling is not None and name == CHUNKS_TABLE:
+                predicate += f" AND _rowid < {rowid_ceiling}"
+            table.delete(predicate)
 
     def _delete_by_source_unlocked(self, source: str) -> None:
         """Delete a single source's chunks, page texts, and chunk-concept rows."""
@@ -1047,7 +1077,9 @@ class Store:
             except Exception:
                 log.debug("Sources table optimize failed", exc_info=True)
 
-    def write_chunks_batch(self, items: list[ChunkWrite]) -> int:
+    def write_chunks_batch(
+        self, items: list[ChunkWrite], *, rowid_ceiling: int | None = None
+    ) -> int:
         """Write several documents' chunks in one locked transaction. Returns chunks added.
 
         One ``write_lock`` acquisition covers the batch's cleanup deletes, page
@@ -1058,6 +1090,11 @@ class Store:
         texts and source row. The embedding-identity gate and per-vector
         dimension check mirror ``add_chunks``; a dimension mismatch raises and
         the whole batch is rejected.
+
+        With *rowid_ceiling* (bulk fragment ingest) the chunks-table cleanup
+        deletes only rows below it: workers commit this run's chunks as their
+        own fragments above the ceiling, so the cleanup removes a source's
+        pre-run rows without deleting the ones this run already appended.
         """
         if not items:
             return 0
@@ -1069,21 +1106,21 @@ class Store:
             all_records = [rec for it in items for rec in it.records]
             _check_vector_dims(all_records, embedding_dim)
             db = self.get_db()
-            self._cleanup_batch_unlocked(items)
+            self._cleanup_batch_unlocked(items, rowid_ceiling=rowid_ceiling)
             self._add_page_texts_unlocked(db, items)
             self._add_chunk_records_unlocked(db, all_records, embedding_model, embedding_dim)
             self._replace_source_rows_unlocked(self._batch_source_rows(items))
         self._invalidate_source_cache()
         return len(all_records)
 
-    def ensure_chunks_dataset(self) -> str:
-        """Create the empty chunks table and meta up front; return its lance dataset URI.
+    def ensure_chunks_dataset(self) -> ChunksDataset:
+        """Create the chunks table and meta up front; return the dataset URI and rowid ceiling.
 
         The parent calls this before spawning ingest workers so a worker's first
         ``write_fragments`` has a dataset to append to. Idempotent: an existing
-        table and meta are left as they are. The return is the on-disk lance
-        dataset path, not a lancedb handle, because workers commit fragments
-        through pylance rather than the table ``add`` API.
+        table and meta are left as they are. The ceiling marks every row written
+        before this call as pre-run, so a later cleanup delete can remove a
+        source's old rows without touching rows workers append during the run.
         """
         with self._write_lock():
             db = self.get_db()
@@ -1093,13 +1130,22 @@ class Store:
                     embedding_model=self._config.embedding_model,
                     embedding_dim=self._config.embedding_dim,
                 )
-        return str(self._config.lancedb_dir / f"{CHUNKS_TABLE}.lance")
+            uri = str(self._config.lancedb_dir / f"{CHUNKS_TABLE}.lance")
+            # optional dep: the bulk-ingest extra; callers gate on fragments_available
+            import lance
 
-    def _cleanup_batch_unlocked(self, items: list[ChunkWrite]) -> None:
+            max_fragment = max(
+                (f.fragment_id for f in lance.dataset(uri).get_fragments()), default=-1
+            )
+        return ChunksDataset(uri, (max_fragment + 1) << _ROWID_FRAGMENT_SHIFT)
+
+    def _cleanup_batch_unlocked(
+        self, items: list[ChunkWrite], *, rowid_ceiling: int | None = None
+    ) -> None:
         """One ``IN`` delete per table for the flagged documents. Caller holds ``write_lock()``."""
         cleanup_sources = [it.source for it in items if it.needs_cleanup]
         if cleanup_sources:
-            self._delete_by_sources_unlocked(cleanup_sources)
+            self._delete_by_sources_unlocked(cleanup_sources, rowid_ceiling=rowid_ceiling)
 
     def _add_page_texts_unlocked(self, db: lancedb.DBConnection, items: list[ChunkWrite]) -> None:
         """Add the batch's page-text rows. Caller holds ``write_lock()``."""

--- a/tests/integration/test_fragment_writer_integration.py
+++ b/tests/integration/test_fragment_writer_integration.py
@@ -67,3 +67,53 @@ def test_concurrent_appends_lose_no_rows(tmp_path):
         )
     assert sum(totals) == workers * per
     assert db.open_table("chunks").count_rows() == workers * per
+
+
+def _ceiling(uri: str) -> int:
+    """The first rowid no existing row reaches, from the live fragment list."""
+    import lance
+
+    max_fragment = max((f.fragment_id for f in lance.dataset(uri).get_fragments()), default=-1)
+    return (max_fragment + 1) << 32
+
+
+def test_worker_appends_then_parent_ceiling_cleanup_keeps_exactly_the_new_rows(tmp_path):
+    """The fragment-ingest loop: a worker re-ingests a source and commits its
+    fragment; the parent's cleanup, bounded by the pre-run ceiling, removes
+    exactly the old rows and none of the ones the worker just appended."""
+    db, uri = _new_table(tmp_path)
+    table = db.open_table("chunks")
+    table.add(_records("doc-a", 3))  # pre-run rows
+    ceiling = _ceiling(uri)
+
+    assert append_chunk_fragment(uri, _records("doc-a", 5), _schema()) == 5
+    db.open_table("chunks").delete(f"source IN ('doc-a') AND _rowid < {ceiling}")
+
+    table = db.open_table("chunks")
+    assert table.count_rows() == 5
+    assert sorted(r["chunk"] for r in table.search().to_list()) == [f"doc-a {i}" for i in range(5)]
+
+
+def test_concurrent_appends_and_ceiling_deletes_lose_no_rows(tmp_path):
+    """A parent cleanup delete racing worker appends touches only pre-run rows."""
+    db, uri = _new_table(tmp_path)
+    db.open_table("chunks").add(_records("doc-z", 2))  # pre-run rows
+    ceiling = _ceiling(uri)
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        futures = [
+            pool.submit(append_chunk_fragment, uri, _records(f"doc-{w}", 50), _schema())
+            for w in range(4)
+        ]
+        futures.append(
+            pool.submit(
+                lambda: db.open_table("chunks").delete(
+                    f"source IN ('doc-z') AND _rowid < {ceiling}"
+                )
+            )
+        )
+        totals = [f.result() for f in futures]
+
+    assert sum(t for t in totals if isinstance(t, int)) == 200
+    # doc-z's 2 pre-run rows are gone; every appended row landed.
+    assert db.open_table("chunks").count_rows() == 200

--- a/tests/integration/test_fragment_writer_integration.py
+++ b/tests/integration/test_fragment_writer_integration.py
@@ -1,0 +1,69 @@
+"""Real pylance round-trip for the worker chunk fragment writer.
+
+Runs only where pylance is installed (the ``bulk-ingest`` extra); the unit suite
+in ``tests/test_fragment_writer.py`` covers the same code with lance mocked.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("lance")
+
+from lilbee.data.ingest.fragment_writer import append_chunk_fragment
+
+_DIM = 16
+
+
+def _schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("source", pa.utf8()),
+            pa.field("chunk", pa.utf8()),
+            pa.field("chunk_index", pa.int32()),
+            pa.field("vector", pa.list_(pa.float32(), _DIM)),
+        ]
+    )
+
+
+def _records(source: str, n: int) -> list[dict]:
+    return [
+        {"source": source, "chunk": f"{source} {i}", "chunk_index": i, "vector": [float(i)] * _DIM}
+        for i in range(n)
+    ]
+
+
+def _new_table(tmp_path):
+    import lancedb
+
+    db = lancedb.connect(str(tmp_path / "lancedb"))
+    db.create_table("chunks", schema=_schema())
+    return db, str(tmp_path / "lancedb" / "chunks.lance")
+
+
+def test_append_preserves_rows_and_vectors(tmp_path):
+    db, uri = _new_table(tmp_path)
+    assert append_chunk_fragment(uri, _records("doc-a", 5), _schema()) == 5
+    table = db.open_table("chunks")
+    assert table.count_rows() == 5
+    row = table.search().where("chunk_index = 3").limit(1).to_list()[0]
+    assert row["vector"] == pytest.approx([3.0] * _DIM)
+    assert row["source"] == "doc-a"
+
+
+def test_concurrent_appends_lose_no_rows(tmp_path):
+    """Eight workers appending at once must all land (Appends do not conflict)."""
+    db, uri = _new_table(tmp_path)
+    workers, per = 8, 250
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        totals = list(
+            pool.map(
+                lambda w: append_chunk_fragment(uri, _records(f"doc-{w}", per), _schema()),
+                range(workers),
+            )
+        )
+    assert sum(totals) == workers * per
+    assert db.open_table("chunks").count_rows() == workers * per

--- a/tests/test_fragment_writer.py
+++ b/tests/test_fragment_writer.py
@@ -1,0 +1,85 @@
+"""Unit tests for the chunk fragment writer, with lance mocked.
+
+These run in the standard (no-extras) suite where pylance is absent, so lance is
+injected as a fake module. The real pylance round-trip lives in
+``tests/integration/test_fragment_writer_integration.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pyarrow as pa
+
+from lilbee.data.ingest import fragment_writer
+
+
+def _install_fake_lance(monkeypatch, *, calls: dict) -> list:
+    """Inject a fake ``lance`` / ``lance.fragment`` and record what the writer calls."""
+    fragments = [object(), object()]
+
+    fake_fragment = types.ModuleType("lance.fragment")
+
+    def write_fragments(table, uri):
+        calls["table_rows"] = table.num_rows
+        calls["write_uri"] = uri
+        return fragments
+
+    fake_fragment.write_fragments = write_fragments
+
+    fake_lance = types.ModuleType("lance")
+    fake_lance.fragment = fake_fragment
+    fake_lance.dataset = lambda uri: types.SimpleNamespace(version=7)
+    fake_lance.LanceOperation = types.SimpleNamespace(Append=lambda frags: ("append", frags))
+
+    def commit(uri, operation, *, read_version, max_retries):
+        calls["commit"] = {
+            "uri": uri,
+            "operation": operation,
+            "read_version": read_version,
+            "max_retries": max_retries,
+        }
+
+    fake_lance.LanceDataset = types.SimpleNamespace(commit=commit)
+
+    monkeypatch.setitem(sys.modules, "lance", fake_lance)
+    monkeypatch.setitem(sys.modules, "lance.fragment", fake_fragment)
+    return fragments
+
+
+def _schema() -> pa.Schema:
+    return pa.schema([pa.field("chunk", pa.utf8()), pa.field("vector", pa.list_(pa.float32(), 2))])
+
+
+def test_fragments_available_true_when_lance_imports(monkeypatch):
+    _install_fake_lance(monkeypatch, calls={})
+    assert fragment_writer.fragments_available() is True
+
+
+def test_fragments_available_false_when_lance_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "lance", None)  # import lance -> ImportError
+    assert fragment_writer.fragments_available() is False
+
+
+def test_append_writes_fragment_and_commits_appended(monkeypatch):
+    calls: dict = {}
+    fragments = _install_fake_lance(monkeypatch, calls=calls)
+    records = [{"chunk": "a", "vector": [1.0, 2.0]}, {"chunk": "b", "vector": [3.0, 4.0]}]
+
+    written = fragment_writer.append_chunk_fragment("/db/chunks.lance", records, _schema())
+
+    assert written == 2
+    assert calls["table_rows"] == 2
+    assert calls["write_uri"] == "/db/chunks.lance"
+    assert calls["commit"]["operation"] == ("append", fragments)
+    assert calls["commit"]["read_version"] == 7
+    assert calls["commit"]["max_retries"] == fragment_writer._COMMIT_MAX_RETRIES
+
+
+def test_append_empty_records_is_a_noop(monkeypatch):
+    # Returns before importing lance, so no fake is needed and nothing is written.
+    calls: dict = {}
+    _install_fake_lance(monkeypatch, calls=calls)
+    assert fragment_writer.append_chunk_fragment("/db/chunks.lance", [], _schema()) == 0
+    assert "commit" not in calls

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -38,12 +38,19 @@ def isolated_env(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def mock_svc():
+def mock_svc(monkeypatch):
     """Provide a mock Services container for all ingest tests."""
+    # Keep ingest on the parent-writes path regardless of whether the dev
+    # machine has the bulk-ingest extra installed; fragment-mode tests opt in.
+    from lilbee.data.ingest import pipeline as _pipeline
     from tests.conftest import make_mock_services
+
+    monkeypatch.setattr(_pipeline, "fragments_available", lambda: False)
 
     _sources: dict[str, dict] = {}
     store = MagicMock()
+    # MagicMock refuses to auto-create attributes named assert_*; assign it.
+    store.assert_embedding_compatible = MagicMock(return_value=None)
     store.search.return_value = []
     store.bm25_probe.return_value = []
     store.get_sources.side_effect = lambda: list(_sources.values())
@@ -62,7 +69,7 @@ def mock_svc():
 
     store.upsert_source.side_effect = _upsert
 
-    def _write_batch(items):
+    def _write_batch(items, **_kw):
         # Mirror the real write: each batched doc upserts a source record so
         # multi-sync tests see it via get_sources().
         for it in items:
@@ -584,6 +591,49 @@ class TestSync:
         assert failed == {}
         assert flush_failed == set()
 
+    def test_flush_writes_forwards_the_rowid_ceiling_to_the_store(self, _mock_extract_file):
+        # Fragment ingest: the ceiling captured before the workers spawned must
+        # reach write_chunks_batch untouched, so the cleanup spares their rows.
+        from lilbee.app.services import get_services
+        from lilbee.data.ingest import pipeline
+        from lilbee.data.ingest.types import _IngestResult
+
+        result = _IngestResult(
+            name="a.txt",
+            path=Path("a.txt"),
+            chunk_count=1,
+            error=None,
+            file_hash="h",
+            records=[{"text": "x"}],
+            needs_cleanup=True,
+        )
+
+        pipeline._flush_writes([result], {"a.txt": None}, {}, {}, {}, set(), 12345)
+
+        store = get_services().store
+        assert store.write_chunks_batch.call_args.kwargs["rowid_ceiling"] == 12345
+
+    def test_flush_writes_defaults_to_no_ceiling(self, _mock_extract_file):
+        # The ordinary single-writer path must not suddenly spare old rows.
+        from lilbee.app.services import get_services
+        from lilbee.data.ingest import pipeline
+        from lilbee.data.ingest.types import _IngestResult
+
+        result = _IngestResult(
+            name="a.txt",
+            path=Path("a.txt"),
+            chunk_count=1,
+            error=None,
+            file_hash="h",
+            records=[{"text": "x"}],
+            needs_cleanup=True,
+        )
+
+        pipeline._flush_writes([result], {"a.txt": None}, {}, {}, {}, set())
+
+        store = get_services().store
+        assert store.write_chunks_batch.call_args.kwargs["rowid_ceiling"] is None
+
     def test_flush_writes_lock_timeout_twice_marks_flush_failed(
         self, _mock_extract_file, monkeypatch
     ):
@@ -850,7 +900,9 @@ class TestSyncCancellation:
         monkeypatch.setattr(
             pipeline_mod,
             "build_pool",
-            lambda n, cfg, inflight: order.append("pool") or RecordingPool(max_workers=2),
+            lambda n, cfg, inflight, chunks_uri: (
+                order.append("pool") or RecordingPool(max_workers=2)
+            ),
         )
         monkeypatch.setattr(
             workers,
@@ -878,6 +930,59 @@ class TestSyncCancellation:
         # Zero chunks is a skip, not an add: the worker produced no searchable text.
         assert set(skipped) == {"w1.txt", "w2.txt"}
         assert added == {}
+
+    async def test_worker_mode_with_pylance_wires_the_fragment_dataset_end_to_end(
+        self, mock_extract_file, isolated_env, mock_svc, monkeypatch
+    ):
+        """The parent prepares one chunks dataset: its URI flows to the pool and
+        its rowid ceiling to the flush, so worker-appended rows survive cleanup."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        from lilbee.data.ingest import ingest_batch, workers
+        from lilbee.data.ingest import pipeline as pipeline_mod
+        from lilbee.data.ingest.types import FileToProcess
+        from lilbee.data.store import ChunksDataset
+
+        async def passthrough(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        captured: dict = {}
+        monkeypatch.setattr(pipeline_mod, "to_ingest_thread", passthrough)
+        monkeypatch.setattr(pipeline_mod, "fragments_available", lambda: True)
+        monkeypatch.setattr(pipeline_mod, "resolve_process_count", lambda count: 2)
+        monkeypatch.setattr(pipeline_mod, "warm_parent_engine", lambda: None)
+        mock_svc.store.ensure_chunks_dataset.return_value = ChunksDataset("/fake/chunks.lance", 999)
+
+        def fake_pool(n, cfg, inflight, chunks_uri):
+            captured["chunks_uri"] = chunks_uri
+            return ThreadPoolExecutor(max_workers=2)
+
+        monkeypatch.setattr(pipeline_mod, "build_pool", fake_pool)
+        monkeypatch.setattr(
+            workers,
+            "run_batch",
+            lambda batch: [
+                workers.WorkerOutcome(name=f.name, records=None, page_texts=[], chunks_written=1)
+                for f in batch
+            ],
+        )
+        real_collect = pipeline_mod._collect_results
+
+        async def spy_collect(pending, total, added, updated, failed, skipped, **kwargs):
+            captured["rowid_ceiling"] = kwargs["rowid_ceiling"]
+            await real_collect(pending, total, added, updated, failed, skipped, **kwargs)
+
+        monkeypatch.setattr(pipeline_mod, "_collect_results", spy_collect)
+
+        (isolated_env / "w1.txt").write_text("one")
+        files = [FileToProcess("w1.txt", isolated_env / "w1.txt", "text", "h1", True)]
+        added: dict[str, None] = {"w1.txt": None}
+
+        await ingest_batch(files, added, {}, {}, {}, quiet=True)
+
+        assert captured["chunks_uri"] == "/fake/chunks.lance"
+        assert captured["rowid_ceiling"] == 999
+        assert added == {"w1.txt": None}  # the fragment-mode outcome stays ingested
 
     async def test_cancel_during_ingest_batch(self, mock_extract_file, isolated_env, mock_svc):
         """Cancel set mid-batch raises CancelledError for pending files."""
@@ -918,7 +1023,7 @@ class TestSyncCancellation:
         added: dict[str, None] = {}
         flushed: list[str] = []
 
-        def _record_flush(buffer, _added, _updated, _failed, _skipped, _flush_failed):
+        def _record_flush(buffer, _added, _updated, _failed, _skipped, _flush_failed, _ceiling):
             flushed.extend(r.name for r in buffer)
 
         # `done` is a set, so the order the loop sees the two completed futures is

--- a/tests/test_ingest_workers.py
+++ b/tests/test_ingest_workers.py
@@ -193,6 +193,33 @@ class TestCollectFromWorker:
         assert error_reason(result.error) == "OSError: disk gone"
 
     @pytest.mark.asyncio
+    async def test_a_fragment_outcome_carries_the_written_count_without_vectors(self):
+        """In fragment mode the records stay in the worker; only their count travels."""
+        from lilbee.runtime.progress import EventType
+
+        events: list = []
+
+        class Dispatcher:
+            async def outcome_for(self, index):
+                return WorkerOutcome(name="a.txt", records=None, chunks_written=3)
+
+        result = await pipeline._collect_from_worker(
+            _entry(),
+            1,
+            Dispatcher(),
+            total_files=1,
+            pages_done=[0],
+            on_progress=lambda *a: events.append(a),
+            cancel=None,
+            fallback=mock.AsyncMock(),
+        )
+        assert result.error is None
+        assert result.chunk_count == 3
+        assert result.records == []  # nothing to flush; the worker already persisted
+        file_done = next(e[1] for e in events if e[0] is EventType.FILE_DONE)
+        assert file_done.chunks == 3
+
+    @pytest.mark.asyncio
     async def test_a_broken_pool_falls_back_to_in_process_ingest(self):
         """A worker OOM must not fail every remaining file in the sync."""
         calls = []
@@ -276,9 +303,10 @@ class TestDispatchPlan:
     def test_multiple_processes_build_a_pool_over_every_file(self, monkeypatch):
         built = {}
 
-        def fake_build_pool(processes, config, inflight):
+        def fake_build_pool(processes, config, inflight, chunks_uri):
             built["processes"] = processes
             built["inflight"] = inflight
+            built["chunks_uri"] = chunks_uri
             return mock.MagicMock()
 
         monkeypatch.setattr(pipeline, "build_pool", fake_build_pool)
@@ -291,6 +319,7 @@ class TestDispatchPlan:
             entries,
             4,
             in_process,
+            chunks_uri="/data/chunks.lance",
             pages_done=[0],
             on_progress=lambda *a, **k: None,
             cancel=None,
@@ -298,6 +327,7 @@ class TestDispatchPlan:
         assert pool is not None
         assert built["processes"] == 4
         assert built["inflight"] > 0  # admission is passed through, not defaulted
+        assert built["chunks_uri"] == "/data/chunks.lance"  # fragment mode reaches the pool
         coros = list(pending)
         assert len(coros) == len(entries)
         for coro in coros:
@@ -356,6 +386,144 @@ class TestRunBatch:
         assert workers.run_batch([]) == []
 
 
+class TestProduceBatchFragmentMode:
+    """With a chunks dataset bound, the worker commits its own fragment per batch
+    and ships no vectors back across IPC."""
+
+    @staticmethod
+    def _patch_fragment_mode(monkeypatch, failing: set[str] | None = None, append_error=None):
+        TestRunBatch._patch_producers(monkeypatch, failing)
+        calls: dict = {}
+
+        def fake_append(uri, records, schema):
+            calls["uri"] = uri
+            calls["records"] = records
+            calls["schema"] = schema
+            if append_error is not None:
+                raise append_error
+            return len(records)
+
+        async def passthrough(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(workers, "append_chunk_fragment", fake_append)
+        monkeypatch.setattr(workers, "to_ingest_thread", passthrough)
+        monkeypatch.setattr(workers._bindings, "chunks_uri", "/fake/chunks.lance")
+        return calls
+
+    def test_one_fragment_per_batch_and_no_vectors_cross_back(self, monkeypatch):
+        calls = self._patch_fragment_mode(monkeypatch)
+
+        outcomes = workers.run_batch([_entry(f"{i}.txt") for i in range(3)])
+
+        assert calls["uri"] == "/fake/chunks.lance"
+        assert calls["records"] == [{"chunk": f"{i}.txt"} for i in range(3)]
+        # The Arrow table is built against the live embedding dim, not a constant.
+        assert calls["schema"].field("vector").type.list_size > 0
+        for i, outcome in enumerate(outcomes):
+            assert outcome.error is None
+            assert outcome.records is None  # vectors stay off the IPC channel
+            assert outcome.chunks_written == 1
+            # Side-table rows still travel: the parent writes those.
+            assert outcome.entity_rows == [{"entity": f"{i}.txt"}]
+
+    def test_a_failed_file_contributes_no_records_and_keeps_its_error(self, monkeypatch):
+        calls = self._patch_fragment_mode(monkeypatch, failing={"1.txt"})
+
+        outcomes = workers.run_batch([_entry(f"{i}.txt") for i in range(3)])
+
+        assert calls["records"] == [{"chunk": "0.txt"}, {"chunk": "2.txt"}]
+        assert error_reason(outcomes[1].error) == "OSError: disk gone"
+        assert outcomes[1].chunks_written is None  # not a fragment-mode outcome
+        assert outcomes[0].chunks_written == 1 and outcomes[2].chunks_written == 1
+
+    def test_an_append_failure_fails_every_produced_file(self, monkeypatch):
+        """All-or-nothing per batch, matching the parent flush's semantics."""
+        self._patch_fragment_mode(
+            monkeypatch, failing={"1.txt"}, append_error=OSError("read-only fs")
+        )
+
+        outcomes = workers.run_batch([_entry(f"{i}.txt") for i in range(3)])
+
+        assert error_reason(outcomes[0].error) == "OSError: read-only fs"
+        assert error_reason(outcomes[2].error) == "OSError: read-only fs"
+        assert outcomes[0].chunks_written == 0 and outcomes[0].records is None
+        # The file that failed before the append keeps its own reason.
+        assert error_reason(outcomes[1].error) == "OSError: disk gone"
+
+    def test_no_successful_records_means_no_commit(self, monkeypatch):
+        calls = self._patch_fragment_mode(monkeypatch, failing={"0.txt", "1.txt"})
+
+        outcomes = workers.run_batch([_entry(f"{i}.txt") for i in range(2)])
+
+        assert "uri" not in calls
+        assert all(o.error is not None for o in outcomes)
+
+    def test_parent_writes_mode_never_appends(self, monkeypatch):
+        TestRunBatch._patch_producers(monkeypatch)
+
+        def fake_append(uri, records, schema):  # pragma: no cover - must not run
+            raise AssertionError("parent-writes mode must not touch fragments")
+
+        monkeypatch.setattr(workers, "append_chunk_fragment", fake_append)
+        monkeypatch.setattr(workers._bindings, "chunks_uri", None)
+
+        outcomes = workers.run_batch([_entry("a.txt")])
+
+        assert outcomes[0].records == [{"chunk": "a.txt"}]
+        assert outcomes[0].chunks_written is None
+
+
+class TestPrepareFragmentWrites:
+    """Fragment mode is gated to bulk multiprocess runs with pylance installed."""
+
+    class _FakeStore:
+        """MagicMock cannot auto-mock a method named ``assert_*``."""
+
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def assert_embedding_compatible(self) -> None:
+            self.calls.append("gate")
+
+        def ensure_chunks_dataset(self) -> pipeline.ChunksDataset:
+            self.calls.append("ensure")
+            return pipeline.ChunksDataset("/d/chunks.lance", 7)
+
+    async def _prepare(self, monkeypatch, processes, available):
+        monkeypatch.setattr(pipeline, "fragments_available", lambda: available)
+
+        async def passthrough(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(pipeline, "to_ingest_thread", passthrough)
+        store = self._FakeStore()
+        monkeypatch.setattr(pipeline, "get_services", lambda: mock.MagicMock(store=store))
+        return await pipeline._prepare_fragment_writes(processes), store
+
+    @pytest.mark.asyncio
+    async def test_single_process_keeps_the_atomic_writer(self, monkeypatch):
+        result, store = await self._prepare(monkeypatch, 1, True)
+
+        assert result is None
+        assert store.calls == []
+
+    @pytest.mark.asyncio
+    async def test_without_pylance_keeps_parent_writes(self, monkeypatch):
+        result, store = await self._prepare(monkeypatch, 4, False)
+
+        assert result is None
+        assert store.calls == []
+
+    @pytest.mark.asyncio
+    async def test_multiprocess_with_pylance_prepares_the_dataset(self, monkeypatch):
+        result, store = await self._prepare(monkeypatch, 4, True)
+
+        assert result == pipeline.ChunksDataset("/d/chunks.lance", 7)
+        # The gate runs pre-spawn because worker commits bypass the per-flush gate.
+        assert store.calls == ["gate", "ensure"]
+
+
 class TestWorkerBootstrap:
     """What has to survive the process boundary before a worker can do anything."""
 
@@ -410,6 +578,24 @@ class TestWorkerBootstrap:
         finally:
             workers._bindings.close()
 
+    def test_init_worker_binds_the_chunks_dataset_for_fragment_writes(self, monkeypatch):
+        """A bound URI is what flips the worker from parent-writes to fragment mode."""
+        import contextlib
+
+        from lilbee.core.config import cfg
+
+        @contextlib.contextmanager
+        def fake_keep_warm():
+            yield
+
+        monkeypatch.setattr("lilbee.providers.fleet.ingest_warmth.keep_fleet_warm", fake_keep_warm)
+        workers.init_worker(cfg, 3, 12, "/data/chunks.lance")
+        try:
+            assert workers._bindings.chunks_uri == "/data/chunks.lance"
+        finally:
+            workers._bindings.close()
+        assert workers._bindings.chunks_uri is None
+
 
 class TestBuildPool:
     """Pool sizing is the guard against N workers oversubscribing the box."""
@@ -436,7 +622,8 @@ class TestBuildPool:
         # forked child would inherit held (see build_pool).
         assert captured["mp_context"].get_start_method() == "spawn"
         assert captured["initializer"] is workers.init_worker
-        assert captured["initargs"] == (mock.sentinel.config, 4, 16)  # cpu 16//4, inflight 64//4
+        # cpu 16//4, inflight 64//4, no fragment dataset
+        assert captured["initargs"] == (mock.sentinel.config, 4, 16, None)
 
     def test_the_share_never_rounds_down_to_zero(self, monkeypatch):
         """More workers than cores must still leave each worker a usable budget."""
@@ -444,7 +631,15 @@ class TestBuildPool:
 
         workers.build_pool(8, mock.sentinel.config, 4)
 
-        assert captured["initargs"] == (mock.sentinel.config, 1, 1)
+        assert captured["initargs"] == (mock.sentinel.config, 1, 1, None)
+
+    def test_a_chunks_dataset_uri_is_handed_to_every_worker(self, monkeypatch):
+        """Fragment mode: the parent's dataset URI must survive into init_worker."""
+        captured = self._capture(monkeypatch, quota=16)
+
+        workers.build_pool(4, mock.sentinel.config, 64, "/data/chunks.lance")
+
+        assert captured["initargs"] == (mock.sentinel.config, 4, 16, "/data/chunks.lance")
 
 
 class TestAdmissionFor:
@@ -482,7 +677,7 @@ class TestInflightIsNotTheCpuBudget:
         # A thin CPU budget must not drag the in-flight budget down with it.
         workers.build_pool(8, mock.sentinel.config, 64)
 
-        _config, cpu_share, inflight_share = captured["initargs"]
+        _config, cpu_share, inflight_share, _chunks_uri = captured["initargs"]
         assert cpu_share == 2  # 16 // 8, cores are shared
         # Divided, so the aggregate targets the fleet's admission ceiling: a sweep
         # on 2xA40 measured 155.6 docs/sec at 32 in flight and 147.6 at 128, so

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -474,6 +474,85 @@ class TestWriteChunksBatch:
         )
         assert len(store.get_chunks_by_source("a.md")) == 2
 
+    def test_cleanup_below_a_rowid_ceiling_spares_run_appended_rows(self, store):
+        """Bulk fragment ingest: workers append a re-ingested source's new chunks
+        before the parent's flush runs, so the cleanup delete must remove only the
+        rows written before the run started (below the ceiling), never the ones
+        this run appended (at or above it)."""
+        from lilbee.data.store import ChunkWrite
+
+        store.add_chunks(_records_for("a.md", 3))  # fragment 0: the pre-run rows
+        store.add_chunks(_records_for("keep.md", 2))  # fragment 1
+        ceiling = 2 << 32  # fragment ids 0 and 1 are below; anything appended next is above
+        store.add_chunks(_records_for("a.md", 5))  # fragment 2: the run's appended rows
+
+        store.write_chunks_batch(
+            [ChunkWrite("a.md", "hash_new", [], needs_cleanup=True)], rowid_ceiling=ceiling
+        )
+
+        # Only the 5 run-appended rows survive; the 3 pre-run rows are gone.
+        assert len(store.get_chunks_by_source("a.md")) == 5
+        assert len(store.get_chunks_by_source("keep.md")) == 2
+
+    def test_cleanup_without_a_ceiling_removes_every_matching_row(self, store):
+        """The default path stays total: no fragment ingest, no spared rows."""
+        from lilbee.data.store import ChunkWrite
+
+        store.add_chunks(_records_for("a.md", 3))
+        store.add_chunks(_records_for("a.md", 5))
+
+        store.write_chunks_batch([ChunkWrite("a.md", "hash_new", [], needs_cleanup=True)])
+
+        assert store.get_chunks_by_source("a.md") == []
+
+
+class TestEnsureChunksDataset:
+    """The fragment-ingest pre-spawn step: table and meta exist, ceiling captured."""
+
+    @staticmethod
+    def _fake_lance(monkeypatch, fragment_ids):
+        """Inject a fake ``lance`` exposing only what ensure_chunks_dataset reads."""
+        import sys
+        import types
+
+        fake = types.ModuleType("lance")
+        fake.dataset = lambda uri: types.SimpleNamespace(
+            get_fragments=lambda: [types.SimpleNamespace(fragment_id=i) for i in fragment_ids]
+        )
+        # lancedb's scannable registry looks the type up when a table opens.
+        fake.LanceDataset = type("LanceDataset", (), {})
+        monkeypatch.setitem(sys.modules, "lance", fake)
+
+    def test_fresh_store_gets_table_meta_and_a_zero_ceiling(self, store, test_config, monkeypatch):
+        self._fake_lance(monkeypatch, [])
+
+        dataset = store.ensure_chunks_dataset()
+
+        assert dataset.uri == str(test_config.lancedb_dir / "chunks.lance")
+        assert dataset.rowid_ceiling == 0
+        assert store.open_table("chunks") is not None
+        meta = store.get_meta()
+        assert meta is not None
+        assert meta["embedding_dim"] == test_config.embedding_dim
+
+    def test_idempotent_and_the_ceiling_covers_every_existing_fragment(self, store, monkeypatch):
+        self._fake_lance(monkeypatch, [0, 1])  # two fragments already committed
+
+        first = store.ensure_chunks_dataset()
+        second = store.ensure_chunks_dataset()
+
+        assert first == second
+        assert first.rowid_ceiling == 2 << 32
+
+    def test_existing_meta_is_not_rewritten(self, store, monkeypatch):
+        store.add_chunks(_make_records(1))  # first write pins the meta row
+        before = store.get_meta()
+        self._fake_lance(monkeypatch, [])
+
+        store.ensure_chunks_dataset()
+
+        assert store.get_meta() == before
+
     def test_empty_batch_is_noop(self, store):
         assert store.write_chunks_batch([]) == 0
         assert store.get_sources() == []

--- a/uv.lock
+++ b/uv.lock
@@ -1505,19 +1505,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.5.2"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/c6/aec0d7752e15536564b50cf9a8926f0e5d7780aa3ab8ce8bca46daa55659/lance_namespace-0.5.2.tar.gz", hash = "sha256:566cc33091b5631793ab411f095d46c66391db0a62343cd6b4470265bb04d577", size = 10274 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/3d/737c008d8fb2861e7ce260e2ffab0d5058eae41556181f80f1a1c3b52ef5/lance_namespace-0.5.2-py3-none-any.whl", hash = "sha256:6ccaf5649bf6ee6aa92eed9c535a114b7b4eb08e89f40426f58bc1466cbcffa3", size = 12087 },
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383 },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.5.2"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1525,9 +1525,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/64/51622c93ec8c164483c83b68764e5e76e52286c0137a8247bc6a7fac25f4/lance_namespace_urllib3_client-0.5.2.tar.gz", hash = "sha256:8a3a238006e6eabc01fc9d385ac3de22ba933aef0ae8987558f3c3199c9b3799", size = 172578 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/10/f86d994498b37f7f35d0b8c2f7626a16fe4cb1949b518c1e5d5052ecf95f/lance_namespace_urllib3_client-0.5.2-py3-none-any.whl", hash = "sha256:83cefb6fd6e5df0b99b5e866ee3d46300d375b75e8af32c27bc16fbf7c1a5978", size = 300351 },
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950 },
 ]
 
 [[package]]
@@ -1666,6 +1666,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+bulk-ingest = [
+    { name = "pylance" },
+]
 crawler = [
     { name = "crawl4ai" },
 ]
@@ -1732,6 +1735,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
+    { name = "pylance", marker = "extra == 'bulk-ingest'", specifier = ">=9.0.0" },
     { name = "spacy", marker = "extra == 'graph'", specifier = ">=3.8" },
     { name = "textual", specifier = ">=0.75" },
     { name = "tiktoken" },
@@ -1741,7 +1745,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["litellm", "graph", "crawler", "cuda12", "release"]
+provides-extras = ["litellm", "graph", "crawler", "bulk-ingest", "cuda12", "release"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3082,6 +3086,24 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pylance"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace" },
+    { name = "numpy" },
+    { name = "pyarrow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/be/45733acd64801991852aac8e658601fd8fc12f76ceb81e57fca690896b90/pylance-9.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8257213501d3298c5b6a344d60938e4bbe4de9f00cd3265371a56d1dc3dd15ca", size = 68377982 },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/1ef707cb215cc7268c63ad84a91344ad6313d3984b343eeb19a9b708698e/pylance-9.0.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:804eedfa1fda2e703cca8580c76f0b44a1b849b725a8908c06f8acfca811732f", size = 71844362 },
+    { url = "https://files.pythonhosted.org/packages/c8/fb/a499e5c53ddb75c7de44100fd2bb1f7cc735966200d20292eed7af9ef552/pylance-9.0.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a0b75595e3766c1d5f4c90abdc52337b4de60f1a52d123a4f8c4e5bcbbbfa8f", size = 75663088 },
+    { url = "https://files.pythonhosted.org/packages/e9/80/0714e09f64a68dbdf62558955e737a7436df763b9834a6aba506861b5352/pylance-9.0.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d2f69c5c390ae3710c35a429905fe15f769951777fafb1b72a359e035ec121f7", size = 71866858 },
+    { url = "https://files.pythonhosted.org/packages/4b/3c/78d3a6d6ca0d843b7c3ac0c30d9cd2cf4635b0c2cabe6ec66583d5bfc1a1/pylance-9.0.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:836268a7832d62f3d5ccbe1c3fca239621971d90297bcfff14a70b3cb6842aa8", size = 75642656 },
+    { url = "https://files.pythonhosted.org/packages/cf/c1/dc9c9a31e171530ec0add024d922488c046437d32a7087c29e254a7eacc7/pylance-9.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:96441d27a5ed3805300388ccf8f31835cd280c98751f80b6a1a11dcd6808fc43", size = 81668288 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1667,6 +1667,7 @@ dependencies = [
 
 [package.optional-dependencies]
 bulk-ingest = [
+    { name = "lance-namespace" },
     { name = "pylance" },
 ]
 crawler = [
@@ -1722,6 +1723,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.11.0" },
     { name = "jinja2", specifier = ">=2.11.3" },
     { name = "kreuzberg", specifier = ">=4.9.1,<5" },
+    { name = "lance-namespace", marker = "extra == 'bulk-ingest'", specifier = ">=0.8.6" },
     { name = "lancedb" },
     { name = "lilbee", extras = ["crawler", "litellm", "graph"], marker = "extra == 'release'" },
     { name = "lilbee-engine", directory = "packaging/engine-wheel" },


### PR DESCRIPTION
> Stacked on #618. Review that one first; this branch contains it.

## Problem

Multiprocess ingest drains every worker's chunks (~16KB of vector each) over IPC to one parent that builds Arrow and writes single-threaded. That drain is the ceiling: 8xH200 sat at ~220 docs/sec with the cards at ~50% while one card alone runs 57.7 at 93%.

## Solution

Workers commit their own chunks as lance fragments straight to the shared dataset (concurrent appends don't conflict); the parent keeps sources, side tables and reconciliation. A row watermark captured before the workers spawn keeps cleanup exact: a re-ingested source's old rows are deleted at flush, the run's own appended rows survive, and crash orphans self-heal next sync.

Active only for multiprocess runs with the new `bulk-ingest` extra (pylance 9); single-process and interactive syncs keep the atomic single-writer path. Verified against real pylance + lancedb 0.33: racing appends and deletes lose no rows, counts reconcile, commit latency flat. Stays on lancedb 0.33; the pre-Haswell channel has no 0.34 compat wheel yet.
