### PR TITLE
Say the engine is missing instead of blaming the model configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ No external services either way; lilbee downloads and runs models locally. Optio
 
 ### The engine, if you install with pip or uv
 
-Everything that runs a model goes through `llama-server`, which lilbee ships as the `[engine]` extra. It is **not on PyPI**: the CUDA and ROCm wheels are 440 MB to 860 MB each, well past PyPI's 100 MB per-file limit, so every backend is published from lilbee's own [PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh` instead. That is what the `--extra-index-url` in the `pip` and `uv` rows is for, and the index you pick is the build you get:
+Everything that runs a model goes through `llama-server`, which lilbee ships as the `[engine]` extra. It is **not on PyPI**: the CUDA and ROCm wheels run 444 MiB to 863 MiB each, several times [PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit), so every backend is published from lilbee's own [PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh` instead. That is what the `--extra-index-url` in the `pip` and `uv` rows is for, and the index you pick is the build you get:
 
 ```bash
 pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/    # NVIDIA (CUDA)

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ No external services either way; lilbee downloads and runs models locally. Optio
 | How                   | Command                                                                                  | Notes                                                                                                                                                                                                                 |
 | --------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **pip**               | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`             | Recommended. The default wheel runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)) and uses your GPU via Vulkan / Metal automatically. The `engine` extra is the bundled llama-server, published on lilbee.sh rather than PyPI, which is why the index is needed. Faster vendor builds: [CUDA](#on-nvidia-hardware), [ROCm](#on-amd-hardware). |
-| **uv**                | `uv tool install --prerelease=allow lilbee`                                              | Same wheel as pip; fetches a Python for you if you need one.                                                                                                                                                          |
+| **uv**                | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheel as pip; fetches a Python for you if you need one.                                                                                                                                                          |
 | **Homebrew**          | `brew tap tobocop2/lilbee && brew install lilbee`                                        | macOS arm64 / Linux x86_64. Bundled build; clears the macOS quarantine flag for you.                                                                                                                                  |
 | **AUR**               | `paru -S lilbee`                                                                         | Arch Linux. Wraps the Linux x86_64 binary; works with `yay` / `pacaur` / any helper.                                                                                                                                  |
 | **Docker**            | `docker run --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:latest --help` | GHCR image, tagged by version and `latest`. Data lives at `/home/lilbee/data`. Mount a volume there. `:cuda` and `:rocm` tags carry the vendor builds.                                                                 |
@@ -412,7 +412,7 @@ The default Vulkan build works on NVIDIA cards, but there's a dedicated CUDA bui
 |              | Command                                                                                                                                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **pip**      | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`                                                                                                        |
-| **uv**       | `uv tool install --prerelease=allow lilbee --extra-index-url https://lilbee.sh/cu125/`                                                                                       |
+| **uv**       | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`                                                                                       |
 | **Homebrew** | `brew install tobocop2/lilbee/lilbee-cuda`                                                                                                                                   |
 | **AUR**      | `paru -S lilbee-cuda`                                                                                                                                                        |
 | **Nix**      | `nix run github:tobocop2/lilbee#lilbee-cuda`                                                                                                                                 |
@@ -432,8 +432,8 @@ The default Vulkan build works on AMD cards, and stays the fallback if ROCm isn'
 
 |              | Command                                                                                                             |
 | ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **pip**      | `pip install --pre lilbee --extra-index-url https://lilbee.sh/rocm/`                                                 |
-| **uv**       | `uv tool install --prerelease=allow lilbee --extra-index-url https://lilbee.sh/rocm/`                                |
+| **pip**      | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`                                        |
+| **uv**       | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`                       |
 | **Homebrew** | `brew install tobocop2/lilbee/lilbee-rocm`                                                                           |
 | **AUR**      | `paru -S lilbee-rocm`                                                                                                |
 | **Nix**      | `nix run github:tobocop2/lilbee#lilbee-rocm`                                                                         |
@@ -481,10 +481,11 @@ The Linux x86_64 wheel and binary link the Vulkan loader at runtime. Most deskto
 
 ### Optional extras
 
-These only matter for a `pip` or `uv` install: add the name in brackets, e.g. `pip install --pre 'lilbee[crawler,litellm]'` (combine multiple, and `--extra-index-url` still works for CUDA). The standalone binary and the Homebrew / AUR / Nix / Docker / Flatpak / Snap builds already include all three. lilbee works without them either way.
+These only matter for a `pip` or `uv` install: add the name in brackets, e.g. `pip install --pre 'lilbee[engine,crawler,litellm]'` (combine multiple, and `--extra-index-url` still works for CUDA). The standalone binary and the Homebrew / AUR / Nix / Docker / Flatpak / Snap builds already include all four. lilbee works without the last three; without `[engine]` it has nothing to run models on.
 
 | Extra       | What it adds                                                                                                                                              |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `[engine]`  | The bundled `llama-server` that runs your models. Published on lilbee.sh rather than PyPI, so it needs the `--extra-index-url` for your hardware; without it nothing can load a model. |
 | `[crawler]` | Index websites alongside your files: crawl a docs site or wiki to markdown, then search it offline.                                                       |
 | `[litellm]` | Bridge to hosted model providers for chat, vision, or embeddings while other roles stay local. The TUI flags when a hosted role is active.                |
 | `[graph]`   | Concept-graph search: extracts the ideas in your documents and uses how they relate to surface matches plain keyword search misses. No extra model calls. |

--- a/README.md
+++ b/README.md
@@ -399,47 +399,6 @@ No external services either way; lilbee downloads and runs models locally. Optio
 | **Scoop**             | `scoop bucket add lilbee https://github.com/tobocop2/lilbee && scoop install lilbee` | Windows x86_64. Installs the CUDA build on machines with a recent NVIDIA driver, otherwise the CPU build. `scoop update lilbee` upgrades. |
 | **Standalone binary** | [download for your platform &rarr;](https://github.com/tobocop2/lilbee/releases/latest)  | One file, own Python runtime, no `pip` needed. Linux needs glibc 2.28+; the macOS / Windows builds are unsigned (`xattr -d com.apple.quarantine ./lilbee-macos-arm64` if Gatekeeper blocks it).                       |
 
-### Developer install: pip and uv
-
-For working on lilbee, or importing it as a library into an environment you
-manage. Everything below needs the `[engine]` extra and its index; the bundled
-builds above do not.
-
-<details>
-<summary><strong>pip / uv install commands, and the engine index per hardware</strong></summary>
-
-| How             | Command                                                                                       | Notes                                                                                                                                                     |
-| --------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **pip**         | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`                  | Python 3.11 to 3.14. Runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)). Swap the index for your hardware, below. |
-| **uv**          | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheels as pip; fetches a Python for you if you need one.                                                                                              |
-| **From source** | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`        | Needs `git` and `uv`. `uv sync` resolves the in-repo engine package, but CI is what fills its `bin/`, so a checkout has no engine binaries: install the `[engine]` extra from the index below, or point `LILBEE_LLAMA_SERVER_PATH` at your own `llama-server`. |
-
-**The engine.** `llama-server` runs every model, and it ships as the `[engine]`
-extra rather than as part of lilbee. It is **not on PyPI**: the CUDA and ROCm
-wheels run 444 MiB to 863 MiB each, several times
-[PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit),
-so every backend is published from lilbee's own
-[PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh`. That
-is what `--extra-index-url` is for, and the index you pick is the build you get:
-`cpu` is compiled with every GPU backend off, `metal` publishes only a macOS
-arm64 wheel, `vulkan` only Linux and Windows ones.
-
-| Hardware          | Index    | Command                                                                                     |
-| ----------------- | -------- | --------------------------------------------------------------------------------------------- |
-| **NVIDIA (CUDA)** | `cu125`  | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`              |
-| **AMD (ROCm)**    | `rocm`   | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`               |
-| **Apple silicon** | `metal`  | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/`              |
-| **Other GPUs**    | `vulkan` | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/`             |
-| **No GPU**        | `cpu`    | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`                |
-
-Leave the extra off and lilbee still installs and starts. The first thing that
-needs a model then fails with an error naming the engine and repeating the
-command for your hardware, so it is recoverable rather than mysterious, but it
-is a step you have to take.
-
-</details>
-
-
 ### On NVIDIA hardware
 
 The default Vulkan build works on NVIDIA cards, but there's a dedicated CUDA build that's faster on NVIDIA hardware and sidesteps the iGPU + dGPU Vulkan-loader crash on Windows.
@@ -531,6 +490,46 @@ These only matter for a `pip` or `uv` install: add the name in brackets, e.g. `p
 | `[graph]`   | Concept-graph search: extracts the ideas in your documents and uses how they relate to surface matches plain keyword search misses. No extra model calls. |
 
 See the [full guide on optional extras](docs/usage.md#optional-extras) for configuration.
+
+### Developer install: pip and uv
+
+For working on lilbee, or importing it as a library into an environment you
+manage. Everything below needs the `[engine]` extra and its index; the bundled
+builds above do not.
+
+<details>
+<summary><strong>pip / uv install commands, and the engine index per hardware</strong></summary>
+
+| How             | Command                                                                                       | Notes                                                                                                                                                     |
+| --------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **pip**         | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`                  | Python 3.11 to 3.14. Runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)). Swap the index for your hardware, below. |
+| **uv**          | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheels as pip; fetches a Python for you if you need one.                                                                                              |
+| **From source** | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`        | Needs `git` and `uv`. `uv sync` resolves the in-repo engine package, but CI is what fills its `bin/`, so a checkout has no engine binaries: install the `[engine]` extra from the index below, or point `LILBEE_LLAMA_SERVER_PATH` at your own `llama-server`. |
+
+**The engine.** `llama-server` runs every model, and it ships as the `[engine]`
+extra rather than as part of lilbee. It is **not on PyPI**: the CUDA and ROCm
+wheels run 444 MiB to 863 MiB each, several times
+[PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit),
+so every backend is published from lilbee's own
+[PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh`. That
+is what `--extra-index-url` is for, and the index you pick is the build you get:
+`cpu` is compiled with every GPU backend off, `metal` publishes only a macOS
+arm64 wheel, `vulkan` only Linux and Windows ones.
+
+| Hardware          | Index    | Command                                                                                     |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------- |
+| **NVIDIA (CUDA)** | `cu125`  | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`              |
+| **AMD (ROCm)**    | `rocm`   | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`               |
+| **Apple silicon** | `metal`  | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/`              |
+| **Other GPUs**    | `vulkan` | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/`             |
+| **No GPU**        | `cpu`    | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`                |
+
+Leave the extra off and lilbee still installs and starts. The first thing that
+needs a model then fails with an error naming the engine and repeating the
+command for your hardware, so it is recoverable rather than mysterious, but it
+is a step you have to take.
+
+</details>
 
 ## First start
 

--- a/README.md
+++ b/README.md
@@ -381,17 +381,15 @@ Standalone mode runs entirely on your machine. No cloud required. **Minimum:** A
 
 **Two routes, and the difference matters:**
 
-- **Into your own Python** with `pip` or `uv` (Python 3.11 to 3.14). Uses the Python and tooling you already have, picks the fastest CPU code path for your machine at runtime, and upgrades like any other package. Recommended if you have Python.
-- **A self-contained bundle**: the standalone binary, or the Homebrew / AUR / Nix / Docker / Flatpak / Snap builds that wrap it. Nothing else to install. The trade-off is a single large download (it bundles its own Python runtime, `llama.cpp`, and the optional extras) and a small cold-start cost the first time it self-extracts. Recommended if you'd rather not deal with Python.
+- **A self-contained bundle** (start here): the standalone binary, or the Homebrew / AUR / Nix / Docker / Flatpak / Snap / Scoop builds that wrap it. It carries its own Python runtime, `llama.cpp`, the model engine, and the optional extras, so there is nothing else to install and nothing to assemble. The trade-off is one large download and a small cold-start cost the first time it self-extracts.
+- **Into your own Python** with `pip` or `uv` (Python 3.11 to 3.14), at the bottom of the table. This is the developer route: it installs lilbee as a library in an environment you manage, and the model engine is a separate extra from a separate index that you have to ask for. Take it if you are working on lilbee or importing it into your own code.
 
-Have a discrete GPU? The default Vulkan build already uses it. There are faster vendor builds too: [NVIDIA (CUDA)](#on-nvidia-hardware) and [AMD (ROCm)](#on-amd-hardware).
+Have a discrete GPU? The bundled builds and the Vulkan engine already use it. There are faster vendor builds too: [NVIDIA (CUDA)](#on-nvidia-hardware) and [AMD (ROCm)](#on-amd-hardware).
 
 No external services either way; lilbee downloads and runs models locally. Optional, for scanned-PDF / image OCR: [Tesseract](https://github.com/tesseract-ocr/tesseract) (`brew install tesseract` / `apt install tesseract-ocr`) or a [GGUF vision model](docs/usage.md#vision-models).
 
 | How                   | Command                                                                                  | Notes                                                                                                                                                                                                                 |
 | --------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **pip**               | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`             | Recommended. The default wheel runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)) and uses your GPU via Vulkan / Metal automatically. The `engine` extra is the bundled llama-server, published on lilbee.sh rather than PyPI, which is why the index is needed. Faster vendor builds: [CUDA](#on-nvidia-hardware), [ROCm](#on-amd-hardware). |
-| **uv**                | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheel as pip; fetches a Python for you if you need one.                                                                                                                                                          |
 | **Homebrew**          | `brew tap tobocop2/lilbee && brew install lilbee`                                        | macOS arm64 / Linux x86_64. Bundled build; clears the macOS quarantine flag for you.                                                                                                                                  |
 | **AUR**               | `paru -S lilbee`                                                                         | Arch Linux. Wraps the Linux x86_64 binary; works with `yay` / `pacaur` / any helper.                                                                                                                                  |
 | **Docker**            | `docker run --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:latest --help` | GHCR image, tagged by version and `latest`. Data lives at `/home/lilbee/data`. Mount a volume there. `:cuda` and `:rocm` tags carry the vendor builds.                                                                 |
@@ -400,7 +398,23 @@ No external services either way; lilbee downloads and runs models locally. Optio
 | **Snap**              | `curl -LO https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-linux-x86_64.snap && sudo snap install ./lilbee-linux-x86_64.snap --dangerous --classic` | Linux x86_64. Sideloaded, so snapd flags it `--dangerous` (it just means unsigned) and it won't auto-update; rerun the same command to upgrade. |
 | **Scoop**             | `scoop bucket add lilbee https://github.com/tobocop2/lilbee && scoop install lilbee` | Windows x86_64. Installs the CUDA build on machines with a recent NVIDIA driver, otherwise the CPU build. `scoop update lilbee` upgrades. |
 | **Standalone binary** | [download for your platform &rarr;](https://github.com/tobocop2/lilbee/releases/latest)  | One file, own Python runtime, no `pip` needed. Linux needs glibc 2.28+; the macOS / Windows builds are unsigned (`xattr -d com.apple.quarantine ./lilbee-macos-arm64` if Gatekeeper blocks it).                       |
-| **From source**       | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`  | For hacking on it. Needs `git` and `uv`.                                                                                                                                                                              |
+| **pip** (devs)        | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`             | For development, or lilbee as a library in an environment you manage. Runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)). The `[engine]` extra and its index are required and are not on PyPI: see [The engine](#the-engine-if-you-install-with-pip-or-uv) for the index per hardware. Vendor builds: [CUDA](#on-nvidia-hardware), [ROCm](#on-amd-hardware). |
+| **uv** (devs)         | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheels as pip; fetches a Python for you if you need one. Same `[engine]` requirement.                                                                                                                       |
+| **From source**       | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`  | For hacking on it. Needs `git` and `uv`. `uv sync` resolves the in-repo engine package, but CI is what fills its `bin/`, so a checkout has no engine binaries: install the `[engine]` extra from the index for your hardware, or point `LILBEE_LLAMA_SERVER_PATH` at your own `llama-server`. |
+
+### The engine, if you install with pip or uv
+
+Everything that runs a model goes through `llama-server`, which lilbee ships as the `[engine]` extra. It is **not on PyPI**: the CUDA and ROCm wheels are 440 MB to 860 MB each, well past PyPI's 100 MB per-file limit, so every backend is published from lilbee's own [PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh` instead. That is what the `--extra-index-url` in the `pip` and `uv` rows is for, and the index you pick is the build you get:
+
+```bash
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/    # NVIDIA (CUDA)
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/     # AMD (ROCm)
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/    # Apple silicon
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/   # other GPUs
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/      # no GPU
+```
+
+Leave the extra off and lilbee still installs and starts. The first thing that needs a model then fails with an error naming the engine and repeating the command for your hardware, so this is recoverable rather than mysterious, but it is a step you have to take. The bundled builds above have the engine inside them and need none of this.
 
 ### On NVIDIA hardware
 
@@ -411,13 +425,13 @@ The default Vulkan build works on NVIDIA cards, but there's a dedicated CUDA bui
 
 |              | Command                                                                                                                                                                      |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **pip**      | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`                                                                                                        |
-| **uv**       | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`                                                                                       |
 | **Homebrew** | `brew install tobocop2/lilbee/lilbee-cuda`                                                                                                                                   |
 | **AUR**      | `paru -S lilbee-cuda`                                                                                                                                                        |
 | **Nix**      | `nix run github:tobocop2/lilbee#lilbee-cuda`                                                                                                                                 |
 | **Scoop**    | `scoop install lilbee` (auto-picks the CUDA build when an NVIDIA driver is present)                                                                                          |
 | **Binary**   | [`lilbee-linux-x86_64-cu125`](https://github.com/tobocop2/lilbee/releases/latest) or [`lilbee-windows-x86_64-cu125.exe`](https://github.com/tobocop2/lilbee/releases/latest) |
+| **pip** (devs) | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`                                                                                             |
+| **uv** (devs)  | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`                                                                            |
 
 Same `lilbee` command after install. The CUDA runtime is bundled; you only need the NVIDIA driver. Already have the regular `lilbee` installed? On AUR `paru -S lilbee-cuda` swaps it automatically; on Homebrew run `brew uninstall lilbee` first. Older driver? `cu124` and `cu121` ship via the matching wheel indexes and as direct-download Linux binaries on the release page.
 
@@ -432,13 +446,13 @@ The default Vulkan build works on AMD cards, and stays the fallback if ROCm isn'
 
 |              | Command                                                                                                             |
 | ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **pip**      | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`                                        |
-| **uv**       | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`                       |
 | **Homebrew** | `brew install tobocop2/lilbee/lilbee-rocm`                                                                           |
 | **AUR**      | `paru -S lilbee-rocm`                                                                                                |
 | **Nix**      | `nix run github:tobocop2/lilbee#lilbee-rocm`                                                                         |
 | **Flatpak**  | `flatpak install lilbee io.github.tobocop2.lilbee.rocm`                                                              |
 | **Binary**   | [`lilbee-linux-x86_64-rocm`](https://github.com/tobocop2/lilbee/releases/latest)                                     |
+| **pip** (devs) | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`                                      |
+| **uv** (devs)  | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`                     |
 
 Same `lilbee` command after install. Linux only. Cards: MI100, MI200, MI300, MI350, RDNA2, RDNA3, RDNA3.5 APUs and RDNA4. ROCm 7 ships no GEMM kernels for the MI50, so it needs the Vulkan build. Largest of the three builds, since the ROCm userspace and per-card kernels ship inside it.
 
@@ -462,7 +476,6 @@ Pre-2013 Intel or pre-Zen AMD CPUs lack [AVX2](https://en.wikipedia.org/wiki/Adv
 
 |              | Command                                                                                                                                                                                  |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **pip**      | `pip install --pre lilbee 'lancedb==0.34.0+compat' --extra-index-url https://lilbee.sh/compat/`                                                                          |
 | **Homebrew** | `brew install tobocop2/lilbee/lilbee-compat`                                                                                                                                            |
 | **AUR**      | `paru -S lilbee-compat`                                                                                                                                                                 |
 | **Nix**      | `nix run github:tobocop2/lilbee#lilbee-compat`                                                                                                                                          |
@@ -470,6 +483,9 @@ Pre-2013 Intel or pre-Zen AMD CPUs lack [AVX2](https://en.wikipedia.org/wiki/Adv
 | **Flatpak**  | `flatpak install lilbee io.github.tobocop2.lilbee.compat`                                                                                                                               |
 | **Snap**     | `curl -LO https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-linux-x86_64.snap && sudo snap install ./lilbee-compat-linux-x86_64.snap --dangerous --classic`    |
 | **Binary**   | [`lilbee-compat-linux-x86_64`](https://github.com/tobocop2/lilbee/releases/latest), [`lilbee-compat-windows-x86_64.exe`](https://github.com/tobocop2/lilbee/releases/latest), or [`lilbee-compat-macos-x86_64`](https://github.com/tobocop2/lilbee/releases/latest) (pre-AVX2 Intel Macs, e.g. the 2013 Mac Pro) |
+| **pip** (devs) | `pip install --pre lilbee 'lancedb==0.34.0+compat' --extra-index-url https://lilbee.sh/compat/` — no engine: there is no compat engine wheel, so use a bundled build above or bring your own `llama-server` |
+
+Use a bundled build here if you can. The compat index carries the patched lancedb only, so the `pip` row installs lilbee without an engine and every model call will fail until you point `LILBEE_LLAMA_SERVER_PATH` at a `llama-server` that runs on your CPU.
 
 Same `lilbee` command after install. The crash is from [lancedb](https://lancedb.github.io/lancedb/)'s AVX2-compiled wheels; this build swaps in a [lancedb fork](https://github.com/tobocop2/lance) that picks instructions at runtime. A 👍 or comment on the upstream [lance PR](https://github.com/lance-format/lance/pull/6630) helps it land.
 
@@ -481,7 +497,7 @@ The Linux x86_64 wheel and binary link the Vulkan loader at runtime. Most deskto
 
 ### Optional extras
 
-These only matter for a `pip` or `uv` install: add the name in brackets, e.g. `pip install --pre 'lilbee[engine,crawler,litellm]'` (combine multiple, and `--extra-index-url` still works for CUDA). The standalone binary and the Homebrew / AUR / Nix / Docker / Flatpak / Snap builds already include all four. lilbee works without the last three; without `[engine]` it has nothing to run models on.
+These only matter for a `pip` or `uv` install: add the name in brackets, e.g. `pip install --pre 'lilbee[engine,crawler,litellm]'` (combine multiple, and `--extra-index-url` still works). The standalone binary and the Homebrew / AUR / Nix / Docker / Flatpak / Snap builds already include all four, which is why they need none of this. `[engine]` is the one that is not really optional; lilbee works fine without the other three.
 
 | Extra       | What it adds                                                                                                                                              |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Standalone mode runs entirely on your machine. No cloud required. **Minimum:** A
 **Two routes, and the difference matters:**
 
 - **A self-contained bundle** (start here): the standalone binary, or the Homebrew / AUR / Nix / Docker / Flatpak / Snap / Scoop builds that wrap it. It carries its own Python runtime, `llama.cpp`, the model engine, and the optional extras, so there is nothing else to install and nothing to assemble. The trade-off is one large download and a small cold-start cost the first time it self-extracts.
-- **Into your own Python** with `pip` or `uv` (Python 3.11 to 3.14), at the bottom of the table. This is the developer route: it installs lilbee as a library in an environment you manage, and the model engine is a separate extra from a separate index that you have to ask for. Take it if you are working on lilbee or importing it into your own code.
+- **Into your own Python** with `pip` or `uv` (Python 3.11 to 3.14), in [its own section below](#developer-install-pip-and-uv). This is the developer route: it installs lilbee as a library in an environment you manage, and the model engine is a separate extra from a separate index that you have to ask for. Take it if you are working on lilbee or importing it into your own code.
 
 Have a discrete GPU? The bundled builds and the Vulkan engine already use it. There are faster vendor builds too: [NVIDIA (CUDA)](#on-nvidia-hardware) and [AMD (ROCm)](#on-amd-hardware).
 
@@ -398,23 +398,47 @@ No external services either way; lilbee downloads and runs models locally. Optio
 | **Snap**              | `curl -LO https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-linux-x86_64.snap && sudo snap install ./lilbee-linux-x86_64.snap --dangerous --classic` | Linux x86_64. Sideloaded, so snapd flags it `--dangerous` (it just means unsigned) and it won't auto-update; rerun the same command to upgrade. |
 | **Scoop**             | `scoop bucket add lilbee https://github.com/tobocop2/lilbee && scoop install lilbee` | Windows x86_64. Installs the CUDA build on machines with a recent NVIDIA driver, otherwise the CPU build. `scoop update lilbee` upgrades. |
 | **Standalone binary** | [download for your platform &rarr;](https://github.com/tobocop2/lilbee/releases/latest)  | One file, own Python runtime, no `pip` needed. Linux needs glibc 2.28+; the macOS / Windows builds are unsigned (`xattr -d com.apple.quarantine ./lilbee-macos-arm64` if Gatekeeper blocks it).                       |
-| **pip** (devs)        | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`             | For development, or lilbee as a library in an environment you manage. Runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)). The `[engine]` extra and its index are required and are not on PyPI: see [The engine](#the-engine-if-you-install-with-pip-or-uv) for the index per hardware. Vendor builds: [CUDA](#on-nvidia-hardware), [ROCm](#on-amd-hardware). |
-| **uv** (devs)         | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheels as pip; fetches a Python for you if you need one. Same `[engine]` requirement.                                                                                                                       |
-| **From source**       | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`  | For hacking on it. Needs `git` and `uv`. `uv sync` resolves the in-repo engine package, but CI is what fills its `bin/`, so a checkout has no engine binaries: install the `[engine]` extra from the index for your hardware, or point `LILBEE_LLAMA_SERVER_PATH` at your own `llama-server`. |
 
-### The engine, if you install with pip or uv
+### Developer install: pip and uv
 
-Everything that runs a model goes through `llama-server`, which lilbee ships as the `[engine]` extra. It is **not on PyPI**: the CUDA and ROCm wheels run 444 MiB to 863 MiB each, several times [PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit), so every backend is published from lilbee's own [PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh` instead. That is what the `--extra-index-url` in the `pip` and `uv` rows is for, and the index you pick is the build you get:
+For working on lilbee, or importing it as a library into an environment you
+manage. Everything below needs the `[engine]` extra and its index; the bundled
+builds above do not.
 
-```bash
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/    # NVIDIA (CUDA)
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/     # AMD (ROCm)
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/    # Apple silicon
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/   # other GPUs
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/      # no GPU
-```
+<details>
+<summary><strong>pip / uv install commands, and the engine index per hardware</strong></summary>
 
-Leave the extra off and lilbee still installs and starts. The first thing that needs a model then fails with an error naming the engine and repeating the command for your hardware, so this is recoverable rather than mysterious, but it is a step you have to take. The bundled builds above have the engine inside them and need none of this.
+| How             | Command                                                                                       | Notes                                                                                                                                                     |
+| --------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **pip**         | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`                  | Python 3.11 to 3.14. Runs on any x86_64 CPU with AVX2 (2013+; older CPUs: [On older CPUs](#on-older-cpus-pre-avx2)). Swap the index for your hardware, below. |
+| **uv**          | `uv tool install --prerelease=allow 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/` | Same wheels as pip; fetches a Python for you if you need one.                                                                                              |
+| **From source** | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`        | Needs `git` and `uv`. `uv sync` resolves the in-repo engine package, but CI is what fills its `bin/`, so a checkout has no engine binaries: install the `[engine]` extra from the index below, or point `LILBEE_LLAMA_SERVER_PATH` at your own `llama-server`. |
+
+**The engine.** `llama-server` runs every model, and it ships as the `[engine]`
+extra rather than as part of lilbee. It is **not on PyPI**: the CUDA and ROCm
+wheels run 444 MiB to 863 MiB each, several times
+[PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit),
+so every backend is published from lilbee's own
+[PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh`. That
+is what `--extra-index-url` is for, and the index you pick is the build you get:
+`cpu` is compiled with every GPU backend off, `metal` publishes only a macOS
+arm64 wheel, `vulkan` only Linux and Windows ones.
+
+| Hardware          | Index    | Command                                                                                     |
+| ----------------- | -------- | --------------------------------------------------------------------------------------------- |
+| **NVIDIA (CUDA)** | `cu125`  | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/`              |
+| **AMD (ROCm)**    | `rocm`   | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/`               |
+| **Apple silicon** | `metal`  | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/`              |
+| **Other GPUs**    | `vulkan` | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/`             |
+| **No GPU**        | `cpu`    | `pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/`                |
+
+Leave the extra off and lilbee still installs and starts. The first thing that
+needs a model then fails with an error naming the engine and repeating the
+command for your hardware, so it is recoverable rather than mysterious, but it
+is a step you have to take.
+
+</details>
+
 
 ### On NVIDIA hardware
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Models are no different: lilbee has its own model manager and multi-GPU fleet, b
 - [Tutorial reel](https://lilbee.sh/tutorial) (long-form videos)
 - [Highlights](#highlights)
 - [Why lilbee](#why-lilbee)
+- [First start](#first-start)
 - [What you can do with it](#what-you-can-do-with-it)
 - [TUI](#tui)
 - [Hardware requirements](#hardware-requirements)
 - [Install](#install)
-- [First start](#first-start)
 - [Agent integration](#agent-integration)
 - [HTTP Server](#http-server) · [REST API reference](https://lilbee.sh/api/)
 - [Supported formats](#supported-formats)
@@ -172,6 +172,36 @@ Even lilbee's CUDA build stays under Ollama's, and it's the whole stack, not jus
 </details>
 
 Already on Ollama or LM Studio? lilbee runs on top of them. Prefer a GUI to the terminal? The [Obsidian plugin](https://obsidian.lilbee.sh/) maps lilbee's model manager and search to a visual interface inside your vault.
+
+## First start
+
+The very first launch does one-time work: a bundled build unpacks itself behind
+a progress bar, and the model loads before your first answer, shown live inside
+the answer bubble. Every launch after that opens straight to chat in a couple
+of seconds.
+
+<table>
+  <tr>
+    <th align="center">Very first launch</th>
+    <th align="center">Every launch after</th>
+  </tr>
+  <tr>
+    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="380"></td>
+    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="380"></td>
+  </tr>
+</table>
+
+Measured with a small chat model (Qwen3 0.6B):
+
+| | Very first launch | Every launch after |
+|---|---|---|
+| Chat on screen | 15 to 20s, one-time unpack | 2 to 3s |
+| First answer of the session | 10 to 20s, the engine load plays in the bubble | the same, or instant with **Keep engine warm** |
+| Answers after that | model speed | model speed |
+
+Bigger models load longer; the bubble shows real progress while weights are read.
+How the engine lifecycle works, and how to keep it warm so relaunches skip the
+load entirely, lives in the [usage guide](docs/usage.md#the-engine-lifecycle).
 
 ## What you can do with it
 
@@ -530,36 +560,6 @@ command for your hardware, so it is recoverable rather than mysterious, but it
 is a step you have to take.
 
 </details>
-
-## First start
-
-The very first launch does one-time work: the executable unpacks itself behind
-a progress bar, and the model loads before your first answer, shown live inside
-the answer bubble. Every launch after that opens straight to chat in a couple
-of seconds.
-
-<table>
-  <tr>
-    <th align="center">Very first launch</th>
-    <th align="center">Every launch after</th>
-  </tr>
-  <tr>
-    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="380"></td>
-    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="380"></td>
-  </tr>
-</table>
-
-Measured with a small chat model (Qwen3 0.6B):
-
-| | Very first launch | Every launch after |
-|---|---|---|
-| Chat on screen | 15 to 20s, one-time unpack | 2 to 3s |
-| First answer of the session | 10 to 20s, the engine load plays in the bubble | the same, or instant with **Keep engine warm** |
-| Answers after that | model speed | model speed |
-
-Bigger models load longer; the bubble shows real progress while weights are read.
-How the engine lifecycle works, and how to keep it warm so relaunches skip the
-load entirely, lives in the [usage guide](docs/usage.md#the-engine-lifecycle).
 
 ## Agent integration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1051,17 +1051,24 @@ reason the defaults are the defaults.
 
 ## Optional extras
 
-lilbee runs local inference on its managed llama-server fleet, which arrives
-with the `[engine]` extra. This section only applies to a `pip` or `uv` install,
-the developer route; the bundled builds (standalone binary, Homebrew, AUR, Nix,
-Docker, Flatpak, Snap, Scoop) carry the engine inside them and need none of it.
+Extras exist only on a `pip` or `uv` install. If you installed a bundled build
+(standalone binary, Homebrew, AUR, Nix, Docker, Flatpak, Snap, Scoop) all four
+are already inside it and none of this applies to you.
+
+`[engine]` is the `llama-server` that runs your models, and it is the one extra
+that is not really optional. `[graph]`, `[crawler]` and `[litellm]` add
+capabilities you can happily live without.
+
+<details>
+<summary><strong>pip / uv: installing the engine extra</strong></summary>
 
 `[engine]` is not on PyPI. The CUDA and ROCm wheels run 444 MiB to 863 MiB each,
 several times [PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit),
 so every backend is published from lilbee's own
-[PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh`. That is what `--extra-index-url` is for. Install without it and
-lilbee still starts, but the first call that needs a model fails with an error
-naming the engine and repeating the command for your hardware.
+[PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh`. That
+is what `--extra-index-url` is for. Install without it and lilbee still starts,
+but the first call that needs a model fails with an error naming the engine and
+repeating the command for your hardware.
 
 The builds are not interchangeable, so pick the index for your hardware: `cpu` is
 built with every GPU backend off, `metal` ships only a macOS arm64 wheel, and
@@ -1075,7 +1082,12 @@ pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/  
 pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/      # no GPU
 ```
 
-The rest add capabilities that require heavier dependencies:
+</details>
+
+<details>
+<summary><strong>pip / uv: the graph, crawler and litellm extras</strong></summary>
+
+These pull heavier dependencies, so they are opt-in:
 
 ```bash
 # pip
@@ -1089,12 +1101,14 @@ uv tool install --prerelease=allow 'lilbee[crawler]'
 uv tool install --prerelease=allow 'lilbee[litellm]'
 ```
 
-Install multiple at once:
+Install several at once, engine included:
 
 ```bash
-pip install --pre 'lilbee[graph,crawler,litellm]'
-uv tool install --prerelease=allow 'lilbee[graph,crawler,litellm]'
+pip install --pre 'lilbee[engine,graph,crawler,litellm]' --extra-index-url https://lilbee.sh/cu125/
+uv tool install --prerelease=allow 'lilbee[engine,graph,crawler,litellm]' --extra-index-url https://lilbee.sh/cu125/
 ```
+
+</details>
 
 **NVIDIA users**: the default Vulkan build works, but the CUDA flavour is
 faster and dodges the Vulkan-loader crash that affects NVIDIA-on-Windows

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1056,10 +1056,10 @@ with the `[engine]` extra. This section only applies to a `pip` or `uv` install,
 the developer route; the bundled builds (standalone binary, Homebrew, AUR, Nix,
 Docker, Flatpak, Snap, Scoop) carry the engine inside them and need none of it.
 
-`[engine]` is not on PyPI. The CUDA and ROCm wheels are 440 MB to 860 MB each,
-well past PyPI's 100 MB per-file limit, so every backend is published from
-lilbee's own [PEP 503](https://peps.python.org/pep-0503/) package index at
-`lilbee.sh`. That is what `--extra-index-url` is for. Install without it and
+`[engine]` is not on PyPI. The CUDA and ROCm wheels run 444 MiB to 863 MiB each,
+several times [PyPI's default 100 MiB per-file limit](https://pypi.org/help/#file-size-limit),
+so every backend is published from lilbee's own
+[PEP 503](https://peps.python.org/pep-0503/) package index at `lilbee.sh`. That is what `--extra-index-url` is for. Install without it and
 lilbee still starts, but the first call that needs a model fails with an error
 naming the engine and repeating the command for your hardware.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1058,11 +1058,16 @@ published on lilbee.sh rather than PyPI, so the index for your hardware is part
 of the command (see the install table in the README). The bundled builds
 (standalone binary, Homebrew, AUR, Nix, Docker, Flatpak, Snap) already carry it.
 
+The builds are not interchangeable, so pick the index for your hardware: `cpu` is
+built with every GPU backend off, `metal` ships only a macOS arm64 wheel, and
+`vulkan` only Linux and Windows ones.
+
 ```bash
-# the engine, per hardware
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/   # NVIDIA
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/    # AMD
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/     # everything else
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/    # NVIDIA (CUDA)
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/     # AMD (ROCm)
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/    # Apple silicon
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/   # other GPUs
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/      # no GPU
 ```
 
 The rest add capabilities that require heavier dependencies:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1052,11 +1052,16 @@ reason the defaults are the defaults.
 ## Optional extras
 
 lilbee runs local inference on its managed llama-server fleet, which arrives
-with the `[engine]` extra. On a `pip` or `uv` install that extra is the one you
-need: without it there is no llama-server, and nothing can load a model. It is
-published on lilbee.sh rather than PyPI, so the index for your hardware is part
-of the command (see the install table in the README). The bundled builds
-(standalone binary, Homebrew, AUR, Nix, Docker, Flatpak, Snap) already carry it.
+with the `[engine]` extra. This section only applies to a `pip` or `uv` install,
+the developer route; the bundled builds (standalone binary, Homebrew, AUR, Nix,
+Docker, Flatpak, Snap, Scoop) carry the engine inside them and need none of it.
+
+`[engine]` is not on PyPI. The CUDA and ROCm wheels are 440 MB to 860 MB each,
+well past PyPI's 100 MB per-file limit, so every backend is published from
+lilbee's own [PEP 503](https://peps.python.org/pep-0503/) package index at
+`lilbee.sh`. That is what `--extra-index-url` is for. Install without it and
+lilbee still starts, but the first call that needs a model fails with an error
+naming the engine and repeating the command for your hardware.
 
 The builds are not interchangeable, so pick the index for your hardware: `cpu` is
 built with every GPU backend off, `metal` ships only a macOS arm64 wheel, and
@@ -1096,10 +1101,10 @@ faster and dodges the Vulkan-loader crash that affects NVIDIA-on-Windows
 setups. Same `lilbee` command, links straight against your NVIDIA driver:
 
 ```bash
-pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/
 brew install tobocop2/lilbee/lilbee-cuda
 paru -S lilbee-cuda
 nix run github:tobocop2/lilbee#lilbee-cuda
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/   # devs
 ```
 
 The `lilbee-cuda` AUR package conflicts with `lilbee` and provides it, so

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1051,9 +1051,21 @@ reason the defaults are the defaults.
 
 ## Optional extras
 
-lilbee works out of the box with its managed llama-server fleet for local
-inference. These optional extras add capabilities that require heavier
-dependencies:
+lilbee runs local inference on its managed llama-server fleet, which arrives
+with the `[engine]` extra. On a `pip` or `uv` install that extra is the one you
+need: without it there is no llama-server, and nothing can load a model. It is
+published on lilbee.sh rather than PyPI, so the index for your hardware is part
+of the command (see the install table in the README). The bundled builds
+(standalone binary, Homebrew, AUR, Nix, Docker, Flatpak, Snap) already carry it.
+
+```bash
+# the engine, per hardware
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/   # NVIDIA
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/    # AMD
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/     # everything else
+```
+
+The rest add capabilities that require heavier dependencies:
 
 ```bash
 # pip
@@ -1079,7 +1091,7 @@ faster and dodges the Vulkan-loader crash that affects NVIDIA-on-Windows
 setups. Same `lilbee` command, links straight against your NVIDIA driver:
 
 ```bash
-pip install --pre lilbee --extra-index-url https://lilbee.sh/cu125/
+pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/
 brew install tobocop2/lilbee/lilbee-cuda
 paru -S lilbee-cuda
 nix run github:tobocop2/lilbee#lilbee-cuda

--- a/packaging/engine-wheel/README.md
+++ b/packaging/engine-wheel/README.md
@@ -12,8 +12,8 @@ engine binaries:
 This is lilbee's core engine dependency, shipped as the `engine` extra:
 `pip install 'lilbee[engine]' --extra-index-url https://lilbee.sh/<backend>/`
 resolves the matching per-platform wheel. It is not on PyPI, since the CUDA and
-ROCm wheels run past PyPI's per-file size limit, so all backends are published
-from lilbee's own PEP 503 index. CI fills `lilbee_engine/bin/` with the three
+ROCm wheels run several times PyPI's default 100 MiB per-file limit, so all
+backends are published from lilbee's own PEP 503 index. CI fills `lilbee_engine/bin/` with the three
 binaries and retags the wheel to the platform before publishing; a source
 checkout has an empty `bin/` and resolves via `PATH` or
 `LILBEE_LLAMA_SERVER_PATH` instead.

--- a/packaging/engine-wheel/README.md
+++ b/packaging/engine-wheel/README.md
@@ -9,9 +9,14 @@ engine binaries:
   servers),
 - `gguf-parser` (UMA-aware VRAM estimator used by the placement planner).
 
-This is lilbee's core engine dependency. `pip install lilbee` resolves the
-matching per-platform wheel from the index; CI fills `lilbee_engine/bin/` with
-the three binaries and retags the wheel to the platform before publishing.
+This is lilbee's core engine dependency, shipped as the `engine` extra:
+`pip install 'lilbee[engine]' --extra-index-url https://lilbee.sh/<backend>/`
+resolves the matching per-platform wheel. It is not on PyPI, since the CUDA and
+ROCm wheels run past PyPI's per-file size limit, so all backends are published
+from lilbee's own PEP 503 index. CI fills `lilbee_engine/bin/` with the three
+binaries and retags the wheel to the platform before publishing; a source
+checkout has an empty `bin/` and resolves via `PATH` or
+`LILBEE_LLAMA_SERVER_PATH` instead.
 
 `lilbee.providers.fleet.binary` resolves each tool via
 `lilbee_engine.get_llama_server_path()` / `get_llama_swap_path()` /

--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -9,15 +9,18 @@ from pathlib import Path
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 
-# Names the extra rather than a command. The engine is published per backend and
-# the right index depends on the machine, so a single one baked in here goes
-# stale and points somebody at the wrong build; the README's install table is
-# where that choice belongs.
+# Every index is spelled out rather than pointing at the README. This is read at
+# the moment the engine is needed, often on a remote box, and listing all three
+# is what keeps naming one from sending a machine to the wrong build.
 _INSTALL_HINT = (
-    "The bundled engine ships as the 'engine' extra: reinstall lilbee with it "
-    "using the index for your hardware (see the install table in the README), or "
-    "set LILBEE_LLAMA_SERVER_PATH to a llama-server binary (a llama.cpp release "
-    "download or `brew install llama.cpp`) and put llama-swap / gguf-parser on PATH."
+    "The engine is lilbee's 'engine' extra, published on lilbee.sh rather than "
+    "PyPI, so the index is part of the command:\n"
+    "  NVIDIA: pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/\n"
+    "  AMD:    pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/\n"
+    "  Other:  pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/\n"
+    "A standalone binary from https://github.com/tobocop2/lilbee/releases/latest "
+    "bundles the engine instead. To bring your own, set LILBEE_LLAMA_SERVER_PATH to "
+    "a llama-server binary and put llama-swap / gguf-parser on PATH."
 )
 
 

--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -10,14 +10,18 @@ from pathlib import Path
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 
 # Every index is spelled out rather than pointing at the README. This is read at
-# the moment the engine is needed, often on a remote box, and listing all three
-# is what keeps naming one from sending a machine to the wrong build.
+# the moment the engine is needed, often on a remote box. One index per hardware
+# because the builds are not interchangeable: cpu is built with every GPU backend
+# off, metal only ships a macOS arm64 wheel, and vulkan only Linux/Windows ones,
+# so naming a single "default" hands somebody an engine that ignores their GPU.
 _INSTALL_HINT = (
     "The engine is lilbee's 'engine' extra, published on lilbee.sh rather than "
     "PyPI, so the index is part of the command:\n"
-    "  NVIDIA: pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/\n"
-    "  AMD:    pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/\n"
-    "  Other:  pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/\n"
+    "  NVIDIA (CUDA): pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cu125/\n"
+    "  AMD (ROCm):    pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/rocm/\n"
+    "  Apple silicon: pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/metal/\n"
+    "  Other GPUs:    pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/vulkan/\n"
+    "  No GPU:        pip install --pre 'lilbee[engine]' --extra-index-url https://lilbee.sh/cpu/\n"
     "A standalone binary from https://github.com/tobocop2/lilbee/releases/latest "
     "bundles the engine instead. To bring your own, set LILBEE_LLAMA_SERVER_PATH to "
     "a llama-server binary and put llama-swap / gguf-parser on PATH."

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -36,7 +36,7 @@ from lilbee.providers.base import (
     prompt_token_budget,
 )
 from lilbee.providers.fleet import planning
-from lilbee.providers.fleet.binary import engine_pin
+from lilbee.providers.fleet.binary import engine_pin, resolve_llama_server
 from lilbee.providers.fleet.client import (
     ChatDeadlineError,
     LlamaServerClient,
@@ -65,6 +65,7 @@ from lilbee.providers.fleet.swap_manager import (
     stop_engine,
 )
 from lilbee.providers.fleet.windowing import window_messages
+from lilbee.providers.model_ref import parse_model_ref
 from lilbee.providers.roles import MODEL_FIELD_TO_ROLE, WorkerRole, configured_model_message
 from lilbee.providers.warm_progress import WarmPhase, WarmProgress, WarmProgressTracker
 from lilbee.runtime.engine_lock import (
@@ -660,6 +661,47 @@ def _configured_model_for(role: WorkerRole) -> str:
     return getattr(cfg, field) or "" if field else ""
 
 
+def _unusable_engine_reason() -> str | None:
+    """Why no server can start on this host, or None once an engine resolves.
+
+    Planning drops an engine-less host to serving nothing and says so only at
+    debug, so by the time a surface has an empty pool the engine is the one cause
+    it cannot see. Re-resolving here is also what keeps an engine installed
+    mid-session from being reported as still missing.
+    """
+    try:
+        resolve_llama_server()
+    except ProviderError as exc:
+        return str(exc)
+    return None
+
+
+def _chat_needs_local_engine() -> bool:
+    """Whether the configured chat model is one this host has to serve itself.
+
+    A chat ref routed to an SDK backend runs without any local engine, so a
+    missing one is not its failure and must not be stamped on its warm.
+    """
+    ref = _configured_model_for(WorkerRole.CHAT)
+    return bool(ref) and not parse_model_ref(ref).is_remote
+
+
+def _no_server_message(role: WorkerRole) -> str:
+    """User-facing reason *role* has no server, engine state first.
+
+    A missing engine and a model that never placed both arrive as an empty pool,
+    and reading the second onto the first sends the reader to a model
+    configuration that is already correct.
+    """
+    reason = _unusable_engine_reason()
+    if reason is not None:
+        return f"No {role.value} model server is running: {reason}"
+    return (
+        f"No {role.value} model server is running. Make sure the {role.value} "
+        "model is installed and configured, then try again."
+    )
+
+
 class _EngineDemand(NamedTuple):
     """What this process needs an engine to serve: pairs plus its chat window."""
 
@@ -1224,11 +1266,7 @@ class FleetProvider:
             with self._lock:
                 clients = self._clients.get(role)
         if not clients:
-            raise ProviderError(
-                f"No {role.value} model server is running. Make sure a {role.value} "
-                "model is installed and configured, then try again.",
-                provider=_PROVIDER_NAME,
-            )
+            raise ProviderError(_no_server_message(role), provider=_PROVIDER_NAME)
         return list(clients)
 
     def _with_rediscover(self, call: Callable[[], _T], *, role: WorkerRole | None = None) -> _T:
@@ -1899,19 +1937,22 @@ class FleetProvider:
 
         ``_warm_chat_role`` always ends in READY or ERROR when it runs, so a
         snapshot still on STARTING after a successful preload means the plan had
-        no chat instance. A chat model that isn't installed fails the warm with a
-        user-facing reason so the prompt path renders "failed to load" instead of
-        spinning a "not ready" retry that can never succeed; any other reason (a
-        remote-routed chat has no local server to warm) clears the stamp.
+        no chat instance. A chat model that isn't installed, and a chat model with
+        no engine to run it, both fail the warm with a user-facing reason so the
+        prompt path renders "failed to load" instead of spinning a "not ready"
+        retry that can never succeed; any other reason (a remote-routed chat has
+        no local server to warm) clears the stamp.
         """
         snapshot = self._warm_tracker.snapshot()
         if snapshot is None or snapshot.phase is not WarmPhase.STARTING:
             return
         missing = self._skipped_not_installed.get(WorkerRole.CHAT)
-        if missing is None:
-            self._warm_tracker.clear()
-        else:
+        if missing is not None:
             self._warm_tracker.fail(f"chat model {clean_display_name(missing)} is not installed")
+        elif _chat_needs_local_engine() and (reason := _unusable_engine_reason()) is not None:
+            self._warm_tracker.fail(reason)
+        else:
+            self._warm_tracker.clear()
 
     def _preload_roles(self, roles: frozenset[WorkerRole] | None = None) -> None:
         """Issue a cheap request per replica so llama-swap loads each upstream now.

--- a/tests/test_fleet_binary.py
+++ b/tests/test_fleet_binary.py
@@ -380,3 +380,23 @@ def test_engine_pin_survives_an_engine_wheel_without_metadata(monkeypatch) -> No
     monkeypatch.setattr(binary_mod, "_pkg_version", _no_metadata)
     assert binary_mod._engine_build_id() == "wheel:unknown"
     assert binary_mod.engine_pin()  # total: a pin is still produced
+
+
+def test_install_hint_indexes_are_documented() -> None:
+    """Every index the error message names must also appear in the install docs.
+
+    The bug this guards was the two disagreeing: the docs shipped install commands
+    that produced no engine while the message that fired blamed the model. A reader
+    who follows the error and then checks the README has to find the same set.
+    """
+    import re
+
+    from lilbee.providers.fleet.binary import _INSTALL_HINT
+
+    hint_indexes = set(re.findall(r"https://lilbee\.sh/(\w+)/", _INSTALL_HINT))
+    assert hint_indexes, "the hint must name at least one index"
+
+    root = Path(__file__).resolve().parents[1]
+    for doc in ("README.md", "docs/usage.md"):
+        documented = set(re.findall(r"https://lilbee\.sh/(\w+)/", (root / doc).read_text()))
+        assert hint_indexes <= documented, f"{doc} is missing {hint_indexes - documented}"

--- a/tests/test_fleet_binary.py
+++ b/tests/test_fleet_binary.py
@@ -398,5 +398,8 @@ def test_install_hint_indexes_are_documented() -> None:
 
     root = Path(__file__).resolve().parents[1]
     for doc in ("README.md", "docs/usage.md"):
-        documented = set(re.findall(r"https://lilbee\.sh/(\w+)/", (root / doc).read_text()))
+        # Explicit utf-8: both files carry non-cp1252 characters, so the locale
+        # default would decode-error on Windows.
+        text = (root / doc).read_text(encoding="utf-8")
+        documented = set(re.findall(r"https://lilbee\.sh/(\w+)/", text))
         assert hint_indexes <= documented, f"{doc} is missing {hint_indexes - documented}"

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -141,6 +141,19 @@ def _install_engine(
     return swap
 
 
+@pytest.fixture
+def engine_installed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Plant a llama-server the conftest engine seal cannot hide.
+
+    An empty pool means something different with and without an engine, so a test
+    about the server state has to say which one it is standing in.
+    """
+    binary = tmp_path / "llama-server"
+    binary.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(cfg, "llama_server_path", str(binary))
+    return binary
+
+
 def _provider_with_clients(clients: dict[WorkerRole, list[MagicMock]]) -> FleetProvider:
     """A provider with a fake swap already up and a client pool per role (no real start)."""
     p = FleetProvider()
@@ -216,7 +229,7 @@ def test_chat_routes_to_chat_server() -> None:
     client.chat_result.assert_called_once()
 
 
-def test_chat_without_server_raises() -> None:
+def test_chat_without_server_raises(engine_installed: Path) -> None:
     from lilbee.providers.base import ProviderError
 
     p = _provider_with_clients({})  # no chat client, no in-process fallback
@@ -571,11 +584,41 @@ def test_adopt_group_gives_embed_client_cold_load_deadline_only(monkeypatch) -> 
     assert captured[WorkerRole.RERANK] is None
 
 
-def test_embed_without_server_raises() -> None:
+def test_embed_without_server_raises(engine_installed: Path) -> None:
     from lilbee.providers.base import ProviderError
 
     p = _provider_with_clients({})
-    with pytest.raises(ProviderError, match="No embed model server is running"):
+    with pytest.raises(ProviderError, match="Make sure the embed model is installed"):
+        p.embed(["a"])
+
+
+def test_missing_engine_is_reported_as_a_missing_engine() -> None:
+    """With no engine anywhere, the message must not send the reader to model config.
+
+    Nothing is wrong with the model here, so a message about installing and
+    configuring one costs the reader the whole search before they find the engine.
+    """
+    from lilbee.providers.base import ProviderError
+
+    p = _provider_with_clients({})
+    with pytest.raises(ProviderError) as caught:
+        p.embed(["a"])
+
+    message = str(caught.value)
+    assert "llama-server" in message
+    assert "lilbee[engine]" in message
+    assert "Make sure the embed model is installed" not in message
+
+
+def test_unusable_configured_engine_path_is_reported_as_the_engine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A LILBEE_LLAMA_SERVER_PATH pointing nowhere is an engine problem too."""
+    from lilbee.providers.base import ProviderError
+
+    monkeypatch.setattr(cfg, "llama_server_path", str(tmp_path / "gone"))
+    p = _provider_with_clients({})
+    with pytest.raises(ProviderError, match="LILBEE_LLAMA_SERVER_PATH is not a file"):
         p.embed(["a"])
 
 
@@ -587,7 +630,7 @@ def test_rerank_routes_to_engine() -> None:
     client.rerank.assert_called_once_with("q", ["a", "b"])
 
 
-def test_rerank_without_server_raises() -> None:
+def test_rerank_without_server_raises(engine_installed: Path) -> None:
     from lilbee.providers.base import ProviderError
 
     p = _provider_with_clients({})
@@ -1737,15 +1780,34 @@ def test_warm_up_blocking_reports_starting_before_fleet_spawn(monkeypatch) -> No
     assert seen == [WarmPhase.STARTING]
 
 
-def test_warm_up_blocking_clears_stamp_when_chat_absent_for_other_reasons(monkeypatch) -> None:
-    """No chat instance placed for a non-install reason (a remote-routed chat has
-    no local server to warm): the early STARTING stamp is dropped so the warm line
-    cannot spin forever, and no spurious failure is stamped."""
+def test_warm_up_blocking_clears_stamp_when_chat_routes_remote(monkeypatch) -> None:
+    """A remote-routed chat has no local server to warm: the early STARTING stamp is
+    dropped so the warm line cannot spin forever, and no spurious failure is stamped.
+    An engine is missing here too (the conftest seal), which is not this chat's
+    problem and must not be stamped on its warm."""
+    monkeypatch.setattr(cfg, "chat_model", "ollama/llama3.2:1b")
     p = FleetProvider()
     monkeypatch.setattr(p, "_ensure_fleet", lambda: None)
     monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
     p._warm_up_blocking()
     assert p.warm_progress() is None
+
+
+def test_warm_up_blocking_fails_with_the_engine_when_no_engine_resolves(monkeypatch) -> None:
+    """A local chat model with no engine to run it: the warm ends in a terminal ERROR
+    naming the engine and the install command. Waiting cannot fix a missing engine, so
+    a 'not ready, send again' bounce would loop for the rest of the session."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    p = FleetProvider()
+    monkeypatch.setattr(p, "_ensure_fleet", lambda: None)
+    monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+    p._warm_up_blocking()
+    snap = p.warm_progress()
+    assert snap is not None
+    assert snap.phase is WarmPhase.ERROR
+    assert "llama-server binary not found" in (snap.error or "")
+    assert "lilbee[engine]" in (snap.error or "")
 
 
 def test_warm_up_blocking_fails_when_chat_model_not_installed(monkeypatch) -> None:
@@ -2275,7 +2337,7 @@ class TestChatWithTools:
         client.chat_tools.assert_called_once()
         assert client.chat_tools.call_args.kwargs["tool_choice"] == "auto"
 
-    def test_without_server_raises(self) -> None:
+    def test_without_server_raises(self, engine_installed: Path) -> None:
         from lilbee.providers.base import ProviderError
 
         p = _provider_with_clients({})
@@ -2955,7 +3017,7 @@ def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
     assert len(clients) == 1
 
 
-def test_require_clients_no_reprobe_when_swap_none(monkeypatch) -> None:
+def test_require_clients_no_reprobe_when_swap_none(monkeypatch, engine_installed: Path) -> None:
     """Empty pool + no swap at all (unconfigured role) still raises, no rebuild."""
     from lilbee.providers.base import ProviderError
 
@@ -2973,7 +3035,7 @@ def test_require_clients_no_reprobe_when_swap_none(monkeypatch) -> None:
     assert rebuilt["called"] is False
 
 
-def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
+def test_require_clients_no_reprobe_when_swap_live(monkeypatch, engine_installed: Path) -> None:
     """Empty pool + live swap (real misconfiguration) still raises, no rebuild."""
     from unittest import mock
 

--- a/tests/test_outbound_hosts.py
+++ b/tests/test_outbound_hosts.py
@@ -29,6 +29,10 @@ ALLOWED_HOSTS: frozenset[str] = frozenset(
         "en.wikipedia.org",
         "example.com",
         "github.com",
+        # lilbee's own package index, named in the engine-missing error message so
+        # the reader gets the install command for their hardware. A string in a
+        # message; nothing fetches it.
+        "lilbee.sh",
         # Agent-client documentation links cited from agent_configs/ module docstrings.
         "docs.litellm.ai",
         "opencode.ai",


### PR DESCRIPTION
## Problem

An install without the `[engine]` extra has no llama-server anywhere, and planning handles that by quietly serving nothing. Ingest reported the empty client pool as `No embed model server is running. Make sure a embed model is installed and configured` — every word pointing at a model that was already installed and correctly configured. Chat had the same hole from the other side: with no engine the warm tracker was cleared, so a prompt rendered "The engine is not ready yet. Send your prompt again in a moment" for the rest of the session.

## The message

`_require_clients` re-resolves the engine before it writes a message, so a missing binary and an unusable `LILBEE_LLAMA_SERVER_PATH` both say so, and carry the install command for each backend index. Fixes "a embed model" while it is here.

## The chat warm

The warm finalizer fails a locally-routed chat model with the same reason. A remote-routed chat still clears, since it needs no local engine.

## The install hint

One command per hardware. The five indexes are not interchangeable: `metal` publishes only a macOS arm64 wheel, `vulkan` only Linux and Windows ones, and `cpu` is built with `GGML_METAL=OFF` and `GGML_VULKAN=OFF`, so a single named default hands somebody an engine that ignores their GPU.

## Install docs

`pip` and `uv` led every table while being the only route that can leave you without an engine. They now sit last, labelled for developers, with the bundled builds first. A new section explains why the engine is not on PyPI — the CUDA and ROCm wheels run 440 MB to 860 MB against PyPI's 100 MB per-file limit, so all backends ship from lilbee's own PEP 503 index — and says plainly that installing without the extra starts fine and fails on the first model call.

## Docs that produced the bug

The main uv row, the CUDA uv row, both ROCm rows and the CUDA line in the usage guide all installed lilbee without an engine, and the extras table never listed `[engine]`. Also corrected: `uv sync` does not give a checkout engine binaries (CI fills the wheel's `bin/`), and the compat channel has no engine wheel at all.

## Not covered

Whether `cpu/` should stay the recommended default index in the main table, given it is built with every GPU backend off.
