### PR TITLE
Add a sticky mega-nav with deep links into the demo and install tabs

### DIFF
--- a/site/code-search/index.html
+++ b/site/code-search/index.html
@@ -122,7 +122,7 @@
         <div class="menu-panel">
           <a href="/model-manager/">model manager</a>
           <a href="/local-rag/">local rag</a>
-          <a href="/code-search/">code search</a>
+          <a href="/code-search/" aria-current="page">code search</a>
           <a href="/mcp/">mcp server</a>
           <a href="/gpu/">gpu fit</a>
           <a href="/vs/">how it compares</a>
@@ -159,8 +159,6 @@
         <span class="pill">offline</span>
       </div>
     </div>
-
-    <p class="crumb"><a href="/">lilbee</a> / code search</p>
 
     <section class="hero">
 <pre class="wordmark" aria-hidden="true">888 d8b 888 888

--- a/site/code-search/index.html
+++ b/site/code-search/index.html
@@ -57,10 +57,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="../style.css?v=20260515a">
-<script src="../main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="../style.css?v=20260731a">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 

--- a/site/gpu/index.html
+++ b/site/gpu/index.html
@@ -124,7 +124,7 @@
           <a href="/local-rag/">local rag</a>
           <a href="/code-search/">code search</a>
           <a href="/mcp/">mcp server</a>
-          <a href="/gpu/">gpu fit</a>
+          <a href="/gpu/" aria-current="page">gpu fit</a>
           <a href="/vs/">how it compares</a>
         </div>
       </div>
@@ -159,8 +159,6 @@
         <span class="pill">multi-gpu</span>
       </div>
     </div>
-
-    <p class="crumb"><a href="/">lilbee</a> / will it fit your GPU</p>
 
     <section class="hero">
 <pre class="wordmark" aria-hidden="true">888 d8b 888 888

--- a/site/gpu/index.html
+++ b/site/gpu/index.html
@@ -57,10 +57,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="../style.css?v=20260515a">
-<script src="../main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="../style.css?v=20260731a">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 

--- a/site/index.html
+++ b/site/index.html
@@ -196,8 +196,8 @@
 888 888 888 888  88888888888888888888
 888 888 888 888 d88PY8b.    Y8b.
 888 888 888 88888P"  "Y8888  "Y8888</pre>
-      <h1 class="tagline">The <strong>whole local AI stack</strong> in <strong>one executable</strong>. lilbee runs and manages the models across every GPU you have, then talks to everything you point it at: your files, your code, and the web. It crawls sites into your library, <a href="/mcp/">plugs into your coding agents</a>, and backs the <a href="https://obsidian.lilbee.sh/">Obsidian plugin</a>. Every answer cites the source, it all runs on your own machine, and there's nothing else to set up.</h1>
-      <p class="sub">A built-in model manager browses Hugging Face, downloads models, gives each one a role, and runs them on your own GPU, on Metal, Vulkan, CUDA, or ROCm. Any coding agent can also use it over MCP.</p>
+      <h1 class="tagline">The <strong>whole local AI stack</strong> in <strong>one executable</strong>. It runs and manages the models on every GPU you have, and answers questions about your files, your code, and the web, every answer cited. It crawls sites into your library, <a href="/mcp/">plugs into your coding agents</a>, and backs the <a href="https://obsidian.lilbee.sh/">Obsidian plugin</a>.</h1>
+      <p class="sub">The built-in model manager browses Hugging Face, downloads models, gives each one a role, and runs them on your GPU: Metal, Vulkan, CUDA, or ROCm.</p>
       <div class="surfaces">
         <span class="surfaces-label">one program, one install</span>
         <span class="surface">terminal app</span>
@@ -895,7 +895,7 @@
 
     <section>
       <h2 class="label">one program</h2>
-      <p class="lede">It's the model, the search through your files, and the chat, all in one program. Run it when you want, close it when you're done; by default nothing's left running in the background, no container to keep alive. Want something long-running? Use the command line and manage it yourself.</p>
+      <p class="lede">It's the model, the search through your files, and the chat, all in one program. Run it when you want, close it when you're done; nothing's left running, no container to keep alive. Want long-running? Use the command line and manage it yourself.</p>
       <div class="shape">
         <div class="shape-box many">
           <div class="shape-h">the usual local-AI setup</div>
@@ -912,9 +912,9 @@
         <div class="shape-box one">
           <div class="shape-h">lilbee</div>
           <ul>
-            <li>the model runtime (llama.cpp) and the vector index (LanceDB) run inside lilbee, not as separate services to stand up</li>
-            <li>use it as a full-screen terminal app, a command-line tool, a Model Context Protocol server, a web API, or a Python library</li>
-            <li>a built-in model catalog: browse and pull straight from Hugging Face Hub, no hunting for model files yourself</li>
+            <li>the model runtime (llama.cpp) and the vector index (LanceDB) run inside lilbee</li>
+            <li>use it as a terminal app, a CLI, an MCP server, a web API, or a Python library</li>
+            <li>a built-in model catalog: browse and pull straight from Hugging Face Hub</li>
             <li>a scoped library per project, so each domain stays its own clean encyclopedia</li>
             <li>runs on a laptop or headless over a remote shell; move it between machines</li>
           </ul>

--- a/site/index.html
+++ b/site/index.html
@@ -84,10 +84,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="style.css?v=20260515a">
-<script src="main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="style.css?v=20260731a">
+<script src="main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 
@@ -122,7 +209,7 @@
       <p class="trust"><strong>It runs on your hardware.</strong> Your files stay on disk, and a cloud model runs only when you pick one. No Docker, no servers, no web stack to maintain, just one file you run on demand.</p>
     </section>
 
-    <section>
+    <section id="demos">
       <h2 class="label">see it work</h2>
 
       <div class="tutorial">
@@ -324,7 +411,7 @@
       </div>
     </section>
 
-    <section>
+    <section id="install">
       <h2 class="label">install</h2>
 
       <div class="installtabs" role="tablist" aria-label="Install methods">

--- a/site/local-rag/index.html
+++ b/site/local-rag/index.html
@@ -121,7 +121,7 @@
         <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
         <div class="menu-panel">
           <a href="/model-manager/">model manager</a>
-          <a href="/local-rag/">local rag</a>
+          <a href="/local-rag/" aria-current="page">local rag</a>
           <a href="/code-search/">code search</a>
           <a href="/mcp/">mcp server</a>
           <a href="/gpu/">gpu fit</a>
@@ -159,8 +159,6 @@
         <span class="pill">no vector DB</span>
       </div>
     </div>
-
-    <p class="crumb"><a href="/">lilbee</a> / local RAG</p>
 
     <section class="hero">
 <pre class="wordmark" aria-hidden="true">888 d8b 888 888

--- a/site/local-rag/index.html
+++ b/site/local-rag/index.html
@@ -57,10 +57,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="../style.css?v=20260515a">
-<script src="../main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="../style.css?v=20260731a">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 

--- a/site/main.js
+++ b/site/main.js
@@ -1,8 +1,13 @@
-// Interactivity for the lilbee landing page: the install-method tabs, the
+// Interactivity for the lilbee site: the mega-nav menus, the install-method
+// tabs, the tutorial reel tabs, hash deep links that activate a tab, the
 // per-method "details" disclosures, and the copy-to-clipboard buttons.
 
 (function () {
   'use strict';
+
+  // tab element -> the select() of the tablist that owns it, so deep links
+  // can activate a tab without synthesizing clicks.
+  var tabSelects = new Map();
 
   /** Wire every [role="tablist"] on the page (install-method tabs, tutorial reel,
       anything else with the same ARIA shape). Click selection plus left/right
@@ -22,6 +27,8 @@
         });
       }
 
+      tabs.forEach(function (tab) { tabSelects.set(tab, select); });
+
       tablist.addEventListener('click', function (event) {
         var tab = event.target.closest('[role="tab"]');
         if (!tab) return;
@@ -39,6 +46,109 @@
         select(next);
         next.focus();
       });
+    });
+  }
+
+  /** Mega-nav dropdowns: click to toggle, Escape or an outside click closes,
+      up/down arrows move through the items, Tab moves on and closes. */
+  function initMenus() {
+    var menus = Array.prototype.slice.call(document.querySelectorAll('.menu'));
+
+    function close(menu) {
+      menu.classList.remove('open');
+      menu.querySelector('.menu-btn').setAttribute('aria-expanded', 'false');
+    }
+    function closeAll() { menus.forEach(close); }
+
+    menus.forEach(function (menu) {
+      var button = menu.querySelector('.menu-btn');
+      var links = Array.prototype.slice.call(menu.querySelectorAll('.menu-panel a'));
+
+      button.addEventListener('click', function () {
+        var willOpen = !menu.classList.contains('open');
+        closeAll();
+        if (willOpen) {
+          menu.classList.add('open');
+          button.setAttribute('aria-expanded', 'true');
+        }
+      });
+
+      menu.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+          close(menu);
+          button.focus();
+          return;
+        }
+        if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+        event.preventDefault();
+        if (!menu.classList.contains('open')) {
+          menu.classList.add('open');
+          button.setAttribute('aria-expanded', 'true');
+          links[event.key === 'ArrowDown' ? 0 : links.length - 1].focus();
+          return;
+        }
+        var index = links.indexOf(document.activeElement);
+        var step = event.key === 'ArrowDown' ? 1 : -1;
+        var next = links[(index + step + links.length) % links.length] || links[0];
+        next.focus();
+      });
+
+      menu.addEventListener('focusout', function (event) {
+        if (event.relatedTarget && menu.contains(event.relatedTarget)) return;
+        close(menu);
+      });
+    });
+
+    document.addEventListener('click', function (event) {
+      if (!event.target.closest('.menu')) closeAll();
+    });
+  }
+
+  function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
+  /** Map a "#demo-chat" / "#install-brew" hash to the tab it names. */
+  function tabForHash(hash) {
+    var match = /^#(demo|install)-(.+)$/.exec(hash || '');
+    if (!match) return null;
+    var id = match[1] === 'demo' ? 'tutorial-tab-' + match[2] : 'tab-' + match[2];
+    return document.getElementById(id);
+  }
+
+  /** Activate the tab a hash names and scroll its section into view. */
+  function activateHash(hash, smooth) {
+    var tab = tabForHash(hash);
+    if (!tab) return false;
+    var select = tabSelects.get(tab);
+    if (select) select(tab);
+    var section = tab.closest('section');
+    if (section) section.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'start' });
+    return true;
+  }
+
+  /** Mega-nav deep links: when the link points at a tab on this page, activate
+      it in place; otherwise let the browser carry the hash to the other page,
+      where the load-time activateHash picks it up. */
+  function initDeepLinks() {
+    document.addEventListener('click', function (event) {
+      var link = event.target.closest('.menu-panel a[href*="/#"]');
+      if (!link) return;
+      var url = new URL(link.href, location.href);
+      if (url.pathname !== location.pathname || !tabForHash(url.hash)) return;
+      event.preventDefault();
+      activateHash(url.hash, !prefersReducedMotion());
+      history.pushState(null, '', url.hash);
+      var menu = link.closest('.menu');
+      if (menu) {
+        menu.classList.remove('open');
+        menu.querySelector('.menu-btn').setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    activateHash(location.hash, false);
+    window.addEventListener('hashchange', function () {
+      activateHash(location.hash, !prefersReducedMotion());
     });
   }
 
@@ -87,6 +197,8 @@
   }
 
   initTablists();
+  initMenus();
+  initDeepLinks();
   initDetailsToggles();
   initCopyButtons();
 })();

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -123,7 +123,7 @@
           <a href="/model-manager/">model manager</a>
           <a href="/local-rag/">local rag</a>
           <a href="/code-search/">code search</a>
-          <a href="/mcp/">mcp server</a>
+          <a href="/mcp/" aria-current="page">mcp server</a>
           <a href="/gpu/">gpu fit</a>
           <a href="/vs/">how it compares</a>
         </div>
@@ -159,8 +159,6 @@
         <span class="pill">self-hosted</span>
       </div>
     </div>
-
-    <p class="crumb"><a href="/">lilbee</a> / MCP server</p>
 
     <section class="hero">
 <pre class="wordmark" aria-hidden="true">888 d8b 888 888

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -57,10 +57,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="../style.css?v=20260515a">
-<script src="../main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="../style.css?v=20260731a">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 

--- a/site/model-manager/index.html
+++ b/site/model-manager/index.html
@@ -57,10 +57,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="../style.css?v=20260515a">
-<script src="../main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="../style.css?v=20260731a">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 

--- a/site/model-manager/index.html
+++ b/site/model-manager/index.html
@@ -120,7 +120,7 @@
       <div class="menu">
         <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
         <div class="menu-panel">
-          <a href="/model-manager/">model manager</a>
+          <a href="/model-manager/" aria-current="page">model manager</a>
           <a href="/local-rag/">local rag</a>
           <a href="/code-search/">code search</a>
           <a href="/mcp/">mcp server</a>
@@ -159,8 +159,6 @@
         <span class="pill">multi-gpu</span>
       </div>
     </div>
-
-    <p class="crumb"><a href="/">lilbee</a> / model manager</p>
 
     <section class="hero">
 <pre class="wordmark" aria-hidden="true">888 d8b 888 888

--- a/site/style.css
+++ b/site/style.css
@@ -225,6 +225,8 @@ h2.label { font-size: inherit; font-weight: inherit; }
 .menu-panel a:hover { color: var(--accent-hot); background: rgba(235, 188, 186, 0.07); }
 .menu-panel a:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
 .menu-panel a.menu-hl { color: var(--accent); }
+.menu-panel a[aria-current="page"] { color: var(--accent); }
+.menu-panel a[aria-current="page"]::after { content: " ·"; color: var(--ink-3); }
 .nav-star {
   font-size: 12.5px;
   letter-spacing: 0.02em;
@@ -1030,11 +1032,7 @@ footer .meta { text-align: right; font-size: 12px; }
   .extra { flex-direction: column; gap: 0.2rem; }
 }
 
-/* satellite landing pages: breadcrumb + FAQ disclosure --------------- */
-.crumb { font-size: 12px; color: var(--ink-3); margin: 0 0 1.6rem; letter-spacing: 0.02em; }
-.crumb a { color: var(--ink-2); text-decoration: none; }
-.crumb a:hover { color: var(--accent); }
-
+/* satellite landing pages: FAQ disclosure ------------------------------ */
 .faq { display: flex; flex-direction: column; gap: 0.5rem; }
 .faq details {
   border: 1px solid var(--rule-2);

--- a/site/style.css
+++ b/site/style.css
@@ -89,6 +89,7 @@ pre { font: inherit; white-space: pre; }
   from { opacity: 0; }
 }
 @media (prefers-reduced-motion: no-preference) {
+  .nav { animation: lb-fade 400ms ease both; }
   .topstrip,
   .main > section { animation: lb-rise 560ms cubic-bezier(0.22, 1, 0.36, 1) both; }
   .topstrip                       { animation-delay: 0ms; }
@@ -121,6 +122,122 @@ h2.label { font-size: inherit; font-weight: inherit; }
 }
 
 .main { min-width: 0; }
+
+/* mega-nav -------------------------------------------------------------
+   Sticky site header. Full-bleed bar: the negative margins cancel the body
+   padding so the border runs edge to edge, while .nav-inner keeps the
+   content on the same 1240px column as .layout. */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  margin: -2.5rem calc(-1 * var(--gutter)) 1.7rem;
+  padding: 0 var(--gutter);
+  background: var(--bg);
+  border-bottom: 1px solid var(--rule);
+}
+.nav-inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  padding: 0.4rem 0;
+}
+.nav-brand {
+  font-size: 13.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  border-bottom: none;
+}
+.nav-brand:hover { color: var(--accent-hot); }
+.nav-menus {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.15rem;
+  flex: 1;
+}
+.menu { position: relative; }
+.menu.open { z-index: 70; }
+.menu-btn {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--ink-2);
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+  transition: color 130ms, border-color 130ms, background-color 130ms;
+}
+.menu-btn::after {
+  content: "▾";
+  margin-left: 0.45em;
+  font-size: 9px;
+  color: var(--ink-3);
+}
+.menu-btn:hover { color: var(--ink); border-color: var(--rule-2); }
+.menu.open .menu-btn { color: var(--accent); border-color: var(--rule-2); background: var(--bg-elev); }
+.menu-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.menu-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 11.5rem;
+  max-height: min(70vh, 32rem);
+  overflow-y: auto;
+  background: var(--bg-card);
+  border: 1px solid var(--rule-2);
+  border-radius: 4px;
+  padding: 0.5rem;
+  box-shadow: 0 22px 60px -26px rgba(0, 0, 0, 0.78);
+}
+.menu.open .menu-panel { display: block; }
+.menu.open .menu-panel.menu-cols { display: flex; gap: 1.2rem; }
+.menu-col { min-width: 10.5rem; }
+.menu.align-right .menu-panel { left: auto; right: 0; }
+.menu-group {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0.45rem 0 0.2rem;
+  padding: 0 0.55rem;
+}
+.menu-panel > .menu-group:first-child,
+.menu-col > .menu-group:first-child { margin-top: 0; }
+.menu-panel a {
+  display: block;
+  padding: 0.26rem 0.55rem;
+  border-bottom: none;
+  border-radius: 3px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.menu-panel a:hover { color: var(--accent-hot); background: rgba(235, 188, 186, 0.07); }
+.menu-panel a:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
+.menu-panel a.menu-hl { color: var(--accent); }
+.nav-star {
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  color: var(--ink-2);
+  border: 1px solid var(--rule-2);
+  border-radius: 4px;
+  padding: 0.26rem 0.6rem;
+  margin-left: auto;
+}
+.nav-star:hover { color: var(--accent-hot); border-color: var(--accent); background: rgba(235, 188, 186, 0.07); }
+
+/* keep anchored sections clear of the sticky nav when jumping to them */
+section[id] { scroll-margin-top: 4.2rem; }
 
 /* top strip ---------------------------------------------------------- */
 .topstrip {
@@ -901,6 +1018,10 @@ footer .meta { text-align: right; font-size: 12px; }
   .bee-art { display: none; }
 }
 @media (max-width: 720px) {
+  :root { --gutter: 1.1rem; }
+  .nav-menus { order: 3; flex-basis: 100%; }
+  .menu-panel { max-width: calc(100vw - 2 * var(--gutter)); }
+  .menu.open .menu-panel.menu-cols { flex-wrap: wrap; }
   body { padding: 1.4rem 1.1rem 3rem; font-size: 14.5px; }
   .wordmark { font-size: 9.5px; }
   .caps, .links, .shape, .routes, .deps { grid-template-columns: 1fr; }

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -25,10 +25,98 @@
 <meta property="og:image:width" content="1400">
 <meta property="og:image:height" content="900">
 
-<link rel="stylesheet" href="../style.css?v=20260604">
+<link rel="stylesheet" href="../style.css?v=20260731a">
 <link rel="stylesheet" href="tutorial.css?v=20260604">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 

--- a/site/vs/index.html
+++ b/site/vs/index.html
@@ -125,7 +125,7 @@
           <a href="/code-search/">code search</a>
           <a href="/mcp/">mcp server</a>
           <a href="/gpu/">gpu fit</a>
-          <a href="/vs/">how it compares</a>
+          <a href="/vs/" aria-current="page">how it compares</a>
         </div>
       </div>
       <div class="menu align-right">
@@ -159,8 +159,6 @@
         <span class="pill">sourced</span>
       </div>
     </div>
-
-    <p class="crumb"><a href="/">lilbee</a> / how it compares</p>
 
     <section class="hero">
 <pre class="wordmark" aria-hidden="true">888 d8b 888 888

--- a/site/vs/index.html
+++ b/site/vs/index.html
@@ -57,10 +57,97 @@
 }
 </script>
 
-<link rel="stylesheet" href="../style.css?v=20260515a">
-<script src="../main.js?v=20260515a" defer></script>
+<link rel="stylesheet" href="../style.css?v=20260731a">
+<script src="../main.js?v=20260731a" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee</a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">TUI</div>
+            <a href="/#demo-whatis">what is lilbee</a>
+            <a href="/#demo-setup">first run</a>
+            <a href="/#demo-startup">startup</a>
+            <a href="/#demo-tour">tui-tour</a>
+            <a href="/#demo-chat">chat</a>
+            <a href="/#demo-sessions">sessions</a>
+            <a href="/#demo-add">add files</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-settings">settings</a>
+            <a href="/#demo-palette">palette</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models &amp; GPUs</div>
+            <a href="/#demo-gpuauto">gpu: auto</a>
+            <a href="/#demo-gpumanual">gpu: manual</a>
+            <a href="/#demo-ollama">ollama</a>
+            <a href="/#demo-lmstudio">lm studio</a>
+            <div class="menu-group">agents</div>
+            <a href="/#demo-agent">agent: code</a>
+            <a href="/#demo-pdf">agent: pdf</a>
+            <a href="/#demo-index">agent: index</a>
+            <a href="/#demo-godot">agent: godot</a>
+            <a href="/#demo-launchoc">launch: opencode</a>
+            <a href="/#demo-launchhm">launch: hermes</a>
+            <div class="menu-group">reel</div>
+            <a class="menu-hl" href="/tutorial/">&#9654; full tutorial reel</a>
+          </div>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
+        <div class="menu-panel">
+          <a href="/#install-pip">pip</a>
+          <a href="/#install-uv">uv</a>
+          <a href="/#install-brew">homebrew</a>
+          <a href="/#install-aur">AUR</a>
+          <a href="/#install-docker">docker</a>
+          <a href="/#install-nix">nix</a>
+          <a href="/#install-flatpak">flatpak</a>
+          <a href="/#install-snap">snap</a>
+          <a href="/#install-scoop">scoop</a>
+          <a href="/#install-binary">binary</a>
+          <a href="/#install-source">source</a>
+        </div>
+      </div>
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">use it for</button>
+        <div class="menu-panel">
+          <a href="/model-manager/">model manager</a>
+          <a href="/local-rag/">local rag</a>
+          <a href="/code-search/">code search</a>
+          <a href="/mcp/">mcp server</a>
+          <a href="/gpu/">gpu fit</a>
+          <a href="/vs/">how it compares</a>
+        </div>
+      </div>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/lilbee">github</a>
+          <a href="https://pypi.org/project/lilbee/">pypi</a>
+          <a href="https://github.com/tobocop2/lilbee/releases">changelog</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="/tutorial/">tutorial reel</a>
+          <a href="/api/">api docs</a>
+          <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks">benchmarks</a>
+          <a href="https://obsidian.lilbee.sh/">obsidian plugin</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 


### PR DESCRIPTION
## Problem

The interactive content (demo reel tabs, install tabs, landing pages) sat below the fold with no header navigation, and satellite pages rendered their title twice (topstrip + breadcrumb).

## Solution

Adds a sticky mega-nav to every page: the demos and install menus deep-link into the tabs (/#demo-crawlsite activates and scrolls to the clip), use-it-for links the landing pages and marks the current one, more holds project/docs links. Menus are keyboard- and touch-friendly, mobile wraps and folds the panels. The redundant breadcrumb is removed and the homepage prose is tightened.