### PR TITLE
Add ROCm install tabs and GPU backend mentions to marketing site

### DIFF
--- a/site/gpu/index.html
+++ b/site/gpu/index.html
@@ -106,7 +106,7 @@
 
     <section>
       <h2 class="label">multiple GPUs, sized to each card</h2>
-      <p class="lede">When a model is too big for one card, lilbee spreads it across the GPUs you have, with a tensor split sized to each device's free VRAM rather than an even cut that overflows the smallest card. It runs on Metal, Vulkan, and CUDA, and can offload part of a model to system RAM when you want to stretch a tight setup. This is part of lilbee's <a href="/model-manager/">model manager</a>.</p>
+      <p class="lede">When a model is too big for one card, lilbee spreads it across the GPUs you have, with a tensor split sized to each device's free VRAM rather than an even cut that overflows the smallest card. It runs on Metal, Vulkan, CUDA, and ROCm, and can offload part of a model to system RAM when you want to stretch a tight setup. This is part of lilbee's <a href="/model-manager/">model manager</a>.</p>
     </section>
 
     <section>

--- a/site/index.html
+++ b/site/index.html
@@ -439,6 +439,7 @@
             <span class="cmd">brew install tobocop2/lilbee/lilbee-rocm</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
+          <p class="variant-note">Linux only. The default build uses Metal on macOS, Vulkan on Windows.</p>
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>

--- a/site/index.html
+++ b/site/index.html
@@ -110,7 +110,7 @@
 888 888 888 888 d88PY8b.    Y8b.
 888 888 888 88888P"  "Y8888  "Y8888</pre>
       <h1 class="tagline">The <strong>whole local AI stack</strong> in <strong>one executable</strong>. lilbee runs and manages the models across every GPU you have, then talks to everything you point it at: your files, your code, and the web. It crawls sites into your library, <a href="/mcp/">plugs into your coding agents</a>, and backs the <a href="https://obsidian.lilbee.sh/">Obsidian plugin</a>. Every answer cites the source, it all runs on your own machine, and there's nothing else to set up.</h1>
-      <p class="sub">A built-in model manager browses Hugging Face, downloads models, gives each one a role, and runs them on your own GPU, on Metal, Vulkan, or CUDA. Any coding agent can also use it over MCP.</p>
+      <p class="sub">A built-in model manager browses Hugging Face, downloads models, gives each one a role, and runs them on your own GPU, on Metal, Vulkan, CUDA, or ROCm. Any coding agent can also use it over MCP.</p>
       <div class="surfaces">
         <span class="surfaces-label">one program, one install</span>
         <span class="surface">terminal app</span>
@@ -356,6 +356,14 @@
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">pip install --pre lilbee --extra-index-url https://lilbee.sh/rocm/</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
           <div class="install">
@@ -382,6 +390,14 @@
           <div class="install">
             <span class="prompt">$</span>
             <span class="cmd">uv tool install --prerelease=allow lilbee --extra-index-url https://lilbee.sh/cu125/</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">uv tool install --prerelease=allow lilbee --extra-index-url https://lilbee.sh/rocm/</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
@@ -414,6 +430,14 @@
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">brew install tobocop2/lilbee/lilbee-rocm</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
           <div class="install">
@@ -440,6 +464,14 @@
           <div class="install">
             <span class="prompt">$</span>
             <span class="cmd">paru -S lilbee-cuda</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">paru -S lilbee-rocm</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
@@ -472,6 +504,14 @@
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">docker run --device=/dev/kfd --device=/dev/dri --group-add video --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:rocm --help</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
           <p class="variant-note">no compat image; run the self-contained <a href="https://github.com/tobocop2/lilbee/releases/latest">lilbee-compat binary</a> instead.</p>
@@ -494,6 +534,14 @@
           <div class="install">
             <span class="prompt">$</span>
             <span class="cmd">nix run github:tobocop2/lilbee#lilbee-cuda</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">nix run github:tobocop2/lilbee#lilbee-rocm</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
@@ -523,6 +571,14 @@
           <div class="install">
             <span class="prompt">$</span>
             <span class="cmd">flatpak install lilbee io.github.tobocop2.lilbee.cuda</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">flatpak install lilbee io.github.tobocop2.lilbee.rocm</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
         </div>
@@ -657,6 +713,19 @@
           </div>
         </div>
 
+        <div class="binary-section rocm">AMD · ROCm</div>
+        <div class="binary-row">
+          <div class="binary-row-h">
+            <span class="oschip">Linux x86_64</span>
+            <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-linux-x86_64-rocm">download lilbee-linux-x86_64-rocm &rarr;</a>
+          </div>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">curl -L https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-linux-x86_64-rocm -o lilbee &amp;&amp; chmod +x lilbee</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+
         <div class="binary-section compat">older CPU · no AVX2</div>
         <div class="binary-row">
           <div class="binary-row-h">
@@ -698,6 +767,10 @@
         <div class="variant cuda">
           <span class="variant-tag">NVIDIA · CUDA</span>
           <p class="variant-note">driven via Vulkan by default; for the CUDA path use pip or the <a href="https://github.com/tobocop2/lilbee/releases/latest">binary</a>.</p>
+        </div>
+        <div class="variant rocm">
+          <span class="variant-tag">AMD · ROCm</span>
+          <p class="variant-note">Linux only. Use the <a href="https://github.com/tobocop2/lilbee/releases/latest">ROCm binary</a> or the pip / uv ROCm index instead.</p>
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
@@ -763,7 +836,7 @@
       <div class="caps">
         <div class="cap">
           <h3>runs local AI models itself</h3>
-          <p>Browse Hugging Face, pull a model, assign it to a role. lilbee runs it on Metal, Vulkan, or CUDA; you never point it at a server you set up.</p>
+          <p>Browse Hugging Face, pull a model, assign it to a role. lilbee runs it on Metal, Vulkan, CUDA, or ROCm; you never point it at a server you set up.</p>
         </div>
         <div class="cap">
           <h3>a real retrieval pipeline (RAG)</h3>
@@ -822,7 +895,7 @@
       <div class="faq">
         <details><summary>What is lilbee?</summary><p>lilbee is a local AI search engine. It runs the models, indexes your files, code, and crawled web pages, and answers your questions in plain English with a citation to the exact source. It is one program, with no separate model server or vector database to set up.</p></details>
         <details><summary>Is it really one program?</summary><p>Yes. The model runtime (llama.cpp) and the vector index (LanceDB) run inside lilbee. You install one thing and reach it as a terminal app, a command-line tool, an MCP server, a web API, or a Python library.</p></details>
-        <details><summary>Is lilbee a model manager? Do I need Ollama or LM Studio?</summary><p>lilbee is a complete model manager on its own. It browses Hugging Face, downloads models, gives each one a role, and runs them on your GPU across Metal, Vulkan, or CUDA, and it places large models across multiple GPUs. You do not need a separate model runner. If you already use Ollama or LM Studio, you can point lilbee at them instead.</p></details>
+        <details><summary>Is lilbee a model manager? Do I need Ollama or LM Studio?</summary><p>lilbee is a complete model manager on its own. It browses Hugging Face, downloads models, gives each one a role, and runs them on your GPU across Metal, Vulkan, CUDA, or ROCm, and it places large models across multiple GPUs. You do not need a separate model runner. If you already use Ollama or LM Studio, you can point lilbee at them instead.</p></details>
         <details><summary>Does my data leave my machine?</summary><p>No. Your files stay on disk and search runs locally. lilbee uses a cloud model only when you pick one.</p></details>
         <details><summary>What can I search?</summary><p>Files and markdown, code, PDFs, office documents, ebooks, and scanned images through OCR, plus whole websites you crawl into markdown. Over 150 file types.</p></details>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -363,6 +363,7 @@
             <span class="cmd">pip install --pre lilbee --extra-index-url https://lilbee.sh/rocm/</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
+          <p class="variant-note">Linux only. The default build uses Metal on macOS, Vulkan on Windows.</p>
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
@@ -400,6 +401,7 @@
             <span class="cmd">uv tool install --prerelease=allow lilbee --extra-index-url https://lilbee.sh/rocm/</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
+          <p class="variant-note">Linux only. The default build uses Metal on macOS, Vulkan on Windows.</p>
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>
@@ -511,6 +513,7 @@
             <span class="cmd">docker run --device=/dev/kfd --device=/dev/dri --group-add video --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:rocm --help</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
+          <p class="variant-note">Linux only. The default build uses Metal on macOS, Vulkan on Windows.</p>
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>

--- a/site/index.html
+++ b/site/index.html
@@ -548,6 +548,7 @@
             <span class="cmd">nix run github:tobocop2/lilbee#lilbee-rocm</span>
             <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
           </div>
+          <p class="variant-note">Linux only. The default build uses Metal on macOS, Vulkan on Windows.</p>
         </div>
         <div class="variant compat">
           <span class="variant-tag">older CPU · no AVX2</span>

--- a/site/style.css
+++ b/site/style.css
@@ -416,11 +416,15 @@ h2.label { font-size: inherit; font-weight: inherit; }
 .variant.compat .variant-tag { color: var(--gold); }
 .variant.compat .install { border-left: 2px solid var(--gold); }
 .variant.compat .variant-note { border-left: 2px solid var(--gold); padding-left: 0.7rem; }
+.variant.rocm .variant-tag { color: var(--trust); }
+.variant.rocm .install { border-left: 2px solid var(--trust); }
+.variant.rocm .variant-note { border-left: 2px solid var(--trust); padding-left: 0.7rem; }
 .variant.cuda .variant-tag { color: var(--iris); }
 .variant.cuda .install { border-left: 2px solid var(--iris); }
 .variant.cuda .variant-note { border-left: 2px solid var(--iris); padding-left: 0.7rem; }
 .binary-section.compat { color: var(--gold); }
 .binary-section.cuda { color: var(--iris); }
+.binary-section.rocm { color: var(--trust); }
 
 /* labelled section divider inside the binary tab (older CPU, NVIDIA) */
 .binary-section {

--- a/site/vs/index.html
+++ b/site/vs/index.html
@@ -48,7 +48,7 @@
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
-    { "@type": "Question", "name": "Is lilbee an alternative to Ollama or LM Studio?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. lilbee is a complete model manager: it browses Hugging Face, downloads models, gives each a role, and runs them on Metal, Vulkan, or CUDA, so it can replace Ollama or LM Studio outright. It also does more, with a search engine over your own files, a web crawler, and an MCP server, and if you would rather keep your current setup it runs on top of Ollama or LM Studio instead." } },
+    { "@type": "Question", "name": "Is lilbee an alternative to Ollama or LM Studio?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. lilbee is a complete model manager: it browses Hugging Face, downloads models, gives each a role, and runs them on Metal, Vulkan, CUDA, or ROCm, so it can replace Ollama or LM Studio outright. It also does more, with a search engine over your own files, a web crawler, and an MCP server, and if you would rather keep your current setup it runs on top of Ollama or LM Studio instead." } },
     { "@type": "Question", "name": "How is lilbee different from vLLM?", "acceptedAnswer": { "@type": "Answer", "text": "vLLM serves one model to many users at high throughput. lilbee runs a whole local fleet, chat, embedding, vision, and reranking, on your own machine to answer questions from your files, with retrieval and citations built in." } },
     { "@type": "Question", "name": "Is lilbee bigger to install than Ollama?", "acceptedAnswer": { "@type": "Answer", "text": "No. lilbee's CUDA build is about the same size as Ollama's, roughly 1.1 GB on Linux and 0.6 GB on Windows, next to Ollama's 1.4 GB GPU download. The difference is that lilbee bundles a search engine, a web crawler, servers, and a terminal UI, not just a model runner." } },
     { "@type": "Question", "name": "Can I use my existing Ollama or LM Studio models?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Point lilbee at a running Ollama or LM Studio and its models appear in the same catalog and role pickers alongside lilbee's own, read-only, so their lifecycle stays in the app you already use." } },
@@ -208,6 +208,13 @@
               <td class="lb">the same, with the faster CUDA runtime</td>
             </tr>
             <tr>
+              <th class="lb"><a href="https://github.com/tobocop2/lilbee/releases">lilbee</a> (ROCm, AMD)</th>
+              <td class="lb">n/a</td>
+              <td class="lb">n/a</td>
+              <td class="lb">854 MB</td>
+              <td class="lb">the same, with the faster ROCm runtime</td>
+            </tr>
+            <tr>
               <th><a href="https://github.com/ollama/ollama/releases">Ollama</a></th>
               <td>164 MB</td>
               <td>1.43 GB</td>
@@ -259,7 +266,7 @@
     <section>
       <h2 class="label">questions</h2>
       <div class="faq">
-        <details><summary>Is lilbee an alternative to Ollama or LM Studio?</summary><p>Yes. lilbee is a complete model manager: it browses Hugging Face, downloads models, gives each a role, and runs them on Metal, Vulkan, or CUDA, so it can replace Ollama or LM Studio outright. It also does more, with a search engine over your own files, a web crawler, and an MCP server, and if you would rather keep your current setup it runs on top of Ollama or LM Studio instead.</p></details>
+        <details><summary>Is lilbee an alternative to Ollama or LM Studio?</summary><p>Yes. lilbee is a complete model manager: it browses Hugging Face, downloads models, gives each a role, and runs them on Metal, Vulkan, CUDA, or ROCm, so it can replace Ollama or LM Studio outright. It also does more, with a search engine over your own files, a web crawler, and an MCP server, and if you would rather keep your current setup it runs on top of Ollama or LM Studio instead.</p></details>
         <details><summary>How is lilbee different from vLLM?</summary><p>vLLM serves one model to many users at high throughput. lilbee runs a whole local fleet, chat, embedding, vision, and reranking, on your own machine to answer questions from your files, with retrieval and citations built in.</p></details>
         <details><summary>Is lilbee bigger to install than Ollama?</summary><p>No. lilbee's CUDA build is about the same size as Ollama's, roughly 1.1 GB on Linux and 0.6 GB on Windows, next to Ollama's 1.4 GB GPU download. The difference is that lilbee bundles a search engine, a web crawler, servers, and a terminal UI, not just a model runner.</p></details>
         <details><summary>Can I use my existing Ollama or LM Studio models?</summary><p>Yes. Point lilbee at a running Ollama or LM Studio and its models appear in the same catalog and role pickers alongside lilbee's own, read-only, so their lifecycle stays in the app you already use.</p></details>


### PR DESCRIPTION
ROCm variant sections in every install pane that has a ROCm build (pip, uv, brew, AUR, docker, Nix, Flatpak, binary, source), with Linux-only disclaimers on cross-platform package managers. ROCm mentioned in hero, FAQ, feature cards, GPU page, and vs comparison table.

4 files changed: site/index.html, site/style.css, site/gpu/index.html, site/vs/index.html