### PR TITLE
Run the formatter over two files that landed unformatted

### DIFF
--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -610,9 +610,7 @@ class Searcher:
         query_vec = self._embedder.embed_query(question)
         # Retrieve the reranker's candidate depth when one is loaded, else top_k.
         retrieve_k = (
-            max(top_k, self._config.rerank_candidates)
-            if self._config.reranker_model
-            else top_k
+            max(top_k, self._config.rerank_candidates) if self._config.reranker_model else top_k
         )
         results = self._store.search(
             query_vec,

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -302,9 +302,7 @@ class TestSearchAppliesReranker:
         cfg.reranker_model = _RERANKER_MODEL
         reranker = mock.MagicMock()
         searcher, _ = self._searcher(reranker)
-        monkeypatch.setattr(
-            searcher, "_search_structured", lambda *a, **k: [_chunk("a.md", "A")]
-        )
+        monkeypatch.setattr(searcher, "_search_structured", lambda *a, **k: [_chunk("a.md", "A")])
         monkeypatch.setattr(searcher, "_apply_temporal_filter", lambda r, q: r)
         searcher.search("vec:plain query", top_k=5)
         reranker.rerank.assert_not_called()


### PR DESCRIPTION
## Problem

`main` fails `make format-check` on `retrieval/query/searcher.py` and `tests/test_reranker.py`, so every branch cut from it inherits a red gate.

## Solution

Ran the formatter. Whitespace only, two lines net, no logic change.