### PR TITLE
Give each lilbee process its own block of engine ports

### DIFF
--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -549,7 +549,12 @@ def _ephemeral_range() -> tuple[int, int] | None:
 # Where lilbee looks for engine ports when the kernel's ephemeral range is known.
 # Above the registered-service crowd, below every default ephemeral range.
 _PORT_SEARCH_FLOOR = 20000
-_PORT_SEARCH_ATTEMPTS = 200
+_PORT_WINDOW_SPAN = 8192
+# Block width. Each process searches one block, so concurrent lilbees hold
+# disjoint ranges. A fleet takes one proxy port plus one per member, and embed
+# and vision replicate per GPU, so 64 covers a 30-GPU host; a wider fleet spills
+# into the next block.
+_PORT_BLOCK = 64
 
 # Ports handed to a child that has not bound them yet. llama-swap binds a member
 # port only on that member's first request, so the probe socket is long closed
@@ -565,15 +570,20 @@ def release_reserved_ports(ports: Iterable[int]) -> None:
         _reserved_ports.difference_update(ports)
 
 
-def _search_start(ceiling: tuple[int, int]) -> int:
-    """Where this process begins its scan of the sub-ephemeral window.
+def _window_span(ceiling: tuple[int, int]) -> int:
+    """How many ports below the ephemeral floor this host leaves to search."""
+    return max(1, min(ceiling[0], _PORT_SEARCH_FLOOR + _PORT_WINDOW_SPAN) - _PORT_SEARCH_FLOOR)
 
-    Spread by pid. Reservation only covers this process, and two lilbee starts
-    racing each other cannot see each other's picks at all, so beginning at a
-    different offset per process is what keeps them apart.
+
+def _search_start(ceiling: tuple[int, int]) -> int:
+    """First port of the block this process owns.
+
+    The pid selects a whole block, not an offset: reservation is per-process, and
+    a fleet takes its ports contiguously, so pid-offset starts one apart overlap
+    on all but one port.
     """
-    span = max(1, min(ceiling[0], _PORT_SEARCH_FLOOR + _PORT_SEARCH_ATTEMPTS) - _PORT_SEARCH_FLOOR)
-    return _PORT_SEARCH_FLOOR + os.getpid() % span
+    blocks = max(1, _window_span(ceiling) // _PORT_BLOCK)
+    return _PORT_SEARCH_FLOOR + (os.getpid() % blocks) * _PORT_BLOCK
 
 
 def _pick_free_ports(count: int) -> list[int]:
@@ -608,8 +618,7 @@ def _bind_below_ephemeral(sock: socket.socket, ceiling: tuple[int, int] | None) 
     ephemeral range for those ports.
     """
     if ceiling is not None and ceiling[0] > _PORT_SEARCH_FLOOR:
-        top = min(ceiling[0], _PORT_SEARCH_FLOOR + _PORT_SEARCH_ATTEMPTS)
-        span = top - _PORT_SEARCH_FLOOR
+        span = _window_span(ceiling)
         start = _search_start(ceiling)
         for offset in range(span):
             port = _PORT_SEARCH_FLOOR + (start - _PORT_SEARCH_FLOOR + offset) % span

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -9,6 +9,8 @@ what it gave the last one.
 
 from __future__ import annotations
 
+import os
+
 from lilbee.providers.fleet import swap_manager as sm
 
 
@@ -53,7 +55,7 @@ class TestConsecutivePicksDoNotOverlap:
     def test_exhausting_the_window_still_yields_ports(self, monkeypatch) -> None:
         # With the sub-ephemeral window fully reserved the picker must fall back
         # to letting the OS choose rather than failing the fleet start.
-        monkeypatch.setattr(sm, "_PORT_SEARCH_ATTEMPTS", 2)
+        monkeypatch.setattr(sm, "_PORT_WINDOW_SPAN", 2)
         held = sm._pick_free_ports(2)
         try:
             extra = sm._pick_free_ports(2)
@@ -72,6 +74,47 @@ def test_separate_processes_do_not_start_at_the_same_offset(monkeypatch) -> None
         monkeypatch.setattr(sm.os, "getpid", lambda p=pid: p)
         starts.add(sm._search_start((32768, 60999)))
     assert len(starts) > 1
+
+
+def _pick_as_pid(monkeypatch, pid: int, count: int) -> list[int]:
+    """One process's allocation: its own pid, its own empty reserved set."""
+    monkeypatch.setattr(sm.os, "getpid", lambda p=pid: p)
+    monkeypatch.setattr(sm, "_reserved_ports", set())
+    return sm._pick_free_ports(count)
+
+
+def test_a_block_holds_a_whole_fleet(monkeypatch) -> None:
+    # A group wider than a block spills into the next one. Stated as arithmetic
+    # rather than by binding 35 real sockets, which depends on the host.
+    widest_real_fleet = 1 + 2 * 16 + 2  # 16-GPU host: proxy, embed+vision, two singles
+    assert widest_real_fleet <= sm._PORT_BLOCK
+    starts = [sm._search_start((32768, 60999)) for _ in (0, 1)]
+    monkeypatch.setattr(sm.os, "getpid", lambda: 4001)
+    next_start = sm._search_start((32768, 60999))
+    monkeypatch.setattr(sm.os, "getpid", lambda: 4000)
+    assert next_start - sm._search_start((32768, 60999)) == sm._PORT_BLOCK
+    assert len(set(starts)) == 1  # same pid, same block, every time
+
+
+def test_concurrent_wide_fleets_do_not_overlap(monkeypatch) -> None:
+    # Fake pids derive from the real one so parallel test workers land in
+    # different blocks instead of fighting over one.
+    monkeypatch.setattr(sm, "_ephemeral_range", lambda: (32768, 60999))
+    real = os.getpid()
+    first = _pick_as_pid(monkeypatch, real, 40)
+    second = _pick_as_pid(monkeypatch, real + 1, 40)
+    assert not set(first) & set(second)
+
+
+def test_concurrent_workers_get_disjoint_port_groups(monkeypatch) -> None:
+    # Ports are taken contiguously and the probe sockets close before
+    # llama-server binds, so pid-offset starts one apart overlap on all but one.
+    monkeypatch.setattr(sm, "_ephemeral_range", lambda: (32768, 60999))
+    groups = [_pick_as_pid(monkeypatch, 4000 + i, 4) for i in range(8)]
+    taken: set[int] = set()
+    for group in groups:
+        assert not taken & set(group)
+        taken.update(group)
 
 
 class TestTheSubEphemeralSearch:


### PR DESCRIPTION
## Problem

Two lilbee processes starting at the same moment could get overlapping engine ports, leaving one worker's client talking to another worker's engine.

- The picker binds a probe socket and closes it; llama-swap binds member ports later, on first request.
- The search start was spread by pid, so consecutive pids start **one port apart**.
- A fleet takes its ports **contiguously** (proxy + one per member).
- Starts one apart therefore overlap on all but one port.

Measured on 2xH100, one lilbee pinned per GPU, 20k passages, changing only the launch stagger:

| launch | docs/s | per-card util |
|---|---|---|
| simultaneous | 53.9 | 8% / 87% |
| 15s stagger | 98.5 | 90% / 88% |

## Solution

Each process takes a whole **block** of the window, not an offset into it.

- **Block = 64 ports.** A fleet needs 1 proxy + 1 per member, and embed/vision replicate per GPU, so 64 covers a 30-GPU host. Narrower, and a wide fleet spills into the next block.
- **Window 200 -> 8192 ports** to hold 128 blocks, still below every default ephemeral floor (Linux 32768, macOS 49152).
- **Fallbacks unchanged:** a full block walks on into its neighbours; an unknown ephemeral range (Windows) still lets the OS choose.

| launch | docs/s | per-card util |
|---|---|---|
| simultaneous, with fix | 100.0 | 95% / 94% |

Faster than the stagger because the stagger itself cost 15s of dead startup per worker.

Caveat: two pids congruent mod 128 still share a block. Consecutive pids, which is what any launcher produces, never collide.