### PR TITLE
Report AMD GPU activity from power draw instead of the pegged busy flag

### DIFF
--- a/src/lilbee/providers/fleet/gpu_backends/amd.py
+++ b/src/lilbee/providers/fleet/gpu_backends/amd.py
@@ -1,4 +1,9 @@
-"""ROCm/HIP GPU utilization via amd-smi (preferred) or rocm-smi (fallback)."""
+"""ROCm/HIP GPU utilization via rocm-smi (preferred) or amd-smi (fallback).
+
+rocm-smi leads because it reports power draw, the board power cap, and VRAM in
+one call; amd-smi (checked on AMDSMI 26.0.2 / MI300X) exposes no power cap in
+metric or static output, so its path cannot derive power-based activity and
+reports the raw busy flag instead."""
 
 from __future__ import annotations
 
@@ -44,12 +49,12 @@ _TIMEOUT_S = 5.0
 
 
 class AmdBackend:
-    """ROCm/HIP util via amd-smi, falling back to rocm-smi."""
+    """ROCm/HIP util via rocm-smi, falling back to amd-smi."""
 
     def sample(self, indices: frozenset[int]) -> dict[int, UtilSample]:
-        result = _amd_smi_samples(indices)
+        result = _rocm_smi_samples(indices)
         if not result:
-            result = _rocm_smi_samples(indices)
+            result = _amd_smi_samples(indices)
         return result
 
 
@@ -79,8 +84,12 @@ def _parse_amd_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
         data = json.loads(raw)
     except json.JSONDecodeError:
         return {}
-    # amd-smi metric --json emits a list of GPU objects or {"gpu": [...]}.
-    items: list[object] = data if isinstance(data, list) else data.get("gpu", [])
+    # amd-smi metric --json emits a list of GPU objects, {"gpu": [...]}, or
+    # {"gpu_data": [...]} (AMDSMI 26.x, seen on MI300X).
+    if isinstance(data, list):
+        items: list[object] = data
+    else:
+        items = data.get("gpu_data") or data.get("gpu", [])
     samples: dict[int, UtilSample] = {}
     for item in items:
         if not isinstance(item, dict):
@@ -136,7 +145,16 @@ def _parse_rocm_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
         cap = extract_int(val, _ROCM_POWER_CAP_KEYS)
         if power is not None and cap:
             util = min(100, round(power * 100 / cap))
-        temp = extract_int(val, ("Temperature (Sensor edge) (C)", "temp_edge", "temp"))
+        # Datacenter cards (MI300X) have no edge sensor; junction carries it.
+        temp = extract_int(
+            val,
+            (
+                "Temperature (Sensor edge) (C)",
+                "Temperature (Sensor junction) (C)",
+                "temp_edge",
+                "temp",
+            ),
+        )
         # VRAM keys carry byte strings; parse when present.
         total_b = extract_int(val, (_ROCM_VRAM_TOTAL_KEY,))
         used_b = extract_int(val, (_ROCM_VRAM_USED_KEY,))

--- a/src/lilbee/providers/fleet/gpu_backends/amd.py
+++ b/src/lilbee/providers/fleet/gpu_backends/amd.py
@@ -16,11 +16,29 @@ _TOOL_AMD_SMI = "amd-smi"
 _TOOL_ROCM_SMI = "rocm-smi"
 
 _AMD_SMI_ARGS = ("metric", "--usage", "--temperature", "--json")
-_ROCM_SMI_ARGS = ("--showuse", "--showmeminfo", "vram", "--showtemp", "--json")
+_ROCM_SMI_ARGS = (
+    "--showuse",
+    "--showmeminfo",
+    "vram",
+    "--showtemp",
+    "--showpower",
+    "--showmaxpower",
+    "--json",
+)
 
 # rocm-smi key names for VRAM (byte values).
 _ROCM_VRAM_TOTAL_KEY = "VRAM Total Memory (B)"
 _ROCM_VRAM_USED_KEY = "VRAM Total Used Memory (B)"
+
+# amdgpu reports 100% busy whenever a compute context is resident, idle or not,
+# so power draw as a fraction of the board cap is the activity signal on AMD.
+# Consumer cards report "Average Graphics Package Power"; datacenter cards
+# (MI300X) report "Current Socket Graphics Package Power".
+_ROCM_POWER_KEYS = (
+    "Average Graphics Package Power (W)",
+    "Current Socket Graphics Package Power (W)",
+)
+_ROCM_POWER_CAP_KEYS = ("Max Graphics Package Power (W)",)
 
 _TIMEOUT_S = 5.0
 
@@ -92,6 +110,8 @@ def _parse_amd_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
 def _parse_rocm_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
     """Parse rocm-smi JSON into UtilSample per index, or {} on failure.
 
+    utilization_pct is power draw as a percent of the board power cap when both
+    keys are present; the busy flag is the fallback for older rocm-smi output.
     VRAM is parsed when the rocm-smi VRAM keys are present (byte values);
     absent keys leave free_bytes/total_bytes as 0 (structural-fallback sentinel).
     """
@@ -112,6 +132,10 @@ def _parse_rocm_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
         if index is None or index not in indices:
             continue
         util = extract_int(val, ("GPU use (%)", "GPU_UTIL", "gfx_activity"))
+        power = extract_int(val, _ROCM_POWER_KEYS)
+        cap = extract_int(val, _ROCM_POWER_CAP_KEYS)
+        if power is not None and cap:
+            util = min(100, round(power * 100 / cap))
         temp = extract_int(val, ("Temperature (Sensor edge) (C)", "temp_edge", "temp"))
         # VRAM keys carry byte strings; parse when present.
         total_b = extract_int(val, (_ROCM_VRAM_TOTAL_KEY,))

--- a/tests/providers/fleet/gpu_backends/test_amd.py
+++ b/tests/providers/fleet/gpu_backends/test_amd.py
@@ -47,6 +47,19 @@ _ROCM_SMI_JSON_VRAM = (
     "}}"
 )
 
+# Captured on an RX 9060 XT (ROCm 7 / Bazzite): busy flag pegs at 100 whenever a
+# compute context is resident, so power draw is the activity signal.
+_ROCM_SMI_JSON_REAL_9060XT = (
+    '{"card0": {"Temperature (Sensor edge) (C)": "39.0",'
+    ' "Temperature (Sensor junction) (C)": "41.0",'
+    ' "Temperature (Sensor memory) (C)": "61.0",'
+    ' "Max Graphics Package Power (W)": "175.0",'
+    ' "Average Graphics Package Power (W)": "17.0",'
+    ' "GPU use (%)": "100",'
+    ' "VRAM Total Memory (B)": "17095983104",'
+    ' "VRAM Total Used Memory (B)": "9518669824"}}'
+)
+
 
 # ---------------------------------------------------------------------------
 # _parse_amd_smi -- flat shape
@@ -150,6 +163,48 @@ def test_parse_rocm_smi_vram_absent_leaves_sentinel() -> None:
     result = _parse_rocm_smi(_ROCM_SMI_JSON, frozenset({0}))
     assert result[0].free_bytes == 0
     assert result[0].total_bytes == 0
+
+
+def test_parse_rocm_smi_power_overrides_pegged_busy_flag() -> None:
+    """Real 9060 XT capture: busy flag reads 100 at idle; power/cap is the signal."""
+    result = _parse_rocm_smi(_ROCM_SMI_JSON_REAL_9060XT, frozenset({0}))
+    assert result[0].utilization_pct == 10  # round(100 * 17 / 175)
+
+
+def test_parse_rocm_smi_power_socket_key_variant() -> None:
+    """Datacenter cards (MI300X) report socket power under a different key."""
+    raw = (
+        '{"card0": {"Current Socket Graphics Package Power (W)": "375.0",'
+        ' "Max Graphics Package Power (W)": "750.0", "GPU use (%)": "100"}}'
+    )
+    result = _parse_rocm_smi(raw, frozenset({0}))
+    assert result[0].utilization_pct == 50
+
+
+def test_parse_rocm_smi_power_clamped_to_100() -> None:
+    """Transient spikes above the cap clamp to 100."""
+    raw = (
+        '{"card0": {"Average Graphics Package Power (W)": "200.0",'
+        ' "Max Graphics Package Power (W)": "175.0", "GPU use (%)": "100"}}'
+    )
+    result = _parse_rocm_smi(raw, frozenset({0}))
+    assert result[0].utilization_pct == 100
+
+
+def test_parse_rocm_smi_busy_flag_fallback_without_power() -> None:
+    """Power keys absent (older rocm-smi): the busy flag is still reported."""
+    result = _parse_rocm_smi(_ROCM_SMI_JSON, frozenset({0}))
+    assert result[0].utilization_pct == 35
+
+
+def test_parse_rocm_smi_busy_flag_fallback_on_zero_cap() -> None:
+    """A zero/unparseable power cap cannot divide; fall back to the busy flag."""
+    raw = (
+        '{"card0": {"Average Graphics Package Power (W)": "44.0",'
+        ' "Max Graphics Package Power (W)": "0", "GPU use (%)": "100"}}'
+    )
+    result = _parse_rocm_smi(raw, frozenset({0}))
+    assert result[0].utilization_pct == 100
 
 
 def test_parse_rocm_smi_empty_string() -> None:

--- a/tests/providers/fleet/gpu_backends/test_amd.py
+++ b/tests/providers/fleet/gpu_backends/test_amd.py
@@ -1,4 +1,4 @@
-"""Tests for the ROCm/HIP utilization backend (amd-smi + rocm-smi fallback)."""
+"""Tests for the ROCm/HIP utilization backend (rocm-smi preferred, amd-smi fallback)."""
 
 from __future__ import annotations
 
@@ -45,6 +45,32 @@ _ROCM_SMI_JSON_VRAM = (
     '"VRAM Total Memory (B)": "17179869184",'
     '"VRAM Total Used Memory (B)": "2147483648"'
     "}}"
+)
+
+# Captured on an MI300X (AMDSMI 26.0.2 / ROCm 7.0.2): modern amd-smi wraps the
+# device list in a top-level "gpu_data" key, readings are value-wrapped under
+# category blocks, edge temp is "N/A" (only hotspot/mem exist), and no power
+# cap is exposed anywhere in metric or static output.
+_AMD_SMI_JSON_GPU_DATA_MI300X = (
+    '{"gpu_data": [{"gpu": 0,'
+    ' "usage": {"gfx_activity": {"value": 0, "unit": "%"},'
+    ' "umc_activity": {"value": 0, "unit": "%"}, "mm_activity": "N/A"},'
+    ' "power": {"socket_power": {"value": 158, "unit": "W"},'
+    ' "gfx_voltage": "N/A", "power_management": "ENABLED"},'
+    ' "temperature": {"edge": "N/A", "hotspot": {"value": 45, "unit": "C"},'
+    ' "mem": {"value": 38, "unit": "C"}}}]}'
+)
+
+# Captured on an MI300X (rocm-smi, same host): socket power spelling, 750W cap,
+# and no edge temp sensor at all (junction and memory only).
+_ROCM_SMI_JSON_REAL_MI300X = (
+    '{"card0": {"Temperature (Sensor junction) (C)": "45.0",'
+    ' "Temperature (Sensor memory) (C)": "38.0",'
+    ' "Max Graphics Package Power (W)": "750.0",'
+    ' "Current Socket Graphics Package Power (W)": "159.0",'
+    ' "GPU use (%)": "0",'
+    ' "VRAM Total Memory (B)": "205822885888",'
+    ' "VRAM Total Used Memory (B)": "299687936"}}'
 )
 
 # Captured on an RX 9060 XT (ROCm 7 / Bazzite): busy flag pegs at 100 whenever a
@@ -165,6 +191,22 @@ def test_parse_rocm_smi_vram_absent_leaves_sentinel() -> None:
     assert result[0].total_bytes == 0
 
 
+def test_parse_amd_smi_gpu_data_wrapper_real_mi300x() -> None:
+    """AMDSMI 26.x wraps devices in a top-level gpu_data key; parsing must not
+    silently return {} (which previously masked the whole amd-smi path)."""
+    result = _parse_amd_smi(_AMD_SMI_JSON_GPU_DATA_MI300X, frozenset({0}))
+    assert result[0].utilization_pct == 0
+    assert result[0].temperature_c == 45  # edge is N/A; hotspot carries the reading
+
+
+def test_parse_rocm_smi_junction_temp_fallback_real_mi300x() -> None:
+    """MI300X has no edge sensor; junction is the reading. Power 159/750 -> 21%."""
+    result = _parse_rocm_smi(_ROCM_SMI_JSON_REAL_MI300X, frozenset({0}))
+    assert result[0].temperature_c == 45
+    assert result[0].utilization_pct == 21
+    assert result[0].total_bytes == 205822885888
+
+
 def test_parse_rocm_smi_power_overrides_pegged_busy_flag() -> None:
     """Real 9060 XT capture: busy flag reads 100 at idle; power/cap is the signal."""
     result = _parse_rocm_smi(_ROCM_SMI_JSON_REAL_9060XT, frozenset({0}))
@@ -225,23 +267,28 @@ def test_parse_rocm_smi_non_dict_top_level() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sample_uses_amd_smi_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sample_prefers_rocm_smi_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """rocm-smi carries power, cap, and VRAM in one call, so it leads even when
+    amd-smi is present (which exposes no power cap at all, verified on MI300X)."""
     monkeypatch.setattr(
         amd_mod,
         "run_smi",
-        lambda tool, *_a, **_k: _AMD_SMI_JSON_FLAT if tool == amd_mod._TOOL_AMD_SMI else "",
+        lambda tool, *_a, **_k: (
+            _ROCM_SMI_JSON_REAL_MI300X if tool == amd_mod._TOOL_ROCM_SMI else _AMD_SMI_JSON_FLAT
+        ),
     )
     result = AmdBackend().sample(frozenset({0}))
-    assert result[0].utilization_pct == 72
+    assert result[0].utilization_pct == 21  # power-derived, not the flat 72 busy value
 
 
-def test_falls_back_to_rocm_smi_when_amd_smi_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_falls_back_to_amd_smi_when_rocm_smi_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     def _run_smi(tool: str, *_a: object, **_k: object) -> str:
-        return "" if tool == amd_mod._TOOL_AMD_SMI else _ROCM_SMI_JSON
+        return "" if tool == amd_mod._TOOL_ROCM_SMI else _AMD_SMI_JSON_GPU_DATA_MI300X
 
     monkeypatch.setattr(amd_mod, "run_smi", _run_smi)
     result = AmdBackend().sample(frozenset({0}))
-    assert result[0].utilization_pct == 35
+    assert result[0].utilization_pct == 0
+    assert result[0].temperature_c == 45
 
 
 def test_sample_returns_empty_when_both_tools_return_empty(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem
On AMD, the live GPU utilization reads a constant 100% whenever a llama-server is resident, idle or generating: amdgpu pins `gpu_busy_percent` for any process holding a compute context. The fleet panel bar carries no signal, and the adaptive ingest controller sees the GPU as permanently saturated. Verified on an RX 9060 XT: 100% at the 17W idle floor and at 103W generation alike. Fixes #676 (rocm-smi half).

## Solution
Sample `--showpower`/`--showmaxpower` in the same rocm-smi call and report utilization as power draw over the board cap, clamped to 100. The busy flag remains the fallback when power keys are absent. Covers both the consumer key and the MI300X socket-power spelling; fixtures use JSON captured from real hardware.

## Verified on hardware
Live on the RX 9060 XT: 10% bare idle, 25–26% model resident, 94–100% during prompt processing, 26–30% during decode — where every post-load sample previously read 100%.

## amd-smi grounding (second commit)
Real AMDSMI 26.x captures from an MI300X grounded the amd-smi path: the gpu_data JSON wrapper now parses (it previously returned nothing and always fell through), rocm-smi leads because amd-smi exposes no power cap, and rocm-smi temps gain the junction fallback datacenter cards need. Both dispatch paths verified live on the MI300X.
The amd-smi path still reports the busy flag; grounding its power parsing needs captured JSON from a machine that ships amd-smi.
