### PR TITLE
Apply reranking in search(), not just the ask/chat path

### DIFF
--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -608,9 +608,15 @@ class Searcher:
             if known_item:
                 return known_item[: top_k * 2]
         query_vec = self._embedder.embed_query(question)
+        # Retrieve the reranker's candidate depth when one is loaded, else top_k.
+        retrieve_k = (
+            max(top_k, self._config.rerank_candidates)
+            if self._config.reranker_model
+            else top_k
+        )
         results = self._store.search(
             query_vec,
-            top_k=top_k,
+            top_k=retrieve_k,
             query_text=question,
             chunk_type=chunk_type,
         )
@@ -650,6 +656,11 @@ class Searcher:
             ]
         results = self._apply_concept_boost(results, question)
         results = order_by_fusion(results)
+        # Rerank when a cross-encoder is loaded so every search surface (HTTP,
+        # MCP, CLI, ask) gets reranked order, not just the ask/chat path. A
+        # mode: prefix returned earlier and stays unreranked by design.
+        if self._config.reranker_model:
+            results = self._reranker.rerank(question, results)
         return results[: top_k * 2]
 
     def _condense_question(self, question: str, history: list[ChatMessage]) -> str:
@@ -908,14 +919,9 @@ class Searcher:
             # trims to the context window, keeping the document's head.
             results = known_item
         else:
+            # search() retrieves the reranker's depth and reranks internally when
+            # a reranker is loaded, so the ask path neither bumps depth nor reranks.
             retrieve_k = top_k or self._config.top_k
-            if self._config.reranker_model:
-                # A cross-encoder re-scores the pool, so fused order is only
-                # candidate generation here: retrieve deep enough that the
-                # reranker actually sees its configured candidate count.
-                # Without a reranker the fused order is final and stays at
-                # top_k, since deep rank-fused pools bury single-arm certainty.
-                retrieve_k = max(retrieve_k, self._config.rerank_candidates)
             results = self.search(retrieval_query, top_k=retrieve_k, chunk_type=chunk_type)
             results = filter_results(
                 results, self._config.max_distance, self._config.min_relevance_score
@@ -930,8 +936,6 @@ class Searcher:
                     return RagContext([], self.direct_messages(question, history))
                 return None
             results = prepare_results(results, self._config.diversity_max_per_source)
-            if self._config.reranker_model:
-                results = self._reranker.rerank(retrieval_query, results)
             # Temporal filtering already ran inside search(); no need to repeat it here.
             results = self.select_context(results, retrieval_query)
         return self._finalize_context(results, question, history)

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -919,9 +919,13 @@ class Searcher:
             # trims to the context window, keeping the document's head.
             results = known_item
         else:
-            # search() retrieves the reranker's depth and reranks internally when
-            # a reranker is loaded, so the ask path neither bumps depth nor reranks.
+            # search() reranks internally now, so the ask path no longer reranks
+            # again. It still requests the reranker's candidate depth so context
+            # assembly (prepare_results, select_context) works from a deep
+            # reranked pool rather than only top_k*2.
             retrieve_k = top_k or self._config.top_k
+            if self._config.reranker_model:
+                retrieve_k = max(retrieve_k, self._config.rerank_candidates)
             results = self.search(retrieval_query, top_k=retrieve_k, chunk_type=chunk_type)
             results = filter_results(
                 results, self._config.max_distance, self._config.min_relevance_score

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -257,6 +257,59 @@ class TestRerank:
         assert captured["cands"] == ["alpha", "beta"]
 
 
+class TestSearchAppliesReranker:
+    """search() reranks whenever a reranker is loaded, so every surface (HTTP,
+    MCP, CLI, ask) gets reranked order, and retrieves the reranker's candidate
+    depth. Without a reranker configured, search() neither bumps depth nor reranks.
+    """
+
+    def _searcher(self, reranker):
+        store = mock.MagicMock()
+        store.search.return_value = [_chunk("a.md", "A"), _chunk("b.md", "B")]
+        embedder = mock.MagicMock()
+        embedder.embed_query.return_value = [0.1]
+        searcher = Searcher(cfg, mock.MagicMock(), store, embedder, reranker, mock.MagicMock())
+        return searcher, store
+
+    def _isolate(self, monkeypatch, searcher):
+        monkeypatch.setattr(cfg, "intent_routing", False)
+        monkeypatch.setattr(searcher, "_should_skip_expansion", lambda *a, **k: True)
+        monkeypatch.setattr(searcher, "_apply_temporal_filter", lambda r, q: r)
+        monkeypatch.setattr(searcher, "_apply_concept_boost", lambda r, q: r)
+
+    def test_search_reranks_and_bumps_depth_when_loaded(self, monkeypatch):
+        cfg.reranker_model = _RERANKER_MODEL
+        cfg.rerank_candidates = 100
+        reranker = mock.MagicMock()
+        reranker.rerank.side_effect = lambda q, r: r
+        searcher, store = self._searcher(reranker)
+        self._isolate(monkeypatch, searcher)
+        searcher.search("plain multi word query", top_k=5)
+        reranker.rerank.assert_called_once()
+        assert store.search.call_args.kwargs["top_k"] == 100  # bumped from top_k=5
+
+    def test_search_skips_rerank_without_model(self, monkeypatch):
+        cfg.reranker_model = ""
+        reranker = mock.MagicMock()
+        searcher, store = self._searcher(reranker)
+        self._isolate(monkeypatch, searcher)
+        searcher.search("plain multi word query", top_k=5)
+        reranker.rerank.assert_not_called()
+        assert store.search.call_args.kwargs["top_k"] == 5  # not bumped
+
+    def test_mode_prefix_stays_unreranked(self, monkeypatch):
+        """A mode: escape (vec:/term:/...) forces a raw strategy and skips rerank."""
+        cfg.reranker_model = _RERANKER_MODEL
+        reranker = mock.MagicMock()
+        searcher, _ = self._searcher(reranker)
+        monkeypatch.setattr(
+            searcher, "_search_structured", lambda *a, **k: [_chunk("a.md", "A")]
+        )
+        monkeypatch.setattr(searcher, "_apply_temporal_filter", lambda r, q: r)
+        searcher.search("vec:plain query", top_k=5)
+        reranker.rerank.assert_not_called()
+
+
 class TestBlendSchedule:
     def test_schedule_weights_sum_to_one(self):
         for key, (fw, rw) in _BLEND_SCHEDULE.items():


### PR DESCRIPTION
## Problem

`search()` did dense + FTS fusion but never reranked. Reranking lived only in the ask/chat RAG path, so HTTP `/api/search`, MCP, and CLI callers got fused-but-unreranked results and left the cross-encoder's gain unused. Grading MS MARCO passage dev/small showed the retrieval API was leaving a large amount of quality on the table.

## Solution

Rerank at the end of `search()` whenever a reranker is loaded, retrieving the reranker's candidate depth so it re-scores a deep pool. The ask path keeps its depth bump (so context assembly still works from a deep pool) but stops reranking a second time. `mode:` escapes (`vec:`/`term:`/...) return early and stay unreranked by design.

## Why reranking helps so much on this corpus

MS MARCO labels ~1 relevant passage per query, so getting that one passage to the very top is everything. Two effects compound:
- **Fusion finds it.** Adding FTS (BM25) to dense retrieval lifts recall@100 from 0.67 to **0.90** — the relevant passage is now almost always somewhere in the pool.
- **The cross-encoder puts it first.** The embedder is a bi-encoder (query and passage encoded separately); a cross-encoder reads the query and passage *together*, so it scores relevance far more precisely and pulls the right passage to the top of the deep pool. That is exactly the top-of-list precision MRR@10 and nDCG@10 reward.

Net effect on the full 6,980-query dev set (official scorers, `ms_marco_eval.py` + `trec_eval`, which agree):

| lilbee retrieval mode | MRR@10 | nDCG@10 | recall@100 |
|---|---|---|---|
| dense only (`vec:`) | 0.347 | 0.398 | 0.67 |
| + FTS fusion (no rerank) | ~0.31 | ~0.37 | 0.90 |
| **+ rerank (this change)** | **0.365** | **0.437** | **0.90** |

Reranker is `bge-reranker-v2-m3`, lilbee's featured default — a **general-purpose** multilingual cross-encoder, not something tuned for this benchmark.

## lilbee vs the field

lilbee is a **general-purpose** system: an off-the-shelf embedder (Qwen3-Embedding-8B) plus a general reranker, pointed at any corpus. It is worth seeing it against both the general embedders it belongs with and the models trained specifically to win MS MARCO.

### Against general-purpose embedders (MTEB MS MARCO, nDCG@10)

| Rank | System | nDCG@10 | Trained only for MS MARCO? |
|---|---|---|---|
| 1 | gte-Qwen2-7B-instruct | 0.460 | no |
| 2 | stella_en_1.5B_v5 | 0.452 | no |
| **3** | **lilbee (reranked)** | **0.437** | **no** |
| 3 | multilingual-e5-large | 0.437 | no |
| 5 | Qwen3-Embedding-8B (lilbee's embedder, exact search) | 0.436 | no |
| 6 | e5-large-v2 | 0.435 | no |
| 7 | bge-large-en-v1.5 | 0.425 | no |
| 8 | mxbai-embed-large-v1 | 0.413 | no |

The reranked pipeline (0.437) **matches multilingual-e5-large and edges past Qwen3-Embedding-8B's own exact-search MTEB score (0.436)** — meaning the full pipeline recovers the quality that approximate ANN retrieval alone (0.398) left behind, and delivers the embedder's ceiling on a 8.8M-passage index.

### Against MS-MARCO specialists (MRR@10)

| Rank | System | MRR@10 | Trained only for MS MARCO? |
|---|---|---|---|
| 1 | SimLM | 0.411 | yes |
| 2 | ColBERTv2 | 0.397 | yes |
| 3 | coCondenser | 0.382 | yes |
| 4 | RocketQA | 0.370 | yes |
| 5 | SPLADEv2 | 0.368 | yes |
| **6** | **lilbee (reranked)** | **0.365** | **no** |
| 7 | ColBERT | 0.360 | yes |
| 8 | TAS-B | 0.347 | yes |
| 9 | ANCE | 0.330 | yes |
| 10 | docTTTTTquery | 0.277 | yes |
| 11 | BM25 | 0.187 | no |

## The result in plain terms

Every system above lilbee on the specialist board — SimLM, ColBERTv2, coCondenser, RocketQA, SPLADEv2 — exists **only** as an MS MARCO retriever, trained end-to-end on this benchmark's training set. lilbee is a general-purpose stack you point at your own documents, and with reranking it lands at **0.365 MRR@10 — above ColBERT, TAS-B, and ANCE, and knocking on the door of SPLADEv2** — while on the general-embedder board it matches the frontier at **0.437 nDCG@10**. The dense-only 0.347 undersold it; reranking is the difference between "a good embedder behind an ANN index" and "a pipeline that delivers that embedder's full quality at scale." That is the number that reflects what a real lilbee deployment returns, and it is genuinely competitive with systems built to do nothing else.

Draft pending CI: covered by new `search()` rerank tests; the local editable install is on an unrelated in-progress branch and can't run the suite.
