### PR TITLE
Mask credentials echoed back by the /set command

### DIFF
--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -875,6 +875,13 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         secret=True,
         help_text="DeepSeek API key (enables frontier models in chat picker)",
     ),
+    "llm_api_key": SettingDef(
+        str,
+        nullable=False,
+        group=SettingGroup.API_KEYS,
+        secret=True,
+        help_text="API key for the remote OpenAI-compatible endpoint (llm_provider = remote)",
+    ),
     "hf_token": SettingDef(
         str,
         nullable=False,

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -123,6 +123,8 @@ IMPORT_STATUS_LOADING = "Loading dataset..."
 EXPORT_STATUS_RUNNING = "Exporting..."
 CMD_SET_UNKNOWN = "Unknown setting: {key}"
 CMD_SET_SUCCESS = "{key} = {value}"
+# Stands in for a credential's value wherever one would otherwise be echoed.
+MASKED_VALUE = "************"
 CMD_SET_INVALID = "Invalid value for {key}: {error}"
 CMD_SET_TYPE_HINT = "{key} needs {kind}"
 CMD_SET_CHOICES = "{key} must be one of {choices}"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1314,7 +1314,8 @@ class ChatScreen(Screen[None]):
             # (model bar, scope chip, status bar) refresh. The boundary's
             # _invalidate_caches now handles llm_provider service reset.
             self.app.set_setting(key, parsed)
-            self.notify(msg.CMD_SET_SUCCESS.format(key=key, value=parsed))
+            shown = msg.MASKED_VALUE if defn.secret and parsed else parsed
+            self.notify(msg.CMD_SET_SUCCESS.format(key=key, value=shown))
         except (ValueError, TypeError) as exc:
             self.notify(msg.CMD_SET_INVALID.format(key=key, error=exc), severity="error")
 

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1319,3 +1319,27 @@ class TestForYouByRole:
             )
         ]
         assert for_you_by_role(rows) == []
+
+
+async def test_spinner_tick_updates_the_loading_more_hint() -> None:
+    """The mid-fetch hint refresh, driven directly rather than via a timer race.
+
+    Only a real interval tick landing while a page fetch was in flight reached
+    this branch, so it covered on fast runners and not on slow ones.
+    """
+    from textual.widgets import Static
+
+    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = pilot.app.query_one(CatalogScreen)
+        screen._activation_settled = True
+        screen._active_tab_id_cache = "chat"
+        screen._grid_view = True
+        hint = screen._grid_container.query_one(".scroll-hint", Static)
+
+        screen._loading_more = True
+        screen._spinner_frame = 0
+        screen._tick_loading_spinner()
+        await pilot.pause()
+
+        assert "loading more models" in str(hint.render()).lower()

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1329,13 +1329,18 @@ async def test_spinner_tick_updates_the_loading_more_hint() -> None:
     """
     from textual.widgets import Static
 
+    from tests._async_wait import wait_until
+
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         screen = pilot.app.query_one(CatalogScreen)
         screen._activation_settled = True
         screen._active_tab_id_cache = "chat"
         screen._grid_view = True
-        hint = screen._grid_container.query_one(".scroll-hint", Static)
+        # The hint mounts via the compose cascade, which needs more than one
+        # tick on the slower runners.
+        await wait_until(pilot, lambda: bool(screen.query("#grid-chat .scroll-hint")))
+        hint = screen.query_one("#grid-chat .scroll-hint", Static)
 
         screen._loading_more = True
         screen._spinner_frame = 0

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -735,3 +735,37 @@ class TestConcurrentConfigWrites:
             held.release()
         assert settings.get(tmp_path, "key") == "value"
         assert "Timed out waiting" in caplog.text
+
+
+class TestCredentialsAreMaskable:
+    """Every credential must reach the settings surface marked as one.
+
+    ``llm_api_key`` was writable but absent from SETTINGS_MAP, so the remote
+    provider's key could not be set from the TUI at all, and nothing marked it
+    for masking.
+    """
+
+    @staticmethod
+    def _write_only_fields() -> set[str]:
+        from lilbee.core.config.model import Config
+
+        found = set()
+        for name, info in Config.model_fields.items():
+            extra = info.json_schema_extra or {}
+            if isinstance(extra, dict) and extra.get("write_only"):
+                found.add(name)
+        return found
+
+    def test_every_write_only_field_is_editable(self):
+        missing = self._write_only_fields() - set(SETTINGS_MAP)
+        assert not missing, f"credentials absent from the settings surface: {sorted(missing)}"
+
+    def test_every_write_only_field_is_marked_secret(self):
+        unmarked = {f for f in self._write_only_fields() if not SETTINGS_MAP[f].secret}
+        assert not unmarked, f"credentials that would render in the clear: {sorted(unmarked)}"
+
+    def test_no_credential_is_exposed_by_the_public_config_api(self):
+        from lilbee.config_meta import PUBLIC_CONFIG_FIELDS
+
+        leaked = self._write_only_fields() & set(PUBLIC_CONFIG_FIELDS)
+        assert not leaked, f"credentials returned by GET /api/config: {sorted(leaked)}"

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3103,6 +3103,30 @@ async def test_chat_slash_set_unknown_key():
             assert "Unknown setting" in mock_notify.call_args[0][0]
 
 
+async def test_chat_slash_set_masks_a_credential_in_the_echo():
+    """/set confirms a credential without printing it back in the toast."""
+    from lilbee.app.settings_map import SETTINGS_MAP
+
+    secret_key = next(k for k, d in SETTINGS_MAP.items() if d.secret and d.writable)
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with patch.object(app.screen, "notify") as mock_notify:
+            app.screen._cmd_set(f"{secret_key} sk-live-do-not-print-me")
+            message = mock_notify.call_args[0][0]
+    assert "sk-live-do-not-print-me" not in message
+    assert secret_key in message
+
+
+async def test_chat_slash_set_still_echoes_a_non_credential():
+    """Masking is keyed on the secret flag, not applied to every setting."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with patch.object(app.screen, "notify") as mock_notify:
+            app.screen._cmd_set("top_k 10")
+            message = mock_notify.call_args[0][0]
+    assert "10" in message
+
+
 async def test_chat_slash_set_invalid_value():
     """A type mismatch reads as human copy, never a raw Python exception."""
     app = ChatTestApp()


### PR DESCRIPTION
## Problem

`/set openai_api_key sk-live-…` from the chat input popped a toast reading `openai_api_key = sk-live-…`. `CMD_SET_SUCCESS` echoes `{value}` and every provider key is writable, so the credential printed in the clear.

## Why the settings-pane masking missed it

`/set` is generic over `SETTINGS_MAP` and never names a credential literally, so it does not turn up when grepping for the key names or for password-capable `Input` widgets.

## Solution

Mask the echoed value on the existing `secret` flag. The confirmation still names the key, so the command reads the same.

## Other surfaces

`GET /api/config` filters through an allowlist that contains none of the seven credentials. No CLI command reads one from `cfg`. `/set` was the only echo site.

## Lint note

The mask constant is `MASKED_VALUE`, not `SECRET_MASK`, because ruff S105 flags the latter name as a hardcoded password.
