### PR TITLE
Pin the engine wheel runners so the manylinux tag stops lying

### DIFF
--- a/.github/workflows/build-multigpu.yml
+++ b/.github/workflows/build-multigpu.yml
@@ -37,11 +37,17 @@ jobs:
       matrix:
         include:
           # Linux: cross-vendor Vulkan, CUDA (multi-GPU via tensor-split), ROCm, cpu fallback.
-          - {os: ubuntu-latest, backend: vulkan, wheel-plat: manylinux_2_17_x86_64}
+          #
+          # Every Linux row pins its runner rather than tracking ubuntu-latest.
+          # The wheels link against the runner's glibc, so the label moving from
+          # 22.04 to 24.04 silently raised what they need from 2.35 to 2.38
+          # while they went on declaring manylinux_2_17. pip installed them and
+          # the engine died in the loader on every current-stable distro.
+          - {os: ubuntu-22.04,  backend: vulkan, wheel-plat: manylinux_2_17_x86_64}
           - {os: ubuntu-22.04,  backend: cu124,  wheel-plat: manylinux_2_17_x86_64, cuda: "12.4.0"}
           - {os: ubuntu-22.04,  backend: cu125,  wheel-plat: manylinux_2_17_x86_64, cuda: "12.5.0"}
           - {os: ubuntu-22.04,  backend: rocm,   wheel-plat: manylinux_2_17_x86_64}
-          - {os: ubuntu-latest, backend: cpu,    wheel-plat: manylinux_2_17_x86_64}
+          - {os: ubuntu-22.04,  backend: cpu,    wheel-plat: manylinux_2_17_x86_64}
           # Windows: Vulkan, CUDA, cpu fallback.
           - {os: windows-2022,   backend: cu124,  wheel-plat: win_amd64, cuda: "12.4.0"}
           - {os: windows-2022,   backend: cu125,  wheel-plat: win_amd64, cuda: "12.5.0"}


### PR DESCRIPTION
## Problem

The `vulkan` and `cpu` engine wheels built on `ubuntu-latest` while the three CUDA/ROCm rows beside them pinned `ubuntu-22.04`. All five declare `manylinux_2_17_x86_64`. When GitHub moved the `ubuntu-latest` label from 22.04 to 24.04, those two began linking against glibc 2.39 with no change in this repository, so pip resolved them on any glibc 2.17+ host and the engine then failed in the dynamic loader.

Affected by glibc version alone: Debian 12 (2.36, current stable), Ubuntu 22.04 LTS (2.35), RHEL 9 and derivatives (2.34), Amazon Linux 2023 (2.34).

Reproduced on a fresh GCP `c3-standard-4` running Debian 12: `pip install` succeeds, `llama-server --version` fails naming `libllama-server-impl.so`, `libllama-common.so.0`, `libmtmd.so.0`, `libllama.so.0`, `libggml-base.so.0` and `libggml-cpu.so.0` as needing `GLIBC_2.38` and `GLIBCXX_3.4.32`. The identical capture on Ubuntu 24.04 (glibc 2.39) runs.

## Solution

Pin every Linux engine row to `ubuntu-22.04`, matching what the CUDA and ROCm rows already did, so the label cannot move the glibc floor again.

## Not covered here

Built on 22.04 the wheels need glibc 2.35, so the `manylinux_2_17` tag still over-promises and RHEL 9 / Amazon Linux 2023 (both 2.34) remain out of reach. Closing that means building in a manylinux container, which `release.yml` already does for the release binaries via `quay.io/pypa/manylinux_2_34_x86_64`. Worth doing separately.

No CI check installs a published wheel in a clean container and execs it. That is what would have caught this at build time rather than on a rented VM.