### PR TITLE
Build the Linux vulkan engine against the LunarG SDK so its wheel exists

### DIFF
--- a/.github/workflows/build-multigpu.yml
+++ b/.github/workflows/build-multigpu.yml
@@ -149,6 +149,15 @@ jobs:
           method: network
           sub-packages: '["nvcc","cudart","cublas","cublas_dev","thrust","visual_studio_integration"]'
 
+      # The SDK tarball is the slow part of the Linux vulkan toolchain; the
+      # unpack into /opt is cheap. Keyed on engine-versions.env, which pins it.
+      - name: Cache Vulkan SDK download (Linux)
+        if: steps.engine.outputs.needs-build == 'true' && matrix.backend == 'vulkan' && runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/lilbee
+          key: vulkan-sdk-${{ runner.os }}-${{ hashFiles('engine-versions.env') }}
+
       - name: Install Vulkan loader (Linux)
         if: steps.engine.outputs.needs-build == 'true' && matrix.backend == 'vulkan' && runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -66,7 +66,10 @@ jobs:
         run: |
           set -euxo pipefail
           dnf install -y libxkbcommon-devel libX11-devel libXrandr-devel libXcursor-devel libXi-devel libXinerama-devel mesa-libGL-devel
-          VULKAN_VERSION="1.3.296.0"
+          # Pinned in engine-versions.env so the SDK cannot drift from the
+          # one install_gpu_toolkit.sh uses.
+          source engine-versions.env
+          VULKAN_VERSION="${ENGINE_VULKAN_SDK_VERSION:?}"
           curl -L -o /tmp/vulkan-sdk.tar.xz \
             "https://sdk.lunarg.com/sdk/download/${VULKAN_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_VERSION}.tar.xz"
           mkdir -p /opt/vulkan

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -388,6 +388,23 @@ jobs:
                   name, ver, rest = whl.name.split("-", 2)
                   shutil.copy(whl, out / f"{name}-{ver}-1.{backend}-{rest}")
           PY
+      # These cells are continue-on-error, so a build that produces nothing is
+      # invisible in the run conclusion. The linux vulkan wheel was missing for
+      # days that way. List what actually arrived so a gap is legible.
+      - name: Report which multi-gpu wheels arrived
+        shell: bash
+        run: |
+          {
+            echo "### Multi-gpu wheels attached"
+            echo
+            for d in multigpu-wheels-staging/wheel-multigpu-*; do
+              [ -d "$d" ] || continue
+              echo "- ${d##*/wheel-multigpu-}"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+          count=$(find multigpu-wheels -name '*.whl' | wc -l | tr -d ' ')
+          echo "::notice::multi-gpu wheels attached: ${count}"
+
       - name: Attach multi-gpu wheels to the release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,10 @@ jobs:
         run: |
           set -euxo pipefail
           dnf install -y libxkbcommon-devel libX11-devel libXrandr-devel libXcursor-devel libXi-devel libXinerama-devel mesa-libGL-devel
-          VULKAN_VERSION="1.3.296.0"
+          # Pinned in engine-versions.env so the SDK cannot drift from the
+          # one install_gpu_toolkit.sh uses.
+          source engine-versions.env
+          VULKAN_VERSION="${ENGINE_VULKAN_SDK_VERSION:?}"
           curl -L -o /tmp/vulkan-sdk.tar.xz \
             "https://sdk.lunarg.com/sdk/download/${VULKAN_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_VERSION}.tar.xz"
           mkdir -p /opt/vulkan

--- a/engine-versions.env
+++ b/engine-versions.env
@@ -13,6 +13,12 @@ ENGINE_LLAMA_CPP_VERSION=0.3.30
 ENGINE_LLAMA_SWAP_VERSION=v223
 ENGINE_GGUF_PARSER_REF=v0.25.0
 
+# ENGINE_VULKAN_SDK_VERSION: the LunarG SDK the Linux vulkan cells build against.
+# It carries glslc and the SPIR-V headers, neither of which apt provides on the
+# jammy runner. Shared by install_gpu_toolkit.sh, release.yml and
+# flatpak-validate.yml so the three cannot drift.
+ENGINE_VULKAN_SDK_VERSION=1.3.296.0
+
 # ENGINE_ROCM_VERSION: installed, compiled against, and bundled by the rocm cell.
 # Below 6.1 llama.cpp refuses to build and 6.1 fails on ggml-cuda/mma.cuh. A bump
 # can drop GPU targets; cmake_args.sh filters those against the toolchain.

--- a/tools/wheel-build/install_gpu_toolkit.sh
+++ b/tools/wheel-build/install_gpu_toolkit.sh
@@ -16,12 +16,39 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/../../engine-versions.env"
 
 linux_install_vulkan() {
-  # spirv-headers provides <spirv/unified1/spirv.hpp> (the `spv` namespace);
-  # ggml-vulkan.cpp needs it to patch SPIR-V, and apt's libvulkan-dev does
-  # not pull it in. The LunarG SDK bundles it, which is why Windows builds
-  # without this. Without it the build fails: "'spv' has not been declared".
+  # The SDK, not apt: jammy carries no glslc (shaderc lands in the archive only
+  # from noble), and apt's libvulkan-dev does not pull in spirv-headers, which
+  # ggml-vulkan.cpp needs for the `spv` namespace ("'spv' has not been declared").
+  # The LunarG SDK carries both, which is why the manylinux and Windows cells
+  # already build against it.
+  local version="${ENGINE_VULKAN_SDK_VERSION:?ENGINE_VULKAN_SDK_VERSION is required}"
   sudo apt-get update
-  sudo apt-get install -y libvulkan-dev libvulkan1 glslc spirv-headers
+  sudo apt-get install -y libvulkan1
+  # Download into a runner-writable directory the workflow can cache; /opt needs
+  # sudo, which actions/cache cannot restore into. The unpack is cheap, the
+  # download is not.
+  local cache_dir="${VULKAN_SDK_CACHE_DIR:-${HOME}/.cache/lilbee}"
+  local tarball="${cache_dir}/vulkansdk-linux-x86_64-${version}.tar.xz"
+  mkdir -p "${cache_dir}"
+  if [ ! -s "${tarball}" ]; then
+    curl -fL -o "${tarball}" \
+      "https://sdk.lunarg.com/sdk/download/${version}/linux/vulkansdk-linux-x86_64-${version}.tar.xz"
+  fi
+  sudo mkdir -p /opt/vulkan
+  sudo tar -xf "${tarball}" -C /opt/vulkan --strip-components=1
+  # Fail here rather than at the cmake step, where a missing glslc reads as a
+  # shader-compilation error instead of a toolchain one.
+  [ -x /opt/vulkan/x86_64/bin/glslc ] || {
+    echo "vulkan sdk ${version} unpacked without glslc" >&2
+    exit 1
+  }
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+      echo "VULKAN_SDK=/opt/vulkan/x86_64"
+      echo "LD_LIBRARY_PATH=/opt/vulkan/x86_64/lib:${LD_LIBRARY_PATH:-}"
+    } >> "${GITHUB_ENV}"
+    echo "/opt/vulkan/x86_64/bin" >> "${GITHUB_PATH}"
+  fi
 }
 
 linux_install_cuda() {


### PR DESCRIPTION
## Problem

`build-multigpu (ubuntu-22.04, vulkan)` has never produced a wheel. `install_gpu_toolkit.sh` installs `glslc` from apt and jammy has no such package, so the step fails with `E: Unable to locate package glslc`.

It hid because the step only runs on an engine-cache miss and the cell is `continue-on-error`. Runs 30251194360 and 30328130251 both failed it and still reported success. `lilbee[multi-gpu]` has had no Linux Vulkan wheel while every sibling cell ships one.

## Solution

- Install the LunarG SDK, which carries `glslc` and the SPIR-V headers apt cannot. Same path the manylinux and Windows cells already use.
- Pin the SDK version once in `engine-versions.env`. `release.yml` and `flatpak-validate.yml` read it instead of repeating `1.3.296.0`.
- Assert `glslc` after unpack, so a bad SDK fails as a toolchain error rather than a shader one.
- Cache the tarball per version. The download is the slow part, the unpack is not.
- `attach-multigpu` lists the wheels that arrived, so a cell producing nothing is visible.