### PR TITLE
Seal engine-binary resolution in unit tests so dev machines match CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ markers = [
     "slow: integration tests that download models or take >10s",
     "real_model_classify: opt out of the global _classify_installed_models mock",
     "real_litellm_probe: opt out of the global litellm_available True override",
+    "real_engine_resolution: opt out of the engine-binary seal (host PATH and LILBEE_LLAMA_SERVER_PATH resolve again)",
     "xdist_group: pin grouped tests to a single xdist worker for serial execution",
     "no_health_default: opt out of the launch tests' default-healthy fixture",
     "no_warm_default: opt out of the launch tests' default chat-warm fixture",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,34 @@ def _assume_litellm_available(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _sealed_engine_resolution(request, monkeypatch):
+    """Seal engine-binary resolution so every machine behaves like CI.
+
+    resolve_engine_tool falls back to PATH when the bundled wheel's bin/ is
+    empty (always, outside a release build), so a developer with llama-server
+    installed resolves a real binary where CI raises ProviderError. Blocking
+    the three engine names in shutil.which and the LILBEE_LLAMA_SERVER_PATH
+    override forces a test that needs a binary to plant its own (a tmp-file
+    ``cfg.llama_server_path``, a fake ``lilbee_engine``, or a
+    ``shutil.which`` patch) or use ``@pytest.mark.real_engine_resolution``.
+    """
+    import shutil
+
+    from lilbee.providers.fleet.binary import EngineTool
+
+    if "real_engine_resolution" in {m.name for m in request.node.iter_markers()}:
+        return
+    monkeypatch.setattr(cfg, "llama_server_path", "")
+    sealed = {tool.value for tool in EngineTool}
+    real_which = shutil.which
+
+    def _engineless_which(cmd, *args, **kwargs):
+        return None if cmd in sealed else real_which(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "which", _engineless_which)
+
+
+@pytest.fixture(autouse=True)
 def _reset_services_after_test():
     """Drop any Services container ``set_services()`` left around.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared test helpers."""
 
 import os
+import shutil
 import sys
 import threading
 import warnings
@@ -35,6 +36,7 @@ from lilbee.core.config import cfg
 from lilbee.data.ingest import file_hash
 from lilbee.data.store import CitationRecord
 from lilbee.modelhub.registry import ModelManifest, ModelRegistry
+from lilbee.providers.fleet.binary import EngineTool
 
 # Stack-dump watchdog for wedged tests (opt-in via LILBEE_TEST_HANG_DUMP_S).
 pytest_plugins = ["tests._hang_watchdog"]
@@ -192,10 +194,6 @@ def _sealed_engine_resolution(request, monkeypatch):
     ``cfg.llama_server_path``, a fake ``lilbee_engine``, or a
     ``shutil.which`` patch) or use ``@pytest.mark.real_engine_resolution``.
     """
-    import shutil
-
-    from lilbee.providers.fleet.binary import EngineTool
-
     if "real_engine_resolution" in {m.name for m in request.node.iter_markers()}:
         return
     monkeypatch.setattr(cfg, "llama_server_path", "")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,6 +48,12 @@ def pytest_collection_modifyitems(items):
 
 
 @pytest.fixture(autouse=True)
+def _sealed_engine_resolution():
+    """Unseal engine resolution: integration tests run the engine CI puts on PATH."""
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _preserve_models_dir():
     """Ensure models_dir stays at canonical location for integration tests."""
     cfg.models_dir = canonical_models_dir()

--- a/tests/test_fleet_binary.py
+++ b/tests/test_fleet_binary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -292,6 +293,46 @@ class TestEnginePin:
         assert env["ENGINE_LLAMA_CPP_VERSION"] in pin
         assert env["ENGINE_LLAMA_SWAP_VERSION"] in pin
         assert env["ENGINE_GGUF_PARSER_REF"] in pin
+
+
+def _plant_host_binary(directory: Path, tool: EngineTool) -> Path:
+    """An executable engine binary as a developer machine would carry on PATH."""
+    exe = directory / (tool.value + (".exe" if os.name == "nt" else ""))
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    return exe
+
+
+class TestEngineResolutionSeal:
+    """The suite-wide seal: engine binaries a test did not plant never resolve."""
+
+    @pytest.mark.parametrize("tool", _ALL_TOOLS)
+    def test_host_path_binary_does_not_resolve(
+        self, tool: EngineTool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "llama_server_path", "")
+        _plant_host_binary(tmp_path, tool)
+        monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+        with pytest.raises(ProviderError, match="not found"):
+            resolve_engine_tool(tool)
+
+    def test_engine_build_id_ignores_host_path_binaries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "llama_server_path", "")
+        monkeypatch.setitem(sys.modules, "lilbee_engine", None)
+        _plant_host_binary(tmp_path, EngineTool.LLAMA_SERVER)
+        monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+        assert _engine_build_id() == "unpinned"
+
+    @pytest.mark.real_engine_resolution
+    def test_marker_restores_host_resolution(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "llama_server_path", "")
+        planted = _plant_host_binary(tmp_path, EngineTool.LLAMA_SERVER)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert resolve_llama_server() == planted
 
 
 def test_engine_pin_survives_an_engine_wheel_without_metadata(monkeypatch) -> None:


### PR DESCRIPTION
## Problem
Tests that reach `resolve_engine_tool` inherit whatever the machine has: the PATH fallback finds a real llama-server, llama-swap, or gguf-parser on a developer box and raises `ProviderError` on CI, so tests pass locally and fail in CI (five did exactly that on #620), and nothing stops the next test repeating it.

## Solution
- An autouse conftest fixture blocks the three engine names in `shutil.which` and clears the `LILBEE_LLAMA_SERVER_PATH` override for every unit test, so every machine resolves like CI.
- Tests that need a binary plant their own (a tmp-file configured path, a fake engine wheel, or a `shutil.which` patch, all of which override the seal) or opt out with `@pytest.mark.real_engine_resolution`.
- The integration directory opts out wholesale: that lane installs a real engine on PATH deliberately.