### PR TITLE
Retry a transient empty device probe before failing GPU placement

### DIFF
--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1642,10 +1642,21 @@ def _resolve_devices_and_refusal(binary: Path) -> tuple[list[FleetDevice], bool]
     to the in-process Vulkan probe there could hang this thread unkillably.
     """
     from lilbee.providers.fleet.cuda_runtime import assert_cuda_devices_usable
+    from lilbee.providers.fleet.gpu_hardware import installed_gpu_vendor_ids
     from lilbee.providers.fleet.gpu_select import enumerate_gpu_vram
     from lilbee.providers.fleet.rocm_runtime import assert_rocm_devices_usable
 
     probe = probe_devices(binary)
+    # An engine that answered but listed no device while a GPU is physically
+    # present may be hitting a transient init error (the card momentarily held by
+    # another process, e.g. an embedder served alongside -- the "ggml_cuda_init:
+    # initialization error" symptom). Re-probe before treating the empty list as
+    # fatal; a persistently empty list still hits the fail-loud asserts below.
+    for _ in range(_DEVICE_PROBE_EMPTY_RETRIES):
+        if probe.devices or not probe.spoke_protocol or not installed_gpu_vendor_ids():
+            break
+        time.sleep(_DEVICE_PROBE_EMPTY_RETRY_DELAY_S)
+        probe = probe_devices(binary)
     devices = probe.devices
     # A GPU build that links a runtime it cannot serve the host's GPU with must
     # fail loud, not silently fall back to CPU (the Vulkan VRAM probe below
@@ -1697,6 +1708,11 @@ _DEVICE_PROBE_TTL_S = 2.0
 # wedged GPU driver costs a full probe timeout, so a per-poll retry would stall
 # every placement read for a minute at a time.
 _DEVICE_PROBE_FAILURE_TTL_S = 60.0
+# An engine that lists no device on a GPU host may be hitting a transient GPU-init
+# error (the card momentarily held by another process); re-probe before treating
+# the empty list as fatal.
+_DEVICE_PROBE_EMPTY_RETRIES = 3
+_DEVICE_PROBE_EMPTY_RETRY_DELAY_S = 0.5
 
 
 class _ReadDeviceCache:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -3214,3 +3214,79 @@ class TestABusyUnifiedHostStillServesASmallModel:
         )
 
         assert WorkerRole.CHAT in plan.unplaceable_roles
+
+
+class TestDeviceProbeEmptyRetry:
+    """A transient empty device probe on a GPU host is re-probed before it is
+    treated as fatal; a persistently empty probe still fails loud, and a CPU
+    host (no GPU) is not retried."""
+
+    _EMPTY = DeviceProbe(
+        devices=[], output="ggml_cuda_init: initialization error", spoke_protocol=True
+    )
+    _OK = DeviceProbe(devices=[_card(24_000_000_000)], output="", spoke_protocol=True)
+
+    def _gpu_present(self, monkeypatch, present=True):
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.gpu_hardware.installed_gpu_vendor_ids",
+            lambda: {"nvidia"} if present else set(),
+        )
+        monkeypatch.setattr(planning_mod.time, "sleep", lambda *_: None)
+
+    def test_transient_empty_probe_recovers(self, monkeypatch):
+        self._gpu_present(monkeypatch)
+        seq = [self._EMPTY, self._OK]
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda *a, **k: seq.pop(0))
+        assert [d.index for d in planning_mod.resolve_devices(Path("/x"))] == [0]
+
+    def test_persistent_empty_still_raises(self, monkeypatch):
+        from lilbee.providers.base import ProviderError
+
+        self._gpu_present(monkeypatch)
+        calls = {"n": 0}
+
+        def _probe(*a, **k):
+            calls["n"] += 1
+            return self._EMPTY
+
+        monkeypatch.setattr(planning_mod, "probe_devices", _probe)
+
+        def _raise(*a, **k):
+            raise ProviderError("no cuda device")
+
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.cuda_runtime.assert_cuda_devices_usable", _raise
+        )
+        with pytest.raises(ProviderError):
+            planning_mod.resolve_devices(Path("/x"))
+        assert calls["n"] == 4  # 1 initial + 3 retries, then fatal
+
+    def test_healthy_probe_not_retried(self, monkeypatch):
+        self._gpu_present(monkeypatch)
+        calls = {"n": 0}
+
+        def _probe(*a, **k):
+            calls["n"] += 1
+            return self._OK
+
+        monkeypatch.setattr(planning_mod, "probe_devices", _probe)
+        planning_mod.resolve_devices(Path("/x"))
+        assert calls["n"] == 1  # devices found first try, no retry
+
+    def test_cpu_host_empty_not_retried(self, monkeypatch):
+        self._gpu_present(monkeypatch, present=False)
+        calls = {"n": 0}
+
+        def _probe(*a, **k):
+            calls["n"] += 1
+            return self._EMPTY
+
+        monkeypatch.setattr(planning_mod, "probe_devices", _probe)
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.cuda_runtime.assert_cuda_devices_usable", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.rocm_runtime.assert_rocm_devices_usable", lambda *a, **k: None
+        )
+        planning_mod.resolve_devices(Path("/x"))
+        assert calls["n"] == 1  # no GPU present, empty is authoritative


### PR DESCRIPTION
## Problem

When lilbee plans a GPU engine while the GPU is already busy — e.g. an embedder served alongside — the engine's `--list-devices` probe can transiently fail CUDA init ("ggml_cuda_init: initialization error") and answer with no devices. `assert_cuda_devices_usable` treats an empty device list on a GPU host as fatal and crashes placement, even though the GPU is working. This made the full search path (hybrid + rerank) unusable on a pod where the served embedder ran fine — the retrieval benchmark could only measure the pure-dense arm because of it.

## Solution

Re-probe (3 × 0.5s) when the engine answers but lists no device while a GPU is physically present, before treating the empty list as fatal. A transient init error clears and placement proceeds; a persistently empty probe still hits the fail-loud CUDA/ROCm asserts, so a genuinely broken runtime is not masked. The healthy path (probe returns devices first try) is unaffected — no retry, no added latency. `probe_devices` raises on timeout, so the loop never spins on a wedged driver.

Verified on an RTX 4090: healthy probe unaffected (no retry), a one-shot empty probe recovers, a persistent empty probe still raises after the retries. Covered by four unit tests.
