### PR TITLE
Derive ROCm card support from shipped rocBLAS kernels instead of compiler bitcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ The default Vulkan build works on AMD cards, and stays the fallback if ROCm isn'
 | **Flatpak**  | `flatpak install lilbee io.github.tobocop2.lilbee.rocm`                                                              |
 | **Binary**   | [`lilbee-linux-x86_64-rocm`](https://github.com/tobocop2/lilbee/releases/latest)                                     |
 
-Same `lilbee` command after install. Linux only. Cards: MI50, MI100, MI200, MI300, MI350, RDNA2, RDNA3, RDNA3.5 APUs and RDNA4. Largest of the three builds, since the ROCm userspace and per-card kernels ship inside it.
+Same `lilbee` command after install. Linux only. Cards: MI100, MI200, MI300, MI350, RDNA2, RDNA3, RDNA3.5 APUs and RDNA4. ROCm 7 ships no GEMM kernels for the MI50, so it needs the Vulkan build. Largest of the three builds, since the ROCm userspace and per-card kernels ship inside it.
 
 </details>
 

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -17,14 +17,13 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lilbee.providers import model_cache
 from lilbee.providers.base import ProviderError
+from lilbee.providers.fleet.engine_diagnostics import device_probe_diagnostic, links_any
 
 if TYPE_CHECKING:
     from lilbee.providers.fleet.devices import FleetDevice
@@ -40,24 +39,8 @@ _CUDA_WHEEL_IMPORTS: tuple[str, ...] = (
 # The sonames those wheels provide, used to tell from ``ldd`` whether a binary is a
 # CUDA build (it lists the soname whether or not the runtime resolves).
 _CUDA_SONAMES: tuple[str, ...] = ("libcudart.so.12", "libcublas.so.12", "libnvrtc.so.12")
-# The HIP equivalents. A ROCm build links these and none of the CUDA sonames, so
-# the CUDA guard above never fired for it.
-_HIP_SONAMES: tuple[str, ...] = ("libamdhip64.so", "librocblas.so", "libhipblas.so")
-# Substrings that mark a CUDA init failure in the engine's --list-devices output.
-_CUDA_ERROR_MARKERS: tuple[str, ...] = ("error", "fail", "no cuda")
-_LDD_TIMEOUT_S = 10
-# PCI vendor id for AMD, as sysfs reports it.
-log = logging.getLogger(__name__)
 
-_AMD_PCI_VENDOR_ID = "0x1002"
-# How much of the probe output to quote when no specific error line is found.
-_DIAGNOSTIC_TAIL_CHARS = 300
-# Backends whose devices run rocBLAS; ggml prints either name depending on version.
-_AMD_BACKENDS = ("ROCm", "HIP")
-# AMD's own escape hatch: makes the runtime treat every device as the given
-# gfx version, which is how a near-miss card (gfx1031) runs a shipped
-# architecture's kernels (gfx1030).
-_HSA_OVERRIDE_VAR = "HSA_OVERRIDE_GFX_VERSION"
+log = logging.getLogger(__name__)
 
 
 def _wheel_lib_dir(import_name: str) -> Path | None:
@@ -91,12 +74,10 @@ def cuda_runtime_env() -> dict[str, str]:
     if not dirs:
         return {}
     parts = [str(d) for d in dirs]
-    # Drop existing entries that are already wheel dirs so calling this on every
-    # reload pass (apply_cuda_runtime_env) is idempotent instead of accumulating
-    # duplicate copies that get baked into each spawned server's environment.
-    wheel_dirs = set(parts)
     existing = os.environ.get("LD_LIBRARY_PATH", "")
-    parts.extend(entry for entry in existing.split(os.pathsep) if entry and entry not in wheel_dirs)
+    for part in existing.split(os.pathsep):
+        if part and part not in parts:
+            parts.append(part)
     return {"LD_LIBRARY_PATH": os.pathsep.join(parts)}
 
 
@@ -110,250 +91,9 @@ def apply_cuda_runtime_env() -> None:
     os.environ.update(cuda_runtime_env())
 
 
-def _ldd_output(binary: Path, env: dict[str, str]) -> str | None:
-    """``ldd`` stdout for *binary* under *env*; None when ldd can't run on it."""
-    ldd = shutil.which("ldd")
-    if ldd is None:
-        return None
-    try:
-        proc = subprocess.run(  # noqa: S603 - ldd path and the resolved binary
-            [ldd, str(binary)],
-            capture_output=True,
-            text=True,
-            timeout=_LDD_TIMEOUT_S,
-            env=env,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        # Not an ELF, a static binary, or a timeout: nothing to inspect.
-        return None
-    return proc.stdout
-
-
 def _links_cuda_runtime(binary: Path, env: dict[str, str]) -> bool:
     """True when *binary* lists a CUDA runtime soname (a CUDA build), resolved or not."""
-    out = _ldd_output(binary, env)
-    if out is None:
-        return False
-    return any(soname in out for soname in _CUDA_SONAMES)
-
-
-def _device_probe_diagnostic(probe_output: str) -> str:
-    """The probe's CUDA error line, or a short tail of its output."""
-    out = probe_output.strip()
-    for line in out.splitlines():
-        lowered = line.lower()
-        if "cuda" in lowered and any(marker in lowered for marker in _CUDA_ERROR_MARKERS):
-            return line.strip()
-    return out[-_DIAGNOSTIC_TAIL_CHARS:] if out else "(the engine's device probe printed nothing)"
-
-
-def _links_hip_runtime(binary: Path, env: dict[str, str]) -> bool:
-    """True when *binary* lists a HIP runtime soname (a ROCm build), resolved or not."""
-    out = _ldd_output(binary, env)
-    if out is None:
-        return False
-    return any(soname in out for soname in _HIP_SONAMES)
-
-
-def _amd_gpu_present() -> bool:
-    """Whether the kernel exposes an AMD GPU, without needing ROCm to work.
-
-    Read from sysfs rather than from amd-smi or rocm-smi: those ship with ROCm,
-    and the failure this guards is precisely ROCm being installed wrong, so a
-    tool-based check would report "no GPU" for the case it exists to catch.
-    """
-    if not Path("/dev/kfd").exists():
-        return False
-    for vendor in Path("/sys/class/drm").glob("card*/device/vendor"):
-        try:
-            if vendor.read_text().strip().lower() == _AMD_PCI_VENDOR_ID:
-                return True
-        except OSError:
-            continue
-    return False
-
-
-def _amd_discrete_gpu_proven() -> bool:
-    """Whether a discrete AMD card is positively known to be present.
-
-    Positive evidence only. The sysfs checks that find an AMD GPU cannot tell a
-    discrete card from an APU, and the difference decides between refusing to
-    start and merely running slower, so the question is put to the Vulkan loader,
-    which reports the device type. An unreachable loader proves nothing and
-    answers no, which keeps the softer path.
-    """
-    from lilbee.providers.fleet.gpu_select import PCIVendorID, discrete_gpu_from_vendor
-
-    return discrete_gpu_from_vendor(PCIVendorID.AMD) is True
-
-
-def _gfx_name(target_version: int) -> str:
-    """The gfx name for a KFD ``gfx_target_version`` (90010 is gfx90a: minor and
-    step print as hex)."""
-    major, rest = divmod(target_version, 10000)
-    minor, step = divmod(rest, 100)
-    return f"gfx{major}{minor:x}{step:x}"
-
-
-def _host_amd_gfx_targets() -> set[str]:
-    """The gfx targets of this host's AMD GPUs, from the kernel driver's KFD topology.
-
-    Read from sysfs for the same reason as :func:`_amd_gpu_present`: ROCm tooling
-    is part of what can be broken. CPU nodes report a target version of 0. Empty
-    when the topology is absent or unreadable, which is "no claim".
-    """
-    targets: set[str] = set()
-    for props in Path("/sys/class/kfd/kfd/topology/nodes").glob("*/properties"):
-        try:
-            text = props.read_text()
-        except OSError:
-            continue
-        for line in text.splitlines():
-            name, _, value = line.partition(" ")
-            if name == "gfx_target_version" and value.strip().isdigit() and int(value.strip()):
-                targets.add(_gfx_name(int(value.strip())))
-    return targets
-
-
-def _bundled_rocblas_gfx_targets(binary: Path) -> set[str] | None:
-    """The gfx targets the rocBLAS kernels bundled beside *binary* cover.
-
-    rocBLAS loads a ``TensileLibrary_lazy_<gfx>.dat`` for the running card and
-    aborts the process when there is none, so the shipped masters are the ground
-    truth for which cards this build can run a GEMM on. ``None`` when no bundle
-    sits beside the binary (a system-ROCm engine): that is "no claim", where an
-    empty set would mean "supports nothing".
-    """
-    library = binary.parent / "rocblas" / "library"
-    if not library.is_dir():
-        return None
-    return {
-        f.name.removeprefix("TensileLibrary_lazy_").removesuffix(".dat")
-        for f in library.glob("TensileLibrary_lazy_gfx*.dat")
-    }
-
-
-def _hsa_override_gfx() -> str | None:
-    """The gfx target a user-set ``HSA_OVERRIDE_GFX_VERSION`` maps every device to."""
-    raw = os.environ.get(_HSA_OVERRIDE_VAR, "")
-    try:
-        major, minor, step = (int(part) for part in raw.split("."))
-    except ValueError:
-        return None
-    return _gfx_name(major * 10000 + minor * 100 + step)
-
-
-def _rocm_support_facts(binary: Path) -> str:
-    """What is known about shipped kernels and host gfx targets, as message text."""
-    shipped = _bundled_rocblas_gfx_targets(binary)
-    parts = []
-    if shipped:
-        parts.append(f"This build ships GPU kernels for: {', '.join(sorted(shipped))}.")
-    if host := _host_amd_gfx_targets():
-        parts.append(f"This host's AMD GPU targets: {', '.join(sorted(host))}.")
-    return " " + " ".join(parts) if parts else ""
-
-
-def _assert_rocblas_covers_enumerated_devices(binary: Path, devices: list[FleetDevice]) -> None:
-    """Refuse a card the bundle ships no rocBLAS kernels for, before rocBLAS aborts.
-
-    An enumerated device is no proof of support: the engine's device code and
-    rocBLAS's kernels are built from different lists, and a card covered by the
-    first but not the second initializes fine and then aborts the whole engine at
-    the first batched matrix multiply. Support is read from the bundled Tensile
-    masters rather than kept as a constant, so it cannot drift from what shipped.
-    """
-    if not any(d.backend in _AMD_BACKENDS for d in devices):
-        return
-    shipped = _bundled_rocblas_gfx_targets(binary)
-    if shipped is None:
-        return
-    if (override := _hsa_override_gfx()) is not None:
-        if override not in shipped:
-            log.warning(
-                "%s maps every AMD device to %s, but this build ships GPU kernels only "
-                "for: %s. The engine will abort at the first matrix multiplication if a "
-                "model runs on the GPU.",
-                _HSA_OVERRIDE_VAR,
-                override,
-                ", ".join(sorted(shipped)),
-            )
-        return
-    host = _host_amd_gfx_targets()
-    if not host:
-        return
-    missing = host - shipped
-    if not missing:
-        return
-    if host & shipped:
-        log.warning(
-            "This host has AMD GPU(s) with target %s, which this build ships no GPU "
-            "kernels for; the engine will abort if a model is placed on one. Restrict "
-            "HIP_VISIBLE_DEVICES to the supported cards, or set %s if the card is a "
-            "near miss of a shipped target (gfx1031 runs gfx1030 kernels with "
-            "%s=10.3.0).",
-            ", ".join(sorted(missing)),
-            _HSA_OVERRIDE_VAR,
-            _HSA_OVERRIDE_VAR,
-        )
-        return
-    raise ProviderError(
-        f"This host's AMD GPU is {', '.join(sorted(host))}, but this engine build ships "
-        f"GPU kernels only for: {', '.join(sorted(shipped))}. The engine would start and "
-        "then abort at the first matrix multiplication, so it is refused up front.\n"
-        f"If the card is a near miss of a shipped target, set {_HSA_OVERRIDE_VAR} to that "
-        f"target's version (a gfx1031 card runs the gfx1030 kernels with "
-        f"{_HSA_OVERRIDE_VAR}=10.3.0). Otherwise install lilbee's Vulkan build, which "
-        "supports AMD cards ROCm does not."
-    )
-
-
-def assert_gpu_devices_usable(binary: Path, devices: list[FleetDevice], probe_output: str) -> None:
-    """Fail loud when a GPU build cannot initialize any device on a host that has one.
-
-    Dispatches on what the binary actually links, so a ROCm build gets the same
-    treatment a CUDA build has always had. ROCm has a wide silent-failure class
-    (kernel and user-space version mismatch, an unsupported gfx target, no
-    permission on /dev/kfd) and every one of them previously ended as a quiet
-    fall back to CPU.
-    """
-    assert_cuda_devices_usable(binary, devices, probe_output)
-    if not sys.platform.startswith("linux"):
-        return
-    _assert_rocblas_covers_enumerated_devices(binary, devices)
-    if devices:
-        return
-    env = {**os.environ, **cuda_runtime_env()}
-    if not (_links_hip_runtime(binary, env) and _amd_gpu_present()):
-        return
-    if not _amd_discrete_gpu_proven():
-        # An APU is an AMD GPU by every check above: amdgpu exposes /dev/kfd for
-        # integrated parts too, and the iGPU carries vendor 0x1002. But AMD's
-        # population of GPUs ROCm legitimately does not support is large, and an
-        # unsupported gfx target is the normal case for an APU rather than a
-        # misconfiguration. Failing here would stop the engine on a laptop where
-        # CPU serving worked, which is worse than the slow fallback this guard
-        # exists to catch, so say so and let it start.
-        log.warning(
-            "The engine links the ROCm/HIP runtime and this host has an AMD GPU, but it "
-            "enumerated no device, so GPU work will fall back to CPU. No discrete AMD card "
-            "was found, so this is most likely an APU whose gfx target this ROCm build does "
-            "not support (check with 'rocminfo').%s The engine reported: %s",
-            _rocm_support_facts(binary),
-            _device_probe_diagnostic(probe_output),
-        )
-        return
-    raise ProviderError(
-        "The engine links the ROCm/HIP runtime and this host has an AMD GPU, but it "
-        "enumerated no device, so GPU work would silently fall back to CPU.\n"
-        f"The engine reported: {_device_probe_diagnostic(probe_output)}\n"
-        "Likely causes: the ROCm user-space version does not match the amdgpu kernel "
-        "driver; the GPU's gfx target is not supported by this ROCm build (check with "
-        "'rocminfo'); no read/write permission on /dev/kfd (the user is usually added "
-        "to the 'render' and 'video' groups); or a restrictive ROCR_VISIBLE_DEVICES or "
-        f"HIP_VISIBLE_DEVICES.{_rocm_support_facts(binary)}"
-    )
+    return links_any(binary, env, _CUDA_SONAMES)
 
 
 def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice], probe_output: str) -> None:
@@ -374,7 +114,7 @@ def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice], probe_o
         return
     if not model_cache.has_nvidia_gpu():
         return
-    diagnostic = _device_probe_diagnostic(probe_output)
+    diagnostic = device_probe_diagnostic(probe_output)
     raise ProviderError(
         "The engine links the CUDA runtime and this host has an NVIDIA GPU, but it "
         "enumerated no CUDA-capable device, so GPU work would silently fall back to CPU.\n"

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -52,6 +52,12 @@ log = logging.getLogger(__name__)
 _AMD_PCI_VENDOR_ID = "0x1002"
 # How much of the probe output to quote when no specific error line is found.
 _DIAGNOSTIC_TAIL_CHARS = 300
+# Backends whose devices run rocBLAS; ggml prints either name depending on version.
+_AMD_BACKENDS = ("ROCm", "HIP")
+# AMD's own escape hatch: makes the runtime treat every device as the given
+# gfx version, which is how a near-miss card (gfx1031) runs a shipped
+# architecture's kernels (gfx1030).
+_HSA_OVERRIDE_VAR = "HSA_OVERRIDE_GFX_VERSION"
 
 
 def _wheel_lib_dir(import_name: str) -> Path | None:
@@ -182,6 +188,127 @@ def _amd_discrete_gpu_proven() -> bool:
     return discrete_gpu_from_vendor(PCIVendorID.AMD) is True
 
 
+def _gfx_name(target_version: int) -> str:
+    """The gfx name for a KFD ``gfx_target_version`` (90010 is gfx90a: minor and
+    step print as hex)."""
+    major, rest = divmod(target_version, 10000)
+    minor, step = divmod(rest, 100)
+    return f"gfx{major}{minor:x}{step:x}"
+
+
+def _host_amd_gfx_targets() -> set[str]:
+    """The gfx targets of this host's AMD GPUs, from the kernel driver's KFD topology.
+
+    Read from sysfs for the same reason as :func:`_amd_gpu_present`: ROCm tooling
+    is part of what can be broken. CPU nodes report a target version of 0. Empty
+    when the topology is absent or unreadable, which is "no claim".
+    """
+    targets: set[str] = set()
+    for props in Path("/sys/class/kfd/kfd/topology/nodes").glob("*/properties"):
+        try:
+            text = props.read_text()
+        except OSError:
+            continue
+        for line in text.splitlines():
+            name, _, value = line.partition(" ")
+            if name == "gfx_target_version" and value.strip().isdigit() and int(value.strip()):
+                targets.add(_gfx_name(int(value.strip())))
+    return targets
+
+
+def _bundled_rocblas_gfx_targets(binary: Path) -> set[str] | None:
+    """The gfx targets the rocBLAS kernels bundled beside *binary* cover.
+
+    rocBLAS loads a ``TensileLibrary_lazy_<gfx>.dat`` for the running card and
+    aborts the process when there is none, so the shipped masters are the ground
+    truth for which cards this build can run a GEMM on. ``None`` when no bundle
+    sits beside the binary (a system-ROCm engine): that is "no claim", where an
+    empty set would mean "supports nothing".
+    """
+    library = binary.parent / "rocblas" / "library"
+    if not library.is_dir():
+        return None
+    return {
+        f.name.removeprefix("TensileLibrary_lazy_").removesuffix(".dat")
+        for f in library.glob("TensileLibrary_lazy_gfx*.dat")
+    }
+
+
+def _hsa_override_gfx() -> str | None:
+    """The gfx target a user-set ``HSA_OVERRIDE_GFX_VERSION`` maps every device to."""
+    raw = os.environ.get(_HSA_OVERRIDE_VAR, "")
+    try:
+        major, minor, step = (int(part) for part in raw.split("."))
+    except ValueError:
+        return None
+    return _gfx_name(major * 10000 + minor * 100 + step)
+
+
+def _rocm_support_facts(binary: Path) -> str:
+    """What is known about shipped kernels and host gfx targets, as message text."""
+    shipped = _bundled_rocblas_gfx_targets(binary)
+    parts = []
+    if shipped:
+        parts.append(f"This build ships GPU kernels for: {', '.join(sorted(shipped))}.")
+    if host := _host_amd_gfx_targets():
+        parts.append(f"This host's AMD GPU targets: {', '.join(sorted(host))}.")
+    return " " + " ".join(parts) if parts else ""
+
+
+def _assert_rocblas_covers_enumerated_devices(binary: Path, devices: list[FleetDevice]) -> None:
+    """Refuse a card the bundle ships no rocBLAS kernels for, before rocBLAS aborts.
+
+    An enumerated device is no proof of support: the engine's device code and
+    rocBLAS's kernels are built from different lists, and a card covered by the
+    first but not the second initializes fine and then aborts the whole engine at
+    the first batched matrix multiply. Support is read from the bundled Tensile
+    masters rather than kept as a constant, so it cannot drift from what shipped.
+    """
+    if not any(d.backend in _AMD_BACKENDS for d in devices):
+        return
+    shipped = _bundled_rocblas_gfx_targets(binary)
+    if shipped is None:
+        return
+    if (override := _hsa_override_gfx()) is not None:
+        if override not in shipped:
+            log.warning(
+                "%s maps every AMD device to %s, but this build ships GPU kernels only "
+                "for: %s. The engine will abort at the first matrix multiplication if a "
+                "model runs on the GPU.",
+                _HSA_OVERRIDE_VAR,
+                override,
+                ", ".join(sorted(shipped)),
+            )
+        return
+    host = _host_amd_gfx_targets()
+    if not host:
+        return
+    missing = host - shipped
+    if not missing:
+        return
+    if host & shipped:
+        log.warning(
+            "This host has AMD GPU(s) with target %s, which this build ships no GPU "
+            "kernels for; the engine will abort if a model is placed on one. Restrict "
+            "HIP_VISIBLE_DEVICES to the supported cards, or set %s if the card is a "
+            "near miss of a shipped target (gfx1031 runs gfx1030 kernels with "
+            "%s=10.3.0).",
+            ", ".join(sorted(missing)),
+            _HSA_OVERRIDE_VAR,
+            _HSA_OVERRIDE_VAR,
+        )
+        return
+    raise ProviderError(
+        f"This host's AMD GPU is {', '.join(sorted(host))}, but this engine build ships "
+        f"GPU kernels only for: {', '.join(sorted(shipped))}. The engine would start and "
+        "then abort at the first matrix multiplication, so it is refused up front.\n"
+        f"If the card is a near miss of a shipped target, set {_HSA_OVERRIDE_VAR} to that "
+        f"target's version (a gfx1031 card runs the gfx1030 kernels with "
+        f"{_HSA_OVERRIDE_VAR}=10.3.0). Otherwise install lilbee's Vulkan build, which "
+        "supports AMD cards ROCm does not."
+    )
+
+
 def assert_gpu_devices_usable(binary: Path, devices: list[FleetDevice], probe_output: str) -> None:
     """Fail loud when a GPU build cannot initialize any device on a host that has one.
 
@@ -192,7 +319,10 @@ def assert_gpu_devices_usable(binary: Path, devices: list[FleetDevice], probe_ou
     fall back to CPU.
     """
     assert_cuda_devices_usable(binary, devices, probe_output)
-    if not sys.platform.startswith("linux") or devices:
+    if not sys.platform.startswith("linux"):
+        return
+    _assert_rocblas_covers_enumerated_devices(binary, devices)
+    if devices:
         return
     env = {**os.environ, **cuda_runtime_env()}
     if not (_links_hip_runtime(binary, env) and _amd_gpu_present()):
@@ -209,7 +339,8 @@ def assert_gpu_devices_usable(binary: Path, devices: list[FleetDevice], probe_ou
             "The engine links the ROCm/HIP runtime and this host has an AMD GPU, but it "
             "enumerated no device, so GPU work will fall back to CPU. No discrete AMD card "
             "was found, so this is most likely an APU whose gfx target this ROCm build does "
-            "not support (check with 'rocminfo'). The engine reported: %s",
+            "not support (check with 'rocminfo').%s The engine reported: %s",
+            _rocm_support_facts(binary),
             _device_probe_diagnostic(probe_output),
         )
         return
@@ -221,7 +352,7 @@ def assert_gpu_devices_usable(binary: Path, devices: list[FleetDevice], probe_ou
         "driver; the GPU's gfx target is not supported by this ROCm build (check with "
         "'rocminfo'); no read/write permission on /dev/kfd (the user is usually added "
         "to the 'render' and 'video' groups); or a restrictive ROCR_VISIBLE_DEVICES or "
-        "HIP_VISIBLE_DEVICES."
+        f"HIP_VISIBLE_DEVICES.{_rocm_support_facts(binary)}"
     )
 
 

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -15,7 +15,6 @@ the wheels' location is only known at install time.
 from __future__ import annotations
 
 import importlib.util
-import logging
 import os
 import sys
 from pathlib import Path
@@ -39,8 +38,6 @@ _CUDA_WHEEL_IMPORTS: tuple[str, ...] = (
 # The sonames those wheels provide, used to tell from ``ldd`` whether a binary is a
 # CUDA build (it lists the soname whether or not the runtime resolves).
 _CUDA_SONAMES: tuple[str, ...] = ("libcudart.so.12", "libcublas.so.12", "libnvrtc.so.12")
-
-log = logging.getLogger(__name__)
 
 
 def _wheel_lib_dir(import_name: str) -> Path | None:

--- a/src/lilbee/providers/fleet/engine_diagnostics.py
+++ b/src/lilbee/providers/fleet/engine_diagnostics.py
@@ -1,0 +1,52 @@
+"""Inspect the engine binary's linked runtimes and its device probe's output."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+_LDD_TIMEOUT_S = 10
+# Substrings that mark a device-init failure in the probe output. The HIP
+# backend is compiled from ggml-cuda, so its error lines also say "cuda".
+_ERROR_MARKERS = ("error", "fail", "no cuda")
+# How much of the probe output to quote when no specific error line is found.
+_DIAGNOSTIC_TAIL_CHARS = 300
+
+
+def ldd_output(binary: Path, env: dict[str, str]) -> str | None:
+    """``ldd`` stdout for *binary* under *env*; None when ldd can't run on it."""
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        return None
+    try:
+        proc = subprocess.run(  # noqa: S603 - ldd path and the resolved binary
+            [ldd, str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=_LDD_TIMEOUT_S,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # Not an ELF, a static binary, or a timeout: nothing to inspect.
+        return None
+    return proc.stdout
+
+
+def links_any(binary: Path, env: dict[str, str], sonames: tuple[str, ...]) -> bool:
+    """True when *binary* lists any of *sonames*, resolved or not."""
+    out = ldd_output(binary, env)
+    if out is None:
+        return False
+    return any(soname in out for soname in sonames)
+
+
+def device_probe_diagnostic(probe_output: str) -> str:
+    """The probe's device-init error line, or a short tail of its output."""
+    out = probe_output.strip()
+    for line in out.splitlines():
+        lowered = line.lower()
+        if "cuda" in lowered and any(marker in lowered for marker in _ERROR_MARKERS):
+            return line.strip()
+    return out[-_DIAGNOSTIC_TAIL_CHARS:] if out else "(the engine's device probe printed nothing)"

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1191,18 +1191,20 @@ def _resolve_devices_and_refusal(binary: Path) -> tuple[list[FleetDevice], bool]
     probe that times out raises instead (a wedged GPU driver); falling through
     to the in-process Vulkan probe there could hang this thread unkillably.
     """
-    from lilbee.providers.fleet.cuda_runtime import assert_gpu_devices_usable
+    from lilbee.providers.fleet.cuda_runtime import assert_cuda_devices_usable
     from lilbee.providers.fleet.gpu_select import enumerate_gpu_vram
+    from lilbee.providers.fleet.rocm_runtime import assert_rocm_devices_usable
 
     probe = probe_devices(binary)
     devices = probe.devices
-    # A CUDA build that links a runtime it cannot init a GPU with must fail loud,
-    # not silently fall back to CPU (the Vulkan VRAM probe below would mask it).
-    # Only when the engine actually answered, though: a binary that does not
-    # support --list-devices enumerated nothing because it was never asked, and
-    # accusing its driver of failing to initialize would be both wrong and fatal.
+    # A GPU build that links a runtime it cannot serve the host's GPU with must
+    # fail loud, not silently fall back to CPU (the Vulkan VRAM probe below
+    # would mask it). Only when the engine actually answered, though: a binary
+    # that does not support --list-devices enumerated nothing because it was
+    # never asked, and accusing its driver of failing would be wrong and fatal.
     if probe.spoke_protocol:
-        assert_gpu_devices_usable(binary, devices, probe.output)
+        assert_cuda_devices_usable(binary, devices, probe.output)
+        assert_rocm_devices_usable(binary, devices, probe.output)
     if not devices and probe.spoke_protocol and model_cache.has_nvidia_gpu():
         log.warning(
             "This host has an NVIDIA GPU but the engine's device probe "

--- a/src/lilbee/providers/fleet/rocm_runtime.py
+++ b/src/lilbee/providers/fleet/rocm_runtime.py
@@ -1,0 +1,234 @@
+"""Guard a ROCm engine build against AMD hosts it cannot actually serve.
+
+ROCm has a wide silent-failure class (kernel and user-space version mismatch,
+an unsupported gfx target, no permission on /dev/kfd) that ends either as a
+quiet CPU fallback or as a rocBLAS abort mid-inference. The checks here read
+the kernel driver and the bundled artifacts rather than ROCm tooling, because
+ROCm being broken is the case they exist to catch.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lilbee.providers.base import ProviderError
+from lilbee.providers.fleet.engine_diagnostics import device_probe_diagnostic, links_any
+from lilbee.providers.fleet.gpu_select import PCIVendorID, discrete_gpu_from_vendor
+
+if TYPE_CHECKING:
+    from lilbee.providers.fleet.devices import FleetDevice
+
+log = logging.getLogger(__name__)
+
+# A ROCm build links these and none of the CUDA sonames.
+_HIP_SONAMES: tuple[str, ...] = ("libamdhip64.so", "librocblas.so", "libhipblas.so")
+# PCI vendor id for AMD, as sysfs reports it.
+_AMD_PCI_VENDOR_ID = "0x1002"
+# Backends whose devices run rocBLAS; ggml prints either name depending on version.
+_AMD_BACKENDS = ("ROCm", "HIP")
+# AMD's escape hatch: the runtime treats every device as the given gfx version.
+_HSA_OVERRIDE_VAR = "HSA_OVERRIDE_GFX_VERSION"
+
+
+def _links_hip_runtime(binary: Path, env: dict[str, str]) -> bool:
+    """True when *binary* lists a HIP runtime soname (a ROCm build), resolved or not."""
+    return links_any(binary, env, _HIP_SONAMES)
+
+
+def _amd_gpu_present() -> bool:
+    """Whether the kernel exposes an AMD GPU, without needing ROCm to work.
+
+    Read from sysfs rather than from amd-smi or rocm-smi: those ship with ROCm,
+    and the failure this guards is precisely ROCm being installed wrong, so a
+    tool-based check would report "no GPU" for the case it exists to catch.
+    """
+    if not Path("/dev/kfd").exists():
+        return False
+    for vendor in Path("/sys/class/drm").glob("card*/device/vendor"):
+        try:
+            if vendor.read_text().strip().lower() == _AMD_PCI_VENDOR_ID:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _amd_discrete_gpu_proven() -> bool:
+    """Whether a discrete AMD card is positively known to be present.
+
+    Positive evidence only. The sysfs checks that find an AMD GPU cannot tell a
+    discrete card from an APU, and the difference decides between refusing to
+    start and merely running slower, so the question is put to the Vulkan loader,
+    which reports the device type. An unreachable loader proves nothing and
+    answers no, which keeps the softer path.
+    """
+    return discrete_gpu_from_vendor(PCIVendorID.AMD) is True
+
+
+def _gfx_name(target_version: int) -> str:
+    """The gfx name for a KFD ``gfx_target_version``; minor and step print as hex."""
+    major, rest = divmod(target_version, 10000)
+    minor, step = divmod(rest, 100)
+    return f"gfx{major}{minor:x}{step:x}"
+
+
+def _host_amd_gfx_targets() -> set[str]:
+    """The gfx targets of this host's AMD GPUs, from the driver's KFD topology.
+
+    CPU nodes report a target version of 0. Empty when the topology is absent
+    or unreadable, which is "no claim".
+    """
+    targets: set[str] = set()
+    for props in Path("/sys/class/kfd/kfd/topology/nodes").glob("*/properties"):
+        try:
+            text = props.read_text()
+        except OSError:
+            continue
+        for line in text.splitlines():
+            name, _, value = line.partition(" ")
+            if name == "gfx_target_version" and value.strip().isdigit() and int(value.strip()):
+                targets.add(_gfx_name(int(value.strip())))
+    return targets
+
+
+def _bundled_rocblas_gfx_targets(binary: Path) -> set[str] | None:
+    """The gfx targets covered by the rocBLAS Tensile masters bundled beside *binary*.
+
+    rocBLAS aborts the process on a card it has no masters for, so the shipped
+    files are the ground truth for which cards this build can run a GEMM on.
+    None when no bundle sits beside the binary (a system-ROCm engine): that is
+    "no claim", where an empty set would mean "supports nothing".
+    """
+    library = binary.parent / "rocblas" / "library"
+    if not library.is_dir():
+        return None
+    return {
+        f.name.removeprefix("TensileLibrary_lazy_").removesuffix(".dat")
+        for f in library.glob("TensileLibrary_lazy_gfx*.dat")
+    }
+
+
+def _hsa_override_gfx() -> str | None:
+    """The gfx target a user-set ``HSA_OVERRIDE_GFX_VERSION`` maps every device to."""
+    raw = os.environ.get(_HSA_OVERRIDE_VAR, "")
+    try:
+        major, minor, step = (int(part) for part in raw.split("."))
+    except ValueError:
+        return None
+    return _gfx_name(major * 10000 + minor * 100 + step)
+
+
+def _rocm_support_facts(binary: Path) -> str:
+    """What is known about shipped kernels and host gfx targets, as message text."""
+    shipped = _bundled_rocblas_gfx_targets(binary)
+    parts = []
+    if shipped:
+        parts.append(f"This build ships GPU kernels for: {', '.join(sorted(shipped))}.")
+    if host := _host_amd_gfx_targets():
+        parts.append(f"This host's AMD GPU targets: {', '.join(sorted(host))}.")
+    return " " + " ".join(parts) if parts else ""
+
+
+def _warn_if_override_uncovered(override: str, shipped: set[str]) -> None:
+    """The user overrode explicitly; respect it, but say what will happen."""
+    if override in shipped:
+        return
+    log.warning(
+        "%s maps every AMD device to %s, but this build ships GPU kernels only "
+        "for: %s. The engine will abort at the first matrix multiplication if a "
+        "model runs on the GPU.",
+        _HSA_OVERRIDE_VAR,
+        override,
+        ", ".join(sorted(shipped)),
+    )
+
+
+def _assert_rocblas_covers_enumerated_devices(binary: Path, devices: list[FleetDevice]) -> None:
+    """Refuse a card the bundle ships no rocBLAS kernels for, before rocBLAS aborts.
+
+    An enumerated device is no proof of support: the engine's device code and
+    rocBLAS's kernels are built from different lists, and a card covered by the
+    first but not the second initializes fine and then aborts the whole engine at
+    the first batched matrix multiply. Support is read from the bundled Tensile
+    masters rather than kept as a constant, so it cannot drift from what shipped.
+    """
+    if not any(d.backend in _AMD_BACKENDS for d in devices):
+        return
+    shipped = _bundled_rocblas_gfx_targets(binary)
+    if shipped is None:
+        return
+    if (override := _hsa_override_gfx()) is not None:
+        _warn_if_override_uncovered(override, shipped)
+        return
+    host = _host_amd_gfx_targets()
+    if not host or host <= shipped:
+        return
+    if host & shipped:
+        log.warning(
+            "This host has AMD GPU(s) with target %s, which this build ships no GPU "
+            "kernels for; the engine will abort if a model is placed on one. Restrict "
+            "HIP_VISIBLE_DEVICES to the supported cards, or set %s if the card is a "
+            "near miss of a shipped target (gfx1031 runs gfx1030 kernels with "
+            "%s=10.3.0).",
+            ", ".join(sorted(host - shipped)),
+            _HSA_OVERRIDE_VAR,
+            _HSA_OVERRIDE_VAR,
+        )
+        return
+    raise ProviderError(
+        f"This host's AMD GPU is {', '.join(sorted(host))}, but this engine build ships "
+        f"GPU kernels only for: {', '.join(sorted(shipped))}. The engine would start and "
+        "then abort at the first matrix multiplication, so it is refused up front.\n"
+        f"If the card is a near miss of a shipped target, set {_HSA_OVERRIDE_VAR} to that "
+        f"target's version (a gfx1031 card runs the gfx1030 kernels with "
+        f"{_HSA_OVERRIDE_VAR}=10.3.0). Otherwise install lilbee's Vulkan build, which "
+        "supports AMD cards ROCm does not."
+    )
+
+
+def assert_rocm_devices_usable(binary: Path, devices: list[FleetDevice], probe_output: str) -> None:
+    """Fail loud when a ROCm build cannot serve the AMD hardware in front of it.
+
+    *devices* and *probe_output* are the engine's own ``--list-devices`` result.
+    An enumerated card is checked against the bundled rocBLAS kernels; an empty
+    list on an AMD host means the runtime loaded and enumerated no device, which
+    would otherwise silently fall back to CPU.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    _assert_rocblas_covers_enumerated_devices(binary, devices)
+    if devices:
+        return
+    if not (_links_hip_runtime(binary, dict(os.environ)) and _amd_gpu_present()):
+        return
+    if not _amd_discrete_gpu_proven():
+        # An APU is an AMD GPU by every check above: amdgpu exposes /dev/kfd for
+        # integrated parts too, and the iGPU carries vendor 0x1002. But AMD's
+        # population of GPUs ROCm legitimately does not support is large, and an
+        # unsupported gfx target is the normal case for an APU rather than a
+        # misconfiguration. Failing here would stop the engine on a laptop where
+        # CPU serving worked, which is worse than the slow fallback this guard
+        # exists to catch, so say so and let it start.
+        log.warning(
+            "The engine links the ROCm/HIP runtime and this host has an AMD GPU, but it "
+            "enumerated no device, so GPU work will fall back to CPU. No discrete AMD card "
+            "was found, so this is most likely an APU whose gfx target this ROCm build does "
+            "not support (check with 'rocminfo').%s The engine reported: %s",
+            _rocm_support_facts(binary),
+            device_probe_diagnostic(probe_output),
+        )
+        return
+    raise ProviderError(
+        "The engine links the ROCm/HIP runtime and this host has an AMD GPU, but it "
+        "enumerated no device, so GPU work would silently fall back to CPU.\n"
+        f"The engine reported: {device_probe_diagnostic(probe_output)}\n"
+        "Likely causes: the ROCm user-space version does not match the amdgpu kernel "
+        "driver; the GPU's gfx target is not supported by this ROCm build (check with "
+        "'rocminfo'); no read/write permission on /dev/kfd (the user is usually added "
+        "to the 'render' and 'video' groups); or a restrictive ROCR_VISIBLE_DEVICES or "
+        f"HIP_VISIBLE_DEVICES.{_rocm_support_facts(binary)}"
+    )

--- a/src/lilbee/providers/fleet/rocm_runtime.py
+++ b/src/lilbee/providers/fleet/rocm_runtime.py
@@ -1,10 +1,7 @@
 """Guard a ROCm engine build against AMD hosts it cannot actually serve.
 
-ROCm has a wide silent-failure class (kernel and user-space version mismatch,
-an unsupported gfx target, no permission on /dev/kfd) that ends either as a
-quiet CPU fallback or as a rocBLAS abort mid-inference. The checks here read
-the kernel driver and the bundled artifacts rather than ROCm tooling, because
-ROCm being broken is the case they exist to catch.
+Reads the kernel driver and the bundled artifacts rather than ROCm tooling,
+because ROCm being broken is the case these checks exist to catch.
 """
 
 from __future__ import annotations
@@ -79,8 +76,7 @@ def _gfx_name(target_version: int) -> str:
 def _host_amd_gfx_targets() -> set[str]:
     """The gfx targets of this host's AMD GPUs, from the driver's KFD topology.
 
-    CPU nodes report a target version of 0. Empty when the topology is absent
-    or unreadable, which is "no claim".
+    CPU nodes report a target version of 0. Empty means "no claim".
     """
     targets: set[str] = set()
     for props in Path("/sys/class/kfd/kfd/topology/nodes").glob("*/properties"):
@@ -98,8 +94,6 @@ def _host_amd_gfx_targets() -> set[str]:
 def _bundled_rocblas_gfx_targets(binary: Path) -> set[str] | None:
     """The gfx targets covered by the rocBLAS Tensile masters bundled beside *binary*.
 
-    rocBLAS aborts the process on a card it has no masters for, so the shipped
-    files are the ground truth for which cards this build can run a GEMM on.
     None when no bundle sits beside the binary (a system-ROCm engine): that is
     "no claim", where an empty set would mean "supports nothing".
     """
@@ -150,11 +144,8 @@ def _warn_if_override_uncovered(override: str, shipped: set[str]) -> None:
 def _assert_rocblas_covers_enumerated_devices(binary: Path, devices: list[FleetDevice]) -> None:
     """Refuse a card the bundle ships no rocBLAS kernels for, before rocBLAS aborts.
 
-    An enumerated device is no proof of support: the engine's device code and
-    rocBLAS's kernels are built from different lists, and a card covered by the
-    first but not the second initializes fine and then aborts the whole engine at
-    the first batched matrix multiply. Support is read from the bundled Tensile
-    masters rather than kept as a constant, so it cannot drift from what shipped.
+    An enumerated device is no proof of support: a card with engine device code
+    but no rocBLAS kernels initializes fine and aborts at the first batched GEMM.
     """
     if not any(d.backend in _AMD_BACKENDS for d in devices):
         return

--- a/tests/test_cmake_args_rocm.py
+++ b/tests/test_cmake_args_rocm.py
@@ -42,13 +42,26 @@ _CURRENT_ISAS = (
 )
 
 
-def _rocm_tree(root: pathlib.Path, isas: tuple[str, ...]) -> pathlib.Path:
-    """A ROCm install whose device bitcode covers *isas*."""
+def _rocm_tree(
+    root: pathlib.Path,
+    isas: tuple[str, ...],
+    *,
+    kernel_isas: tuple[str, ...] | None = None,
+) -> pathlib.Path:
+    """A ROCm install with device bitcode for *isas* and rocBLAS kernels for *kernel_isas*.
+
+    *kernel_isas* defaults to *isas*; pass a subset to model a ROCm whose compiler
+    still targets an architecture rocBLAS no longer ships GEMM kernels for.
+    """
     bitcode = root / "amdgcn/bitcode"
     bitcode.mkdir(parents=True)
     (root / "lib/llvm/bin").mkdir(parents=True)
+    kernels = root / "lib/rocblas/library"
+    kernels.mkdir(parents=True)
     for isa in isas:
         (bitcode / f"oclc_isa_version_{isa}.bc").write_text("")
+    for isa in isas if kernel_isas is None else kernel_isas:
+        (kernels / f"TensileLibrary_lazy_gfx{isa}.dat").write_text("")
     return root
 
 
@@ -74,7 +87,8 @@ def test_builds_every_target_a_current_rocm_supports(tmp_path):
     """Nothing is dropped when the toolchain knows every card we ship for."""
     targets, stderr = _targets(_rocm_tree(tmp_path / "rocm", _CURRENT_ISAS))
     assert targets.split(";") == [f"gfx{isa}" for isa in _CURRENT_ISAS]
-    assert "cannot build" not in stderr
+    assert "no device bitcode for" not in stderr
+    assert "no GEMM kernels for" not in stderr
 
 
 def test_never_asks_for_the_target_rocm_7_removed(tmp_path):
@@ -100,6 +114,46 @@ def test_falls_back_loudly_when_there_is_no_bitcode_to_read(tmp_path):
     targets, stderr = _targets(root)
     assert "gfx942" in targets
     assert "no device bitcode" in stderr
+
+
+def test_drops_targets_rocblas_ships_no_kernels_for(tmp_path):
+    """Bitcode alone is not support: ROCm 7.2 still compiles gfx906 but ships zero
+    rocBLAS kernels for it, and the built engine aborts on the first batched GEMM."""
+    kernel_isas = tuple(i for i in _CURRENT_ISAS if i != "906")
+    targets, stderr = _targets(
+        _rocm_tree(tmp_path / "rocm", _CURRENT_ISAS, kernel_isas=kernel_isas)
+    )
+    assert "gfx906" not in targets
+    assert targets.split(";") == [f"gfx{isa}" for isa in kernel_isas]
+    assert "gfx906" in stderr and "GEMM kernels" in stderr
+
+
+def test_a_target_returns_when_rocblas_restores_its_kernels(tmp_path):
+    """The wanted list is intent: nothing needs editing when AMD brings kernels back."""
+    without, _ = _targets(
+        _rocm_tree(tmp_path / "a", _CURRENT_ISAS, kernel_isas=("908", "90a"))
+    )
+    restored, _ = _targets(_rocm_tree(tmp_path / "b", _CURRENT_ISAS))
+    assert "gfx906" not in without
+    assert "gfx906" in restored
+
+
+def test_missing_kernel_library_keeps_the_bitcode_filter_alone(tmp_path):
+    """A ROCm tree without rocBLAS kernels at all is filtered on bitcode only,
+    loudly, rather than dropping every target."""
+    root = _rocm_tree(tmp_path / "rocm", _CURRENT_ISAS, kernel_isas=())
+    (root / "lib/rocblas/library").rmdir()
+    targets, stderr = _targets(root)
+    assert targets.split(";") == [f"gfx{isa}" for isa in _CURRENT_ISAS]
+    assert "bitcode alone" in stderr
+
+
+def test_no_surviving_target_falls_back_to_everything_loudly(tmp_path):
+    """A kernel library that covers nothing we want is an install this script does
+    not understand; build everything rather than emit a wheel for no card."""
+    targets, stderr = _targets(_rocm_tree(tmp_path / "rocm", _CURRENT_ISAS, kernel_isas=()))
+    assert targets.split(";") == [f"gfx{isa}" for isa in _CURRENT_ISAS]
+    assert "unfiltered" in stderr
 
 
 @pytest.mark.parametrize("isas", [_CURRENT_ISAS, ("942", "1030")])

--- a/tests/test_cmake_args_rocm.py
+++ b/tests/test_cmake_args_rocm.py
@@ -130,9 +130,7 @@ def test_drops_targets_rocblas_ships_no_kernels_for(tmp_path):
 
 def test_a_target_returns_when_rocblas_restores_its_kernels(tmp_path):
     """The wanted list is intent: nothing needs editing when AMD brings kernels back."""
-    without, _ = _targets(
-        _rocm_tree(tmp_path / "a", _CURRENT_ISAS, kernel_isas=("908", "90a"))
-    )
+    without, _ = _targets(_rocm_tree(tmp_path / "a", _CURRENT_ISAS, kernel_isas=("908", "90a")))
     restored, _ = _targets(_rocm_tree(tmp_path / "b", _CURRENT_ISAS))
     assert "gfx906" not in without
     assert "gfx906" in restored

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from lilbee.providers.base import ProviderError
-from lilbee.providers.fleet import cuda_runtime
+from lilbee.providers.fleet import cuda_runtime, engine_diagnostics
 from lilbee.providers.fleet.cuda_runtime import (
     apply_cuda_runtime_env,
     assert_cuda_devices_usable,
@@ -24,13 +23,13 @@ def _force_linux(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _have_ldd(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cuda_runtime.shutil, "which", lambda _name: "/usr/bin/ldd")
+    monkeypatch.setattr(engine_diagnostics.shutil, "which", lambda _name: "/usr/bin/ldd")
 
 
 def _ldd_returns(monkeypatch: pytest.MonkeyPatch, stdout: str) -> None:
     _have_ldd(monkeypatch)
     monkeypatch.setattr(
-        cuda_runtime.subprocess,
+        engine_diagnostics.subprocess,
         "run",
         lambda *_a, **_k: SimpleNamespace(stdout=stdout, stderr=""),
     )
@@ -38,20 +37,6 @@ def _ldd_returns(monkeypatch: pytest.MonkeyPatch, stdout: str) -> None:
 
 _LINKS_CUDA = "\tlibcudart.so.12 => /usr/lib/libcudart.so.12 (0x00007f00)\n"
 _NO_CUDA = "\tlibstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f00)\n"
-
-
-def _root_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *prefixes: str) -> None:
-    """Reroute cuda_runtime's absolute /dev and /sys lookups under *tmp_path*."""
-    real_path = cuda_runtime.Path
-
-    class _RootedPath(type(real_path())):  # type: ignore[misc]
-        def __new__(cls, *args):
-            first = str(args[0]) if args else ""
-            if first.startswith(prefixes):
-                return real_path(str(tmp_path) + first)
-            return real_path(*args)
-
-    monkeypatch.setattr(cuda_runtime, "Path", _RootedPath)
 
 
 def test_links_cuda_runtime_true_when_soname_present(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -70,7 +55,7 @@ def test_links_cuda_runtime_false_for_non_cuda_build(monkeypatch: pytest.MonkeyP
 
 
 def test_links_cuda_runtime_false_when_ldd_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cuda_runtime.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(engine_diagnostics.shutil, "which", lambda _name: None)
     assert cuda_runtime._links_cuda_runtime(Path("/bin/llama-server"), {}) is False
 
 
@@ -121,7 +106,7 @@ def test_assert_devices_noop_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
     def _boom(*_a: object, **_k: object) -> None:
         raise AssertionError("must not probe off Linux")
 
-    monkeypatch.setattr(cuda_runtime.subprocess, "run", _boom)
+    monkeypatch.setattr(engine_diagnostics.subprocess, "run", _boom)
     assert_cuda_devices_usable(Path("/bin/llama-server"), [], "")  # no raise
 
 
@@ -238,425 +223,3 @@ def test_cuda_wheel_lib_dirs_collects_only_installed(monkeypatch: pytest.MonkeyP
     }
     monkeypatch.setattr(cuda_runtime, "_wheel_lib_dir", lambda name: found[name])
     assert cuda_runtime._cuda_wheel_lib_dirs() == [Path("/r/lib"), Path("/n/lib")]
-
-
-def test_ldd_output_none_when_subprocess_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    _have_ldd(monkeypatch)
-
-    def _raise(*_a: object, **_k: object) -> None:
-        raise OSError("not an ELF binary")
-
-    monkeypatch.setattr(cuda_runtime.subprocess, "run", _raise)
-    assert cuda_runtime._ldd_output(Path("/bin/llama-server"), {}) is None
-
-
-def test_device_probe_diagnostic_returns_tail_when_no_error_line() -> None:
-    out = cuda_runtime._device_probe_diagnostic("CUDA0: NVIDIA L40 (45 GiB)\n")
-    assert "NVIDIA L40" in out  # no error marker -> falls through to the output tail
-
-
-def test_device_probe_diagnostic_picks_the_cuda_error_line() -> None:
-    output = "loading backends\nggml_cuda_init: CUDA error: unknown error\ntrailing noise\n"
-    assert (
-        cuda_runtime._device_probe_diagnostic(output) == "ggml_cuda_init: CUDA error: unknown error"
-    )
-
-
-def test_device_probe_diagnostic_when_no_output() -> None:
-    assert (
-        cuda_runtime._device_probe_diagnostic("") == "(the engine's device probe printed nothing)"
-    )
-
-
-def test_rocm_build_enumerating_nothing_on_an_amd_host_fails_loud(monkeypatch, tmp_path) -> None:
-    """ROCm's silent-failure class had no counterpart to the CUDA guard.
-
-    A version mismatch, an unsupported gfx target or no access to /dev/kfd all
-    end with the runtime loaded and zero devices, which used to fall quietly to
-    CPU on a machine bought for its GPU.
-    """
-    from lilbee.providers.base import ProviderError
-    from lilbee.providers.fleet import cuda_runtime
-
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: False)
-    monkeypatch.setattr(cuda_runtime, "_links_hip_runtime", lambda *_a: True)
-    monkeypatch.setattr(cuda_runtime, "_amd_gpu_present", lambda: True)
-    monkeypatch.setattr(cuda_runtime, "_amd_discrete_gpu_proven", lambda: True)
-
-    with pytest.raises(ProviderError) as err:
-        cuda_runtime.assert_gpu_devices_usable(tmp_path / "llama-server", [], "rocBLAS error\n")
-    assert "/dev/kfd" in str(err.value)
-
-
-def test_rocm_build_is_silent_when_the_host_has_no_amd_gpu(monkeypatch, tmp_path) -> None:
-    """A ROCm build on a machine without an AMD card is just a CPU host."""
-    from lilbee.providers.fleet import cuda_runtime
-
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: False)
-    monkeypatch.setattr(cuda_runtime, "_links_hip_runtime", lambda *_a: True)
-    monkeypatch.setattr(cuda_runtime, "_amd_gpu_present", lambda: False)
-
-    cuda_runtime.assert_gpu_devices_usable(tmp_path / "llama-server", [], "")
-
-
-class TestAmdPresenceReadsTheKernelNotRocmTooling:
-    """The failure this detects is ROCm being installed wrong, so a check built
-    on amd-smi or rocm-smi would report "no GPU" for the very case it exists to
-    catch. Driven through a fake sysfs rather than by reading the source, so it
-    tests what the function does and not how it is written."""
-
-    def _fake_sysfs(self, monkeypatch, tmp_path, *, kfd: bool, vendors: list[str]) -> None:
-        drm = tmp_path / "sys/class/drm"
-        for i, vendor in enumerate(vendors):
-            device = drm / f"card{i}" / "device"
-            device.mkdir(parents=True)
-            (device / "vendor").write_text(f"{vendor}\n")
-        (tmp_path / "dev").mkdir(exist_ok=True)
-        if kfd:
-            (tmp_path / "dev/kfd").write_text("")
-        _root_paths(monkeypatch, tmp_path, "/dev/kfd", "/sys/class/drm")
-
-    def test_an_amd_card_is_found_with_no_rocm_installed(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._fake_sysfs(monkeypatch, tmp_path, kfd=True, vendors=["0x1002"])
-
-        assert cuda_runtime._amd_gpu_present() is True
-
-    def test_a_non_amd_card_is_not_an_amd_gpu(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._fake_sysfs(monkeypatch, tmp_path, kfd=True, vendors=["0x10de"])
-
-        assert cuda_runtime._amd_gpu_present() is False
-
-    def test_no_kfd_means_the_kernel_driver_is_not_there(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._fake_sysfs(monkeypatch, tmp_path, kfd=False, vendors=["0x1002"])
-
-        assert cuda_runtime._amd_gpu_present() is False
-
-    def test_it_never_shells_out(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._fake_sysfs(monkeypatch, tmp_path, kfd=True, vendors=["0x1002"])
-
-        def _boom(*_a: object, **_k: object) -> None:
-            raise AssertionError("_amd_gpu_present shelled out; ROCm tooling may be broken")
-
-        monkeypatch.setattr(cuda_runtime.subprocess, "run", _boom)
-
-        assert cuda_runtime._amd_gpu_present() is True
-
-
-class TestAnApuLaptopIsNotRefusedTheEngine:
-    """Every check that finds an AMD GPU also finds an APU.
-
-    amdgpu exposes /dev/kfd for integrated parts and the iGPU carries vendor
-    0x1002, but AMD's population of GPUs ROCm does not support is large, and an
-    unsupported gfx target is the normal case for an APU. Refusing to start
-    there is worse than the slow CPU fallback the guard exists to catch: it
-    breaks a laptop that worked.
-    """
-
-    def _rocm_host_with_no_devices(self, monkeypatch) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        monkeypatch.setattr(sys, "platform", "linux")
-        monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: False)
-        monkeypatch.setattr(cuda_runtime, "_links_hip_runtime", lambda *_a: True)
-        monkeypatch.setattr(cuda_runtime, "_amd_gpu_present", lambda: True)
-
-    def test_an_apu_only_host_warns_and_starts(self, monkeypatch, tmp_path, caplog) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._rocm_host_with_no_devices(monkeypatch)
-        monkeypatch.setattr(cuda_runtime, "_amd_discrete_gpu_proven", lambda: False)
-
-        with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
-            cuda_runtime.assert_gpu_devices_usable(tmp_path / "llama-server", [], "rocBLAS error\n")
-
-        assert "rocminfo" in caplog.text
-
-    def test_an_unreachable_loader_is_not_read_as_proof_of_a_card(
-        self, monkeypatch, tmp_path
-    ) -> None:
-        """No Vulkan loader means no evidence either way, which must not fail loud."""
-        from lilbee.providers.fleet import cuda_runtime, gpu_select
-
-        self._rocm_host_with_no_devices(monkeypatch)
-        monkeypatch.setattr(gpu_select, "_enumerate_vulkan_devices", lambda: None)
-
-        cuda_runtime.assert_gpu_devices_usable(tmp_path / "llama-server", [], "rocBLAS error\n")
-
-    def test_a_discrete_amd_card_is_proven_from_the_loader(self, monkeypatch) -> None:
-        from lilbee.providers.fleet import cuda_runtime, gpu_select
-
-        monkeypatch.setattr(
-            gpu_select,
-            "_enumerate_vulkan_devices",
-            lambda: [
-                gpu_select.VulkanDevice(
-                    0, gpu_select.VkDeviceType.DISCRETE_GPU, "RX 7900 XTX", 0x1002, 0
-                )
-            ],
-        )
-
-        assert cuda_runtime._amd_discrete_gpu_proven() is True
-
-    def test_an_integrated_amd_adapter_is_not_a_discrete_card(self, monkeypatch) -> None:
-        from lilbee.providers.fleet import cuda_runtime, gpu_select
-
-        monkeypatch.setattr(
-            gpu_select,
-            "_enumerate_vulkan_devices",
-            lambda: [
-                gpu_select.VulkanDevice(
-                    0, gpu_select.VkDeviceType.INTEGRATED_GPU, "Radeon Graphics", 0x1002, 0
-                )
-            ],
-        )
-
-        assert cuda_runtime._amd_discrete_gpu_proven() is False
-
-
-def test_hip_link_check_is_false_when_ldd_cannot_run(monkeypatch, tmp_path) -> None:
-    """No linkage evidence is not evidence of linkage: a binary whose libraries
-    cannot be listed must not be accused of linking ROCm."""
-    from lilbee.providers.fleet import cuda_runtime
-
-    monkeypatch.setattr(cuda_runtime, "_ldd_output", lambda *_a: None)
-
-    assert cuda_runtime._links_hip_runtime(tmp_path / "llama-server", {}) is False
-
-
-def test_an_unreadable_sysfs_vendor_entry_is_skipped(monkeypatch, tmp_path) -> None:
-    """A card whose vendor file cannot be read is passed over, not fatal: sysfs
-    entries come and go as devices are bound and unbound."""
-    from lilbee.providers.fleet import cuda_runtime
-
-    drm = tmp_path / "sys/class/drm"
-    unreadable = drm / "card0" / "device"
-    unreadable.mkdir(parents=True)
-    (unreadable / "vendor").mkdir()  # a directory where a file is expected -> OSError
-    (tmp_path / "dev").mkdir()
-    (tmp_path / "dev/kfd").write_text("")
-    _root_paths(monkeypatch, tmp_path, "/dev/kfd", "/sys/class/drm")
-
-    assert cuda_runtime._amd_gpu_present() is False
-
-
-def _bundled_engine(tmp_path, shipped: tuple[str, ...]):
-    """A bundled engine dir shaped like bundle_rocm_runtime.sh output: the binary
-    with rocBLAS lazy Tensile masters for *shipped* beside it."""
-    library = tmp_path / "rocblas" / "library"
-    library.mkdir(parents=True)
-    for gfx in shipped:
-        (library / f"TensileLibrary_lazy_{gfx}.dat").write_text("")
-    return tmp_path / "llama-server"
-
-
-def _rocm_device(name: str = "AMD Instinct MI50/MI60"):
-    from lilbee.providers.fleet.devices import FleetDevice
-
-    return FleetDevice("ROCm", 0, name, 32 * 1024**3, 32 * 1024**3)
-
-
-class TestEnumeratedCardWithoutShippedKernelsIsRefused:
-    """A card the engine enumerates but the bundle has no rocBLAS kernels for does
-    not fall back to CPU: rocBLAS aborts the engine at the first batched GEMM. The
-    supported set is read from the shipped Tensile masters, not a constant, so it
-    cannot drift from what is actually in the wheel."""
-
-    def _linux(self, monkeypatch) -> None:
-        monkeypatch.setattr(sys, "platform", "linux")
-        monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
-
-    def test_an_mi50_against_a_gfx906_less_bundle_fails_loud(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.base import ProviderError
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx908", "gfx90a", "gfx1030"))
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
-
-        with pytest.raises(ProviderError) as err:
-            cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
-        message = str(err.value)
-        assert "gfx906" in message
-        assert "gfx1030" in message
-        assert "HSA_OVERRIDE_GFX_VERSION" in message
-
-    def test_a_covered_card_passes(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx1030",))
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1030"})
-
-        cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device("Radeon RX 6800")], "")
-
-    def test_a_mixed_host_warns_about_the_uncovered_card_only(
-        self, monkeypatch, tmp_path, caplog
-    ) -> None:
-        """One supported card beside an unsupported iGPU must not stop the engine."""
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx1100",))
-        monkeypatch.setattr(
-            cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1100", "gfx1036"}
-        )
-
-        with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
-            cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
-        assert "gfx1036" in caplog.text
-
-    def test_an_engine_without_a_bundle_makes_no_claim(self, monkeypatch, tmp_path) -> None:
-        """A system-ROCm engine has no shipped kernel list to check against."""
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
-
-        cuda_runtime.assert_gpu_devices_usable(tmp_path / "llama-server", [_rocm_device()], "")
-
-    def test_an_unreadable_kfd_topology_makes_no_claim(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx1030",))
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: set())
-
-        cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
-
-    def test_a_covering_hsa_override_is_respected(self, monkeypatch, tmp_path) -> None:
-        """gfx1031 with HSA_OVERRIDE_GFX_VERSION=10.3.0 runs the gfx1030 kernels."""
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx1030",))
-        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "10.3.0")
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1031"})
-
-        cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
-
-    def test_an_override_naming_an_unshipped_target_warns_not_raises(
-        self, monkeypatch, tmp_path, caplog
-    ) -> None:
-        """The user overrode explicitly; respect it, but say what will happen."""
-        from lilbee.providers.fleet import cuda_runtime
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx1030",))
-        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "9.0.6")
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
-
-        with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
-            cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
-        assert "gfx906" in caplog.text
-
-    def test_a_non_amd_device_list_is_left_alone(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime, devices
-
-        self._linux(monkeypatch)
-        binary = _bundled_engine(tmp_path, ("gfx1030",))
-        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
-        vulkan = devices.FleetDevice("Vulkan", 0, "RX 6800", 16 * 1024**3, 16 * 1024**3)
-
-        cuda_runtime.assert_gpu_devices_usable(binary, [vulkan], "")
-
-
-class TestGfxTargetsAreReadFromTheDriverAndTheBundle:
-    def test_gfx_names_format_minor_and_step_as_hex(self) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        assert cuda_runtime._gfx_name(90006) == "gfx906"
-        assert cuda_runtime._gfx_name(90010) == "gfx90a"
-        assert cuda_runtime._gfx_name(90012) == "gfx90c"
-        assert cuda_runtime._gfx_name(100300) == "gfx1030"
-        assert cuda_runtime._gfx_name(110001) == "gfx1101"
-
-    def test_bundled_targets_come_from_the_lazy_tensile_masters(self, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        binary = _bundled_engine(tmp_path, ("gfx906", "gfx1030"))
-        (tmp_path / "rocblas/library/TensileLibrary_gfx942.dat").write_text("")
-
-        assert cuda_runtime._bundled_rocblas_gfx_targets(binary) == {"gfx906", "gfx1030"}
-
-    def test_no_bundle_directory_is_none_not_empty(self, tmp_path) -> None:
-        """None is "no claim"; an empty set would read as "supports nothing"."""
-        from lilbee.providers.fleet import cuda_runtime
-
-        assert cuda_runtime._bundled_rocblas_gfx_targets(tmp_path / "llama-server") is None
-
-    def test_host_targets_come_from_kfd_topology_skipping_cpu_nodes(
-        self, monkeypatch, tmp_path
-    ) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        nodes = tmp_path / "sys/class/kfd/kfd/topology/nodes"
-        (nodes / "0").mkdir(parents=True)
-        (nodes / "0/properties").write_text("cpu_cores_count 16\ngfx_target_version 0\n")
-        (nodes / "1").mkdir()
-        (nodes / "1/properties").write_text("simd_count 240\ngfx_target_version 90006\n")
-        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
-
-        assert cuda_runtime._host_amd_gfx_targets() == {"gfx906"}
-
-    def test_a_missing_kfd_topology_is_an_empty_set(self, monkeypatch, tmp_path) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
-        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
-
-        assert cuda_runtime._host_amd_gfx_targets() == set()
-
-    def test_an_unreadable_node_is_skipped_not_fatal(self, monkeypatch, tmp_path) -> None:
-        """Topology entries come and go as devices bind and unbind."""
-        from lilbee.providers.fleet import cuda_runtime
-
-        nodes = tmp_path / "sys/class/kfd/kfd/topology/nodes"
-        (nodes / "0/properties").mkdir(parents=True)  # a directory where a file is expected
-        (nodes / "1").mkdir()
-        (nodes / "1/properties").write_text("gfx_target_version 90006\n")
-        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
-
-        assert cuda_runtime._host_amd_gfx_targets() == {"gfx906"}
-
-
-def test_the_apu_warning_names_the_shipped_targets_when_known(
-    monkeypatch, tmp_path, caplog
-) -> None:
-    """The empty-device APU path used to guess at an unsupported gfx target; with a
-    bundled engine the shipped set is a readable fact and the message states it."""
-    from lilbee.providers.fleet import cuda_runtime
-
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: False)
-    monkeypatch.setattr(cuda_runtime, "_links_hip_runtime", lambda *_a: True)
-    monkeypatch.setattr(cuda_runtime, "_amd_gpu_present", lambda: True)
-    monkeypatch.setattr(cuda_runtime, "_amd_discrete_gpu_proven", lambda: False)
-    monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1103"})
-    binary = _bundled_engine(tmp_path, ("gfx1030", "gfx1100"))
-
-    with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
-        cuda_runtime.assert_gpu_devices_usable(binary, [], "rocBLAS error\n")
-
-    assert "gfx1030" in caplog.text
-    assert "gfx1103" in caplog.text
-
-
-def test_hip_link_check_reads_the_sonames_the_binary_lists(monkeypatch, tmp_path) -> None:
-    """A ROCm build is identified by its linkage, resolved or not, so a stub
-    engine on a host with no ROCm still gets the AMD treatment."""
-    from lilbee.providers.fleet import cuda_runtime
-
-    monkeypatch.setattr(cuda_runtime, "_ldd_output", lambda *_a: "libamdhip64.so.6 => not found\n")
-    assert cuda_runtime._links_hip_runtime(tmp_path / "llama-server", {}) is True
-
-    monkeypatch.setattr(cuda_runtime, "_ldd_output", lambda *_a: "libc.so.6 => /lib/libc.so.6\n")
-    assert cuda_runtime._links_hip_runtime(tmp_path / "llama-server", {}) is False

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -40,6 +40,20 @@ _LINKS_CUDA = "\tlibcudart.so.12 => /usr/lib/libcudart.so.12 (0x00007f00)\n"
 _NO_CUDA = "\tlibstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f00)\n"
 
 
+def _root_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *prefixes: str) -> None:
+    """Reroute cuda_runtime's absolute /dev and /sys lookups under *tmp_path*."""
+    real_path = cuda_runtime.Path
+
+    class _RootedPath(type(real_path())):  # type: ignore[misc]
+        def __new__(cls, *args):
+            first = str(args[0]) if args else ""
+            if first.startswith(prefixes):
+                return real_path(str(tmp_path) + first)
+            return real_path(*args)
+
+    monkeypatch.setattr(cuda_runtime, "Path", _RootedPath)
+
+
 def test_links_cuda_runtime_true_when_soname_present(monkeypatch: pytest.MonkeyPatch) -> None:
     _ldd_returns(monkeypatch, _LINKS_CUDA)
     assert cuda_runtime._links_cuda_runtime(Path("/bin/llama-server"), {}) is True
@@ -294,8 +308,6 @@ class TestAmdPresenceReadsTheKernelNotRocmTooling:
     tests what the function does and not how it is written."""
 
     def _fake_sysfs(self, monkeypatch, tmp_path, *, kfd: bool, vendors: list[str]) -> None:
-        from lilbee.providers.fleet import cuda_runtime
-
         drm = tmp_path / "sys/class/drm"
         for i, vendor in enumerate(vendors):
             device = drm / f"card{i}" / "device"
@@ -304,17 +316,7 @@ class TestAmdPresenceReadsTheKernelNotRocmTooling:
         (tmp_path / "dev").mkdir(exist_ok=True)
         if kfd:
             (tmp_path / "dev/kfd").write_text("")
-
-        real_path = cuda_runtime.Path
-
-        class _RootedPath(type(real_path())):  # type: ignore[misc]
-            def __new__(cls, *args):
-                first = str(args[0]) if args else ""
-                if first.startswith(("/dev/kfd", "/sys/class/drm")):
-                    return real_path(str(tmp_path) + first)
-                return real_path(*args)
-
-        monkeypatch.setattr(cuda_runtime, "Path", _RootedPath)
+        _root_paths(monkeypatch, tmp_path, "/dev/kfd", "/sys/class/drm")
 
     def test_an_amd_card_is_found_with_no_rocm_installed(self, monkeypatch, tmp_path) -> None:
         from lilbee.providers.fleet import cuda_runtime
@@ -442,19 +444,210 @@ def test_an_unreadable_sysfs_vendor_entry_is_skipped(monkeypatch, tmp_path) -> N
     (unreadable / "vendor").mkdir()  # a directory where a file is expected -> OSError
     (tmp_path / "dev").mkdir()
     (tmp_path / "dev/kfd").write_text("")
-
-    real_path = cuda_runtime.Path
-
-    class _RootedPath(type(real_path())):  # type: ignore[misc]
-        def __new__(cls, *args):
-            first = str(args[0]) if args else ""
-            if first.startswith(("/dev/kfd", "/sys/class/drm")):
-                return real_path(str(tmp_path) + first)
-            return real_path(*args)
-
-    monkeypatch.setattr(cuda_runtime, "Path", _RootedPath)
+    _root_paths(monkeypatch, tmp_path, "/dev/kfd", "/sys/class/drm")
 
     assert cuda_runtime._amd_gpu_present() is False
+
+
+def _bundled_engine(tmp_path, shipped: tuple[str, ...]):
+    """A bundled engine dir shaped like bundle_rocm_runtime.sh output: the binary
+    with rocBLAS lazy Tensile masters for *shipped* beside it."""
+    library = tmp_path / "rocblas" / "library"
+    library.mkdir(parents=True)
+    for gfx in shipped:
+        (library / f"TensileLibrary_lazy_{gfx}.dat").write_text("")
+    return tmp_path / "llama-server"
+
+
+def _rocm_device(name: str = "AMD Instinct MI50/MI60"):
+    from lilbee.providers.fleet.devices import FleetDevice
+
+    return FleetDevice("ROCm", 0, name, 32 * 1024**3, 32 * 1024**3)
+
+
+class TestEnumeratedCardWithoutShippedKernelsIsRefused:
+    """A card the engine enumerates but the bundle has no rocBLAS kernels for does
+    not fall back to CPU: rocBLAS aborts the engine at the first batched GEMM. The
+    supported set is read from the shipped Tensile masters, not a constant, so it
+    cannot drift from what is actually in the wheel."""
+
+    def _linux(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+
+    def test_an_mi50_against_a_gfx906_less_bundle_fails_loud(self, monkeypatch, tmp_path) -> None:
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx908", "gfx90a", "gfx1030"))
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        with pytest.raises(ProviderError) as err:
+            cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
+        message = str(err.value)
+        assert "gfx906" in message
+        assert "gfx1030" in message
+        assert "HSA_OVERRIDE_GFX_VERSION" in message
+
+    def test_a_covered_card_passes(self, monkeypatch, tmp_path) -> None:
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1030"})
+
+        cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device("Radeon RX 6800")], "")
+
+    def test_a_mixed_host_warns_about_the_uncovered_card_only(
+        self, monkeypatch, tmp_path, caplog
+    ) -> None:
+        """One supported card beside an unsupported iGPU must not stop the engine."""
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1100",))
+        monkeypatch.setattr(
+            cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1100", "gfx1036"}
+        )
+
+        with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
+            cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
+        assert "gfx1036" in caplog.text
+
+    def test_an_engine_without_a_bundle_makes_no_claim(self, monkeypatch, tmp_path) -> None:
+        """A system-ROCm engine has no shipped kernel list to check against."""
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        cuda_runtime.assert_gpu_devices_usable(tmp_path / "llama-server", [_rocm_device()], "")
+
+    def test_an_unreadable_kfd_topology_makes_no_claim(self, monkeypatch, tmp_path) -> None:
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: set())
+
+        cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
+
+    def test_a_covering_hsa_override_is_respected(self, monkeypatch, tmp_path) -> None:
+        """gfx1031 with HSA_OVERRIDE_GFX_VERSION=10.3.0 runs the gfx1030 kernels."""
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "10.3.0")
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1031"})
+
+        cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
+
+    def test_an_override_naming_an_unshipped_target_warns_not_raises(
+        self, monkeypatch, tmp_path, caplog
+    ) -> None:
+        """The user overrode explicitly; respect it, but say what will happen."""
+        from lilbee.providers.fleet import cuda_runtime
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "9.0.6")
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
+            cuda_runtime.assert_gpu_devices_usable(binary, [_rocm_device()], "")
+        assert "gfx906" in caplog.text
+
+    def test_a_non_amd_device_list_is_left_alone(self, monkeypatch, tmp_path) -> None:
+        from lilbee.providers.fleet import cuda_runtime, devices
+
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+        vulkan = devices.FleetDevice("Vulkan", 0, "RX 6800", 16 * 1024**3, 16 * 1024**3)
+
+        cuda_runtime.assert_gpu_devices_usable(binary, [vulkan], "")
+
+
+class TestGfxTargetsAreReadFromTheDriverAndTheBundle:
+    def test_gfx_names_format_minor_and_step_as_hex(self) -> None:
+        from lilbee.providers.fleet import cuda_runtime
+
+        assert cuda_runtime._gfx_name(90006) == "gfx906"
+        assert cuda_runtime._gfx_name(90010) == "gfx90a"
+        assert cuda_runtime._gfx_name(90012) == "gfx90c"
+        assert cuda_runtime._gfx_name(100300) == "gfx1030"
+        assert cuda_runtime._gfx_name(110001) == "gfx1101"
+
+    def test_bundled_targets_come_from_the_lazy_tensile_masters(self, tmp_path) -> None:
+        from lilbee.providers.fleet import cuda_runtime
+
+        binary = _bundled_engine(tmp_path, ("gfx906", "gfx1030"))
+        (tmp_path / "rocblas/library/TensileLibrary_gfx942.dat").write_text("")
+
+        assert cuda_runtime._bundled_rocblas_gfx_targets(binary) == {"gfx906", "gfx1030"}
+
+    def test_no_bundle_directory_is_none_not_empty(self, tmp_path) -> None:
+        """None is "no claim"; an empty set would read as "supports nothing"."""
+        from lilbee.providers.fleet import cuda_runtime
+
+        assert cuda_runtime._bundled_rocblas_gfx_targets(tmp_path / "llama-server") is None
+
+    def test_host_targets_come_from_kfd_topology_skipping_cpu_nodes(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from lilbee.providers.fleet import cuda_runtime
+
+        nodes = tmp_path / "sys/class/kfd/kfd/topology/nodes"
+        (nodes / "0").mkdir(parents=True)
+        (nodes / "0/properties").write_text("cpu_cores_count 16\ngfx_target_version 0\n")
+        (nodes / "1").mkdir()
+        (nodes / "1/properties").write_text("simd_count 240\ngfx_target_version 90006\n")
+        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
+
+        assert cuda_runtime._host_amd_gfx_targets() == {"gfx906"}
+
+    def test_a_missing_kfd_topology_is_an_empty_set(self, monkeypatch, tmp_path) -> None:
+        from lilbee.providers.fleet import cuda_runtime
+
+        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
+
+        assert cuda_runtime._host_amd_gfx_targets() == set()
+
+    def test_an_unreadable_node_is_skipped_not_fatal(self, monkeypatch, tmp_path) -> None:
+        """Topology entries come and go as devices bind and unbind."""
+        from lilbee.providers.fleet import cuda_runtime
+
+        nodes = tmp_path / "sys/class/kfd/kfd/topology/nodes"
+        (nodes / "0/properties").mkdir(parents=True)  # a directory where a file is expected
+        (nodes / "1").mkdir()
+        (nodes / "1/properties").write_text("gfx_target_version 90006\n")
+        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
+
+        assert cuda_runtime._host_amd_gfx_targets() == {"gfx906"}
+
+
+def test_the_apu_warning_names_the_shipped_targets_when_known(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    """The empty-device APU path used to guess at an unsupported gfx target; with a
+    bundled engine the shipped set is a readable fact and the message states it."""
+    from lilbee.providers.fleet import cuda_runtime
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: False)
+    monkeypatch.setattr(cuda_runtime, "_links_hip_runtime", lambda *_a: True)
+    monkeypatch.setattr(cuda_runtime, "_amd_gpu_present", lambda: True)
+    monkeypatch.setattr(cuda_runtime, "_amd_discrete_gpu_proven", lambda: False)
+    monkeypatch.setattr(cuda_runtime, "_host_amd_gfx_targets", lambda: {"gfx1103"})
+    binary = _bundled_engine(tmp_path, ("gfx1030", "gfx1100"))
+
+    with caplog.at_level("WARNING", logger=cuda_runtime.__name__):
+        cuda_runtime.assert_gpu_devices_usable(binary, [], "rocBLAS error\n")
+
+    assert "gfx1030" in caplog.text
+    assert "gfx1103" in caplog.text
 
 
 def test_hip_link_check_reads_the_sonames_the_binary_lists(monkeypatch, tmp_path) -> None:

--- a/tests/test_fleet_engine_diagnostics.py
+++ b/tests/test_fleet_engine_diagnostics.py
@@ -1,0 +1,69 @@
+"""Tests for the shared engine-binary linkage and probe-output inspection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lilbee.providers.fleet import engine_diagnostics
+
+_LINKS_CUDA = "\tlibcudart.so.12 => /usr/lib/libcudart.so.12 (0x00007f00)\n"
+
+
+def test_ldd_output_none_when_ldd_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(engine_diagnostics.shutil, "which", lambda _name: None)
+    assert engine_diagnostics.ldd_output(Path("/bin/llama-server"), {}) is None
+
+
+def test_ldd_output_none_when_subprocess_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(engine_diagnostics.shutil, "which", lambda _name: "/usr/bin/ldd")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise OSError("not an ELF binary")
+
+    monkeypatch.setattr(engine_diagnostics.subprocess, "run", _raise)
+    assert engine_diagnostics.ldd_output(Path("/bin/llama-server"), {}) is None
+
+
+def test_links_any_matches_a_listed_soname_resolved_or_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(engine_diagnostics.shutil, "which", lambda _name: "/usr/bin/ldd")
+    monkeypatch.setattr(
+        engine_diagnostics.subprocess,
+        "run",
+        lambda *_a, **_k: SimpleNamespace(stdout=_LINKS_CUDA, stderr=""),
+    )
+    binary = Path("/bin/llama-server")
+    assert engine_diagnostics.links_any(binary, {}, ("libcudart.so.12",)) is True
+    assert engine_diagnostics.links_any(binary, {}, ("libamdhip64.so",)) is False
+
+
+def test_links_any_false_when_binary_cannot_be_inspected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No linkage evidence is not evidence of linkage."""
+    monkeypatch.setattr(engine_diagnostics, "ldd_output", lambda *_a: None)
+    assert engine_diagnostics.links_any(Path("/bin/llama-server"), {}, ("libc.so.6",)) is False
+
+
+def test_device_probe_diagnostic_returns_tail_when_no_error_line() -> None:
+    out = engine_diagnostics.device_probe_diagnostic("CUDA0: NVIDIA L40 (45 GiB)\n")
+    assert "NVIDIA L40" in out  # no error marker -> falls through to the output tail
+
+
+def test_device_probe_diagnostic_picks_the_cuda_error_line() -> None:
+    output = "loading backends\nggml_cuda_init: CUDA error: unknown error\ntrailing noise\n"
+    assert (
+        engine_diagnostics.device_probe_diagnostic(output)
+        == "ggml_cuda_init: CUDA error: unknown error"
+    )
+
+
+def test_device_probe_diagnostic_when_no_output() -> None:
+    assert (
+        engine_diagnostics.device_probe_diagnostic("")
+        == "(the engine's device probe printed nothing)"
+    )

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -2725,7 +2725,10 @@ def test_capturing_the_plan_snapshot_probes_the_engine_once(monkeypatch) -> None
     monkeypatch.setattr("lilbee.providers.fleet.gpu_env.apply_fleet_gpu_env", lambda: None)
     monkeypatch.setattr("lilbee.providers.fleet.cuda_runtime.apply_cuda_runtime_env", lambda: None)
     monkeypatch.setattr(
-        "lilbee.providers.fleet.cuda_runtime.assert_gpu_devices_usable", lambda *_a: None
+        "lilbee.providers.fleet.cuda_runtime.assert_cuda_devices_usable", lambda *_a: None
+    )
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.rocm_runtime.assert_rocm_devices_usable", lambda *_a: None
     )
     monkeypatch.setattr(planning_mod, "probe_devices", _counting)
     monkeypatch.setattr("lilbee.providers.model_cache.get_available_memory", lambda _f: 20 * _GB)

--- a/tests/test_fleet_rocm_runtime.py
+++ b/tests/test_fleet_rocm_runtime.py
@@ -1,0 +1,364 @@
+"""Tests for the ROCm-build guards against AMD hosts the engine cannot serve."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from lilbee.providers.base import ProviderError
+from lilbee.providers.fleet import engine_diagnostics, gpu_select, rocm_runtime
+from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.rocm_runtime import assert_rocm_devices_usable
+
+
+def _root_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *prefixes: str) -> None:
+    """Reroute rocm_runtime's absolute /dev and /sys lookups under *tmp_path*."""
+    real_path = rocm_runtime.Path
+
+    class _RootedPath(type(real_path())):  # type: ignore[misc]
+        def __new__(cls, *args):
+            first = str(args[0]) if args else ""
+            if first.startswith(prefixes):
+                return real_path(str(tmp_path) + first)
+            return real_path(*args)
+
+    monkeypatch.setattr(rocm_runtime, "Path", _RootedPath)
+
+
+def _bundled_engine(tmp_path, shipped: tuple[str, ...]):
+    """A bundled engine dir shaped like bundle_rocm_runtime.sh output: the binary
+    with rocBLAS lazy Tensile masters for *shipped* beside it."""
+    library = tmp_path / "rocblas" / "library"
+    library.mkdir(parents=True)
+    for gfx in shipped:
+        (library / f"TensileLibrary_lazy_{gfx}.dat").write_text("")
+    return tmp_path / "llama-server"
+
+
+def _rocm_device(name: str = "AMD Instinct MI50/MI60") -> FleetDevice:
+    return FleetDevice("ROCm", 0, name, 32 * 1024**3, 32 * 1024**3)
+
+
+def test_rocm_build_enumerating_nothing_on_an_amd_host_fails_loud(monkeypatch, tmp_path) -> None:
+    """ROCm's silent-failure class had no counterpart to the CUDA guard.
+
+    A version mismatch, an unsupported gfx target or no access to /dev/kfd all
+    end with the runtime loaded and zero devices, which used to fall quietly to
+    CPU on a machine bought for its GPU.
+    """
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(rocm_runtime, "_links_hip_runtime", lambda *_a: True)
+    monkeypatch.setattr(rocm_runtime, "_amd_gpu_present", lambda: True)
+    monkeypatch.setattr(rocm_runtime, "_amd_discrete_gpu_proven", lambda: True)
+
+    with pytest.raises(ProviderError) as err:
+        assert_rocm_devices_usable(tmp_path / "llama-server", [], "rocBLAS error\n")
+    assert "/dev/kfd" in str(err.value)
+
+
+def test_rocm_build_is_silent_when_the_host_has_no_amd_gpu(monkeypatch, tmp_path) -> None:
+    """A ROCm build on a machine without an AMD card is just a CPU host."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(rocm_runtime, "_links_hip_runtime", lambda *_a: True)
+    monkeypatch.setattr(rocm_runtime, "_amd_gpu_present", lambda: False)
+
+    assert_rocm_devices_usable(tmp_path / "llama-server", [], "")
+
+
+def test_the_guard_is_a_noop_off_linux(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("the guard inspected the binary off Linux")
+
+    monkeypatch.setattr(rocm_runtime, "_links_hip_runtime", _boom)
+    assert_rocm_devices_usable(tmp_path / "llama-server", [], "")
+
+
+class TestAmdPresenceReadsTheKernelNotRocmTooling:
+    """The failure this detects is ROCm being installed wrong, so a check built
+    on amd-smi or rocm-smi would report "no GPU" for the very case it exists to
+    catch. Driven through a fake sysfs rather than by reading the source, so it
+    tests what the function does and not how it is written."""
+
+    def _fake_sysfs(self, monkeypatch, tmp_path, *, kfd: bool, vendors: list[str]) -> None:
+        drm = tmp_path / "sys/class/drm"
+        for i, vendor in enumerate(vendors):
+            device = drm / f"card{i}" / "device"
+            device.mkdir(parents=True)
+            (device / "vendor").write_text(f"{vendor}\n")
+        (tmp_path / "dev").mkdir(exist_ok=True)
+        if kfd:
+            (tmp_path / "dev/kfd").write_text("")
+        _root_paths(monkeypatch, tmp_path, "/dev/kfd", "/sys/class/drm")
+
+    def test_an_amd_card_is_found_with_no_rocm_installed(self, monkeypatch, tmp_path) -> None:
+        self._fake_sysfs(monkeypatch, tmp_path, kfd=True, vendors=["0x1002"])
+
+        assert rocm_runtime._amd_gpu_present() is True
+
+    def test_a_non_amd_card_is_not_an_amd_gpu(self, monkeypatch, tmp_path) -> None:
+        self._fake_sysfs(monkeypatch, tmp_path, kfd=True, vendors=["0x10de"])
+
+        assert rocm_runtime._amd_gpu_present() is False
+
+    def test_no_kfd_means_the_kernel_driver_is_not_there(self, monkeypatch, tmp_path) -> None:
+        self._fake_sysfs(monkeypatch, tmp_path, kfd=False, vendors=["0x1002"])
+
+        assert rocm_runtime._amd_gpu_present() is False
+
+    def test_it_never_shells_out(self, monkeypatch, tmp_path) -> None:
+        self._fake_sysfs(monkeypatch, tmp_path, kfd=True, vendors=["0x1002"])
+
+        def _boom(*_a: object, **_k: object) -> None:
+            raise AssertionError("_amd_gpu_present shelled out; ROCm tooling may be broken")
+
+        monkeypatch.setattr(engine_diagnostics.subprocess, "run", _boom)
+
+        assert rocm_runtime._amd_gpu_present() is True
+
+    def test_an_unreadable_sysfs_vendor_entry_is_skipped(self, monkeypatch, tmp_path) -> None:
+        """A card whose vendor file cannot be read is passed over, not fatal: sysfs
+        entries come and go as devices are bound and unbound."""
+        drm = tmp_path / "sys/class/drm"
+        unreadable = drm / "card0" / "device"
+        unreadable.mkdir(parents=True)
+        (unreadable / "vendor").mkdir()  # a directory where a file is expected -> OSError
+        (tmp_path / "dev").mkdir()
+        (tmp_path / "dev/kfd").write_text("")
+        _root_paths(monkeypatch, tmp_path, "/dev/kfd", "/sys/class/drm")
+
+        assert rocm_runtime._amd_gpu_present() is False
+
+
+class TestAnApuLaptopIsNotRefusedTheEngine:
+    """Every check that finds an AMD GPU also finds an APU.
+
+    amdgpu exposes /dev/kfd for integrated parts and the iGPU carries vendor
+    0x1002, but AMD's population of GPUs ROCm does not support is large, and an
+    unsupported gfx target is the normal case for an APU. Refusing to start
+    there is worse than the slow CPU fallback the guard exists to catch: it
+    breaks a laptop that worked.
+    """
+
+    def _rocm_host_with_no_devices(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(rocm_runtime, "_links_hip_runtime", lambda *_a: True)
+        monkeypatch.setattr(rocm_runtime, "_amd_gpu_present", lambda: True)
+
+    def test_an_apu_only_host_warns_and_starts(self, monkeypatch, tmp_path, caplog) -> None:
+        self._rocm_host_with_no_devices(monkeypatch)
+        monkeypatch.setattr(rocm_runtime, "_amd_discrete_gpu_proven", lambda: False)
+
+        with caplog.at_level("WARNING", logger=rocm_runtime.__name__):
+            assert_rocm_devices_usable(tmp_path / "llama-server", [], "rocBLAS error\n")
+
+        assert "rocminfo" in caplog.text
+
+    def test_the_apu_warning_names_the_shipped_targets_when_known(
+        self, monkeypatch, tmp_path, caplog
+    ) -> None:
+        """With a bundled engine the shipped set is a readable fact, so the
+        warning states it instead of guessing at an unsupported gfx target."""
+        self._rocm_host_with_no_devices(monkeypatch)
+        monkeypatch.setattr(rocm_runtime, "_amd_discrete_gpu_proven", lambda: False)
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx1103"})
+        binary = _bundled_engine(tmp_path, ("gfx1030", "gfx1100"))
+
+        with caplog.at_level("WARNING", logger=rocm_runtime.__name__):
+            assert_rocm_devices_usable(binary, [], "rocBLAS error\n")
+
+        assert "gfx1030" in caplog.text
+        assert "gfx1103" in caplog.text
+
+    def test_an_unreachable_loader_is_not_read_as_proof_of_a_card(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """No Vulkan loader means no evidence either way, which must not fail loud."""
+        self._rocm_host_with_no_devices(monkeypatch)
+        monkeypatch.setattr(gpu_select, "_enumerate_vulkan_devices", lambda: None)
+
+        assert_rocm_devices_usable(tmp_path / "llama-server", [], "rocBLAS error\n")
+
+    def test_a_discrete_amd_card_is_proven_from_the_loader(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                gpu_select.VulkanDevice(
+                    0, gpu_select.VkDeviceType.DISCRETE_GPU, "RX 7900 XTX", 0x1002, 0
+                )
+            ],
+        )
+
+        assert rocm_runtime._amd_discrete_gpu_proven() is True
+
+    def test_an_integrated_amd_adapter_is_not_a_discrete_card(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                gpu_select.VulkanDevice(
+                    0, gpu_select.VkDeviceType.INTEGRATED_GPU, "Radeon Graphics", 0x1002, 0
+                )
+            ],
+        )
+
+        assert rocm_runtime._amd_discrete_gpu_proven() is False
+
+
+def test_hip_link_check_reads_the_sonames_the_binary_lists(monkeypatch, tmp_path) -> None:
+    """A ROCm build is identified by its linkage, resolved or not, so a stub
+    engine on a host with no ROCm still gets the AMD treatment."""
+    monkeypatch.setattr(
+        engine_diagnostics, "ldd_output", lambda *_a: "libamdhip64.so.6 => not found\n"
+    )
+    assert rocm_runtime._links_hip_runtime(tmp_path / "llama-server", {}) is True
+
+    monkeypatch.setattr(engine_diagnostics, "ldd_output", lambda *_a: "libc.so.6 => /lib/x\n")
+    assert rocm_runtime._links_hip_runtime(tmp_path / "llama-server", {}) is False
+
+
+class TestEnumeratedCardWithoutShippedKernelsIsRefused:
+    """A card the engine enumerates but the bundle has no rocBLAS kernels for does
+    not fall back to CPU: rocBLAS aborts the engine at the first batched GEMM. The
+    supported set is read from the shipped Tensile masters, not a constant, so it
+    cannot drift from what is actually in the wheel."""
+
+    def _linux(self, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+
+    def test_an_mi50_against_a_gfx906_less_bundle_fails_loud(self, monkeypatch, tmp_path) -> None:
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx908", "gfx90a", "gfx1030"))
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        with pytest.raises(ProviderError) as err:
+            assert_rocm_devices_usable(binary, [_rocm_device()], "")
+        message = str(err.value)
+        assert "gfx906" in message
+        assert "gfx1030" in message
+        assert "HSA_OVERRIDE_GFX_VERSION" in message
+
+    def test_a_covered_card_passes(self, monkeypatch, tmp_path) -> None:
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx1030"})
+
+        assert_rocm_devices_usable(binary, [_rocm_device("Radeon RX 6800")], "")
+
+    def test_a_mixed_host_warns_about_the_uncovered_card_only(
+        self, monkeypatch, tmp_path, caplog
+    ) -> None:
+        """One supported card beside an unsupported iGPU must not stop the engine."""
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1100",))
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx1100", "gfx1036"})
+
+        with caplog.at_level("WARNING", logger=rocm_runtime.__name__):
+            assert_rocm_devices_usable(binary, [_rocm_device()], "")
+        assert "gfx1036" in caplog.text
+
+    def test_an_engine_without_a_bundle_makes_no_claim(self, monkeypatch, tmp_path) -> None:
+        """A system-ROCm engine has no shipped kernel list to check against."""
+        self._linux(monkeypatch)
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        assert_rocm_devices_usable(tmp_path / "llama-server", [_rocm_device()], "")
+
+    def test_an_unreadable_kfd_topology_makes_no_claim(self, monkeypatch, tmp_path) -> None:
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: set())
+
+        assert_rocm_devices_usable(binary, [_rocm_device()], "")
+
+    def test_a_covering_hsa_override_is_respected(self, monkeypatch, tmp_path) -> None:
+        """gfx1031 with HSA_OVERRIDE_GFX_VERSION=10.3.0 runs the gfx1030 kernels."""
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "10.3.0")
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx1031"})
+
+        assert_rocm_devices_usable(binary, [_rocm_device()], "")
+
+    def test_an_override_naming_an_unshipped_target_warns_not_raises(
+        self, monkeypatch, tmp_path, caplog
+    ) -> None:
+        """The user overrode explicitly; respect it, but say what will happen."""
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "9.0.6")
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        with caplog.at_level("WARNING", logger=rocm_runtime.__name__):
+            assert_rocm_devices_usable(binary, [_rocm_device()], "")
+        assert "gfx906" in caplog.text
+
+    def test_a_malformed_override_does_not_disable_the_guard(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "not-a-version")
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+
+        with pytest.raises(ProviderError):
+            assert_rocm_devices_usable(binary, [_rocm_device()], "")
+
+    def test_a_non_amd_device_list_is_left_alone(self, monkeypatch, tmp_path) -> None:
+        self._linux(monkeypatch)
+        binary = _bundled_engine(tmp_path, ("gfx1030",))
+        monkeypatch.setattr(rocm_runtime, "_host_amd_gfx_targets", lambda: {"gfx906"})
+        vulkan = FleetDevice("Vulkan", 0, "RX 6800", 16 * 1024**3, 16 * 1024**3)
+
+        assert_rocm_devices_usable(binary, [vulkan], "")
+
+
+class TestGfxTargetsAreReadFromTheDriverAndTheBundle:
+    def test_gfx_names_format_minor_and_step_as_hex(self) -> None:
+        assert rocm_runtime._gfx_name(90006) == "gfx906"
+        assert rocm_runtime._gfx_name(90010) == "gfx90a"
+        assert rocm_runtime._gfx_name(90012) == "gfx90c"
+        assert rocm_runtime._gfx_name(100300) == "gfx1030"
+        assert rocm_runtime._gfx_name(110001) == "gfx1101"
+
+    def test_bundled_targets_come_from_the_lazy_tensile_masters(self, tmp_path) -> None:
+        binary = _bundled_engine(tmp_path, ("gfx906", "gfx1030"))
+        (tmp_path / "rocblas/library/TensileLibrary_gfx942.dat").write_text("")
+
+        assert rocm_runtime._bundled_rocblas_gfx_targets(binary) == {"gfx906", "gfx1030"}
+
+    def test_no_bundle_directory_is_none_not_empty(self, tmp_path) -> None:
+        """None is "no claim"; an empty set would read as "supports nothing"."""
+        assert rocm_runtime._bundled_rocblas_gfx_targets(tmp_path / "llama-server") is None
+
+    def test_host_targets_come_from_kfd_topology_skipping_cpu_nodes(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        nodes = tmp_path / "sys/class/kfd/kfd/topology/nodes"
+        (nodes / "0").mkdir(parents=True)
+        (nodes / "0/properties").write_text("cpu_cores_count 16\ngfx_target_version 0\n")
+        (nodes / "1").mkdir()
+        (nodes / "1/properties").write_text("simd_count 240\ngfx_target_version 90006\n")
+        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
+
+        assert rocm_runtime._host_amd_gfx_targets() == {"gfx906"}
+
+    def test_a_missing_kfd_topology_is_an_empty_set(self, monkeypatch, tmp_path) -> None:
+        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
+
+        assert rocm_runtime._host_amd_gfx_targets() == set()
+
+    def test_an_unreadable_node_is_skipped_not_fatal(self, monkeypatch, tmp_path) -> None:
+        """Topology entries come and go as devices bind and unbind."""
+        nodes = tmp_path / "sys/class/kfd/kfd/topology/nodes"
+        (nodes / "0/properties").mkdir(parents=True)  # a directory where a file is expected
+        (nodes / "1").mkdir()
+        (nodes / "1/properties").write_text("gfx_target_version 90006\n")
+        _root_paths(monkeypatch, tmp_path, "/sys/class/kfd")
+
+        assert rocm_runtime._host_amd_gfx_targets() == {"gfx906"}

--- a/tests/test_fleet_rocm_runtime.py
+++ b/tests/test_fleet_rocm_runtime.py
@@ -298,9 +298,7 @@ class TestEnumeratedCardWithoutShippedKernelsIsRefused:
             assert_rocm_devices_usable(binary, [_rocm_device()], "")
         assert "gfx906" in caplog.text
 
-    def test_a_malformed_override_does_not_disable_the_guard(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_a_malformed_override_does_not_disable_the_guard(self, monkeypatch, tmp_path) -> None:
         self._linux(monkeypatch)
         binary = _bundled_engine(tmp_path, ("gfx1030",))
         monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "not-a-version")

--- a/tools/wheel-build/cmake_args.sh
+++ b/tools/wheel-build/cmake_args.sh
@@ -63,23 +63,17 @@ esac
 common_x86="-DLLAMA_BUILD_UI=OFF -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF"
 common_arm="-DLLAMA_BUILD_UI=OFF -DGGML_NATIVE=OFF"
 
-# Every AMD target ROCm supports that lilbee ships for: gfx906 (MI50), gfx908 (MI100),
+# Every AMD target lilbee wants to ship for: gfx906 (MI50), gfx908 (MI100),
 # gfx90a (MI200), gfx942 (MI300), gfx950 (MI350), gfx1030 (RDNA2), gfx1100/1101/1102
-# (RDNA3), gfx1150/1151 (RDNA3.5 APUs), gfx1200/1201 (RDNA4). This is intent, not
-# support: anything the installed ROCm cannot both compile and run GEMM on is
-# filtered below rather than dropped from this list, so a target AMD un-drops
-# comes back without an edit here.
+# (RDNA3), gfx1150/1151 (RDNA3.5 APUs), gfx1200/1201 (RDNA4). Intent, not support:
+# targets the installed ROCm cannot serve are filtered below, not removed here.
 rocm_wanted_targets="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1150 gfx1151 gfx1200 gfx1201"
 
-# The subset of those the ROCm at $1 actually supports, as a cmake list.
-#
-# Two facts intersect, both readable without a GPU. The device bitcode is the
-# toolchain's own list of ISAs it can compile (one unsupported target fails the
-# whole configure, and AMD drops targets between releases: 7.0 removed gfx940).
-# The rocBLAS lazy Tensile masters are what the runtime can execute: an
-# architecture with bitcode but no TensileLibrary_lazy_<arch>.dat builds fine
-# and then aborts inside rocBLAS on the first batched GEMM (7.2 ships zero
-# gfx906 kernel files while its bitcode still advertises gfx906).
+# The subset of those the ROCm at $1 actually supports, as a cmake list: the
+# intersection of the device bitcode (what clang can compile; one unsupported
+# target fails the whole configure) and the rocBLAS lazy Tensile masters (what
+# the runtime can execute; a target with bitcode but no masters builds fine and
+# aborts inside rocBLAS at the first batched GEMM, as 7.2's gfx906 does).
 rocm_buildable_targets() {
   local root="$1" arch targets="" no_bitcode="" no_kernels=""
   local kernels_dir="${root}/lib/rocblas/library" check_kernels="1"

--- a/tools/wheel-build/cmake_args.sh
+++ b/tools/wheel-build/cmake_args.sh
@@ -65,34 +65,52 @@ common_arm="-DLLAMA_BUILD_UI=OFF -DGGML_NATIVE=OFF"
 
 # Every AMD target ROCm supports that lilbee ships for: gfx906 (MI50), gfx908 (MI100),
 # gfx90a (MI200), gfx942 (MI300), gfx950 (MI350), gfx1030 (RDNA2), gfx1100/1101/1102
-# (RDNA3), gfx1150/1151 (RDNA3.5 APUs), gfx1200/1201 (RDNA4). Anything the installed
-# ROCm cannot build is filtered below rather than dropped from this list.
+# (RDNA3), gfx1150/1151 (RDNA3.5 APUs), gfx1200/1201 (RDNA4). This is intent, not
+# support: anything the installed ROCm cannot both compile and run GEMM on is
+# filtered below rather than dropped from this list, so a target AMD un-drops
+# comes back without an edit here.
 rocm_wanted_targets="gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1150 gfx1151 gfx1200 gfx1201"
 
-# The subset of those the ROCm at $1 can build, as a cmake list.
+# The subset of those the ROCm at $1 actually supports, as a cmake list.
 #
-# One unsupported target fails the whole configure rather than being skipped, and
-# AMD drops targets between releases (7.0 removed gfx940). The device bitcode is the
-# toolchain's own list of ISAs it knows, and reading it needs no GPU.
+# Two facts intersect, both readable without a GPU. The device bitcode is the
+# toolchain's own list of ISAs it can compile (one unsupported target fails the
+# whole configure, and AMD drops targets between releases: 7.0 removed gfx940).
+# The rocBLAS lazy Tensile masters are what the runtime can execute: an
+# architecture with bitcode but no TensileLibrary_lazy_<arch>.dat builds fine
+# and then aborts inside rocBLAS on the first batched GEMM (7.2 ships zero
+# gfx906 kernel files while its bitcode still advertises gfx906).
 rocm_buildable_targets() {
-  local root="$1" arch targets="" dropped=""
+  local root="$1" arch targets="" no_bitcode="" no_kernels=""
+  local kernels_dir="${root}/lib/rocblas/library" check_kernels="1"
+  if [ ! -d "${kernels_dir}" ]; then
+    check_kernels=""
+    echo "cmake_args.sh: no rocBLAS kernel library under ${kernels_dir}," \
+      "filtering on device bitcode alone" >&2
+  fi
   for arch in ${rocm_wanted_targets}; do
-    if [ -e "${root}/amdgcn/bitcode/oclc_isa_version_${arch#gfx}.bc" ]; then
-      targets="${targets}${targets:+;}${arch}"
-    else
-      dropped="${dropped} ${arch}"
+    if [ ! -e "${root}/amdgcn/bitcode/oclc_isa_version_${arch#gfx}.bc" ]; then
+      no_bitcode="${no_bitcode} ${arch}"
+      continue
     fi
+    if [ -n "${check_kernels}" ] && [ ! -e "${kernels_dir}/TensileLibrary_lazy_${arch}.dat" ]; then
+      no_kernels="${no_kernels} ${arch}"
+      continue
+    fi
+    targets="${targets}${targets:+;}${arch}"
   done
+
+  [ -z "${no_bitcode}" ] || echo "cmake_args.sh: ROCm at ${root} has no device bitcode for:${no_bitcode}" >&2
+  [ -z "${no_kernels}" ] || echo "cmake_args.sh: rocBLAS at ${root} has no GEMM kernels for:${no_kernels}" >&2
 
   # An install this script does not understand. Build everything rather than
   # silently emitting a wheel for no card at all.
   if [ -z "${targets}" ]; then
-    echo "cmake_args.sh: no device bitcode under ${root}/amdgcn/bitcode," \
+    echo "cmake_args.sh: no wanted target survives the filter," \
       "building every wanted target unfiltered" >&2
     echo "${rocm_wanted_targets}" | tr ' ' ';'
     return
   fi
-  [ -z "${dropped}" ] || echo "cmake_args.sh: ROCm at ${root} cannot build:${dropped}" >&2
   printf '%s' "${targets}"
 }
 


### PR DESCRIPTION
## Problem

ROCm 7.2 still ships gfx906 compiler bitcode but zero rocBLAS kernels, so the wheel claimed MI50 support and aborted at the first matrix multiply. Build targets were filtered on bitcode alone, and nothing at runtime checked the card against what shipped.

## Solution

- Build targets = bitcode AND rocBLAS lazy Tensile kernels, one function, drops reported per reason. The wanted list stays as intent, so a restored target comes back on its own.
- At runtime, supported targets are read from the bundled kernels and the host's gfx from the KFD topology. An uncovered card is refused at startup, naming HSA_OVERRIDE_GFX_VERSION as the near-miss escape hatch; mixed hosts warn; a user override is respected.
- AMD guards move from cuda_runtime.py into a new rocm_runtime module; shared ldd/probe helpers land in engine_diagnostics.
- README drops the MI50 claim.