### PR TITLE
refactor(store): migrate FTS index to lancedb 0.34 create_index(config=FTS()) API

### DIFF
--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -406,18 +406,20 @@ class Store:
         runs LanceDB's default compaction + version pruning (default prune
         window: 7 days). Work scales with recent deltas rather than total
         chunk count, so large corpora no longer pay the full
-        ``create_fts_index(replace=True)`` rebuild cost on every sync.
+        ``create_index(config=FTS(), replace=True)`` rebuild cost on every sync.
         """
         with self._write_lock():
             table = self.open_table(CHUNKS_TABLE)
             if table is None:
                 return
+            from lancedb.index import FTS
+
             try:
                 if _has_fts_index(table):
                     table.optimize()
                     log.debug("FTS index optimized on '%s'", CHUNKS_TABLE)
                 else:
-                    table.create_fts_index("chunk", replace=False)
+                    table.create_index("chunk", config=FTS(), replace=False)
                     log.debug("FTS index created on '%s'", CHUNKS_TABLE)
                 self._fts_ready = True
             except Exception:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -170,7 +170,7 @@ class TestEnsureFtsIndex:
         assert table is not None
         with mock.patch.object(
             type(table),
-            "create_fts_index",
+            "create_index",
             side_effect=RuntimeError("boom"),
         ):
             store.ensure_fts_index()
@@ -183,7 +183,7 @@ class TestEnsureFtsIndex:
         assert table is not None
         with mock.patch.object(
             type(table),
-            "create_fts_index",
+            "create_index",
             side_effect=RuntimeError("boom"),
         ):
             assert store.bm25_probe("anything") == []
@@ -199,7 +199,7 @@ class TestEnsureFtsIndex:
         table = store.open_table("chunks")
         assert table is not None
         with (
-            mock.patch.object(type(table), "create_fts_index") as create_spy,
+            mock.patch.object(type(table), "create_index") as create_spy,
             mock.patch.object(type(table), "optimize") as optimize_spy,
         ):
             store.ensure_fts_index()
@@ -208,17 +208,22 @@ class TestEnsureFtsIndex:
         optimize_spy.assert_called_once()
 
     def test_first_call_creates_without_replace(self, store):
-        """Fresh table goes through create_fts_index path with replace=False."""
+        """Fresh table goes through create_index(config=FTS()) with replace=False."""
+        from lancedb.index import FTS
+
         store.add_chunks(_make_records())
         table = store.open_table("chunks")
         assert table is not None
 
-        with mock.patch.object(type(table), "create_fts_index") as create_spy:
+        with mock.patch.object(type(table), "create_index") as create_spy:
             store.ensure_fts_index()
 
         create_spy.assert_called_once()
-        # Verify replace was NOT True (would defeat the purpose of incremental)
-        _args, kwargs = create_spy.call_args
+        # Builds an FTS index on the chunk column, incrementally (replace was not
+        # True, which would defeat the purpose of incremental optimize()).
+        args, kwargs = create_spy.call_args
+        assert args[0] == "chunk"
+        assert isinstance(kwargs.get("config"), FTS)
         assert kwargs.get("replace") is False
 
     def test_bm25_probe_populates_bm25_score(self, store):


### PR DESCRIPTION
## Problem

Stepping up to lancedb 0.34 (#627) left one deprecated call: the chunks FTS index was built with `create_fts_index()`, which lancedb deprecates in favor of `create_index(config=FTS())`. The suite emitted a `DeprecationWarning` on every `ensure_fts_index` build.

## Solution

- Migrate `ensure_fts_index` to `table.create_index("chunk", config=FTS(), replace=False)`. `FTS()`'s defaults match the old `create_fts_index()` defaults exactly — native backend (`use_tantivy=False`), `simple` tokenizer, English, `max_token_length=40`, `lower_case`/`stem`/`remove_stop_words`/`ascii_folding=True`, no positions — so the index and search behavior are unchanged; this only clears the deprecation.
- Update the four store tests that mocked `create_fts_index` to observe the new `create_index` call. Two were failing under deprecation-as-error; the other two had silently become dead mocks (patching a method the code no longer calls, making their assertions vacuous).

## Testing

- `make check` green: 10406 passed, 3 skipped, 2 xpassed, **100% coverage**.
- Store tests pass under `-W error::DeprecationWarning` (177).
- Full-suite warning scan confirms **no lancedb deprecations remain anywhere**.