### PR TITLE
Size llama-server's thread count to the container's CPU quota

### DIFF
--- a/docs/tested-gpus.md
+++ b/docs/tested-gpus.md
@@ -6,7 +6,7 @@ lilbee places models by reading what the engine reports: which devices exist, ho
 
 | Machine | Backend | What ran on it |
 |---------|---------|----------------|
-| 2x NVIDIA A40 (46 GB) | CUDA | Readback on a tensor split, cgroup limits honoured over `/proc/meminfo` |
+| 2x NVIDIA A40 (46 GB) | CUDA | Readback on a tensor split, cgroup memory and CPU limits honoured over the host's totals |
 | NVIDIA A100 80GB PCIe | CUDA | Shared-engine load benchmark, concurrency sweep, 600-round endurance and chaos soaks |
 | 8x NVIDIA A100 | CUDA | Ingest throughput at scale, 161 docs/sec |
 | 3x NVIDIA A100 | CUDA | Auto-placement of a 235B chat model across three cards |

--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from lilbee.core.config.enums import RerankerType
 from lilbee.providers.roles import RerankMode, WorkerRole
+from lilbee.runtime.cpu import engine_thread_count
 
 log = logging.getLogger(__name__)
 
@@ -101,6 +102,7 @@ _RERANK_MODE_SPECS: dict[RerankMode, RoleServerSpec] = {
 LLM_RERANK_CONCURRENCY = 8
 
 _FLAG_MAIN_GPU = "--main-gpu"
+_FLAG_THREADS = "--threads"
 
 
 def resolve_rerank_mode(reranker_type: RerankerType, arch: str | None) -> RerankMode:
@@ -221,6 +223,17 @@ def _main_gpu_args(devices: tuple[int, ...]) -> list[str]:
     return [_FLAG_MAIN_GPU, str(main_gpu)]
 
 
+def _thread_args() -> list[str]:
+    """``--threads`` when a CPU cap applies to this process, else empty.
+
+    llama.cpp counts host cores and sees neither a cgroup quota nor an affinity
+    mask, so a container-bound engine oversubscribes its quota badly. Only the
+    generation flag is emitted: ``--threads-batch`` defaults to ``--threads``.
+    """
+    threads = engine_thread_count()
+    return [] if threads is None else [_FLAG_THREADS, str(threads)]
+
+
 def build_server_argv(
     *,
     binary: Path,
@@ -263,6 +276,7 @@ def build_server_argv(
         str(ctx_per_slot * slots),
     ]
     argv += _main_gpu_args(devices)
+    argv += _thread_args()
     argv += _attention_args(flash_attn, cache_type_k, cache_type_v)
     if batch_size is not None:
         argv += [FLAG_BATCH_SIZE, str(batch_size), FLAG_UBATCH_SIZE, str(batch_size)]

--- a/src/lilbee/runtime/cpu.py
+++ b/src/lilbee/runtime/cpu.py
@@ -125,8 +125,8 @@ def engine_thread_count() -> int | None:
     The budget rounds DOWN here, unlike :func:`available_cpu_count`. An engine's
     threads compute in lockstep across a barrier, so one thread over the quota
     gets the whole group throttled and every other thread waits for it. Measured
-    on a 96-core pod with a 7.65-core quota, one server generating: 11.4 tok/s at
-    the engine's own count of 48, 60.3 at 8 threads, 63.5 at 7.
+    on a 96-core pod with a 7.65-core quota, one server generating: 11.4 tok/s on
+    the engine's own count, 60.3 at 8 threads, 63.5 at 7.
 
     Not ``cpu_quota()``: that halves the budget to leave the asyncio scheduler a
     share, which an out-of-process engine does not compete with.

--- a/src/lilbee/runtime/cpu.py
+++ b/src/lilbee/runtime/cpu.py
@@ -9,6 +9,9 @@ storm is in flight.
 Do NOT use this for HTTP request concurrency: that lives under
 ``cfg.crawl_max_concurrent`` and is governed by remote-side rate
 limits, not local CPU.
+
+``engine_thread_count()`` is the out-of-process counterpart, sizing a
+spawned llama-server's thread count.
 """
 
 from __future__ import annotations
@@ -98,3 +101,20 @@ def cpu_quota() -> int:
             override,
         )
     return max(1, available_cpu_count() // 2)
+
+
+def engine_thread_count() -> int | None:
+    """Threads for a spawned engine, or None to keep the engine's own default.
+
+    llama.cpp sizes its default from host topology (physical cores, minus
+    efficiency cores) and cannot see a CFS quota or an affinity mask, so inside a
+    CPU-limited container it starts several times more threads than the quota
+    admits and generation slows down: 33.75 tok/s at 8 threads against 13.45 at
+    32, on a pod with 96 visible cores and a 7.65-core quota. Where nothing caps
+    this process, upstream's count is the better informed one and stays.
+
+    Not ``cpu_quota()``: that halves the budget to leave the asyncio scheduler a
+    share, which an out-of-process engine does not compete with.
+    """
+    quota = available_cpu_count()
+    return quota if quota < (os.cpu_count() or 1) else None

--- a/src/lilbee/runtime/cpu.py
+++ b/src/lilbee/runtime/cpu.py
@@ -29,12 +29,14 @@ _ENV_VAR = "LILBEE_CPU_QUOTA"
 _CGROUP_ROOT = Path("/sys/fs/cgroup")
 
 
-def _cgroup_cpu_quota(root: Path = _CGROUP_ROOT) -> int | None:
-    """CPUs the CFS quota allows, or None when unlimited or unreadable.
+def _cgroup_cpu_quota(root: Path = _CGROUP_ROOT) -> float | None:
+    """Cores the CFS quota allows, unrounded, or None when unlimited or unreadable.
 
     cgroup v2 keeps ``<quota> <period>`` (or ``max`` for unlimited) in
     ``cpu.max``; v1 splits it across ``cpu.cfs_quota_us`` (-1 = unlimited) and
-    ``cpu.cfs_period_us``. The effective core count is ``ceil(quota / period)``.
+    ``cpu.cfs_period_us``. Quotas are routinely fractional (a rented pod gets
+    765ms per 100ms period, i.e. 7.65 cores), and which way that rounds differs
+    per caller, so it is left to them.
     """
     try:
         v2 = (root / "cpu.max").read_text().split()
@@ -47,7 +49,7 @@ def _cgroup_cpu_quota(root: Path = _CGROUP_ROOT) -> int | None:
             quota, period = int(v2[0]), int(v2[1])
         except (ValueError, IndexError):
             return None
-        return max(1, math.ceil(quota / period)) if period > 0 else None
+        return quota / period if period > 0 else None
     try:
         quota = int((root / "cpu" / "cpu.cfs_quota_us").read_text())
         period = int((root / "cpu" / "cpu.cfs_period_us").read_text())
@@ -55,29 +57,37 @@ def _cgroup_cpu_quota(root: Path = _CGROUP_ROOT) -> int | None:
         return None
     if quota <= 0 or period <= 0:
         return None
-    return max(1, math.ceil(quota / period))
+    return quota / period
 
 
-def available_cpu_count() -> int:
-    """Usable CPUs for this process, honoring cgroup quota and CPU affinity.
+def _cpu_budget() -> float:
+    """Cores this process may use, unrounded: the tightest of the three signals.
 
     ``os.cpu_count()`` reports the host's cores, which over-reports inside a
     CPU-limited container (a rented multi-vCPU box hands a pod a fraction of the
     machine). Fold in the process's scheduling affinity and the cgroup CFS quota
     so a container-bound run sizes to its real budget rather than the host's.
-    Always at least 1.
 
     ``os.process_cpu_count()`` folds these in for us, but it landed in 3.13 and
     the project floor is 3.11, so the cgroup read is done by hand here.
     """
-    limits = [os.cpu_count() or 1]
+    limits = [float(os.cpu_count() or 1)]
     if hasattr(os, "sched_getaffinity"):
         with contextlib.suppress(OSError):
-            limits.append(len(os.sched_getaffinity(0)))
+            limits.append(float(len(os.sched_getaffinity(0))))
     quota = _cgroup_cpu_quota()
     if quota is not None:
         limits.append(quota)
-    return max(1, min(limits))
+    return min(limits)
+
+
+def available_cpu_count() -> int:
+    """Usable CPUs for this process, honoring cgroup quota and CPU affinity.
+
+    A fractional quota rounds up: a worker pool of that size is right for work
+    that blocks as well as computes. Always at least 1.
+    """
+    return max(1, math.ceil(_cpu_budget()))
 
 
 def cpu_quota() -> int:
@@ -109,12 +119,19 @@ def engine_thread_count() -> int | None:
     llama.cpp sizes its default from host topology (physical cores, minus
     efficiency cores) and cannot see a CFS quota or an affinity mask, so inside a
     CPU-limited container it starts several times more threads than the quota
-    admits and generation slows down: 33.75 tok/s at 8 threads against 13.45 at
-    32, on a pod with 96 visible cores and a 7.65-core quota. Where nothing caps
-    this process, upstream's count is the better informed one and stays.
+    admits and generation collapses. Where nothing caps this process, upstream's
+    count is the better informed one and stays.
+
+    The budget rounds DOWN here, unlike :func:`available_cpu_count`. An engine's
+    threads compute in lockstep across a barrier, so one thread over the quota
+    gets the whole group throttled and every other thread waits for it. Measured
+    on a 96-core pod with a 7.65-core quota, one server generating: 11.4 tok/s at
+    the engine's own count of 48, 60.3 at 8 threads, 63.5 at 7.
 
     Not ``cpu_quota()``: that halves the budget to leave the asyncio scheduler a
     share, which an out-of-process engine does not compete with.
     """
-    quota = available_cpu_count()
-    return quota if quota < (os.cpu_count() or 1) else None
+    budget = _cpu_budget()
+    if budget >= (os.cpu_count() or 1):
+        return None
+    return max(1, math.floor(budget))

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from lilbee.core.config.enums import RerankerType
+from lilbee.providers.fleet import adapters
 from lilbee.providers.fleet.adapters import (
     LLM_RERANK_SPEC,
     ROLE_SPECS,
@@ -182,12 +183,13 @@ def test_build_argv_batch_size_raises_both_batch_and_ubatch() -> None:
     assert argv[argv.index("--ubatch-size") + 1] == "8192"
 
 
-def test_build_argv_never_sets_a_thread_count() -> None:
+def test_build_argv_leaves_the_thread_count_alone_on_an_unconstrained_host(monkeypatch) -> None:
     """llama-server counts physical math cores and skips efficiency cores itself.
 
-    Any count lilbee computes here is worse informed than that default, so the
-    knob is gone rather than merely unused.
+    Where nothing caps this process, that default is better informed than any
+    count lilbee could compute.
     """
+    monkeypatch.setattr(adapters, "engine_thread_count", lambda: None)
     argv = build_server_argv(
         binary=Path("/bin/llama-server"),
         spec=ROLE_SPECS[WorkerRole.VISION],
@@ -201,6 +203,22 @@ def test_build_argv_never_sets_a_thread_count() -> None:
     assert "--threads-batch" not in argv
 
 
+def test_build_argv_caps_threads_at_the_cpu_budget_when_one_applies(monkeypatch) -> None:
+    monkeypatch.setattr(adapters, "engine_thread_count", lambda: 8)
+    argv = build_server_argv(
+        binary=Path("/bin/llama-server"),
+        spec=ROLE_SPECS[WorkerRole.CHAT],
+        model_path=Path("/models/chat.gguf"),
+        devices=(0,),
+        n_gpu_layers=-1,
+        slots=1,
+        ctx_per_slot=4096,
+    )
+    assert argv[argv.index("--threads") + 1] == "8"
+    # llama-server's batch threads default to --threads, so one flag covers both.
+    assert "--threads-batch" not in argv
+
+
 def test_build_argv_omits_optional_flags_by_default() -> None:
     argv = build_server_argv(
         binary=Path("/bin/llama-server"),
@@ -211,7 +229,7 @@ def test_build_argv_omits_optional_flags_by_default() -> None:
         slots=4,
         ctx_per_slot=4096,
     )
-    for flag in ("--flash-attn", "--cache-type-k", "--cache-type-v", "--batch-size", "--threads"):
+    for flag in ("--flash-attn", "--cache-type-k", "--cache-type-v", "--batch-size"):
         assert flag not in argv
 
 

--- a/tests/test_runtime_cpu.py
+++ b/tests/test_runtime_cpu.py
@@ -56,9 +56,10 @@ def _write_cgroup(root: Path, files: dict[str, str]) -> None:
         target.write_text(text)
 
 
-def test_cgroup_v2_quota_ceils_to_cores(tmp_path) -> None:
+def test_cgroup_v2_quota_keeps_the_fraction(tmp_path) -> None:
+    # Unrounded: available_cpu_count rounds it up, engine_thread_count down.
     _write_cgroup(tmp_path, {"cpu.max": "250000 100000\n"})
-    assert _cgroup_cpu_quota(tmp_path) == 3  # ceil(2.5)
+    assert _cgroup_cpu_quota(tmp_path) == 2.5
 
 
 def test_cgroup_v2_unlimited_is_none(tmp_path) -> None:
@@ -90,6 +91,14 @@ def test_cgroup_v1_unlimited_is_none(tmp_path) -> None:
 
 def test_cgroup_absent_is_none(tmp_path) -> None:
     assert _cgroup_cpu_quota(tmp_path) is None
+
+
+def test_available_cpu_count_rounds_a_fractional_quota_up() -> None:
+    with (
+        mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=7.65),
+    ):
+        assert available_cpu_count() == 8
 
 
 def test_available_cpu_count_takes_min_of_signals() -> None:
@@ -125,14 +134,38 @@ def test_available_cpu_count_floors_at_one() -> None:
 def test_engine_thread_count_is_none_when_nothing_constrains_the_process() -> None:
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=16),
-        mock.patch("lilbee.runtime.cpu.available_cpu_count", return_value=16),
+        mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=None),
+        mock.patch(
+            "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(16)), create=True
+        ),
     ):
         assert engine_thread_count() is None
 
 
-def test_engine_thread_count_is_the_quota_when_it_is_below_visible_cores() -> None:
+def test_engine_thread_count_rounds_a_fractional_quota_down() -> None:
+    # 7 threads out-generate 8 on a 7.65-core quota: the eighth gets the whole
+    # lockstep group throttled (measured 63.5 vs 60.3 tok/s).
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
-        mock.patch("lilbee.runtime.cpu.available_cpu_count", return_value=8),
+        mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=7.65),
+    ):
+        assert engine_thread_count() == 7
+
+
+def test_engine_thread_count_follows_an_affinity_mask() -> None:
+    with (
+        mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=None),
+        mock.patch(
+            "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(8)), create=True
+        ),
     ):
         assert engine_thread_count() == 8
+
+
+def test_engine_thread_count_floors_at_one() -> None:
+    with (
+        mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=0.4),
+    ):
+        assert engine_thread_count() == 1

--- a/tests/test_runtime_cpu.py
+++ b/tests/test_runtime_cpu.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from unittest import mock
 
-from lilbee.runtime.cpu import _cgroup_cpu_quota, available_cpu_count, cpu_quota
+from lilbee.runtime.cpu import (
+    _cgroup_cpu_quota,
+    available_cpu_count,
+    cpu_quota,
+    engine_thread_count,
+)
 
 
 def test_default_is_half_of_available() -> None:
@@ -115,3 +120,19 @@ def test_available_cpu_count_floors_at_one() -> None:
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=None),
     ):
         assert available_cpu_count() >= 1
+
+
+def test_engine_thread_count_is_none_when_nothing_constrains_the_process() -> None:
+    with (
+        mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=16),
+        mock.patch("lilbee.runtime.cpu.available_cpu_count", return_value=16),
+    ):
+        assert engine_thread_count() is None
+
+
+def test_engine_thread_count_is_the_quota_when_it_is_below_visible_cores() -> None:
+    with (
+        mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        mock.patch("lilbee.runtime.cpu.available_cpu_count", return_value=8),
+    ):
+        assert engine_thread_count() == 8

--- a/tests/test_runtime_cpu.py
+++ b/tests/test_runtime_cpu.py
@@ -49,6 +49,14 @@ def test_env_override_rejects_non_integer(monkeypatch, caplog) -> None:
     assert any("LILBEE_CPU_QUOTA" in rec.message for rec in caplog.records)
 
 
+def _affinity(cpus: int):
+    """Pin the affinity signal. Unpatched, the runner's own mask joins the min
+    and a test that fixes cpu_count and the quota still reads the host."""
+    return mock.patch(
+        "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(cpus)), create=True
+    )
+
+
 def _write_cgroup(root: Path, files: dict[str, str]) -> None:
     for rel, text in files.items():
         target = root / rel
@@ -96,6 +104,7 @@ def test_cgroup_absent_is_none(tmp_path) -> None:
 def test_available_cpu_count_rounds_a_fractional_quota_up() -> None:
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        _affinity(96),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=7.65),
     ):
         assert available_cpu_count() == 8
@@ -104,9 +113,7 @@ def test_available_cpu_count_rounds_a_fractional_quota_up() -> None:
 def test_available_cpu_count_takes_min_of_signals() -> None:
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=128),
-        mock.patch(
-            "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(64)), create=True
-        ),
+        _affinity(64),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=8),
     ):
         assert available_cpu_count() == 8
@@ -115,9 +122,7 @@ def test_available_cpu_count_takes_min_of_signals() -> None:
 def test_available_cpu_count_ignores_absent_quota() -> None:
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=16),
-        mock.patch(
-            "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(16)), create=True
-        ),
+        _affinity(16),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=None),
     ):
         assert available_cpu_count() == 16
@@ -135,9 +140,7 @@ def test_engine_thread_count_is_none_when_nothing_constrains_the_process() -> No
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=16),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=None),
-        mock.patch(
-            "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(16)), create=True
-        ),
+        _affinity(16),
     ):
         assert engine_thread_count() is None
 
@@ -147,6 +150,7 @@ def test_engine_thread_count_rounds_a_fractional_quota_down() -> None:
     # lockstep group throttled (measured 63.5 vs 60.3 tok/s).
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        _affinity(96),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=7.65),
     ):
         assert engine_thread_count() == 7
@@ -156,9 +160,7 @@ def test_engine_thread_count_follows_an_affinity_mask() -> None:
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=None),
-        mock.patch(
-            "lilbee.runtime.cpu.os.sched_getaffinity", return_value=set(range(8)), create=True
-        ),
+        _affinity(8),
     ):
         assert engine_thread_count() == 8
 
@@ -166,6 +168,7 @@ def test_engine_thread_count_follows_an_affinity_mask() -> None:
 def test_engine_thread_count_floors_at_one() -> None:
     with (
         mock.patch("lilbee.runtime.cpu.os.cpu_count", return_value=96),
+        _affinity(96),
         mock.patch("lilbee.runtime.cpu._cgroup_cpu_quota", return_value=0.4),
     ):
         assert engine_thread_count() == 1


### PR DESCRIPTION
## Problem
A container can advertise far more CPUs than it may use. A RunPod A40 reports 96 cores but its cgroup quota allows 7.65 cores of CPU time. llama.cpp cannot see that limit: it counts visible cores and starts a thread per physical core, roughly 48. Those threads run in lockstep across a barrier, so once the kernel throttles the group for exceeding its quota, every thread waits on the throttled ones and generation collapses.

## Solution
Every spawned server gets `--threads` at the process's real CPU budget whenever a cgroup quota or affinity mask caps it below the visible core count. `--threads-batch` follows `--threads`, so prompt processing is covered by the one flag. Where nothing caps the process no flag is emitted, and the engine keeps its own count, which knows about efficiency cores and SMT siblings where ours does not.

## The budget rounds down
7.65 cores becomes 7 threads, not 8. One thread more than the quota can run is enough to get the whole lockstep group throttled.

## Validated on the pod, not just simulated
This branch installed on a RunPod A40 (cgroup v1, 7.65-core quota, 96 visible cores), calling its own functions against the real cgroup. The last row is the command line lilbee actually built:

| lilbee function | normally | under `taskset -c 0-3` |
|---|---|---|
| `_cgroup_cpu_quota()` reads the cgroup | 7.65 cores | 7.65 cores |
| `_cpu_budget()` folds in the affinity mask | 7.65 | 4.0 |
| `available_cpu_count()` sizes worker pools (rounds up) | 8 | 4 |
| `engine_thread_count()` sizes the engine (rounds down) | 7 | 4 |
| the argv `build_server_argv` produced | `--threads 7` | `--threads 4` |

The `taskset` column pins the process to 4 CPUs, which is tighter than the quota, and the budget follows the mask instead. Both paths work.

## What the thread count is worth
Qwen2.5-0.5B Q8_0 generating 128 tokens, 3 interleaved reps, medians. "Total" sums the servers; "slowest" is the worst single server, which is the latency a waiting user feels.

| configuration | threads | model on | tok/s total | slowest | vs engine default |
|---|---|---|---|---|---|
| 1 server, what lilbee does today | ~48 (engine's own) | CPU | 10.81 | 10.81 | baseline |
| 1 server, **this PR** | 7 | CPU | **65.09** | 65.09 | **6.0x** |
| 1 server, if the budget rounded up | 8 | CPU | 62.05 | 62.05 | 5.7x |
| 2 servers busy at once, **this PR** | 7 each | CPU | **59.75** | 29.33 | - |
| 2 servers busy at once, rounding up | 8 each | CPU | 57.94 | 28.66 | - |
| 1 server, today | ~48 (engine's own) | GPU | 449.95 | 449.95 | baseline |
| 1 server, this PR | 7 | GPU | 450.80 | 450.80 | 1.00x |
| 1 server, rounding up | 8 | GPU | 454.34 | 454.34 | 1.01x |
| 2 servers, today | ~48 (engine's own) | GPU | 510.65 | 254.38 | baseline |
| 2 servers, this PR | 7 each | GPU | 511.13 | 254.55 | 1.00x |
| 2 servers, rounding up | 8 each | GPU | 510.45 | 254.26 | 1.00x |

Read the two halves against each other. With the model on the CPU, capping the threads is worth 6x and rounding down another 5%. With the model on the GPU the CPU threads barely work, so every arm lands within 1% of every other: the flag cannot hurt the deployment most fleets run, which is what makes it safe to emit whenever a cap applies.

## Not covered
The two-server CPU default arm was dropped from this run: under the CUDA build it decodes at ~0.14 tok/s per server, and the same collapse was measured twice on the CPU-only build (1.93 and 1.89 tok/s total). cgroup v2 parsing is unit-tested only; both pods came up v1. Windows job-object CPU limits are not read at all, so a capped Windows container gets no flag.

Each instance is sized against the whole quota, so several busy servers can still oversubscribe it. Dividing the quota between them measured 45% faster when both generate at once and 32% slower when only one does, and llama-server fixes its thread count at launch, so there is no adaptive middle. Full quota per instance is the better default for an interactive workload.