### PR TITLE
Finish an add when some files skip instead of failing the whole task

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -41,6 +41,7 @@ from lilbee.app.version import get_version
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp, apply_active_model
 from lilbee.cli.tui.screens.chat_helpers import (
+    add_indexed_anything,
     build_add_progress_callback,
     build_import_progress_callback,
     build_sync_progress_callback,
@@ -768,8 +769,13 @@ class ChatScreen(Screen[None]):
             unregister_added_roots(registered)
             raise RuntimeError(msg.SYNC_FAILED_FILES.format(files=", ".join(sync_result.failed)))
         if sync_result.skipped:
-            unregister_added_roots(registered)
-            raise RuntimeError(msg.sync_skipped_message(", ".join(sync_result.skipped)))
+            # Files yielding no text beside indexed siblings are a partial
+            # success; only an add whose own roots contributed nothing failed.
+            skipped_msg = msg.sync_skipped_message(", ".join(sync_result.skipped))
+            if registered and not add_indexed_anything(registered, sync_result):
+                unregister_added_roots(registered)
+                raise RuntimeError(skipped_msg)
+            call_from_thread(self, self.notify, skipped_msg, severity="warning")
         if sync_result.relocated:
             call_from_thread(
                 self,

--- a/src/lilbee/cli/tui/screens/chat_helpers.py
+++ b/src/lilbee/cli/tui/screens/chat_helpers.py
@@ -10,7 +10,7 @@ import time
 import webbrowser
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -29,6 +29,9 @@ from lilbee.runtime.progress import (
     ProgressEvent,
     SyncDoneEvent,
 )
+
+if TYPE_CHECKING:
+    from lilbee.data.types import SyncResult
 
 log = logging.getLogger(__name__)
 
@@ -143,6 +146,19 @@ def unregister_added_roots(labels: list[str]) -> None:
 
     if labels:
         unregister_roots(labels)
+
+
+def add_indexed_anything(registered: list[str], result: SyncResult) -> bool:
+    """Whether any file under this add's registered roots reached the index.
+
+    Sync is global, so its added/updated/relocated lists can name files from
+    other sources; only names keyed under a registered label count. A directory
+    root keys files as ``label/relpath``; a single-file root keys as ``label``.
+    """
+    indexed = (*result.added, *result.updated, *result.relocated)
+    return any(
+        name == root or name.startswith(f"{root}/") for root in registered for name in indexed
+    )
 
 
 def _throttled_embed_tick(reporter: ProgressReporter) -> Callable[[EmbedEvent], None]:

--- a/tests/test_chat_add_cancel.py
+++ b/tests/test_chat_add_cancel.py
@@ -169,3 +169,26 @@ class TestDoAddCancelCleanup:
 
         assert "corpus" not in cfg.linked_roots
         assert (source / "a.txt").exists()
+
+
+@pytest.mark.parametrize(
+    ("registered", "result", "expected"),
+    [
+        pytest.param(["corpus"], {"added": ["corpus/a.py"]}, True, id="file_under_root"),
+        pytest.param(["scan.pdf"], {"added": ["scan.pdf"]}, True, id="single_file_root"),
+        pytest.param(["corpus"], {"updated": ["corpus/a.py"]}, True, id="updated_counts"),
+        pytest.param(["corpus"], {"relocated": ["corpus/a.py"]}, True, id="relocated_counts"),
+        pytest.param(
+            ["scan.pdf"], {"added": ["other.md"], "unchanged": 5}, False, id="other_sources_only"
+        ),
+        pytest.param(
+            ["corpus"], {"added": ["corpus2/a.py"]}, False, id="prefix_not_a_path_boundary"
+        ),
+        pytest.param(["corpus"], {}, False, id="nothing_indexed"),
+    ],
+)
+def test_add_indexed_anything(registered, result, expected):
+    from lilbee.cli.tui.screens.chat_helpers import add_indexed_anything
+    from lilbee.data.types import SyncResult
+
+    assert add_indexed_anything(registered, SyncResult(**result)) is expected

--- a/tests/test_chat_controller_integration.py
+++ b/tests/test_chat_controller_integration.py
@@ -1093,8 +1093,58 @@ def test_do_sync_notifies_on_skipped(tmp_path: Path) -> None:
     assert any("scan.pdf" in str(call) for call in notify_calls)
 
 
-def test_do_add_raises_on_skipped(tmp_path: Path) -> None:
-    """When sync returns skipped files, _do_add raises so the worker surfaces the error."""
+def test_do_add_skipped_alongside_indexed_is_partial_success(tmp_path: Path) -> None:
+    """Skipped files beside indexed ones finish the add: warn, keep roots, no raise."""
+    import threading
+
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.data.types import SyncResult
+
+    src = tmp_path / "corpus"
+    src.mkdir()
+    screen = ChatScreen.__new__(ChatScreen)
+    reporter = MagicMock(spec=ProgressReporter)
+
+    from lilbee.app.ingest import RegisterResult
+
+    reg_result = RegisterResult(registered=[src.name], skipped=[])
+    captured: list[Exception] = []
+    notify_calls: list[tuple[object, ...]] = []
+    unregister = MagicMock()
+
+    def _worker() -> None:
+        try:
+            screen.notify = lambda *a, **kw: None  # type: ignore[assignment]
+            with (
+                patch("lilbee.app.ingest.register_sources", return_value=reg_result),
+                patch(
+                    "lilbee.runtime.asyncio_loop.run",
+                    new=MagicMock(
+                        return_value=SyncResult(
+                            added=["corpus/store.py"], skipped=["corpus/__init__.py"]
+                        )
+                    ),
+                ),
+                patch("lilbee.cli.tui.screens.chat.unregister_added_roots", new=unregister),
+                patch(
+                    "lilbee.cli.tui.screens.chat.call_from_thread",
+                    side_effect=lambda *a, **kw: notify_calls.append(a),
+                ),
+            ):
+                screen._do_add([src], reporter)
+        except Exception as e:
+            captured.append(e)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    t.join(timeout=5)
+    assert not captured, f"partial success must not raise: {captured}"
+    unregister.assert_not_called()
+    assert any("__init__.py" in str(call) for call in notify_calls)
+
+
+def test_do_add_raises_when_nothing_indexed(tmp_path: Path) -> None:
+    """Every file skipped and nothing indexed: the add failed and its roots are dropped."""
     import threading
 
     from lilbee.cli.tui.screens.chat import ChatScreen
@@ -1109,6 +1159,7 @@ def test_do_add_raises_on_skipped(tmp_path: Path) -> None:
 
     reg_result = RegisterResult(registered=[src.name], skipped=[])
     captured: list[Exception] = []
+    unregister = MagicMock()
 
     def _worker() -> None:
         try:
@@ -1119,7 +1170,7 @@ def test_do_add_raises_on_skipped(tmp_path: Path) -> None:
                     "lilbee.runtime.asyncio_loop.run",
                     new=MagicMock(return_value=SyncResult(skipped=["scan.pdf"])),
                 ),
-                patch("lilbee.cli.tui.screens.chat.unregister_added_roots"),
+                patch("lilbee.cli.tui.screens.chat.unregister_added_roots", new=unregister),
             ):
                 screen._do_add([src], reporter)
         except Exception as e:
@@ -1129,6 +1180,51 @@ def test_do_add_raises_on_skipped(tmp_path: Path) -> None:
     t.start()
     t.join(timeout=5)
     assert captured and "scan.pdf" in str(captured[0])
+    unregister.assert_called_once()
+
+
+def test_do_add_other_sources_do_not_mask_a_dead_add(tmp_path: Path) -> None:
+    """Sync is global: activity on other sources must not turn an all-skipped add into a success."""
+    import threading
+
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.data.types import SyncResult
+
+    src = tmp_path / "scan.pdf"
+    src.write_bytes(b"x")
+    screen = ChatScreen.__new__(ChatScreen)
+    reporter = MagicMock(spec=ProgressReporter)
+
+    from lilbee.app.ingest import RegisterResult
+
+    reg_result = RegisterResult(registered=[src.name], skipped=[])
+    captured: list[Exception] = []
+    unregister = MagicMock()
+
+    def _worker() -> None:
+        try:
+            screen.notify = lambda *a, **kw: None  # type: ignore[assignment]
+            with (
+                patch("lilbee.app.ingest.register_sources", return_value=reg_result),
+                patch(
+                    "lilbee.runtime.asyncio_loop.run",
+                    new=MagicMock(
+                        return_value=SyncResult(
+                            added=["other-doc.md"], unchanged=5, skipped=["scan.pdf"]
+                        )
+                    ),
+                ),
+                patch("lilbee.cli.tui.screens.chat.unregister_added_roots", new=unregister),
+            ):
+                screen._do_add([src], reporter)
+        except Exception as e:
+            captured.append(e)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    t.join(timeout=5)
+    assert captured and "scan.pdf" in str(captured[0])
+    unregister.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Adding a directory where a few files yield no extractable text (empty `__init__.py` files, scans without OCR) reports the entire add as failed at 100%, even though every other file indexed and answers queries. The roots the add registered are also dropped. Anything watching the task for a terminal done state hangs, because done never comes for work that succeeded.

## Solution

Skipped files beside indexed ones now finish the add: the task completes and a warning toast lists the skipped files, the same way plain `/sync` already reports them. Failure, and the root cleanup that goes with it, is reserved for an add that indexed nothing.

Sync is global, so the sync totals can include activity from other sources; the indexed-anything check is scoped to the add's own registered roots (`label` or `label/...` keys) so unrelated activity cannot mask a dead add.