### PR TITLE
Record why the litellm cap holds and test the real constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,16 +68,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# litellm <1.92: 1.92+ ships compiled (maturin) manylinux-only wheels, and the
-# beta channel's --prerelease=allow would resolve to 1.92.0rc1, whose sdist
-# fails to build on Windows/macOS. Raise the cap once litellm publishes wheels
-# for all supported platforms again.
 # The bundled llama-server and gguf-parser. Not a hard dependency because the
 # distribution is published on lilbee.sh rather than PyPI, and a hard reference
 # to a name PyPI answers 404 for made the documented install command backtrack
 # to a months-old release that predated it. Installing without this leaves a
 # working lilbee that says what to install the moment it needs an engine.
 engine = ["lilbee-engine"]
+# 1.92 moved litellm to a maturin build, and PyPI carries no macOS wheel for any
+# release since, so a mac install compiles the Rust crate out of the sdist or
+# fails outright without a toolchain. 1.93.1 added win_amd64 but no macOS, and
+# the beta channel's --prerelease=allow reaches the same line. Raise the cap
+# when macOS wheels land.
 litellm = ["litellm>=1.84.0,<1.92"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.9.0"]

--- a/tests/test_dependency_constraints.py
+++ b/tests/test_dependency_constraints.py
@@ -29,12 +29,14 @@ def _extra_requirement(extra: str, name: str) -> Requirement:
     return next(r for r in reqs if r.name == name)
 
 
-def test_litellm_extra_rejects_compiled_prerelease_line() -> None:
-    # litellm >=1.92 switched to compiled (maturin) builds that ship
-    # manylinux-only wheels; under --prerelease=allow an unbounded range
-    # resolves to 1.92.0rc1 and Windows installs fail building the sdist.
+def test_litellm_extra_stops_below_the_compiled_line() -> None:
+    # litellm 1.92 moved to a maturin build. PyPI publishes no macOS wheel for
+    # any release since, so a mac install compiles the Rust crate out of the
+    # sdist or fails without a toolchain. 1.93.1 added win_amd64 but no macOS,
+    # so the whole line stays out, prereleases included.
     req = _extra_requirement("litellm", "litellm")
-    assert not req.specifier.contains("1.92.0rc1", prereleases=True)
+    for version in ("1.92.0rc1", "1.92.0", "1.93.0", "1.93.1", "1.94.1"):
+        assert not req.specifier.contains(version, prereleases=True), version
 
 
 def test_litellm_extra_admits_locked_stable() -> None:


### PR DESCRIPTION
## Problem

The litellm cap's note said 1.92+ ships manylinux-only wheels and to raise it once litellm publishes wheels for every platform again. Half of that is now stale: 1.93.1 added `win_amd64`. Read literally the note invites the bump, which is how #650 got as far as it did.

PyPI still carries no macOS wheel for any release on the compiled line, 1.94.1 included, so a mac install runs maturin over the Rust crate out of the sdist and needs a toolchain to do it. Building 1.94.1 locally takes ~31s against a warm cargo registry, where 1.91.x installed a `py3-none-any` wheel. macOS is a first-class target, so the cap stays at `<1.92`.

## Solution

- The note now records the real blocker and moves down onto the entry it describes, having sat above `engine`.
- The constraint test only pinned `1.92.0rc1`, which reads as a prerelease-channel guard. It now covers the stable line through 1.94.1, so the next bump attempt fails on the reason that actually blocks it.

No version change. This closes the loop on #650 rather than reopening it.
