### PR TITLE
Fix smoke-wheels asking for an engine wheel name that no longer exists

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -229,7 +229,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # engine_os is the runner the build-multigpu cpu cell used, which names
+        # its artifact. The Linux rows there are pinned to ubuntu-22.04, so it is
+        # not the same as the runner this smoke test happens to run on.
+        include:
+          - {os: ubuntu-latest,  engine_os: ubuntu-22.04}
+          - {os: macos-latest,   engine_os: macos-latest}
+          - {os: windows-latest, engine_os: windows-latest}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -246,7 +252,7 @@ jobs:
       - name: Download the cpu engine wheel
         uses: actions/download-artifact@v8
         with:
-          name: wheel-multigpu-${{ matrix.os }}-cpu
+          name: wheel-multigpu-${{ matrix.engine_os }}-cpu
           path: engine/
       - name: Restore CI models (inference smoke)
         uses: ./.github/actions/restore-ci-models


### PR DESCRIPTION
## Problem

`smoke-wheels (ubuntu-latest)` fails at `Download the cpu engine wheel`:

```
Unable to download artifact(s): Artifact not found for name: wheel-multigpu-ubuntu-latest-cpu
```

The job names the artifact from `matrix.os`, the runner it executes on. #628 pinned the Linux build rows to `ubuntu-22.04`, so the cpu cell uploads `wheel-multigpu-ubuntu-22.04-cpu`. macOS and Windows still pass because their build runners kept the `-latest` names.

This blocks the release: `smoke-wheels` is the real-inference gate on the PyPI channel.

## Solution

- Carry the build runner as its own matrix value (`engine_os`) so where the smoke runs and which engine wheel it fetches stop being the same variable.
- Underscored, not hyphenated: `matrix.engine-os` would parse as subtraction in an expression.