### PR TITLE
Show the reels the README and site were missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,6 @@ Either way, your files and the index stay on your computer. Only what you ask an
 
 When a chat model won't fit on a single GPU, lilbee spreads it across the ones you have. It sizes each role's memory with gguf-parser, keeps headroom on every card, and tensor-splits the chat model across the fewest GPUs that fit, with the embedder, reranker, and vision models placed alongside it behind a load-balancing router. This is automatic: ask a question and the model loads split across your cards, answering from your own indexed source.
 
-![a model too big for one card auto-split across the GPUs, answering from lilbee's own indexed source](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-multi-gpu-self-index.gif)
-
 You can also place it by hand. The placement editor pins each role to the cards you choose, previews the fit before anything loads, and applies it live. Ask for a layout that can't fit and it tells you the exact shortfall instead of failing at load time.
 
 ![the placement editor: a too-small layout refused with the exact shortfall, then spread across the cards and applied](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.gif)

--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ One representative per architecture family, pulled with `lilbee model pull` and 
 - **They stay read-only.** lilbee lists and runs them but never pulls or deletes them, so their lifecycle stays in the app you already use.
 - **On `pip` / `uv`,** this needs the `[litellm]` extra (`pip install --pre 'lilbee[litellm]'`); the Homebrew, AUR, Nix, Docker, Flatpak, and Snap builds already include it. See [Install](#install).
 
+Both reels run chat *and* embedding on the other manager's models, picked out of the catalog's Library tab where each row names the server it runs on.
+
+![models served by Ollama, picked from the catalog, answering from an indexed manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-ollama-document.gif)
+
+![models served by LM Studio, picked from the catalog, answering from an indexed manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-lmstudio-document.gif)
+
 ### See when a model won't load before you download it
 
 Hugging Face has thousands of GGUFs, but the bundled llama.cpp only supports a subset of architectures and brand-new ones take time to reach the pinned runtime. lilbee tags incompatible models in the catalog and refuses the download (with an override confirm), so you don't wait through a multi-GB pull only to hit "unsupported architecture" at load.
@@ -334,6 +340,20 @@ You can also place it by hand. The placement editor pins each role to the cards 
 `Ctrl+P` opens the Textual command palette, `?` on an empty prompt (or `F1` anywhere) toggles the keybinding cheat sheet, `/help` opens the slash-command catalog. Every action lilbee can take is reachable from one of those three.
 
 ![command palette, keybinding cheat sheet, slash-command catalog](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-palette.gif)
+
+Conversations are kept. Reopen an earlier one and it comes back with its history and citations intact.
+
+![resume an earlier conversation from the sessions drawer](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/sessions.gif)
+
+Tell it something about yourself and it remembers, across conversations rather than only within one.
+
+![remember a fact and a preference, then answer from them in a brand new chat](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-memory.gif)
+
+Every setting is editable in the app, and a first run walks you through picking models.
+
+![walk every settings pane without leaving the terminal](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-settings.gif)
+
+![the first-run wizard: pick a chat model and an embedding model, and go](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-setup.gif)
 
 Every GIF on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) as an embedded video with long-form captions. Tape sources are in [`demos/`](demos). For commands and settings, see the [usage guide](docs/usage.md).
 
@@ -569,6 +589,10 @@ Plus notebooks, bibliographies, iWork, and audio/video, among others. See the [u
 ## Wiki
 
 lilbee reads the documents you've indexed and writes a wiki about them: one page per concept or entity, not per document. A subject that recurs earns its own page, written and cited from the source that mentions it most and cross-linked with `[[wiki link]]`, with coverage across sources coming from synthesis pages. Every section is citation-verified against the source text before it publishes; lower-confidence pages wait in a `drafts/` queue for review.
+
+Pages are written on demand: open one that does not exist yet and lilbee writes it from the sources it has, then links it into the rest.
+
+![browse a cited wiki, then watch lilbee write a new page on demand](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/wiki-lazy.gif)
 
 See the [usage guide](docs/usage.md#wiki) for commands and configuration, and [how the wiki is validated](docs/benchmarks/wiki-validation.md) for the evidence behind it.
 

--- a/site/index.html
+++ b/site/index.html
@@ -248,8 +248,10 @@
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-pdf"      aria-controls="tutorial-pane-pdf"      aria-selected="false" tabindex="-1">agent: pdf</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-index"    aria-controls="tutorial-pane-index"    aria-selected="false" tabindex="-1">agent: index</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-godot"    aria-controls="tutorial-pane-godot"    aria-selected="false" tabindex="-1">agent: godot</button>
-              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchoc" aria-controls="tutorial-pane-launchoc" aria-selected="false" tabindex="-1">launch: opencode</button>
-              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchhm" aria-controls="tutorial-pane-launchhm" aria-selected="false" tabindex="-1">launch: hermes</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchoc" aria-controls="tutorial-pane-launchoc" aria-selected="false" tabindex="-1">agents: qwen3 coder</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchhm" aria-controls="tutorial-pane-launchhm" aria-selected="false" tabindex="-1">agents: minimax</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-memory" aria-controls="tutorial-pane-memory" aria-selected="false" tabindex="-1">memory</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-wiki" aria-controls="tutorial-pane-wiki" aria-selected="false" tabindex="-1">wiki</button>
             </div>
           </div>
         </div>
@@ -382,17 +384,32 @@
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-launchoc" aria-labelledby="tutorial-tab-launchoc" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-opencode.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption"><code>lilbee launch opencode</code> opens opencode on a local model with lilbee configured. It adds a <code>lilbee launch status</code> subcommand to lilbee's own source, runs it, and writes a test that passes.</p>
+          <p class="tutorial-caption">Four agents at once against a single local model (Qwen3 Coder 30B A3B): finding and fixing the bug behind a failing test, refactoring duplicated logic out of two functions, and searching the indexed project with <code>lilbee_search</code>.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-launchhm" aria-labelledby="tutorial-tab-launchhm" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-hermes.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption"><code>lilbee launch hermes</code> does the same for hermes: launched on a local model, it adds a <code>lilbee launch list</code> subcommand and lands a passing test.</p>
+          <p class="tutorial-caption">The same four-up shape on MiniMax M2.7, each pane writing a small Python function through lilbee.</p>
         </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-memory" aria-labelledby="tutorial-tab-memory" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-memory.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">Tell lilbee a fact and a preference, then ask in a brand new conversation. The answer comes from memory, not from the transcript.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-wiki" aria-labelledby="tutorial-tab-wiki" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/wiki-lazy.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">Browse a cited encyclopedia built from your own documents, then open a page that does not exist yet and watch lilbee write it on demand.</p>
+        </div>
+
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-gpuauto" aria-labelledby="tutorial-tab-gpuauto" hidden>
           <div class="tutorial-clip">

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -147,7 +147,6 @@
           <li><a href="#command-surface">Command surface</a></li>
           <li class="toc-group"><a href="#tui-ask">Ask your library</a></li>
           <li><a href="#chat">Chat with cited answers</a></li>
-          <li><a href="#tow-limits">A straight answer, with the page</a></li>
           <li><a href="#sessions">Leave, come back, keep going</a></li>
           <li><a href="#add">Add files</a></li>
           <li><a href="#crawl">Crawl a URL</a></li>
@@ -237,17 +236,6 @@
           <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.png">
             <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.mp4" type="video/mp4">
             <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.mp4">chat with cited answers (MP4)</a>
-          </video>
-        </div>
-      </section>
-
-      <section class="tutorial-section" id="tow-limits">
-        <h4><a href="#tow-limits">Get a straight answer, with the page it came from</a></h4>
-        <p>A customer wants to tow a 3,500 lb boat trailer. The Crown Vic can't, and lilbee says so: it gives the weight the car <em>is</em> rated for, the combined limit, what to check before towing, and the page it read each of those on. The fleet panel on the right is the GPU answering, on this machine.</p>
-        <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tow-limits.mp4">towing limits, cited (MP4)</a>
           </video>
         </div>
       </section>
@@ -444,24 +432,24 @@
         </div>
       </section>
 
-      <section class="tutorial-section" id="launch-opencode">
-        <h4><a href="#launch-opencode">Launch: opencode on a local model</a></h4>
-        <p><code>lilbee launch opencode</code> wires lilbee's local models into opencode in one command and opens it pointed at one, with no API keys or provider setup. Here it adds a <code>lilbee launch status</code> subcommand to lilbee's own source, runs it, and writes a test that passes.</p>
+      <section class="tutorial-section" id="agents-qwen3-coder">
+        <h4><a href="#agents-qwen3-coder">Four agents on one local model</a></h4>
+        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder 30B A3B: finding and fixing the bug behind a failing test, refactoring duplicated logic out of two functions, and searching the indexed project with <code>lilbee_search</code>.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-opencode.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-opencode.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-opencode.mp4">launch: opencode (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.mp4">four agents on Qwen3 Coder (MP4)</a>
           </video>
         </div>
       </section>
 
-      <section class="tutorial-section" id="launch-hermes">
-        <h4><a href="#launch-hermes">Launch: hermes on a local model</a></h4>
-        <p><code>lilbee launch hermes</code> does the same for hermes: launched on a local model, it adds a <code>lilbee launch list</code> subcommand and lands a passing test.</p>
+      <section class="tutorial-section" id="agents-minimax">
+        <h4><a href="#agents-minimax">The same, on MiniMax M2.7</a></h4>
+        <p>The same four-up shape on a different local model, each pane writing a small Python function through lilbee.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-hermes.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-hermes.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agent-launcher-hermes.mp4">launch: hermes (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.mp4">four agents on MiniMax M2.7 (MP4)</a>
           </video>
         </div>
       </section>


### PR DESCRIPTION
## Problem

Eight verified reels appeared nowhere. The wiki section described a wiki and showed none of it; sessions, memory, settings and the first-run wizard were recorded and never embedded; the Ollama and LM Studio section linked out to videos rather than showing either.

## Solution

Each is embedded next to the prose that describes it, rather than collected at the bottom.

On the site, the two launch tabs become the four-agent reels, and memory and wiki get tabs they never had.

The tutorial page’s towing section is removed rather than repointed. Aimed at tui-chat it would have played the same clip the chat section already shows, under a second heading.

## Checked

All 75 asset references across the README and the site resolve against gh-pages. Tab and pane ids on the site match one to one.