### PR TITLE
Fix the 2GB export ceiling and make the ingest bar measure the corpus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "lancedb",
+    "lancedb[pylance]",
     "xberg>=1.0.4",
     # 3.26 changed is_singleton reentrancy; breaks the engine user-lock warm-off reclaim.
     "filelock<3.26",

--- a/src/lilbee/data/export.py
+++ b/src/lilbee/data/export.py
@@ -73,31 +73,35 @@ def build_page_dataset(store: Store, source: str | None = None) -> pa.Table:
     (bb-bqg).
     """
     import pyarrow as pa
-    import pyarrow.compute as pc
 
-    captured = store.page_text_sources()
+    tracked = _with_wide_offsets(store.sources_arrow())
     if source is not None:
         table = _with_wide_offsets(store.page_texts_arrow(source))
-        if source not in captured:
+        if table.num_rows == 0:
             table = _reconstructed_arrow(store, [source], table.schema)
     else:
         # One scan for every captured page instead of a filtered query per source:
         # the per-source loop was O(sources) and its fixed per-query overhead, not
-        # data size, hung the export on a large store. Restrict to tracked sources
-        # so an orphaned page-text row (source record gone) stays out, matching the
-        # old get_sources()-scoped universe.
-        names = {s["filename"] for s in store.get_sources()}
-        table = _with_wide_offsets(store.page_texts_arrow())
-        if names:
-            table = table.filter(
-                pc.is_in(
-                    table.column("source"), value_set=pa.array(sorted(names), pa.large_string())
-                )
-            )
-        extra = _reconstructed_arrow(store, sorted(names - captured), table.schema)
+        # data size, hung the export on a large store. The semi-join restricts it
+        # to tracked sources, so an orphaned page-text row (source record gone)
+        # stays out, matching the old get_sources()-scoped universe.
+        keys = tracked.select(["source"])
+        table = _with_wide_offsets(store.page_texts_arrow()).join(
+            keys, keys="source", join_type="left semi"
+        )
+        # Tracked sources the scan found no page text for: older indexes and code,
+        # rebuilt from their chunks. Normally empty, and an anti-join keeps the
+        # comparison in Arrow rather than differencing two sets of every filename.
+        missing = keys.join(table.select(["source"]), keys="source", join_type="left anti")
+        extra = _reconstructed_arrow(
+            store, sorted(missing.column("source").to_pylist()), table.schema
+        )
         if extra.num_rows:
             table = pa.concat_tables([table, extra])
-    table = _with_source_metadata(store, table)
+    # Denormalize each source's title/authors/created_at onto its page rows, so an
+    # export/import cycle keeps them instead of falling back to the filename stem.
+    # Left outer: a source with no metadata keeps its pages, with nulls.
+    table = table.join(tracked, keys="source", join_type="left outer")
     return table.sort_by([("source", "ascending"), ("page", "ascending")])
 
 
@@ -122,23 +126,6 @@ def _with_wide_offsets(table: pa.Table) -> pa.Table:
             ]
         )
     )
-
-
-def _with_source_metadata(store: Store, table: pa.Table) -> pa.Table:
-    """Denormalize each source's extraction metadata onto its page rows.
-
-    The dataset is per page while title/authors/created_at live per source, so
-    without this an export/import cycle drops them and the import can only fall
-    back to the filename stem. Absent metadata stays null.
-    """
-    import pyarrow as pa
-
-    by_name: dict[str, dict] = {s["filename"]: dict(s) for s in store.get_sources()}
-    sources = table.column("source").to_pylist()
-    for column in SourceMeta._fields:
-        values = [by_name.get(name, {}).get(column) for name in sources]
-        table = table.append_column(column, pa.array(values, pa.large_string()))
-    return table
 
 
 def _reconstructed_arrow(store: Store, sources: list[str], schema: pa.Schema) -> pa.Table:

--- a/src/lilbee/data/export.py
+++ b/src/lilbee/data/export.py
@@ -7,7 +7,7 @@ import json
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import IO, TYPE_CHECKING, cast
 
 from lilbee.data.extract.document import _title_scope, chunk_and_embed_pages
 from lilbee.data.store import ChunkWrite, PageTextRecord, SourceMeta, SourceType
@@ -167,33 +167,56 @@ def _reconstruct_from_chunks(store: Store, source: str) -> list[PageTextRecord]:
     return rows
 
 
-def _serialize_parquet(table: pa.Table) -> bytes:
-    import io
+# Rows encoded per write. A page row is a few hundred bytes of text, so this
+# keeps a batch in the low megabytes whatever the corpus size.
+_WRITE_BATCH_ROWS = 10_000
 
+
+def _write_parquet(table: pa.Table, sink: IO[bytes]) -> None:
+    """Encode *table* into *sink* as parquet, one row group per batch.
+
+    Build-vs-buy: pyarrow's own writer does the batching, and feeding a
+    ParquetWriter row group by row group produces byte-identical output.
+    """
     import pyarrow.parquet as pq
 
-    buffer = io.BytesIO()
-    pq.write_table(table, buffer)
-    return buffer.getvalue()
+    pq.write_table(table, sink, row_group_size=_WRITE_BATCH_ROWS)
 
 
-def _serialize_jsonl(table: pa.Table) -> bytes:
-    # One JSON object per row, keyed by the table's columns, so jsonl stays in
-    # step with the schema (and with parquet) rather than a hardcoded field list.
-    return "".join(json.dumps(row) + "\n" for row in table.to_pylist()).encode("utf-8")
+def _write_jsonl(table: pa.Table, sink: IO[bytes]) -> None:
+    """Encode *table* into *sink* as jsonl, one write per batch.
+
+    One JSON object per row, keyed by the table's columns, so jsonl stays in step
+    with the schema (and with parquet) rather than a hardcoded field list. Only a
+    batch is converted to Python objects at a time: converting the whole table
+    cost about 19x the size of the file it produced (77GB peak for a 4.15GB
+    export of an 8.8M-row corpus), because the row dicts, the joined string and
+    its encoded bytes were all live at once.
+    """
+    for batch in table.to_batches(max_chunksize=_WRITE_BATCH_ROWS):
+        sink.write("".join(json.dumps(row) + "\n" for row in batch.to_pylist()).encode("utf-8"))
 
 
-_SERIALIZERS = {DatasetFormat.PARQUET: _serialize_parquet, DatasetFormat.JSONL: _serialize_jsonl}
+_WRITERS = {DatasetFormat.PARQUET: _write_parquet, DatasetFormat.JSONL: _write_jsonl}
 
 
 def serialize_dataset(table: pa.Table, fmt: DatasetFormat) -> bytes:
-    """Encode the dataset *table* to bytes in the given format."""
-    return _SERIALIZERS[fmt](table)
+    """Encode the dataset *table* to bytes in the given format.
+
+    For callers that must hand back one buffer (the HTTP download). A file
+    export uses :func:`write_dataset`, which never holds the encoded dataset.
+    """
+    import io
+
+    buffer = io.BytesIO()
+    _WRITERS[fmt](table, buffer)
+    return buffer.getvalue()
 
 
 def write_dataset(table: pa.Table, path: Path, fmt: DatasetFormat) -> None:
-    """Write the dataset *table* to *path* in the given format."""
-    path.write_bytes(serialize_dataset(table, fmt))
+    """Write the dataset *table* to *path* in the given format, a batch at a time."""
+    with path.open("wb") as sink:
+        _WRITERS[fmt](table, sink)
 
 
 def _coerce_row(raw: dict) -> PageTextRecord:

--- a/src/lilbee/data/export.py
+++ b/src/lilbee/data/export.py
@@ -77,7 +77,7 @@ def build_page_dataset(store: Store, source: str | None = None) -> pa.Table:
 
     captured = store.page_text_sources()
     if source is not None:
-        table = store.page_texts_arrow(source)
+        table = _with_wide_offsets(store.page_texts_arrow(source))
         if source not in captured:
             table = _reconstructed_arrow(store, [source], table.schema)
     else:
@@ -87,16 +87,41 @@ def build_page_dataset(store: Store, source: str | None = None) -> pa.Table:
         # so an orphaned page-text row (source record gone) stays out, matching the
         # old get_sources()-scoped universe.
         names = {s["filename"] for s in store.get_sources()}
-        table = store.page_texts_arrow()
+        table = _with_wide_offsets(store.page_texts_arrow())
         if names:
             table = table.filter(
-                pc.is_in(table.column("source"), value_set=pa.array(sorted(names), pa.string()))
+                pc.is_in(
+                    table.column("source"), value_set=pa.array(sorted(names), pa.large_string())
+                )
             )
         extra = _reconstructed_arrow(store, sorted(names - captured), table.schema)
         if extra.num_rows:
             table = pa.concat_tables([table, extra])
     table = _with_source_metadata(store, table)
     return table.sort_by([("source", "ascending"), ("page", "ascending")])
+
+
+def _with_wide_offsets(table: pa.Table) -> pa.Table:
+    """*table* with its string columns retyped to 64-bit offsets.
+
+    pyarrow's ``string`` addresses a column's data with int32 offsets, capping it
+    at 2GB, and every step below this one (filter, concat, metadata append, sort)
+    materializes one array per column. A corpus whose page text passes 2GB
+    overflows there, so the export widens on the way out of the scan; the store's
+    own schema is untouched. Both writers take the wider type, and parquet records
+    it in its arrow metadata and reads it back as ``large_string``, so the rows an
+    import decodes are ordinary strings either way.
+    """
+    import pyarrow as pa
+
+    return table.cast(
+        pa.schema(
+            [
+                field.with_type(pa.large_string()) if pa.types.is_string(field.type) else field
+                for field in table.schema
+            ]
+        )
+    )
 
 
 def _with_source_metadata(store: Store, table: pa.Table) -> pa.Table:
@@ -112,7 +137,7 @@ def _with_source_metadata(store: Store, table: pa.Table) -> pa.Table:
     sources = table.column("source").to_pylist()
     for column in SourceMeta._fields:
         values = [by_name.get(name, {}).get(column) for name in sources]
-        table = table.append_column(column, pa.array(values, pa.string()))
+        table = table.append_column(column, pa.array(values, pa.large_string()))
     return table
 
 

--- a/src/lilbee/data/ingest/fanout.py
+++ b/src/lilbee/data/ingest/fanout.py
@@ -33,8 +33,6 @@ from lilbee.runtime.progress import (
     BatchStatus,
     DetailedProgressCallback,
     EventType,
-    FileDoneEvent,
-    FileStartEvent,
     ProgressEvent,
 )
 
@@ -72,8 +70,6 @@ _FINAL_DRAIN_S = 1.0
 
 # How long a worker gets to exit on its own before it is killed.
 _WORKER_EXIT_GRACE_S = 30.0
-
-_ERROR_STATUS = "error"
 
 # Where a worker's console output lands, under its own data root.
 WORKER_LOG_NAME = "sync.log"
@@ -215,7 +211,13 @@ def _redirect_output(path: Path) -> None:
 
 
 class _ShardReporter:
-    """Throttled per-file counters from a worker onto the parent's queue."""
+    """Throttled relay of a worker's counters onto the parent's queue.
+
+    The counters are the pipeline's own: how much of this worker's slice is done
+    and how big that slice is. Counting files here instead would only re-derive
+    the first, and the per-file events carry no slice size -- FILE_START's total
+    is the plan so far, which grows all run.
+    """
 
     def __init__(self, index: int, messages: Queue[ShardMessage]) -> None:
         self._index = index
@@ -225,21 +227,15 @@ class _ShardReporter:
         self._last_sent = 0.0
 
     def __call__(self, event_type: EventType, data: ProgressEvent) -> None:
-        if event_type is EventType.FILE_START and isinstance(data, FileStartEvent):
-            self._planned = data.total_files
-        elif event_type is EventType.FILE_DONE and isinstance(data, FileDoneEvent):
-            self._done += 1
-            self._report(data)
-
-    def _report(self, data: FileDoneEvent) -> None:
-        """Send the counters, at most once per report interval."""
+        if event_type is not EventType.BATCH_PROGRESS or not isinstance(data, BatchProgressEvent):
+            return
+        self._done = data.current
+        self._planned = data.total
         now = time.monotonic()
         if now - self._last_sent < _REPORT_INTERVAL_S:
             return
         self._last_sent = now
-        self._send(
-            data.file, BatchStatus.FAILED if data.status == _ERROR_STATUS else BatchStatus.INGESTED
-        )
+        self._send(data.file, data.status)
 
     def flush(self) -> None:
         """Send the final counters past the throttle, so the bar lands on its total."""

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -662,6 +662,23 @@ class _StreamedPlan:
     relocated: list[str] = field(default_factory=list)
     unchanged: int = 0
     planned: int = 0
+    # Files this pass's slice holds, from the discovery walk. Fixed before the
+    # first batch is planned, so it is what progress is measured against: the
+    # plan's own running totals grow as batches land and cannot say how much of
+    # the corpus is left. Summed across a fan-out's workers it is the corpus.
+    corpus_total: int = 0
+
+    @property
+    def resolved(self) -> int:
+        """Files the plan disposed of without ingest, as it disposes of them.
+
+        Unchanged (or skip-marked) files and repointed moves are done as far as
+        the corpus is concerned, and nothing downstream reports them, so an
+        incremental sync would otherwise show a handful of changed files against
+        the whole corpus. Files a cancelled plan never classified are absent from
+        both counts and so are not claimed as done.
+        """
+        return self.unchanged + len(self.relocated)
 
 
 async def _absorb_plan_batch(
@@ -1019,7 +1036,7 @@ async def sync(
     # batch off the event loop and overlapped with ingest. A brand-new file whose
     # content hash matches an absent source is folded in per batch as a move, not an
     # add: repointed in place so its chunks and embeddings are reused, not rebuilt.
-    state = _StreamedPlan()
+    state = _StreamedPlan(corpus_total=len(disk_files))
     added, updated, pending_hashes = state.added, state.updated, state.pending_hashes
     plan_batches = _plan_batches(disk_files, existing_sources, skip_markers, absent, state, cancel)
 
@@ -1046,6 +1063,7 @@ async def sync(
                     updated,
                     failed,
                     skipped,
+                    plan=state,
                     quiet=quiet,
                     on_progress=on_progress,
                     cancel=cancel,
@@ -1233,6 +1251,7 @@ async def ingest_stream(
     failed: dict[str, None],
     skipped: dict[str, None],
     *,
+    plan: _StreamedPlan | None = None,
     quiet: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
     cancel: CancelSignal | None = None,
@@ -1245,6 +1264,10 @@ async def ingest_stream(
     batch instead of waiting for the whole corpus to be diffed. Old chunks are
     deleted in the same transaction as the new write, so the two are atomic per
     file. When *cancel* is set, pending files raise CancelledError before starting.
+
+    *plan* is the bookkeeping the batches were planned into; it carries the corpus
+    the run is measured against. Without it progress is reported with no total,
+    since a bare stream of batches does not say what corpus it came from.
     """
     # Honor LILBEE_INGEST_TRACE once per batch: it raises the trace loggers above
     # the default WARNING so per-file extraction lines actually surface.
@@ -1323,7 +1346,7 @@ async def ingest_stream(
                     exc, entry, pages_done=pages_done, on_progress=on_progress, cancel=cancel
                 )
 
-    feed = _ResultFeed(_stream_tasks(plan_batches, _process_one))
+    feed = _ResultFeed(_stream_tasks(plan_batches, _process_one), plan)
     collect = _collect_results if quiet else _collect_under_bar
     try:
         # extract_batching coalesces extractions into xberg batch calls when the
@@ -1368,13 +1391,26 @@ class _ResultFeed:
     """
 
     def __init__(
-        self, plan_batches: AsyncGenerator[list[Coroutine[Any, Any, _IngestResult]]]
+        self,
+        plan_batches: AsyncGenerator[list[Coroutine[Any, Any, _IngestResult]]],
+        plan: _StreamedPlan | None = None,
     ) -> None:
         self._plan_batches = plan_batches
         self._buffer: deque[Coroutine[Any, Any, _IngestResult]] = deque()
         self._pull: asyncio.Task[list[Coroutine[Any, Any, _IngestResult]] | None] | None = None
         self._drained = False
+        self._plan = plan if plan is not None else _StreamedPlan()
         self.planned = 0
+
+    @property
+    def corpus_total(self) -> int:
+        """Files the run's slice holds, or 0 when the caller declared no corpus."""
+        return self._plan.corpus_total
+
+    @property
+    def resolved(self) -> int:
+        """Files already disposed of by the plan, which never reach this feed."""
+        return self._plan.resolved
 
     def pull(self) -> asyncio.Task[list[Coroutine[Any, Any, _IngestResult]] | None] | None:
         """The in-flight plan-batch prefetch, so a waiting collector wakes when it lands."""
@@ -1524,7 +1560,13 @@ async def _collect_results(
                     # purge pass (see _purge_emptied_sources).
                     to_purge.append(result.name)
                 _report_file_progress(
-                    result, status, completed_count, feed.planned, on_progress, progress, ptask
+                    result,
+                    status,
+                    feed.resolved + completed_count,
+                    feed.corpus_total,
+                    on_progress,
+                    progress,
+                    ptask,
                 )
             if saw_cancel:
                 # Completed siblings in this batch are now buffered; propagate the
@@ -1569,9 +1611,9 @@ async def _collect_under_bar(
         TimeElapsedColumn(),
         transient=True,
     ) as progress:
-        # No total yet: the corpus is still being planned, so the bar's total is
-        # filled in (and grows) as batches land.
-        ptask = progress.add_task("Ingesting documents...", total=None)
+        # The corpus the discovery walk found, known before the first batch is
+        # planned. None only when the caller supplied no plan to measure against.
+        ptask = progress.add_task("Ingesting documents...", total=feed.corpus_total or None)
         # The bar advances once per file (in _collect_results), so a single
         # multi-page scanned PDF would freeze at "0/1" through its whole
         # OCR + embed phase. Drive the spinner's description off the same
@@ -1636,13 +1678,15 @@ def _report_file_progress(
 ) -> None:
     """Advance the Rich bar (when present) and emit one BATCH_PROGRESS event.
 
-    *total* is what the plan has produced so far, which grows while the corpus is
-    still being planned, so the bar's total is refreshed on every file.
+    *completed_count* counts every file the pass has disposed of and *total* is
+    the corpus the discovery walk found, so the pair answers how much of the
+    corpus is done rather than how much of the plan so far is.
     """
     if progress is not None and ptask is not None:
         desc = f"Ingested {result.name}" if result.error is None else f"Failed {result.name}"
-        progress.update(ptask, description=desc, total=total)
-        progress.advance(ptask)
+        # Set, not advanced: files the plan resolved without ingest produce no
+        # result of their own and would otherwise never reach the bar.
+        progress.update(ptask, description=desc, completed=completed_count)
     with contextlib.suppress(TaskCancelledError):
         on_progress(
             EventType.BATCH_PROGRESS,

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -1336,12 +1336,42 @@ class Store:
             query = query.where(f"source = '{escape_sql_string(source)}'")
         return query.limit(None).to_arrow()
 
-    def page_text_sources(self) -> set[str]:
-        """Return the distinct sources present in the page-text table."""
-        table = self.open_table(PAGE_TEXTS_TABLE)
+    def sources_arrow(self) -> pa.Table:
+        """Return each tracked source's extraction metadata as an Arrow table.
+
+        The columnar sibling of :meth:`get_sources`, keyed by ``source`` so it
+        joins straight onto the page-text table. ``get_sources`` builds a dict per
+        source, which on a corpus of millions of single-page documents costs more
+        than the text being exported. An index written before the metadata columns
+        existed gets them as nulls rather than missing, so the join has one shape.
+        """
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        table = self.open_table(SOURCES_TABLE)
+        columns = ["source", *SourceMeta._fields]
         if table is None:
-            return set()
-        return {row["source"] for row in table.search().select(["source"]).limit(None).to_list()}
+            return pa.schema([pa.field(name, pa.utf8()) for name in columns]).empty_table()
+        present = [name for name in SourceMeta._fields if name in table.schema.names]
+        arrow = table.search().select(["filename", *present]).limit(None).to_arrow()
+        arrow = arrow.rename_columns(["source", *present])
+        for name in SourceMeta._fields:
+            if name not in present:
+                arrow = arrow.append_column(name, pa.nulls(arrow.num_rows, pa.utf8()))
+        arrow = arrow.select(columns)
+        if pc.count_distinct(arrow.column("source")).as_py() == arrow.num_rows:
+            return arrow
+        # One row per source, so a caller joining on it cannot fan out. A doubled
+        # row (a source re-merged from a shard) would otherwise multiply every page
+        # it owns. Last wins, matching the dict this replaced; single-threaded
+        # because that is the only execution mode with an ordered aggregate.
+        grouped = arrow.group_by("source", use_threads=False).aggregate(
+            [(name, "last") for name in SourceMeta._fields]
+        )
+        renamed = grouped.rename_columns(
+            [name.removesuffix("_last") for name in grouped.schema.names]
+        )
+        return renamed.select(columns)
 
     def get_sources(
         self,

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -77,6 +77,7 @@ from .types import (
 )
 
 if TYPE_CHECKING:
+    import lance
     import lancedb
     import lancedb.table
     from lancedb.index import FTS
@@ -816,6 +817,30 @@ class Store:
             self._stamp_meta_unlocked(self._config.embedding_model, self._config.embedding_dim)
             return int(rows.num_rows)
 
+    def _assert_schemas_match(
+        self,
+        name: str,
+        target: Path,
+        shard_tables: list[Path],
+        sources: Sequence[lance.LanceDataset],
+    ) -> None:
+        """Refuse shards whose schema differs from the table's.
+
+        A mismatched vector width is the realistic case: two workers built with
+        different embedding models. Adoption commits fragment metadata and never
+        passes the rows through a writer, so nothing else would notice.
+        """
+        import lance
+
+        expected = lance.dataset(str(target)).schema
+        for shard_table, source in zip(shard_tables, sources, strict=True):
+            if not source.schema.equals(expected):
+                raise ValueError(
+                    f"Cannot adopt {shard_table} into {name}: its schema does not match "
+                    f"the index. A shard built with a different embedding model cannot be "
+                    f"folded in; re-ingest it with the model this index was built on."
+                )
+
     def adopt_fragments(self, name: str, shard_tables: list[Path]) -> int:
         """Take over *shard_tables*' data files for table *name* without copying rows.
 
@@ -830,31 +855,52 @@ class Store:
         named sources, where a fragment holds both touched and untouched rows and
         the scoped row copy is both correct and already cheap.
 
-        Returns the rows adopted. Raises OSError if a shard is on another
-        filesystem (hard links cannot cross one) or if a data file name collides,
-        leaving the parent untouched: the commit happens once, at the end.
+        Returns the rows adopted. Raises ValueError when a shard's schema differs
+        from the table's, and OSError when a shard is on another filesystem (hard
+        links cannot cross one) or a data file name collides. The parent is left
+        as it was in every failure: schemas are checked before anything is linked,
+        links made before a failure are removed, and the commit happens once at
+        the end.
         """
         import lance
 
         with self._write_lock():
             self._ensure_embedding_compat()
             target = self._config.lancedb_dir / f"{name}.lance"
+            sources = [lance.dataset(str(shard_table)) for shard_table in shard_tables]
+            if not sources:
+                return 0
+            if name not in table_names(self.get_db()):
+                ensure_table(self.get_db(), name, sources[0].schema)
+            # Before anything is linked. Committing a fragment whose schema does
+            # not match writes an index that reads back as a panic inside Arrow
+            # rather than an error: the row copy is rejected by the writer, and
+            # adoption has no writer to reject it.
+            self._assert_schemas_match(name, target, shard_tables, sources)
+            # A table created empty has no data directory yet: nothing has been
+            # written into it, and the links below need somewhere to go.
+            (target / "data").mkdir(parents=True, exist_ok=True)
             adopted: list[lance.FragmentMetadata] = []
+            linked: list[Path] = []
             rows = 0
-            for shard_table in shard_tables:
-                source = lance.dataset(str(shard_table))
-                if name not in table_names(self.get_db()):
-                    ensure_table(self.get_db(), name, source.schema)
-                # A table created empty has no data directory yet: nothing has
-                # been written into it, and the links below need somewhere to go.
-                (target / "data").mkdir(parents=True, exist_ok=True)
-                for fragment in source.get_fragments():
-                    meta = fragment.metadata
-                    for data_file in meta.files:
-                        filename = Path(data_file.path).name
-                        os.link(shard_table / "data" / filename, target / "data" / filename)
-                    adopted.append(meta)
-                rows += source.count_rows()
+            try:
+                for shard_table, source in zip(shard_tables, sources, strict=True):
+                    for fragment in source.get_fragments():
+                        meta = fragment.metadata
+                        for data_file in meta.files:
+                            filename = Path(data_file.path).name
+                            link = target / "data" / filename
+                            os.link(shard_table / "data" / filename, link)
+                            linked.append(link)
+                        adopted.append(meta)
+                    rows += source.count_rows()
+            except OSError:
+                # A link made before the failure is a file the manifest never
+                # names, so nothing would ever remove it. The caller falls back
+                # to copying rows.
+                for link in linked:
+                    link.unlink(missing_ok=True)
+                raise
             if not adopted:
                 return 0
             self._fts_ready = False

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pyarrow as pa
@@ -813,6 +815,58 @@ class Store:
             ensure_table(self.get_db(), name, rows.schema).add(rows)
             self._stamp_meta_unlocked(self._config.embedding_model, self._config.embedding_dim)
             return int(rows.num_rows)
+
+    def adopt_fragments(self, name: str, shard_tables: list[Path]) -> int:
+        """Take over *shard_tables*' data files for table *name* without copying rows.
+
+        Every fragment's data file is hard-linked into this table's directory and
+        the whole set committed as one metadata-only append, so the rows are never
+        read or rewritten and the bytes exist once on disk with two names. That is
+        the difference between a merge that costs the corpus and one that costs its
+        fragment count: the copy path rewrites every vector, and because the shard
+        stores are kept as resume state the corpus would then be on disk twice.
+
+        Whole-fragment only, so this serves the first full merge. A re-sync merges
+        named sources, where a fragment holds both touched and untouched rows and
+        the scoped row copy is both correct and already cheap.
+
+        Returns the rows adopted. Raises OSError if a shard is on another
+        filesystem (hard links cannot cross one) or if a data file name collides,
+        leaving the parent untouched: the commit happens once, at the end.
+        """
+        import lance
+
+        with self._write_lock():
+            self._ensure_embedding_compat()
+            target = self._config.lancedb_dir / f"{name}.lance"
+            adopted: list[lance.FragmentMetadata] = []
+            rows = 0
+            for shard_table in shard_tables:
+                source = lance.dataset(str(shard_table))
+                if name not in table_names(self.get_db()):
+                    ensure_table(self.get_db(), name, source.schema)
+                # A table created empty has no data directory yet: nothing has
+                # been written into it, and the links below need somewhere to go.
+                (target / "data").mkdir(parents=True, exist_ok=True)
+                for fragment in source.get_fragments():
+                    meta = fragment.metadata
+                    for data_file in meta.files:
+                        filename = Path(data_file.path).name
+                        os.link(shard_table / "data" / filename, target / "data" / filename)
+                    adopted.append(meta)
+                rows += source.count_rows()
+            if not adopted:
+                return 0
+            self._fts_ready = False
+            self._scalar_ready = False
+            existing = lance.dataset(str(target))
+            lance.LanceDataset.commit(
+                str(target),
+                lance.LanceOperation.Append(adopted),
+                read_version=existing.version,
+            )
+            self._stamp_meta_unlocked(self._config.embedding_model, self._config.embedding_dim)
+            return rows
 
     def bm25_probe(
         self, query_text: str, top_k: int = 5, chunk_type: ChunkType | None = None

--- a/src/lilbee/data/store/shard_merge.py
+++ b/src/lilbee/data/store/shard_merge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from lilbee.core.config import INGEST_SOURCE_COLUMNS, META_TABLE, SOURCES_TABLE
+from lilbee.core.config import CHUNKS_TABLE, INGEST_SOURCE_COLUMNS, META_TABLE, SOURCES_TABLE
 from lilbee.data.store.lance_helpers import escape_sql_string, table_names
 
 if TYPE_CHECKING:
@@ -42,6 +42,9 @@ def merge_shards(
     if sources is not None:
         store.remove_documents(sorted(sources))
     merged: dict[str, int] = {}
+    adopted = _adopt_chunks(store, shard_dirs, sources)
+    if adopted is not None:
+        merged[CHUNKS_TABLE] = adopted
     for shard_dir in shard_dirs:
         database = lancedb.connect(str(shard_dir))
         for name in table_names(database):
@@ -49,11 +52,41 @@ def merge_shards(
             # a shard's copy would land beside it as a second row.
             if name == META_TABLE:
                 continue
+            if name == CHUNKS_TABLE and adopted is not None:
+                continue  # already taken over whole, without reading a row
             rows = _copy_table(database.open_table(name), store, name, sources)
             merged[name] = merged.get(name, 0) + rows
     log.info("Merged %d shard(s): %s", len(shard_dirs), merged)
     _reconcile_sources(store, shard_dirs)
     return merged
+
+
+def _adopt_chunks(store: Store, shard_dirs: list[Path], sources: set[str] | None) -> int | None:
+    """Take over every shard's chunk fragments whole; None when that cannot apply.
+
+    The chunks table carries the vectors, so it is the whole cost of the merge:
+    at 8.8M rows by 4096 dims the row copy rewrites about 144GB, and since the
+    shard stores stay as resume state the corpus then sits on disk twice.
+    Adopting the fragments is metadata only, and the hard links mean one physical
+    copy with two names.
+
+    Whole-fragment, so only a full merge qualifies: a scoped re-sync names its
+    sources, and a fragment there holds touched and untouched rows together.
+    Returns None when the caller should copy rows instead, which also covers a
+    shard on another filesystem or a data file whose name is already taken; the
+    merge is correct either way, only slower.
+    """
+    if sources is not None:
+        return None
+    tables = [shard_dir / f"{CHUNKS_TABLE}.lance" for shard_dir in shard_dirs]
+    present = [table for table in tables if table.exists()]
+    if not present:
+        return None
+    try:
+        return store.adopt_fragments(CHUNKS_TABLE, present)
+    except OSError as exc:
+        log.warning("Adopting shard fragments failed (%s); copying rows instead", exc)
+        return None
 
 
 def _reconcile_sources(store: Store, shard_dirs: list[Path]) -> None:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,6 @@
 """Tests for the per-page text dataset export/import (lilbee.data.export)."""
 
+import io
 from pathlib import Path
 
 import pyarrow as pa
@@ -7,6 +8,7 @@ import pytest
 
 from lilbee.app import services as svc_mod
 from lilbee.core.config import cfg
+from lilbee.data import export as export_mod
 from lilbee.data.export import (
     DatasetFormat,
     _source_meta_from_rows,
@@ -14,6 +16,7 @@ from lilbee.data.export import (
     import_dataset,
     load_page_dataset,
     resolve_format,
+    serialize_dataset,
     write_dataset,
 )
 from lilbee.data.store import EmbeddingModelMismatchError, SourceType, Store
@@ -283,6 +286,92 @@ class TestSixtyFourBitOffsets:
         write_dataset(build_page_dataset(store), path, fmt)
         loaded = load_page_dataset(path, fmt)
         assert [(r["source"], r["page"], r["text"]) for r in loaded] == [("a.pdf", 1, "body text")]
+
+
+class _CountingSink:
+    """A binary sink that keeps each write separate, rather than one buffer.
+
+    Not a BytesIO subclass: subclassing would mean overriding ``write`` against a
+    wider signature than it accepts. Good enough for the jsonl writer, which uses
+    nothing else; the parquet writer needs a real file object (pyarrow reaches
+    for ``closed``), so its test writes into a BytesIO.
+    """
+
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    @property
+    def writes(self) -> int:
+        return len(self.chunks)
+
+    def write(self, data: bytes) -> int:
+        self.chunks.append(data)
+        return len(data)
+
+    def getvalue(self) -> bytes:
+        return b"".join(self.chunks)
+
+
+class TestStreamingWrites:
+    """An export is written batch by batch, never assembled whole in memory.
+
+    A full-corpus jsonl export measured ~77GB of peak memory for a 4.15GB file,
+    because the old path built a dict per row, joined them into one string and
+    then encoded that: three copies of the corpus alive at once. The writers take
+    a sink and feed it one batch at a time, so peak memory is a batch, not a
+    corpus.
+    """
+
+    def _table(self, rows):
+        return pa.table(
+            {
+                "source": pa.array([f"s{i}.pdf" for i in range(rows)], pa.large_string()),
+                "page": pa.array(list(range(rows)), pa.int32()),
+                "text": pa.array([f"body {i}" for i in range(rows)], pa.large_string()),
+                "content_type": pa.array(["pdf"] * rows, pa.large_string()),
+            }
+        )
+
+    def test_jsonl_writes_once_per_batch_not_once_per_export(self, monkeypatch):
+        monkeypatch.setattr(export_mod, "_WRITE_BATCH_ROWS", 2)
+        sink = _CountingSink()
+        export_mod._write_jsonl(self._table(5), sink)
+        # 5 rows in batches of 2 is three batches; a single write means the whole
+        # corpus was assembled before anything reached the sink.
+        assert sink.writes == 3
+        assert len(sink.getvalue().decode().strip().splitlines()) == 5
+
+    def test_parquet_writes_one_row_group_per_batch(self, monkeypatch):
+        import pyarrow.parquet as pq
+
+        monkeypatch.setattr(export_mod, "_WRITE_BATCH_ROWS", 2)
+        sink = io.BytesIO()
+        export_mod._write_parquet(self._table(5), sink)
+        parquet = pq.ParquetFile(io.BytesIO(sink.getvalue()))
+        assert parquet.num_row_groups == 3
+        assert parquet.metadata.num_rows == 5
+
+    @pytest.mark.parametrize("fmt", [DatasetFormat.PARQUET, DatasetFormat.JSONL])
+    def test_write_dataset_does_not_encode_to_bytes_first(self, tmp_path, monkeypatch, fmt):
+        # The file export is the one that handles a full corpus, so it must go
+        # straight to the file. Routing it through the byte-returning API is the
+        # regression: that is what held a whole encoded corpus in memory.
+        def boom(*_args, **_kwargs):
+            raise AssertionError("write_dataset must stream to the file, not encode to bytes")
+
+        monkeypatch.setattr(export_mod, "serialize_dataset", boom)
+        path = tmp_path / f"pages.{fmt}"
+        write_dataset(self._table(5), path, fmt)
+        assert len(load_page_dataset(path, fmt)) == 5
+
+    @pytest.mark.parametrize("fmt", [DatasetFormat.PARQUET, DatasetFormat.JSONL])
+    def test_serialize_and_write_agree(self, tmp_path, fmt):
+        # The HTTP download encodes to bytes and the CLI writes a file; both go
+        # through the same writer, so the two must not drift.
+        table = self._table(5)
+        path = tmp_path / f"pages.{fmt}"
+        write_dataset(table, path, fmt)
+        assert path.read_bytes() == serialize_dataset(table, fmt)
 
 
 class TestImportDataset:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -230,6 +230,61 @@ class TestBuildPageDataset:
         ]
 
 
+class TestSixtyFourBitOffsets:
+    """Every string column of an export carries 64-bit offsets.
+
+    A 32-bit `string` column holds at most 2GB, and the concat, metadata append
+    and sort in `build_page_dataset` all materialize one array per column, so a
+    corpus past that ceiling fails the export outright. A fixture that actually
+    crosses 2GB costs the RAM and minutes CI does not have, so what is asserted
+    is the type that removes the ceiling, on a table that has been through the
+    whole pipeline.
+    """
+
+    # Named rather than derived from the table: comparing the schema against
+    # itself would pass on a table that had lost its text columns entirely.
+    TEXT_COLUMNS = ("source", "text", "content_type", "title", "authors", "created_at")
+
+    def _text_types(self, table):
+        return {
+            field.name: field.type for field in table.schema if not pa.types.is_integer(field.type)
+        }
+
+    def test_captured_scan_is_large_string_through_sort_and_metadata(self, store):
+        store.add_page_texts([_page("a.pdf", 1, "one"), _page("a.pdf", 2, "two")])
+        store.upsert_source("a.pdf", "h", 2)
+        types = self._text_types(build_page_dataset(store))
+        assert types == dict.fromkeys(self.TEXT_COLUMNS, pa.large_string())
+
+    def test_reconstructed_rows_are_large_string(self, store):
+        # The chunk-reconstructed table is concatenated onto the scanned one, so a
+        # 32-bit column here would overflow the concat regardless of the scan.
+        store.add_page_texts([_page("cap.pdf", 1, "captured")])
+        store.upsert_source("cap.pdf", "h", 1)
+        store.add_chunks([_chunk("recon.pdf", 1, 0, "rebuilt")])
+        store.upsert_source("recon.pdf", "h", 1)
+        types = self._text_types(build_page_dataset(store))
+        assert types == dict.fromkeys(self.TEXT_COLUMNS, pa.large_string())
+
+    def test_single_source_export_is_large_string(self, store):
+        store.add_page_texts([_page("a.pdf", 1, "one")])
+        store.upsert_source("a.pdf", "h", 1)
+        types = self._text_types(build_page_dataset(store, source="a.pdf"))
+        assert types == dict.fromkeys(self.TEXT_COLUMNS, pa.large_string())
+
+    @pytest.mark.parametrize("fmt", [DatasetFormat.PARQUET, DatasetFormat.JSONL])
+    def test_large_string_round_trips_back_to_rows(self, tmp_path, store, fmt):
+        # Both writers have to accept the wider type, and the import path has to
+        # read back what the export wrote: a table export cannot be fixed by
+        # breaking the pair.
+        store.add_page_texts([_page("a.pdf", 1, "body text")])
+        store.upsert_source("a.pdf", "h", 1)
+        path = tmp_path / f"pages.{fmt}"
+        write_dataset(build_page_dataset(store), path, fmt)
+        loaded = load_page_dataset(path, fmt)
+        assert [(r["source"], r["page"], r["text"]) for r in loaded] == [("a.pdf", 1, "body text")]
+
+
 class TestImportDataset:
     async def test_round_trip_into_fresh_store(self, services):
         store = services

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -19,7 +19,7 @@ from lilbee.data.export import (
     serialize_dataset,
     write_dataset,
 )
-from lilbee.data.store import EmbeddingModelMismatchError, SourceType, Store
+from lilbee.data.store import EmbeddingModelMismatchError, SourceMeta, SourceType, Store
 from tests.conftest import make_mock_services
 
 
@@ -286,6 +286,68 @@ class TestSixtyFourBitOffsets:
         write_dataset(build_page_dataset(store), path, fmt)
         loaded = load_page_dataset(path, fmt)
         assert [(r["source"], r["page"], r["text"]) for r in loaded] == [("a.pdf", 1, "body text")]
+
+
+class TestColumnarSourceMetadata:
+    """The export reads tracked sources columnar, never as Python rows.
+
+    get_sources() returns a dict per source and the old metadata denormalization
+    built another dict per source plus a Python list per column. On a corpus of
+    8.8M single-page sources that is its own multi-GB cost, independent of the
+    encoded output, so it has to come out of the Python heap entirely.
+    """
+
+    def test_build_page_dataset_never_reads_sources_as_python_rows(self, store, monkeypatch):
+        store.add_page_texts([_page("a.pdf", 1, "one"), _page("a.pdf", 2, "two")])
+        store.upsert_source("a.pdf", "h", 2)
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("the export must read sources columnar, not row by row")
+
+        monkeypatch.setattr(store, "get_sources", boom)
+        assert build_page_dataset(store).num_rows == 2
+
+    def test_metadata_lands_on_every_page_of_its_source(self, store):
+        store.add_page_texts([_page("a.pdf", 1, "one"), _page("a.pdf", 2, "two")])
+        store.upsert_source("a.pdf", "h", 2, meta=SourceMeta("Alpha", "Ada", "2020-01-01"))
+        rows = build_page_dataset(store).to_pylist()
+        assert [(r["page"], r["title"], r["authors"]) for r in rows] == [
+            (1, "Alpha", "Ada"),
+            (2, "Alpha", "Ada"),
+        ]
+
+    def test_a_duplicate_source_row_does_not_multiply_its_pages(self, store):
+        # A join fans out on duplicate keys where the dict it replaced took the
+        # last one, so a doubled source row (a re-merged shard) would silently
+        # export every one of its pages twice.
+        import pyarrow as pa
+
+        store.add_page_texts([_page("a.pdf", 1, "one")])
+        store.get_db().create_table(
+            "_sources",
+            pa.table(
+                {
+                    "filename": pa.array(["a.pdf", "a.pdf"]),
+                    "file_hash": pa.array(["h1", "h2"]),
+                    "title": pa.array(["First", "Second"]),
+                    "authors": pa.array(["x", "y"]),
+                    "created_at": pa.array(["2020", "2021"]),
+                }
+            ),
+        )
+        rows = build_page_dataset(store).to_pylist()
+        assert len(rows) == 1
+        # Last wins, as the dict did, and the metadata comes from one row.
+        assert (rows[0]["title"], rows[0]["authors"]) == ("Second", "y")
+
+    def test_a_source_without_metadata_joins_to_nulls(self, store):
+        # Left outer, not inner: a source row with no captured title must keep its
+        # pages rather than drop them out of the export.
+        store.add_page_texts([_page("bare.pdf", 1, "text")])
+        store.upsert_source("bare.pdf", "h", 1)
+        rows = build_page_dataset(store).to_pylist()
+        assert len(rows) == 1
+        assert rows[0]["title"] in (None, "")
 
 
 class _CountingSink:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -388,6 +388,24 @@ class TestSync:
         file_done = next(d for t, d in events if t == "file_done")
         assert file_done.status == "ok"
 
+    async def test_batch_progress_measures_the_corpus_not_the_plan_so_far(
+        self, mock_extract_file, isolated_env
+    ):
+        # Two files indexed, one then edited. The re-sync replans only the edited
+        # file, so a total taken from the plan reads 1/1 and says nothing about
+        # the corpus. The total is the files on disk, and the untouched file
+        # counts as done because it is.
+        (isolated_env / "a.txt").write_text("first")
+        (isolated_env / "b.txt").write_text("second")
+        from lilbee.data.ingest import sync
+
+        await sync(quiet=True)
+        (isolated_env / "b.txt").write_text("second, edited")
+        events: list[tuple] = []
+        await sync(quiet=True, on_progress=lambda t, d: events.append((t, d)))
+        batch = [d for t, d in events if t == "batch_progress"]
+        assert [(d.current, d.total) for d in batch] == [(2, 2)]
+
     async def test_ingest_markdown_file(self, mock_extract_file, isolated_env):
         (isolated_env / "readme.md").write_text("# Title\n\nSome markdown content.")
         from lilbee.data.ingest import sync

--- a/tests/test_ingest_fanout.py
+++ b/tests/test_ingest_fanout.py
@@ -14,6 +14,7 @@ from lilbee.core.config import cfg
 from lilbee.data.ingest import fanout
 from lilbee.data.types import ShardId, SyncResult
 from lilbee.runtime.progress import (
+    BatchProgressEvent,
     BatchStatus,
     EventType,
     FileDoneEvent,
@@ -250,13 +251,16 @@ class TestShardEnvironment:
         assert "from the worker" in log.read_text()
 
 
+def _progress(current, total, *, file="a", status=BatchStatus.INGESTED):
+    return BatchProgressEvent(file=file, status=status, current=current, total=total)
+
+
 class TestShardReporter:
-    def test_counters_carry_the_plan_total_and_the_running_count(self, monkeypatch):
+    def test_counters_carry_the_shards_slice_and_its_running_count(self, monkeypatch):
         monkeypatch.setattr(fanout, "_REPORT_INTERVAL_S", 0.0)
         messages = queue_mod.Queue()
         reporter = fanout._ShardReporter(2, messages)
-        reporter(EventType.FILE_START, FileStartEvent(file="a", total_files=9, current_file=1))
-        reporter(EventType.FILE_DONE, FileDoneEvent(file="a", status="ok", chunks=1))
+        reporter(EventType.BATCH_PROGRESS, _progress(1, 9))
         sent = messages.get_nowait()
         assert (sent.index, sent.done, sent.planned) == (2, 1, 9)
         assert sent.status is BatchStatus.INGESTED
@@ -265,26 +269,36 @@ class TestShardReporter:
         monkeypatch.setattr(fanout, "_REPORT_INTERVAL_S", 0.0)
         messages = queue_mod.Queue()
         reporter = fanout._ShardReporter(0, messages)
-        reporter(EventType.FILE_DONE, FileDoneEvent(file="a", status="error", chunks=0))
+        reporter(EventType.BATCH_PROGRESS, _progress(1, 9, status=BatchStatus.FAILED))
         assert messages.get_nowait().status is BatchStatus.FAILED
 
     def test_the_final_counters_are_sent_past_the_throttle(self):
         """Otherwise the one bar stops short of its total when the workers finish."""
         messages = queue_mod.Queue()
         reporter = fanout._ShardReporter(0, messages)
-        for _ in range(5):
-            reporter(EventType.FILE_DONE, FileDoneEvent(file="a", status="ok", chunks=1))
+        for done in range(1, 6):
+            reporter(EventType.BATCH_PROGRESS, _progress(done, 5))
         reporter.flush()
         last = [messages.get_nowait() for _ in range(messages.qsize())][-1]
-        assert last.done == 5
+        assert (last.done, last.planned) == (5, 5)
 
     def test_reports_are_throttled(self):
         """One message per file across a million-file shard would swamp the parent."""
         messages = queue_mod.Queue()
         reporter = fanout._ShardReporter(0, messages)
-        for _ in range(50):
-            reporter(EventType.FILE_DONE, FileDoneEvent(file="a", status="ok", chunks=1))
+        for done in range(1, 51):
+            reporter(EventType.BATCH_PROGRESS, _progress(done, 50))
         assert messages.qsize() == 1
+
+    def test_per_file_events_do_not_set_the_total(self):
+        """FILE_START carries the plan so far, which grows; the bar's total must not."""
+        messages = queue_mod.Queue()
+        reporter = fanout._ShardReporter(0, messages)
+        reporter(EventType.FILE_START, FileStartEvent(file="a", total_files=3, current_file=1))
+        reporter(EventType.FILE_DONE, FileDoneEvent(file="a", status="ok", chunks=1))
+        reporter.flush()
+        sent = messages.get_nowait()
+        assert (sent.done, sent.planned) == (0, 0)
 
     def test_other_events_are_ignored(self):
         messages = queue_mod.Queue()

--- a/tests/test_shard_merge.py
+++ b/tests/test_shard_merge.py
@@ -55,6 +55,102 @@ class TestWholeShardMerge:
         assert store.get_meta()["embedding_model"] == cfg.embedding_model
 
 
+class TestFragmentAdoption:
+    """A full merge takes over the shards' chunk files instead of rewriting them.
+
+    The chunks table carries the vectors, so copying it is the whole cost of a
+    merge, and the shard stores are kept as resume state: a copied corpus is on
+    disk twice. Adoption hard-links the fragments and commits metadata, so the
+    bytes exist once with two names.
+    """
+
+    def test_chunk_rows_are_never_read_during_a_full_merge(self, tmp_path, store, monkeypatch):
+        # absorb_rows is the row-copy path. Chunks must not go through it.
+        _write_shard(tmp_path / "w0", ["a.txt", "b.txt"])
+        _write_shard(tmp_path / "w1", ["c.txt"])
+        absorbed: list[str] = []
+        real = store.absorb_rows
+
+        def spy(name, rows):
+            absorbed.append(name)
+            return real(name, rows)
+
+        monkeypatch.setattr(store, "absorb_rows", spy)
+        merged = merge_shards(store, [tmp_path / "w0", tmp_path / "w1"])
+        assert merged[CHUNKS_TABLE] == 3
+        assert store.open_table(CHUNKS_TABLE).count_rows() == 3
+        assert CHUNKS_TABLE not in absorbed
+        # The small tables still copy: they carry no vectors.
+        assert SOURCES_TABLE in absorbed
+
+    def test_the_data_files_are_shared_rather_than_duplicated(self, tmp_path, store):
+        # The point of adoption. A copy leaves two independent sets of bytes; a
+        # hard link leaves one, which every link counts as its own name for.
+        _write_shard(tmp_path / "w0", ["a.txt", "b.txt"])
+        merge_shards(store, [tmp_path / "w0"])
+        shard_files = sorted((tmp_path / "w0" / f"{CHUNKS_TABLE}.lance" / "data").iterdir())
+        assert shard_files
+        for path in shard_files:
+            assert path.stat().st_nlink > 1, f"{path.name} was copied, not linked"
+
+    def test_an_adopted_index_matches_what_copying_the_rows_produces(self, tmp_path):
+        # The acceptance question: same rows, same sources, same content.
+        _write_shard(tmp_path / "w0", ["a.txt", "b.txt"])
+        _write_shard(tmp_path / "w1", ["c.txt"])
+        shards = [tmp_path / "w0", tmp_path / "w1"]
+
+        adopted_store = Store(cfg.model_copy(update={"lancedb_dir": tmp_path / "adopted"}))
+        merge_shards(adopted_store, shards)
+
+        copied_store = Store(cfg.model_copy(update={"lancedb_dir": tmp_path / "copied"}))
+        merge_shards(copied_store, shards, sources={"a.txt", "b.txt", "c.txt"})
+
+        def rows(store):
+            table = store.open_table(CHUNKS_TABLE).search().limit(None).to_arrow()
+            return sorted(
+                (r["source"], r["chunk"]) for r in table.select(["source", "chunk"]).to_pylist()
+            )
+
+        assert rows(adopted_store) == rows(copied_store)
+        assert len(rows(adopted_store)) == 3
+
+    def test_a_scoped_resync_still_copies_rows(self, tmp_path, store, monkeypatch):
+        # A named-source merge cannot adopt: a fragment holds touched and
+        # untouched rows together, so taking it whole would drag in the rest.
+        _write_shard(tmp_path / "w0", ["a.txt", "b.txt"])
+        absorbed: list[str] = []
+        real = store.absorb_rows
+        monkeypatch.setattr(store, "absorb_rows", lambda n, r: (absorbed.append(n), real(n, r))[1])
+        merge_shards(store, [tmp_path / "w0"], sources={"a.txt"})
+        assert CHUNKS_TABLE in absorbed
+
+    def test_a_shard_with_no_chunks_table_is_not_adopted(self, tmp_path, store):
+        # A worker that indexed nothing writes its source and meta rows but no
+        # chunks table; there is no fragment to take over and the merge goes on.
+        database = lancedb.connect(str(tmp_path / "w0"))
+        database.create_table(SOURCES_TABLE, pa.table({"filename": ["a.txt"]}))
+        database.create_table(META_TABLE, pa.table({"embedding_model": ["shard-model"]}))
+        merged = merge_shards(store, [tmp_path / "w0"])
+        assert CHUNKS_TABLE not in merged
+        assert store.open_table(SOURCES_TABLE).count_rows() == 1
+
+    def test_a_shard_that_cannot_be_linked_falls_back_to_copying(self, tmp_path, store):
+        # Hard links cannot cross a filesystem, and a data file name could already
+        # be taken. Either way the merge has to complete, just more slowly.
+        import os
+
+        _write_shard(tmp_path / "w0", ["a.txt", "b.txt"])
+
+        def refuse(*_args, **_kwargs):
+            raise OSError("Invalid cross-device link")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "link", refuse)
+            merged = merge_shards(store, [tmp_path / "w0"])
+        assert merged[CHUNKS_TABLE] == 2
+        assert store.open_table(CHUNKS_TABLE).count_rows() == 2
+
+
 class TestWholeShardMergeAtScale:
     def test_a_shard_larger_than_any_default_query_limit_lands_whole(self, tmp_path, store):
         """A capped scan would drop the tail of every shard and say nothing."""

--- a/tests/test_shard_merge.py
+++ b/tests/test_shard_merge.py
@@ -193,6 +193,21 @@ class TestFragmentAdoption:
         assert merged[CHUNKS_TABLE] == 2
         assert store.open_table(CHUNKS_TABLE).count_rows() == 2
 
+    def test_adopting_nothing_is_a_no_op(self, store):
+        # A guard on a public method: merge_shards never calls it with an empty
+        # list, but the method does not get to assume its only caller.
+        assert store.adopt_fragments(CHUNKS_TABLE, []) == 0
+
+    def test_a_shard_whose_chunks_table_is_empty_contributes_nothing(self, tmp_path, store):
+        # A worker that indexed nothing still creates its tables. There is no
+        # fragment to take over, and the merge has to carry on regardless.
+        database = lancedb.connect(str(tmp_path / "w0"))
+        database.create_table(CHUNKS_TABLE, schema=_chunk_rows([]).schema)
+        database.create_table(SOURCES_TABLE, pa.table({"filename": ["a.txt"]}))
+        merged = merge_shards(store, [tmp_path / "w0"])
+        assert merged[CHUNKS_TABLE] == 0
+        assert store.open_table(SOURCES_TABLE).count_rows() == 1
+
     def test_a_shard_that_cannot_be_linked_falls_back_to_copying(self, tmp_path, store):
         # Hard links cannot cross a filesystem, and a data file name could already
         # be taken. Either way the merge has to complete, just more slowly.

--- a/tests/test_shard_merge.py
+++ b/tests/test_shard_merge.py
@@ -134,6 +134,65 @@ class TestFragmentAdoption:
         assert CHUNKS_TABLE not in merged
         assert store.open_table(SOURCES_TABLE).count_rows() == 1
 
+    def test_a_shard_with_a_different_schema_is_refused(self, tmp_path, store):
+        # The dangerous case. Adoption commits fragment metadata and never passes
+        # rows through a writer, so a mismatched vector width is not rejected by
+        # anything downstream: before this guard the merge reported success and
+        # the index then panicked inside Arrow on the next read.
+        _write_shard(tmp_path / "w0", ["a.txt"])
+        merge_shards(store, [tmp_path / "w0"])
+
+        narrow = lancedb.connect(str(tmp_path / "w1"))
+        narrow.create_table(
+            CHUNKS_TABLE,
+            pa.table(
+                {
+                    "source": ["b.txt"],
+                    "chunk": ["body of b.txt"],
+                    "vector": [[1.0] * 16],
+                }
+            ),
+        )
+        with pytest.raises(ValueError, match="does not match"):
+            merge_shards(store, [tmp_path / "w1"])
+        # And the index it refused to touch is intact and still readable.
+        table = store.open_table(CHUNKS_TABLE)
+        assert table.count_rows() == 1
+        assert table.search().limit(None).to_arrow().num_rows == 1
+
+    def test_a_failed_link_leaves_no_files_behind(self, tmp_path, store):
+        # A link made before the failure is a file the manifest never names, so
+        # nothing would ever remove it. Fail on the second shard, after the first
+        # has already been linked.
+        import os
+
+        _write_shard(tmp_path / "w0", ["a.txt"])
+        _write_shard(tmp_path / "w1", ["b.txt"])
+        real_link = os.link
+        calls = {"n": 0}
+
+        def fail_after_first(src, dst, **kwargs):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise OSError("Invalid cross-device link")
+            return real_link(src, dst, **kwargs)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "link", fail_after_first)
+            merged = merge_shards(store, [tmp_path / "w0", tmp_path / "w1"])
+        # The link that succeeded before the failure must be gone: nothing names
+        # it, so it would sit in the table's directory forever.
+        data = tmp_path / "merged" / f"{CHUNKS_TABLE}.lance" / "data"
+        shard_names = {
+            path.name
+            for shard in ("w0", "w1")
+            for path in (tmp_path / shard / f"{CHUNKS_TABLE}.lance" / "data").iterdir()
+        }
+        assert not {p.name for p in data.iterdir()} & shard_names
+        # And the fallback copy still landed every row exactly once.
+        assert merged[CHUNKS_TABLE] == 2
+        assert store.open_table(CHUNKS_TABLE).count_rows() == 2
+
     def test_a_shard_that_cannot_be_linked_falls_back_to_copying(self, tmp_path, store):
         # Hard links cannot cross a filesystem, and a data file name could already
         # be taken. Either way the merge has to complete, just more slowly.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1756,13 +1756,38 @@ class TestPageTexts:
         assert store.get_page_texts() == []
         assert store.get_page_texts("x.pdf") == []
 
-    def test_page_text_sources(self, store):
-        store.add_page_texts(_page_rows("a.pdf", (1,)))
-        store.add_page_texts(_page_rows("b.pdf", (1,)))
-        assert store.page_text_sources() == {"a.pdf", "b.pdf"}
+    def test_sources_arrow_keys_metadata_by_source(self, store):
+        from lilbee.data.store import SourceMeta
 
-    def test_page_text_sources_missing_table(self, store):
-        assert store.page_text_sources() == set()
+        store.upsert_source("a.pdf", "h", 1, meta=SourceMeta("Alpha", "Ada", "2020-01-01"))
+        store.upsert_source("b.pdf", "h", 1)
+        arrow = store.sources_arrow()
+        assert arrow.schema.names == ["source", "title", "authors", "created_at"]
+        by_source = {r["source"]: r for r in arrow.to_pylist()}
+        assert by_source["a.pdf"]["title"] == "Alpha"
+        assert by_source["a.pdf"]["authors"] == "Ada"
+        assert set(by_source) == {"a.pdf", "b.pdf"}
+
+    def test_sources_arrow_missing_table(self, store):
+        arrow = store.sources_arrow()
+        assert arrow.num_rows == 0
+        assert arrow.schema.names == ["source", "title", "authors", "created_at"]
+
+    def test_sources_arrow_fills_columns_an_older_index_lacks(self, store):
+        # A sources table written before the metadata columns existed must still
+        # join, with nulls, rather than losing the column and breaking the export.
+        import pyarrow as pa
+
+        db = store.get_db()
+        db.create_table(
+            "_sources",
+            pa.table({"filename": pa.array(["old.pdf"]), "file_hash": pa.array(["h"])}),
+        )
+        arrow = store.sources_arrow()
+        assert arrow.schema.names == ["source", "title", "authors", "created_at"]
+        assert arrow.to_pylist() == [
+            {"source": "old.pdf", "title": None, "authors": None, "created_at": None}
+        ]
 
     def test_delete_by_source_removes_page_texts(self, store):
         store.add_chunks(_make_records(n=1))

--- a/uv.lock
+++ b/uv.lock
@@ -1661,19 +1661,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.9.0"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/fe/f38747c9610ade83dd9a99a0470b9432b6f21ce4e2bb5524edbe66f626fd/lance_namespace-0.9.0-py3-none-any.whl", hash = "sha256:f785ff10927e4ce0db69986576670fedd37f8a33521e8a4630c6be22db8061b2", size = 13501 },
+    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383 },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.9.0"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1681,9 +1681,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/ab/c8754da0a1efc817f8480100cfe12b7e04034df834759de8ecf02beff3cc/lance_namespace_urllib3_client-0.9.0-py3-none-any.whl", hash = "sha256:be819c8cffb1e460a3a504dbf52d1ca009560a48e7202b8c4279998e4adf9fe4", size = 405586 },
+    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950 },
 ]
 
 [[package]]
@@ -1705,6 +1705,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501 },
     { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359 },
     { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726 },
+]
+
+[package.optional-dependencies]
+pylance = [
+    { name = "pylance" },
 ]
 
 [[package]]
@@ -1803,7 +1808,7 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "jinja2" },
-    { name = "lancedb" },
+    { name = "lancedb", extra = ["pylance"] },
     { name = "litestar" },
     { name = "mcp" },
     { name = "numpy" },
@@ -1879,7 +1884,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "huggingface-hub", specifier = ">=1.11.0" },
     { name = "jinja2", specifier = ">=2.11.3" },
-    { name = "lancedb" },
+    { name = "lancedb", extras = ["pylance"] },
     { name = "lilbee", extras = ["crawler", "litellm", "graph"], marker = "extra == 'release'" },
     { name = "lilbee-engine", marker = "extra == 'engine'", directory = "packaging/engine-wheel" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.84.0,<1.92" },
@@ -3313,6 +3318,24 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pylance"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace" },
+    { name = "numpy" },
+    { name = "pyarrow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/be/45733acd64801991852aac8e658601fd8fc12f76ceb81e57fca690896b90/pylance-9.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8257213501d3298c5b6a344d60938e4bbe4de9f00cd3265371a56d1dc3dd15ca", size = 68377982 },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/1ef707cb215cc7268c63ad84a91344ad6313d3984b343eeb19a9b708698e/pylance-9.0.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:804eedfa1fda2e703cca8580c76f0b44a1b849b725a8908c06f8acfca811732f", size = 71844362 },
+    { url = "https://files.pythonhosted.org/packages/c8/fb/a499e5c53ddb75c7de44100fd2bb1f7cc735966200d20292eed7af9ef552/pylance-9.0.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a0b75595e3766c1d5f4c90abdc52337b4de60f1a52d123a4f8c4e5bcbbbfa8f", size = 75663088 },
+    { url = "https://files.pythonhosted.org/packages/e9/80/0714e09f64a68dbdf62558955e737a7436df763b9834a6aba506861b5352/pylance-9.0.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d2f69c5c390ae3710c35a429905fe15f769951777fafb1b72a359e035ec121f7", size = 71866858 },
+    { url = "https://files.pythonhosted.org/packages/4b/3c/78d3a6d6ca0d843b7c3ac0c30d9cd2cf4635b0c2cabe6ec66583d5bfc1a1/pylance-9.0.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:836268a7832d62f3d5ccbe1c3fca239621971d90297bcfff14a70b3cb6842aa8", size = 75642656 },
+    { url = "https://files.pythonhosted.org/packages/cf/c1/dc9c9a31e171530ec0add024d922488c046437d32a7087c29e254a7eacc7/pylance-9.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:96441d27a5ed3805300388ccf8f31835cd280c98751f80b6a1a11dcd6808fc43", size = 81668288 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`lilbee export` fails on any corpus with more than 2GB of page text: `ArrowInvalid: offset overflow while concatenating arrays`. pyarrow's `string` type uses int32 offsets, and the export's concat, metadata append and sort each materialize one array per column. The full 8.8M-passage index could not be exported at all.

The export also assembled the whole encoded dataset in memory before writing a byte, peaking at about 77GB to produce a 4.15GB jsonl file. On top of that it read tracked sources as Python rows three times over, which on millions of single-page documents is its own multi-GB cost.

Separately, the aggregate ingest progress bar's denominator was the plan's running total, which grows as workers discover work. On the 8.8M run it read `335089/391168` while 336,000 of 8,841,823 passages were indexed, so its percentage and time estimate were both meaningless.

## Solution

Widen the export's string columns to `large_string` (int64 offsets) as they leave the page-text scan, before anything downstream materializes them. The store's own schema is unchanged, and parquet records the type in its metadata so export/import still round-trips.

Encode both formats into a sink a batch at a time, and write a file export straight to the file. Parquet hands pyarrow a row group size and lets its own writer batch; jsonl converts one batch of rows at a time. The byte-returning API the HTTP download needs is kept over the same writers.

Add `Store.sources_arrow()`, the columnar sibling of `get_sources()`, and join the per-source metadata onto the page rows instead of building a dict per source. It returns one row per source, since a join fans out on duplicate keys where the dict took the last one.

Measure ingest progress against the file count the discovery walk found, fixed before the first batch is planned, and count the files the plan resolves without ingest toward it. Summed across a fan-out's workers the denominator is the corpus.

## Verification

Run against the real 8,841,823-passage index that produced the failure, on a 1xH100 pod at commit `c98c0fad`:

| | parquet | jsonl |
|---|---|---|
| rows exported | 8,841,823 | 8,841,823 |
| output | 1.65 GB | 4.15 GB |
| wall clock | 66s (was ~180s) | 119s (was ~180s) |
| peak memory | 22.7 GB | 22.6 GB |

Peaks land within 0.1GB of each other while the outputs differ by 2.5x, which is the signature of a cost bounded by the Arrow table rather than by the encoded corpus. The same jsonl export previously cost about 77GB. Row count matches the passage count exactly, every string column is `large_string` on disk, and an import of the exported file round-trips all 8,841,823 records.

`build_page_dataset` still returns one whole Arrow table, so 22.6GB is the floor for a 3GB-of-text corpus. Getting below it needs a streaming build, which is a larger change than this one.

Two things that run could not prove: the real index holds no duplicate source rows, so the dedup guard is covered only by its unit test; and it holds no title/authors/created_at values, so the join is verified for column presence, type and row multiplicity but not for value propagation.

Parquet files are about 1.3% larger, from writing 10k-row row groups instead of one.