### PR TITLE
build: step lilbee up to lancedb 0.34 (stock + pre-Haswell compat)

### DIFF
--- a/.github/workflows/build-cuda-executables.yml
+++ b/.github/workflows/build-cuda-executables.yml
@@ -204,7 +204,7 @@ jobs:
       # pre-Haswell build from the private index. --no-deps leaves the rest of the
       # synced venv untouched, so this swap is local to this cell -- pyproject and
       # uv.lock never change, and no other cell or job sees it. Pinned to the latest
-      # stable lancedb for Python (0.33), served by the fork as +compat; bump when the
+      # stable lancedb for Python (0.34), served by the fork as +compat; bump when the
       # fork moves. continue-on-error keeps a missing wheel off the release.
       - name: Swap in the pre-Haswell lancedb
         if: matrix.compat
@@ -212,7 +212,7 @@ jobs:
         run: |
           uv pip install --reinstall --no-deps \
             --extra-index-url https://lilbee.sh/compat/ \
-            lancedb==0.33.0+compat
+            lancedb==0.34.0+compat
 
       # Build the self-contained CUDA llama-server (binary + ggml/llama/mtmd libs
       # with a baked rpath) and install lilbee_engine so Nuitka bundles the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,7 +287,7 @@ jobs:
 
       # compat cell only: swap the synced stock lancedb for the pre-Haswell build.
       # --no-deps leaves the rest of the venv intact, so nothing leaves this cell.
-      # Pinned to the latest stable lancedb for Python (0.33), served by the fork as
+      # Pinned to the latest stable lancedb for Python (0.34), served by the fork as
       # +compat; lilbee's own stock pin can lag. Bump when the fork moves.
       - name: Swap in the pre-Haswell lancedb
         if: matrix.compat
@@ -295,7 +295,7 @@ jobs:
         run: |
           uv pip install --reinstall --no-deps \
             --extra-index-url https://lilbee.sh/compat/ \
-            lancedb==0.33.0+compat
+            lancedb==0.34.0+compat
 
       # Build the self-contained llama-server (binary + ggml/llama/mtmd libs with a
       # baked rpath) and install lilbee_engine so Nuitka bundles the whole

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Pre-2013 Intel or pre-Zen AMD CPUs lack [AVX2](https://en.wikipedia.org/wiki/Adv
 
 |              | Command                                                                                                                                                                                  |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **pip**      | `pip install --pre lilbee 'lancedb==0.33.0+compat' --extra-index-url https://lilbee.sh/compat/`                                                                          |
+| **pip**      | `pip install --pre lilbee 'lancedb==0.34.0+compat' --extra-index-url https://lilbee.sh/compat/`                                                                          |
 | **Homebrew** | `brew install tobocop2/lilbee/lilbee-compat`                                                                                                                                            |
 | **AUR**      | `paru -S lilbee-compat`                                                                                                                                                                 |
 | **Nix**      | `nix run github:tobocop2/lilbee#lilbee-compat`                                                                                                                                          |

--- a/site/index.html
+++ b/site/index.html
@@ -360,7 +360,7 @@
           <span class="variant-tag">older CPU · no AVX2</span>
           <div class="install">
             <span class="prompt">$</span>
-            <span class="cmd">pip install --pre lilbee 'lancedb==0.33.0+compat' --extra-index-url https://lilbee.sh/compat/</span>
+            <span class="cmd">pip install --pre lilbee 'lancedb==0.34.0+compat' --extra-index-url https://lilbee.sh/compat/</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
@@ -389,7 +389,7 @@
           <span class="variant-tag">older CPU · no AVX2</span>
           <div class="install">
             <span class="prompt">$</span>
-            <span class="cmd">uv tool install --prerelease=allow --extra-index-url https://lilbee.sh/compat/ --with 'lancedb==0.33.0+compat' lilbee</span>
+            <span class="cmd">uv tool install --prerelease=allow --extra-index-url https://lilbee.sh/compat/ --with 'lancedb==0.34.0+compat' lilbee</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
@@ -701,7 +701,7 @@
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
-          <p class="variant-note">add <code>--extra-index-url https://lilbee.sh/compat/</code> and pin <code>lancedb==0.33.0+compat</code> to your sync.</p>
+          <p class="variant-note">add <code>--extra-index-url https://lilbee.sh/compat/</code> and pin <code>lancedb==0.34.0+compat</code> to your sync.</p>
         </div>
         <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-source">details</button>
         <div class="notes-body" id="notes-source" hidden>

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -106,8 +106,8 @@ _MAX_FILTER_ITERATIONS = 20  # safety cap to prevent runaway loops
 
 # Vector ANN index. IVF_PQ compresses vectors so search scales to millions;
 # refine_factor re-ranks the PQ candidates against full vectors to recover recall.
+# The index type is carried by the lancedb IvfPq config at build time.
 _VECTOR_METRIC = "cosine"
-_ANN_INDEX_TYPE = "IVF_PQ"
 _ANN_NPROBES_FLOOR = 20
 _ANN_NPROBES_PARTITION_FRACTION = 0.05
 _ANN_REFINE_FACTOR = 10
@@ -443,8 +443,10 @@ class Store:
                 return True
             if not force and (threshold <= 0 or table.count_rows() < threshold):
                 return False
+            from lancedb.index import IvfPq
+
             try:
-                table.create_index(metric=_VECTOR_METRIC, index_type=_ANN_INDEX_TYPE)
+                table.create_index("vector", config=IvfPq(distance_type=_VECTOR_METRIC))
                 log.info("Vector ANN index created on '%s'", CHUNKS_TABLE)
                 return True
             except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -1532,7 +1532,7 @@ wheels = [
 
 [[package]]
 name = "lancedb"
-version = "0.33.0"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
@@ -1545,12 +1545,10 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/2f/d5a4b2a5bb1f800936c76a6d8a4daf127a86fcab621eeb70b574a5adc774/lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b", size = 48338115 },
-    { url = "https://files.pythonhosted.org/packages/07/12/31787b93a856b2c31382c7771dc22fb05575b70b87c9efe454269f4f0948/lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302", size = 51162262 },
-    { url = "https://files.pythonhosted.org/packages/49/b7/081cc29f8e06bf12191b99ab3fe702aceebdb0914476b821a8c0445cacc8/lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8", size = 54381368 },
-    { url = "https://files.pythonhosted.org/packages/1c/bd/e0f4bd621f10ecf96a801b0166e87799ed7ca5a9dbabcef9a6c766a58ef3/lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c", size = 51188986 },
-    { url = "https://files.pythonhosted.org/packages/d9/1a/a8647a432ac6aa59cdce1fc061a7050ea4278bcab364539b78af2ecf72d2/lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346", size = 54440958 },
-    { url = "https://files.pythonhosted.org/packages/08/6c/d0cc8da784cd7ed3b4940a5d1f3e7702e2d99a0a348ba81a376eed782810/lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9", size = 58751944 },
+    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213 },
+    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501 },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359 },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

lilbee was on lancedb 0.33 — both the resolved stock dependency in `uv.lock` and the pre-Haswell compat install path (`lancedb==0.33.0+compat`). lancedb 0.34 is now the current stable release, and matching pre-Haswell `0.34.0+compat` wheels are already built and served from `lilbee.sh/compat`. lancedb 0.34 also deprecates the `create_index(metric=, index_type=)` API that the vector store used.

## Solution

- Bump the resolved stock lancedb to `0.34.0` in `uv.lock` (the pyproject constraint stays unpinned).
- Move the pre-Haswell compat pin `0.33.0+compat` → `0.34.0+compat` in the release and CUDA compat build cells and the user-facing install docs (README table, marketing site pip/uv/sync commands).
- Migrate the vector ANN index build to the new unified `create_index("vector", config=IvfPq(distance_type="cosine"))` API. This is equivalent to the old call by construction — same cosine metric, same auto-tuned partition/sub-vector counts (both left at defaults), same `num_bits`/`max_iterations`/`sample_rate` — so index quality is unchanged; it only clears the deprecation. Drops the now-unused `_ANN_INDEX_TYPE` constant.

## Testing

- Full suite green on lancedb 0.34: 10406 passed, 3 skipped, 2 xpassed.
- Vector index tests pass with `-W error::DeprecationWarning`; the migrated call emits no deprecation and builds an identical cosine IVF_PQ index (verified metric_type COSINE, num_bits 8, sample_rate 256).
- ruff check / format / mypy clean on the changed file.

Note: `create_fts_index` carries a separate deprecation that predates this bump (deprecated since lancedb 0.25.0, unrelated to 0.34). Left for a follow-up to keep this change scoped to the 0.34 step-up.