### PR TITLE
Unblock the filelock upgrade and take 3.32.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ classifiers = [
 dependencies = [
     "lancedb",
     "xberg>=1.0.4",
-    # 3.26 changed is_singleton reentrancy; breaks the engine user-lock warm-off reclaim.
-    "filelock<3.26",
+    # The engine user-lock protocol leans on release(), is_singleton reentrancy
+    # and the SoftFileLock fallback; the ceiling is the line verified against it.
+    "filelock<3.33",
     "tree-sitter-language-pack>=1.8.0,<2.0",
     "typer>=0.12",
     "tiktoken",

--- a/tests/test_engine_lock.py
+++ b/tests/test_engine_lock.py
@@ -121,6 +121,33 @@ class TestUserLocks:
             proc.kill()
             proc.wait()
 
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is POSIX-only")
+    def test_a_forked_child_does_not_reap_its_parents_membership(self, tmp_path: Path):
+        """A child inheriting a hold must not release or unlink the parent's lock.
+
+        Before filelock 3.30 the inherited instance released the parent's flock
+        through the shared file description and deleted the file, so the child
+        read as last out and would stop an engine its parent was still serving.
+        """
+        hold = hold_user_lock(tmp_path)
+        read_fd, write_fd = os.pipe()
+        if (pid := os.fork()) == 0:
+            os.close(read_fd)
+            verdict = b"E"
+            try:
+                verdict = b"1" if hold.release_and_check_last() else b"0"
+            finally:
+                os.write(write_fd, verdict)
+                os._exit(0)
+        os.close(write_fd)
+        try:
+            assert os.read(read_fd, 1) == b"0"  # the parent is still a live user
+        finally:
+            os.close(read_fd)
+            os.waitpid(pid, 0)
+        assert hold.path.exists()
+        assert hold.release_and_check_last() is True
+
     def test_two_holds_in_one_process_share_the_lock(self, tmp_path: Path):
         """Two providers in one process hold the same pid-named lock file.
 

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -3714,10 +3714,12 @@ def test_a_prior_runs_keep_warm_is_reclaimed_when_the_setting_goes_off(
     monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
     # An earlier run of this same installation opted in, then exited.
     request_keep_warm(machine, prov_mod.cfg.data_root)
-    p = FleetProvider()
-    assert p._ensure_fleet() is True
+    # A restarted run binds and releases under one pid, so the patch covers the
+    # whole run. filelock 3.30+ no-ops release() when the pid moved mid-hold.
     restarted_pid = os.getpid() + 4242
     monkeypatch.setattr(os, "getpid", lambda: restarted_pid)  # this run is a new process
+    p = FleetProvider()
+    assert p._ensure_fleet() is True
     p.shutdown()
     assert stopped == [machine]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1053,11 +1053,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759 },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830 },
 ]
 
 [[package]]
@@ -1873,7 +1873,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=7.1.4" },
     { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.9.0" },
     { name = "diskcache", specifier = ">=5.6.1" },
-    { name = "filelock", specifier = "<3.26" },
+    { name = "filelock", specifier = "<3.33" },
     { name = "gguf", specifier = ">=0.18" },
     { name = "graspologic-native", marker = "extra == 'graph'", specifier = ">=1.2" },
     { name = "httpx" },


### PR DESCRIPTION
## Problem

The `filelock<3.26` pin blocked #651. Its note blamed "3.26 is_singleton reentrancy", but filelock has no 3.26 or 3.27 release and that is not what moved. `test_a_prior_runs_keep_warm_is_reclaimed_when_the_setting_goes_off` bound its user lock under the real pid and then moved `os.getpid` mid-hold. filelock 3.30 added fork safety, which makes `release()` a no-op once the pid has moved, so the lock stayed held, the file was never unlinked, and `live_users_exist` reported the slot in use.

## Solution

- A restarted run binds and releases under one pid, so the patch now covers the whole run. The reclaim was never broken: disabling `withdraw_keep_warm` still fails the test.
- Pin moves to `<3.33` on 3.32.2, with a note recording what the ceiling is verified against.
- Under the old 3.25.2 pin a forked child released its parent's flock through the shared file description and deleted the lock file, so it read as last out and would stop an engine the parent was serving. 3.32.2 gets both right; a regression test covers it. Latent today since ingest forces `spawn`.
