### PR TITLE
Require an explicit encoding on new file I/O, and fix the shipped sites

### DIFF
--- a/scripts/check_style_rules.py
+++ b/scripts/check_style_rules.py
@@ -85,6 +85,12 @@ ORIGINAL_FILE_RE = re.compile(r"\boriginal\s+[a-z_][a-z0-9_]*\.py\b", re.IGNOREC
 _ALWAYS_TEXT_CALLS = frozenset({"read_text", "write_text"})
 _TEXT_IO_CALLS = _ALWAYS_TEXT_CALLS | {"open", "NamedTemporaryFile"}
 
+# subprocess decodes its pipes with the locale's encoding too, whenever text
+# mode is asked for. Same defect, different call: the output of a GPU tool or a
+# probe script is decoded before any of this code sees it.
+_SUBPROCESS_CALLS = frozenset({"run", "Popen", "check_output", "check_call", "call"})
+_TEXT_MODE_KEYWORDS = frozenset({"text", "universal_newlines"})
+
 # A ``.open`` attribute call is only a file open when it says so. ``os.open``
 # returns a descriptor and ``webbrowser.open`` takes a URL; neither accepts an
 # encoding, so reporting them would be a finding nobody can resolve. Require
@@ -134,6 +140,20 @@ def _is_file_io(node: ast.Call, name: str) -> bool:
     return mode is not None and bool(_FILE_MODE_RE.match(mode))
 
 
+def _asks_for_text_pipes(node: ast.Call) -> bool:
+    """Whether *node* puts subprocess into text mode, which decodes its pipes.
+
+    Without a text-mode keyword the pipes stay bytes and there is nothing to
+    decode; ``capture_output`` alone does not change that.
+    """
+    return any(
+        keyword.arg in _TEXT_MODE_KEYWORDS
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value is True
+        for keyword in node.keywords
+    )
+
+
 def _opens_in_binary_mode(node: ast.Call, name: str) -> bool:
     """Whether *node* reads bytes, which have no encoding to declare.
 
@@ -167,9 +187,13 @@ def _unspecified_encoding_hits(path: Path) -> Iterator[tuple[int, str]]:
         if not isinstance(node, ast.Call):
             continue
         name = _call_name(node)
-        if name not in _TEXT_IO_CALLS:
+        if name not in _TEXT_IO_CALLS and name not in _SUBPROCESS_CALLS:
             continue
         if any(keyword.arg == "encoding" for keyword in node.keywords):
+            continue
+        if name in _SUBPROCESS_CALLS:
+            if _asks_for_text_pipes(node):
+                yield node.lineno, name
             continue
         if not _is_file_io(node, name) or _opens_in_binary_mode(node, name):
             continue

--- a/scripts/check_style_rules.py
+++ b/scripts/check_style_rules.py
@@ -151,7 +151,10 @@ def _is_subprocess_call(node: ast.Call) -> bool:
 
 
 def _asks_for_text_pipes(node: ast.Call) -> bool:
-    """Whether *node* asks subprocess for text pipes; without it they stay bytes."""
+    """Whether *node* asks subprocess for text pipes; without it they stay bytes.
+
+    Direct keywords only: a kwargs dict splatted with ``**`` hides the mode.
+    """
     return any(
         keyword.arg in _TEXT_MODE_KEYWORDS
         and isinstance(keyword.value, ast.Constant)

--- a/scripts/check_style_rules.py
+++ b/scripts/check_style_rules.py
@@ -85,10 +85,10 @@ ORIGINAL_FILE_RE = re.compile(r"\boriginal\s+[a-z_][a-z0-9_]*\.py\b", re.IGNOREC
 _ALWAYS_TEXT_CALLS = frozenset({"read_text", "write_text"})
 _TEXT_IO_CALLS = _ALWAYS_TEXT_CALLS | {"open", "NamedTemporaryFile"}
 
-# subprocess decodes its pipes with the locale's encoding too, whenever text
-# mode is asked for. Same defect, different call: the output of a GPU tool or a
-# probe script is decoded before any of this code sees it.
+# subprocess decodes its pipes with the locale's encoding in text mode.
 _SUBPROCESS_CALLS = frozenset({"run", "Popen", "check_output", "check_call", "call"})
+# Names that mean subprocess wherever they appear, so they need no receiver.
+_DISTINCTIVE_SUBPROCESS_CALLS = frozenset({"Popen", "check_output", "check_call"})
 _TEXT_MODE_KEYWORDS = frozenset({"text", "universal_newlines"})
 
 # A ``.open`` attribute call is only a file open when it says so. ``os.open``
@@ -127,9 +127,8 @@ def _mode_argument(node: ast.Call, name: str) -> str | None:
 def _is_file_io(node: ast.Call, name: str) -> bool:
     """Whether *node* is text file I/O this rule governs.
 
-    Everything but a bare ``.open`` attribute is unambiguous by name. For that
-    one, a ``Path(...)`` receiver or a mode-shaped first argument separates a
-    file open from ``os.open`` and ``webbrowser.open``.
+    A bare ``.open`` needs a ``Path(...)`` receiver or a mode-shaped first
+    argument; ``os.open`` and ``webbrowser.open`` accept no encoding.
     """
     if name != "open" or isinstance(node.func, ast.Name):
         return True
@@ -140,12 +139,19 @@ def _is_file_io(node: ast.Call, name: str) -> bool:
     return mode is not None and bool(_FILE_MODE_RE.match(mode))
 
 
-def _asks_for_text_pipes(node: ast.Call) -> bool:
-    """Whether *node* puts subprocess into text mode, which decodes its pipes.
+def _is_subprocess_call(node: ast.Call) -> bool:
+    """Whether *node* is subprocess's own call, not a same-named method elsewhere.
 
-    Without a text-mode keyword the pipes stay bytes and there is nothing to
-    decode; ``capture_output`` alone does not change that.
+    ``run`` and ``call`` are generic, so they need the receiver; ``Popen`` and
+    ``check_output`` are not.
     """
+    if isinstance(node.func, ast.Attribute):
+        return isinstance(node.func.value, ast.Name) and node.func.value.id == "subprocess"
+    return isinstance(node.func, ast.Name) and node.func.id in _DISTINCTIVE_SUBPROCESS_CALLS
+
+
+def _asks_for_text_pipes(node: ast.Call) -> bool:
+    """Whether *node* asks subprocess for text pipes; without it they stay bytes."""
     return any(
         keyword.arg in _TEXT_MODE_KEYWORDS
         and isinstance(keyword.value, ast.Constant)
@@ -157,8 +163,8 @@ def _asks_for_text_pipes(node: ast.Call) -> bool:
 def _opens_in_binary_mode(node: ast.Call, name: str) -> bool:
     """Whether *node* reads bytes, which have no encoding to declare.
 
-    ``NamedTemporaryFile`` defaults to ``w+b``, so it is binary until a text
-    mode says otherwise; ``open`` defaults to ``r``, so it is the reverse.
+    ``NamedTemporaryFile`` defaults to ``w+b`` and ``open`` to ``r``, so the
+    absent-mode default is opposite between them.
     """
     if name in _ALWAYS_TEXT_CALLS:
         return False
@@ -169,15 +175,10 @@ def _opens_in_binary_mode(node: ast.Call, name: str) -> bool:
 
 
 def _unspecified_encoding_hits(path: Path) -> Iterator[tuple[int, str]]:
-    """Yield ``(line, call name)`` for text file I/O that names no encoding.
+    """Yield ``(line, call name)`` for text I/O in *path* that names no encoding.
 
-    Without ``encoding=`` Python decodes with the locale's, so a file holding
-    anything outside cp1252 raises ``UnicodeDecodeError`` on Windows while
-    passing everywhere else. Ruff expresses this as PLW1514, but only under
-    preview mode, which turns on 900 unrelated findings across the tree.
-
-    An unparsable file yields nothing rather than raising: this runs over many
-    files, and a syntax error is already every other tool's finding.
+    An unparsable file yields nothing; a syntax error is already every other
+    tool's finding.
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -192,7 +193,7 @@ def _unspecified_encoding_hits(path: Path) -> Iterator[tuple[int, str]]:
         if any(keyword.arg == "encoding" for keyword in node.keywords):
             continue
         if name in _SUBPROCESS_CALLS:
-            if _asks_for_text_pipes(node):
+            if _is_subprocess_call(node) and _asks_for_text_pipes(node):
                 yield node.lineno, name
             continue
         if not _is_file_io(node, name) or _opens_in_binary_mode(node, name):
@@ -215,13 +216,7 @@ def _check_unspecified_encoding(paths: Iterable[Path]) -> Iterator[str]:
 
 
 def _check_new_unspecified_encoding(added: Iterable[tuple[str, int, str]]) -> Iterator[str]:
-    """Yield findings only where this branch added the offending line.
-
-    Whole-tree enforcement would mean touching 700-odd call sites, nearly all of
-    them ``tmp_path`` writes in tests that cannot fail. Diff scoping stops the
-    bug arriving without demanding that cleanup first, matching how the
-    code-smell check above is scoped.
-    """
+    """Yield findings only where this branch added the offending line."""
     added_lines: dict[str, set[int]] = {}
     for rel_path, lineno, _text in added:
         added_lines.setdefault(rel_path, set()).add(lineno)

--- a/scripts/check_style_rules.py
+++ b/scripts/check_style_rules.py
@@ -34,6 +34,7 @@ are found.
 
 from __future__ import annotations
 
+import ast
 import re
 import subprocess
 import sys
@@ -76,6 +77,134 @@ STALE_SINGLE_FILE_RE = re.compile(
 # "the original X.py" / "original foo.py" phrasing is historical narrative
 # pointing at a file that no longer exists in its single-file form.
 ORIGINAL_FILE_RE = re.compile(r"\boriginal\s+[a-z_][a-z0-9_]*\.py\b", re.IGNORECASE)
+
+
+# Names that always denote text file I/O, whatever they are called on:
+# ``Path.read_text`` / ``Path.write_text`` take no mode, and the builtin
+# ``open`` and ``NamedTemporaryFile`` are files by definition.
+_ALWAYS_TEXT_CALLS = frozenset({"read_text", "write_text"})
+_TEXT_IO_CALLS = _ALWAYS_TEXT_CALLS | {"open", "NamedTemporaryFile"}
+
+# A ``.open`` attribute call is only a file open when it says so. ``os.open``
+# returns a descriptor and ``webbrowser.open`` takes a URL; neither accepts an
+# encoding, so reporting them would be a finding nobody can resolve. Require
+# either a literal ``Path(...)`` receiver or a first argument that is a real
+# mode string, which is what tells a file open from its homonyms.
+_FILE_MODE_RE = re.compile(r"^[rwxa][bt+]*$")
+# ``open``'s mode is its second positional argument; the rest are keyword-only.
+_OPEN_MODE_POSITION = 1
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """The bare function name of *node*, ignoring whatever it is called on."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _mode_argument(node: ast.Call, name: str) -> str | None:
+    """The literal mode *node* opens with, or None when it names none."""
+    for keyword in node.keywords:
+        if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+            return str(keyword.value.value)
+    position = _OPEN_MODE_POSITION if name == "open" and isinstance(node.func, ast.Name) else 0
+    if name == "open" and len(node.args) > position:
+        first = node.args[position]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return first.value
+    return None
+
+
+def _is_file_io(node: ast.Call, name: str) -> bool:
+    """Whether *node* is text file I/O this rule governs.
+
+    Everything but a bare ``.open`` attribute is unambiguous by name. For that
+    one, a ``Path(...)`` receiver or a mode-shaped first argument separates a
+    file open from ``os.open`` and ``webbrowser.open``.
+    """
+    if name != "open" or isinstance(node.func, ast.Name):
+        return True
+    receiver = node.func.value if isinstance(node.func, ast.Attribute) else None
+    if isinstance(receiver, ast.Call) and _call_name(receiver) == "Path":
+        return True
+    mode = _mode_argument(node, name)
+    return mode is not None and bool(_FILE_MODE_RE.match(mode))
+
+
+def _opens_in_binary_mode(node: ast.Call, name: str) -> bool:
+    """Whether *node* reads bytes, which have no encoding to declare.
+
+    ``NamedTemporaryFile`` defaults to ``w+b``, so it is binary until a text
+    mode says otherwise; ``open`` defaults to ``r``, so it is the reverse.
+    """
+    if name in _ALWAYS_TEXT_CALLS:
+        return False
+    mode = _mode_argument(node, name)
+    if mode is None:
+        return name == "NamedTemporaryFile"
+    return "b" in mode
+
+
+def _unspecified_encoding_hits(path: Path) -> Iterator[tuple[int, str]]:
+    """Yield ``(line, call name)`` for text file I/O that names no encoding.
+
+    Without ``encoding=`` Python decodes with the locale's, so a file holding
+    anything outside cp1252 raises ``UnicodeDecodeError`` on Windows while
+    passing everywhere else. Ruff expresses this as PLW1514, but only under
+    preview mode, which turns on 900 unrelated findings across the tree.
+
+    An unparsable file yields nothing rather than raising: this runs over many
+    files, and a syntax error is already every other tool's finding.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        if name not in _TEXT_IO_CALLS:
+            continue
+        if any(keyword.arg == "encoding" for keyword in node.keywords):
+            continue
+        if not _is_file_io(node, name) or _opens_in_binary_mode(node, name):
+            continue
+        yield node.lineno, name
+
+
+def _encoding_finding(path: Path | str, lineno: int, name: str) -> str:
+    return (
+        f"{path}:{lineno}: {name}() without encoding= decodes as the locale's "
+        "(pass encoding='utf-8', or open in binary mode)"
+    )
+
+
+def _check_unspecified_encoding(paths: Iterable[Path]) -> Iterator[str]:
+    """Yield findings for every text file I/O call in *paths* naming no encoding."""
+    for path in paths:
+        for lineno, name in _unspecified_encoding_hits(path):
+            yield _encoding_finding(path, lineno, name)
+
+
+def _check_new_unspecified_encoding(added: Iterable[tuple[str, int, str]]) -> Iterator[str]:
+    """Yield findings only where this branch added the offending line.
+
+    Whole-tree enforcement would mean touching 700-odd call sites, nearly all of
+    them ``tmp_path`` writes in tests that cannot fail. Diff scoping stops the
+    bug arriving without demanding that cleanup first, matching how the
+    code-smell check above is scoped.
+    """
+    added_lines: dict[str, set[int]] = {}
+    for rel_path, lineno, _text in added:
+        added_lines.setdefault(rel_path, set()).add(lineno)
+    for rel_path, linenos in sorted(added_lines.items()):
+        for lineno, name in _unspecified_encoding_hits(REPO_ROOT / rel_path):
+            if lineno in linenos:
+                yield _encoding_finding(rel_path, lineno, name)
 
 
 def _iter_python_files(*roots: Path) -> Iterator[Path]:
@@ -216,8 +345,13 @@ def _smell_base_ref() -> str | None:
 
 def _git_diff_src(base: str) -> str:
     """Return ``git diff --unified=0`` of ``src/`` against the base sha."""
+    return _git_diff(base, "src")
+
+
+def _git_diff(base: str, *paths: str) -> str:
+    """Return ``git diff --unified=0`` of *paths* against the base sha."""
     out = subprocess.run(
-        ["git", "diff", "--unified=0", base, "--", "src"],
+        ["git", "diff", "--unified=0", base, "--", *paths],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -280,6 +414,9 @@ def main() -> int:
     base = _smell_base_ref()
     if base is not None:
         findings.extend(_check_code_smells(_parse_added_lines(_git_diff_src(base))))
+        findings.extend(
+            _check_new_unspecified_encoding(_parse_added_lines(_git_diff(base, "src", "tests")))
+        )
 
     for finding in findings:
         print(finding)

--- a/src/lilbee/cli/commands/meta.py
+++ b/src/lilbee/cli/commands/meta.py
@@ -101,7 +101,7 @@ def init() -> None:
     data = root / "data"
     docs.mkdir(parents=True)
     data.mkdir(parents=True)
-    (root / ".gitignore").write_text("data/\n")
+    (root / ".gitignore").write_text("data/\n", encoding="utf-8")
 
     if cfg.json_mode:
         json_output({"command": "init", "path": str(root), "created": True})

--- a/src/lilbee/cli/commands/serve_logging.py
+++ b/src/lilbee/cli/commands/serve_logging.py
@@ -58,7 +58,7 @@ class _FaultLog:
         log_dir.mkdir(parents=True, exist_ok=True)
         fault_path = log_dir / _FAULT_LOG_FILE_NAME
         if self._handle is None or self._handle.closed:
-            self._handle = fault_path.open("a")
+            self._handle = fault_path.open("a", encoding="utf-8")
             faulthandler.enable(file=self._handle)
         return fault_path
 

--- a/src/lilbee/cli/commands/servers.py
+++ b/src/lilbee/cli/commands/servers.py
@@ -95,7 +95,7 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
             sock = server.servers[0].sockets[0]
             actual_port = sock.getsockname()[1]
             port_path.parent.mkdir(parents=True, exist_ok=True)
-            port_path.write_text(str(actual_port))
+            port_path.write_text(str(actual_port), encoding="utf-8")
             atexit.register(_cleanup_port_file)
             console.print(f"Listening on http://{host}:{actual_port}")
         await server.main_loop()

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -399,9 +399,7 @@ def token(
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         tok = data.get("token", "")
-    # UnicodeDecodeError is a ValueError but not a JSONDecodeError, so a
-    # server.json holding bytes that are not UTF-8 needs naming separately to
-    # reach the message below instead of a bare traceback.
+    # UnicodeDecodeError is a ValueError, not a JSONDecodeError.
     except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
         if cfg.json_mode:
             json_output({"error": f"Could not read server.json: {exc}"})

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -397,9 +397,12 @@ def token(
             console.print("No running server found (server.json missing).")
         raise SystemExit(1)
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         tok = data.get("token", "")
-    except (json.JSONDecodeError, OSError) as exc:
+    # UnicodeDecodeError is a ValueError but not a JSONDecodeError, so a
+    # server.json holding bytes that are not UTF-8 needs naming separately to
+    # reach the message below instead of a bare traceback.
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
         if cfg.json_mode:
             json_output({"error": f"Could not read server.json: {exc}"})
         else:

--- a/src/lilbee/cli/launchers/hermes_mcp.py
+++ b/src/lilbee/cli/launchers/hermes_mcp.py
@@ -84,10 +84,8 @@ def _mcp_extra_requirements(interpreter: str) -> list[str]:
             [interpreter, "-c", _EXTRA_REQS_SNIPPET],
             capture_output=True,
             text=True,
-            # text=True decodes with the locale's encoding, so the JSON this
-            # prints would fail to decode on a non-UTF-8 console before it ever
-            # reaches json.loads.
             encoding="utf-8",
+            errors="replace",
             check=False,
         )
         reqs = json.loads(result.stdout or "[]")
@@ -135,6 +133,7 @@ def ensure_hermes_http_mcp(
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             check=False,
         )
     except OSError as exc:

--- a/src/lilbee/cli/launchers/hermes_mcp.py
+++ b/src/lilbee/cli/launchers/hermes_mcp.py
@@ -84,6 +84,10 @@ def _mcp_extra_requirements(interpreter: str) -> list[str]:
             [interpreter, "-c", _EXTRA_REQS_SNIPPET],
             capture_output=True,
             text=True,
+            # text=True decodes with the locale's encoding, so the JSON this
+            # prints would fail to decode on a non-UTF-8 console before it ever
+            # reaches json.loads.
+            encoding="utf-8",
             check=False,
         )
         reqs = json.loads(result.stdout or "[]")
@@ -130,6 +134,7 @@ def ensure_hermes_http_mcp(
             [interpreter, "-m", "pip", "install", *_mcp_extra_requirements(interpreter)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
         )
     except OSError as exc:

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -80,7 +80,7 @@ def _session_token() -> str | None:
     """The bearer token from server.json, or None if it is not readable yet."""
     try:
         data = json.loads(server_json_path().read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
         return None
     token = data.get("token")
     return token if isinstance(token, str) and token else None

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -42,7 +42,7 @@ def _read_spec(spec: str | None) -> PlacementSpec | None:
     elif spec.lstrip().startswith("{"):
         raw = spec  # inline JSON rather than a file path
     else:
-        raw = Path(spec).read_text()
+        raw = Path(spec).read_text(encoding="utf-8")
     return PlacementSpec.from_json(raw)
 
 

--- a/src/lilbee/core/system.py
+++ b/src/lilbee/core/system.py
@@ -178,7 +178,7 @@ def cgroup_memory_limit() -> int | None:
     """
     for path in (_CGROUP_ROOT / "memory.max", _CGROUP_ROOT / "memory" / "memory.limit_in_bytes"):
         try:
-            raw = path.read_text().strip()
+            raw = path.read_text(encoding="utf-8").strip()
         except OSError:
             continue
         if raw == "max":
@@ -197,7 +197,7 @@ def cgroup_memory_used() -> int | None:
         _CGROUP_ROOT / "memory" / "memory.usage_in_bytes",
     ):
         try:
-            return int(path.read_text().strip())
+            return int(path.read_text(encoding="utf-8").strip())
         except (OSError, ValueError):
             continue
     return None

--- a/src/lilbee/crawler/save.py
+++ b/src/lilbee/crawler/save.py
@@ -103,7 +103,7 @@ def load_crawl_metadata() -> dict[str, CrawlMeta]:
         return {}
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
         # A corrupt sidecar means every known URL looks new and gets re-crawled;
         # surface why rather than silently discarding the whole mapping.
         log.warning("Discarding unreadable crawl metadata sidecar %s: %s", path, exc)

--- a/src/lilbee/data/ingest/skip_marker.py
+++ b/src/lilbee/data/ingest/skip_marker.py
@@ -34,7 +34,7 @@ def _load_str_map(path: Path) -> dict[str, str]:
         return {}
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         log.debug("Sidecar %s unreadable, treating as empty: %s", path.name, exc)
         return {}
     if not isinstance(raw, dict):

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -517,7 +517,7 @@ def init(path: str = "") -> dict[str, Any]:
     if not root.is_dir():
         (root / "documents").mkdir(parents=True)
         (root / "data").mkdir(parents=True)
-        (root / ".gitignore").write_text("data/\n")
+        (root / ".gitignore").write_text("data/\n", encoding="utf-8")
         created = True
 
     # Switch MCP session to this project's KB. Overlay any persisted

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -624,9 +624,7 @@ class ModelRegistry:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             return ModelManifest(**data)
-        # UnicodeDecodeError is a ValueError but not a JSONDecodeError, so a
-        # manifest holding bytes that are not UTF-8 needs naming separately to
-        # stay "corrupt manifests read as absent" rather than crashing the scan.
+        # UnicodeDecodeError is a ValueError, not a JSONDecodeError.
         except (json.JSONDecodeError, UnicodeDecodeError, TypeError, KeyError):
             log.warning("Corrupt manifest: %s", path)
             return None

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -608,7 +608,7 @@ class ModelRegistry:
         tmp_path: str | None = None
         try:
             with tempfile.NamedTemporaryFile(
-                dir=path.parent, suffix=".tmp", mode="w", delete=False
+                dir=path.parent, suffix=".tmp", mode="w", encoding="utf-8", delete=False
             ) as tmp:
                 tmp_path = tmp.name
                 tmp.write(data)
@@ -622,9 +622,12 @@ class ModelRegistry:
         if not path.exists():
             return None
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
             return ModelManifest(**data)
-        except (json.JSONDecodeError, TypeError, KeyError):
+        # UnicodeDecodeError is a ValueError but not a JSONDecodeError, so a
+        # manifest holding bytes that are not UTF-8 needs naming separately to
+        # stay "corrupt manifests read as absent" rather than crashing the scan.
+        except (json.JSONDecodeError, UnicodeDecodeError, TypeError, KeyError):
             log.warning("Corrupt manifest: %s", path)
             return None
 

--- a/src/lilbee/providers/fleet/engine_diagnostics.py
+++ b/src/lilbee/providers/fleet/engine_diagnostics.py
@@ -24,6 +24,7 @@ def ldd_output(binary: Path, env: dict[str, str]) -> str | None:
             [ldd, str(binary)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=_LDD_TIMEOUT_S,
             env=env,
             check=False,

--- a/src/lilbee/providers/fleet/engine_diagnostics.py
+++ b/src/lilbee/providers/fleet/engine_diagnostics.py
@@ -25,6 +25,7 @@ def ldd_output(binary: Path, env: dict[str, str]) -> str | None:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=_LDD_TIMEOUT_S,
             env=env,
             check=False,

--- a/src/lilbee/providers/fleet/gpu_backends/fdinfo.py
+++ b/src/lilbee/providers/fleet/gpu_backends/fdinfo.py
@@ -92,7 +92,7 @@ def _client_engine_ns(pid: Path, driver: str) -> list[tuple[str, int]]:
         return pairs
     for entry in entries:
         try:
-            text = entry.read_text()
+            text = entry.read_text(encoding="utf-8")
         except OSError:
             continue
         if not _driver_matches(text, driver):

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -165,6 +165,7 @@ def _intel_gpu_top_output() -> str:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=_IGT_CAPTURE_S,
             check=False,
         )
@@ -256,6 +257,7 @@ def _igt_permission_denied(binary: str) -> bool:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=_IGT_PERM_CHECK_S,
             check=False,
         )

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -164,6 +164,7 @@ def _intel_gpu_top_output() -> str:
             [binary, "-J", "-s", str(_IGT_SAMPLE_MS)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=_IGT_CAPTURE_S,
             check=False,
         )
@@ -254,6 +255,7 @@ def _igt_permission_denied(binary: str) -> bool:
             [binary, "-J", "-s", str(_IGT_SAMPLE_MS)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=_IGT_PERM_CHECK_S,
             check=False,
         )

--- a/src/lilbee/providers/fleet/gpu_hardware.py
+++ b/src/lilbee/providers/fleet/gpu_hardware.py
@@ -78,7 +78,7 @@ def _linux_gpu_vendor_ids() -> Iterator[int]:
 def _read_sysfs_hex(path: Path) -> int | None:
     """The ``0x``-prefixed integer in a sysfs attribute, ``None`` when unreadable."""
     try:
-        return int(path.read_text().strip(), 16)
+        return int(path.read_text(encoding="utf-8").strip(), 16)
     except (OSError, ValueError):
         return None
 

--- a/src/lilbee/providers/fleet/proc.py
+++ b/src/lilbee/providers/fleet/proc.py
@@ -50,6 +50,10 @@ def run_bounded(
         "stdout": subprocess.PIPE,
         "stderr": subprocess.STDOUT if merge_stderr else subprocess.DEVNULL,
         "text": True,
+        # A probe writes its pipe in its own encoding; a GPU device name that is
+        # not locale-decodable must not raise out of a sampling call.
+        "encoding": "utf-8",
+        "errors": "replace",
         "env": env,
         "start_new_session": os.name == "posix",
     }

--- a/src/lilbee/providers/fleet/readback.py
+++ b/src/lilbee/providers/fleet/readback.py
@@ -245,7 +245,7 @@ def check_launch(
     renumbers its verbosity levels. Loud, it names itself as the thing to fix.
     """
     try:
-        text = engine_log_path(log_dir, model_id).read_text(errors="replace")
+        text = engine_log_path(log_dir, model_id).read_text(encoding="utf-8", errors="replace")
     except OSError:
         # No log at all. Usually the engine simply has not written one yet, so
         # this is silent by default. It is also exactly what a wrong environment

--- a/src/lilbee/providers/fleet/rocm_runtime.py
+++ b/src/lilbee/providers/fleet/rocm_runtime.py
@@ -47,7 +47,7 @@ def _amd_gpu_present() -> bool:
         return False
     for vendor in Path("/sys/class/drm").glob("card*/device/vendor"):
         try:
-            if vendor.read_text().strip().lower() == _AMD_PCI_VENDOR_ID:
+            if vendor.read_text(encoding="utf-8").strip().lower() == _AMD_PCI_VENDOR_ID:
                 return True
         except OSError:
             continue
@@ -81,7 +81,7 @@ def _host_amd_gfx_targets() -> set[str]:
     targets: set[str] = set()
     for props in Path("/sys/class/kfd/kfd/topology/nodes").glob("*/properties"):
         try:
-            text = props.read_text()
+            text = props.read_text(encoding="utf-8")
         except OSError:
             continue
         for line in text.splitlines():

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -538,6 +538,7 @@ def _ephemeral_range() -> tuple[int, int] | None:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=5,
             check=False,
         )

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -537,6 +537,7 @@ def _ephemeral_range() -> tuple[int, int] | None:
             ["/usr/sbin/sysctl", "-n", "net.inet.ip.portrange.first", "net.inet.ip.portrange.last"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=5,
             check=False,
         )

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -160,7 +160,7 @@ def _atomic_write(path: Path, text: str) -> None:
     from a live writer's file in flight -- see ``_clean_stale_tmp_files``.
     """
     tmp_path = path.with_name(f"{_STATE_TMP_PREFIX}{path.name}{_STATE_TMP_SUFFIX}")
-    tmp_path.write_text(text)
+    tmp_path.write_text(text, encoding="utf-8")
     os.replace(tmp_path, path)
 
 
@@ -517,7 +517,7 @@ _PROC_PORT_RANGE = Path("/proc/sys/net/ipv4/ip_local_port_range")
 def _port_range_from(path: Path) -> tuple[int, int] | None:
     """The two integers in *path*, or ``None`` when it is absent or unreadable."""
     try:
-        low, high = path.read_text().split()[:2]
+        low, high = path.read_text(encoding="utf-8").split()[:2]
         return int(low), int(high)
     except (OSError, ValueError):
         return None
@@ -916,7 +916,7 @@ def _hard_stop_proc(proc: psutil.Process) -> None:
 def _load_state(path: Path) -> SwapState | None:
     """Parse a state file into a :class:`SwapState`; ``None`` when absent/corrupt."""
     try:
-        payload = json.loads(path.read_text())
+        payload = json.loads(path.read_text(encoding="utf-8"))
         raw_pgid = payload.get(_STATE_KEY_PGID)
         raw_created = payload.get(_STATE_KEY_CREATED_AT)
         raw_ports = payload.get(_STATE_KEY_MEMBER_PORTS) or []

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -249,6 +249,7 @@ def _nvidia_device_totals() -> list[tuple[str, int]] | None:
             ["nvidia-smi", "--query-gpu=memory.total,uuid", "--format=csv,noheader,nounits"],  # noqa: S607
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=5,
         )
         if result.returncode == 0:

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -250,6 +250,7 @@ def _nvidia_device_totals() -> list[tuple[str, int]] | None:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
         if result.returncode == 0:

--- a/src/lilbee/runtime/cpu.py
+++ b/src/lilbee/runtime/cpu.py
@@ -39,7 +39,7 @@ def _cgroup_cpu_quota(root: Path = _CGROUP_ROOT) -> float | None:
     per caller, so it is left to them.
     """
     try:
-        v2 = (root / "cpu.max").read_text().split()
+        v2 = (root / "cpu.max").read_text(encoding="utf-8").split()
     except OSError:
         v2 = []
     if v2:
@@ -51,8 +51,8 @@ def _cgroup_cpu_quota(root: Path = _CGROUP_ROOT) -> float | None:
             return None
         return quota / period if period > 0 else None
     try:
-        quota = int((root / "cpu" / "cpu.cfs_quota_us").read_text())
-        period = int((root / "cpu" / "cpu.cfs_period_us").read_text())
+        quota = int((root / "cpu" / "cpu.cfs_quota_us").read_text(encoding="utf-8"))
+        period = int((root / "cpu" / "cpu.cfs_period_us").read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     if quota <= 0 or period <= 0:

--- a/src/lilbee/runtime/lock.py
+++ b/src/lilbee/runtime/lock.py
@@ -113,14 +113,14 @@ def acquire_scope_lock(
     except FileLockTimeout:
         return None
     owner_path = scope_dir / _SCOPE_OWNER_NAME
-    owner_path.write_text(json.dumps({"data_dir": str(data_dir)}))
+    owner_path.write_text(json.dumps({"data_dir": str(data_dir)}), encoding="utf-8")
     return ScopeHold(lock, owner_path)
 
 
 def read_scope_owner(scope_dir: Path) -> ScopeOwner | None:
     """The scope's recorded owner, or None when absent or unreadable."""
     try:
-        payload = json.loads((scope_dir / _SCOPE_OWNER_NAME).read_text())
+        payload = json.loads((scope_dir / _SCOPE_OWNER_NAME).read_text(encoding="utf-8"))
         return ScopeOwner(data_dir=str(payload["data_dir"]))
     except (OSError, ValueError, KeyError, TypeError):
         return None

--- a/src/lilbee/sessions/store.py
+++ b/src/lilbee/sessions/store.py
@@ -239,7 +239,10 @@ class SessionStore:
 
     @staticmethod
     def _iter_events(path: Path) -> Iterator[dict[str, Any]]:
-        with path.open(encoding="utf-8") as fh:
+        # errors="replace": a crash mid-write can tear a multi-byte character, and
+        # that decodes here in the for-loop, outside the try below that exists
+        # to skip torn lines. Replacing makes it a JSON failure it can catch.
+        with path.open(encoding="utf-8", errors="replace") as fh:
             for raw in fh:
                 line = raw.strip()
                 if not line:

--- a/src/lilbee/sessions/store.py
+++ b/src/lilbee/sessions/store.py
@@ -239,9 +239,8 @@ class SessionStore:
 
     @staticmethod
     def _iter_events(path: Path) -> Iterator[dict[str, Any]]:
-        # errors="replace": a crash mid-write can tear a multi-byte character, and
-        # that decodes here in the for-loop, outside the try below that exists
-        # to skip torn lines. Replacing makes it a JSON failure it can catch.
+        # A torn multi-byte character decodes here, outside the try that skips
+        # torn lines; replacing makes it a JSON failure that try can catch.
         with path.open(encoding="utf-8", errors="replace") as fh:
             for raw in fh:
                 line = raw.strip()

--- a/src/lilbee/wiki/stubs.py
+++ b/src/lilbee/wiki/stubs.py
@@ -142,7 +142,7 @@ def _read_stub_index(config: Config | None = None) -> dict[str, WikiStub] | None
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         log.warning("Wiki stub index unreadable", exc_info=True)
         return None
     if not isinstance(payload, dict) or payload.get("version") != _INDEX_VERSION:

--- a/tests/test_check_style_rules.py
+++ b/tests/test_check_style_rules.py
@@ -222,3 +222,41 @@ class TestDiffScopedEncodingCheck:
 
         assert len(findings) == 1
         assert ":2:" in findings[0]
+
+
+class TestSubprocessTextPipes:
+    """subprocess decodes its pipes with the locale's encoding in text mode.
+
+    Same defect as read_text: a GPU tool or probe script printing a non-ASCII
+    device name or path fails to decode before any of our code sees it.
+    """
+
+    def _findings(self, tmp_path: Path, source: str) -> list[str]:
+        target = tmp_path / "sample.py"
+        target.write_text(source, encoding="utf-8")
+        return list(csr._check_unspecified_encoding([target]))
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("subprocess.run(cmd, text=True)", id="run_text"),
+            pytest.param("subprocess.run(cmd, universal_newlines=True)", id="run_universal"),
+            pytest.param("subprocess.Popen(cmd, text=True)", id="popen"),
+            pytest.param("subprocess.check_output(cmd, text=True)", id="check_output"),
+        ],
+    )
+    def test_flags_text_pipes_without_encoding(self, tmp_path: Path, source: str) -> None:
+        assert self._findings(tmp_path, source), f"should have flagged: {source}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("subprocess.run(cmd, text=True, encoding='utf-8')", id="encoded"),
+            pytest.param("subprocess.run(cmd, capture_output=True)", id="bytes_pipes"),
+            pytest.param("subprocess.run(cmd)", id="no_pipes"),
+            pytest.param("subprocess.run(cmd, text=False)", id="text_disabled"),
+            pytest.param("chunk(raw, heading_context=True)", id="unrelated_true_kwarg"),
+        ],
+    )
+    def test_leaves_byte_pipes_and_encoded_calls_alone(self, tmp_path: Path, source: str) -> None:
+        assert not self._findings(tmp_path, source), f"should not have flagged: {source}"

--- a/tests/test_check_style_rules.py
+++ b/tests/test_check_style_rules.py
@@ -111,3 +111,114 @@ class TestCheckCodeSmells:
     def test_clean_line_yields_nothing(self):
         added = [("src/x.py", 1, "    return result.content")]
         assert list(csr._check_code_smells(added)) == []
+
+
+class TestUnspecifiedEncoding:
+    """Text file I/O must name its encoding, or it decodes as the locale's.
+
+    The bug is invisible on macOS and Linux (UTF-8 locales) and raises
+    UnicodeDecodeError on Windows, so only one CI cell in nine ever goes red.
+    """
+
+    def _findings(self, tmp_path: Path, source: str) -> list[str]:
+        target = tmp_path / "sample.py"
+        target.write_text(source, encoding="utf-8")
+        return list(csr._check_unspecified_encoding([target]))
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("Path('a').read_text()", id="read_text"),
+            pytest.param("Path('a').write_text('x')", id="write_text"),
+            pytest.param("Path('a').open()", id="path_open"),
+            pytest.param("open('a')", id="builtin_open"),
+            pytest.param("open('a', 'w')", id="builtin_open_text_mode"),
+            pytest.param("tempfile.NamedTemporaryFile(mode='w')", id="named_temporary_file"),
+        ],
+    )
+    def test_flags_text_io_without_encoding(self, tmp_path: Path, source: str) -> None:
+        assert self._findings(tmp_path, source), f"should have flagged: {source}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("Path('a').read_text(encoding='utf-8')", id="read_text_encoded"),
+            pytest.param("open('a', encoding='utf-8')", id="open_encoded"),
+            pytest.param("Path('a').read_bytes()", id="read_bytes"),
+            pytest.param("Path('a').write_bytes(b'x')", id="write_bytes"),
+            pytest.param("open('a', 'rb')", id="binary_positional"),
+            pytest.param("open('a', mode='wb')", id="binary_keyword"),
+            pytest.param("tempfile.NamedTemporaryFile(mode='wb')", id="temp_binary"),
+            pytest.param("socket.open()", id="unrelated_open_receiver"),
+        ],
+    )
+    def test_leaves_encoded_and_binary_io_alone(self, tmp_path: Path, source: str) -> None:
+        assert not self._findings(tmp_path, source), f"should not have flagged: {source}"
+
+    def test_reports_path_and_line(self, tmp_path: Path) -> None:
+        findings = self._findings(tmp_path, "x = 1\ny = Path('a').read_text()\n")
+        assert len(findings) == 1
+        assert ":2:" in findings[0]
+        assert "encoding" in findings[0]
+
+    def test_a_syntactically_invalid_file_is_skipped_not_crashed(self, tmp_path: Path) -> None:
+        # The checker runs over the whole tree in make lint; one unparsable file
+        # must not take the entire gate down with a SyntaxError.
+        assert self._findings(tmp_path, "def broken(:\n") == []
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("os.open(os.devnull, os.O_WRONLY)", id="os_open_fd"),
+            pytest.param("webbrowser.open('https://example.com')", id="webbrowser_open"),
+            pytest.param("zf.open(name)", id="zipfile_member"),
+        ],
+    )
+    def test_leaves_open_homonyms_alone(self, tmp_path: Path, source: str) -> None:
+        """These take no encoding at all, so flagging them is unresolvable."""
+        assert not self._findings(tmp_path, source), f"should not have flagged: {source}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("log_path.open('a')", id="path_variable_text_append"),
+            pytest.param("fault_path.open('w')", id="path_variable_text_write"),
+        ],
+    )
+    def test_flags_a_path_variable_opened_in_a_text_mode(self, tmp_path: Path, source: str) -> None:
+        """The mode string is what identifies a file open on an unresolved name."""
+        assert self._findings(tmp_path, source), f"should have flagged: {source}"
+
+
+class TestDiffScopedEncodingCheck:
+    """The check runs on added lines, so it must survive paths that are gone.
+
+    A branch that adds a file and then deletes it still has added lines in the
+    diff while the path no longer exists on disk, and make lint must not die on
+    it. ``scripts/`` is outside the coverage gate's scope, so nothing else would
+    catch a regression here.
+    """
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            pytest.param("src/lilbee/deleted_on_this_branch.py", id="path_removed"),
+            pytest.param("src", id="path_is_a_directory"),
+        ],
+    )
+    def test_an_unreadable_path_yields_nothing_instead_of_raising(self, rel_path: str) -> None:
+        assert list(csr._check_new_unspecified_encoding([(rel_path, 1, "x")])) == []
+
+    def test_it_reports_only_the_lines_the_branch_added(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two offences in the file, one of them added: only that one is reported."""
+        monkeypatch.setattr(csr, "REPO_ROOT", tmp_path)
+        (tmp_path / "sample.py").write_text(
+            "Path('a').read_text()\nPath('b').read_text()\n", encoding="utf-8"
+        )
+
+        findings = list(csr._check_new_unspecified_encoding([("sample.py", 2, "x")]))
+
+        assert len(findings) == 1
+        assert ":2:" in findings[0]

--- a/tests/test_check_style_rules.py
+++ b/tests/test_check_style_rules.py
@@ -260,3 +260,28 @@ class TestSubprocessTextPipes:
     )
     def test_leaves_byte_pipes_and_encoded_calls_alone(self, tmp_path: Path, source: str) -> None:
         assert not self._findings(tmp_path, source), f"should not have flagged: {source}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("scheduler.run(job, text=True)", id="unrelated_run_method"),
+            pytest.param("harness.call(step, text=True)", id="unrelated_call_method"),
+            pytest.param("run(job, text=True)", id="bare_generic_run"),
+        ],
+    )
+    def test_leaves_same_named_methods_on_other_objects_alone(
+        self, tmp_path: Path, source: str
+    ) -> None:
+        """run and call are generic; flagging an API with no encoding= is unresolvable."""
+        assert not self._findings(tmp_path, source), f"should not have flagged: {source}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param("Popen(cmd, text=True)", id="bare_popen"),
+            pytest.param("check_output(cmd, text=True)", id="bare_check_output"),
+        ],
+    )
+    def test_flags_distinctive_names_without_a_receiver(self, tmp_path: Path, source: str) -> None:
+        """Popen and check_output mean subprocess wherever they appear."""
+        assert self._findings(tmp_path, source), f"should have flagged: {source}"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1300,3 +1300,30 @@ class TestShardAccounting:
         total, shard_blobs = _shard_accounting(tmp_path / "m-00001-of-00003.gguf")
         assert total == 20  # only the two present shards
         assert len(shard_blobs) == 1  # only shard 3 (primary is shard 1)
+
+
+class TestManifestEncodingIsTotal:
+    """A manifest that is not valid UTF-8 reads as absent, not as a crash.
+
+    ``read_text(encoding="utf-8")`` raises UnicodeDecodeError, which is a
+    ValueError and NOT a JSONDecodeError, so it needs naming in the except or a
+    single unreadable manifest takes down the whole installed-model scan.
+    """
+
+    def test_a_manifest_holding_invalid_utf8_reads_as_none(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        path = registry._manifest_path("org/repo", "model.gguf")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"hf_repo": "org/repo", "name": "\xff\xfe not utf-8"}')
+
+        assert registry._load_manifest_file(path) is None
+
+    def test_the_scan_survives_one_unreadable_manifest(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        path = registry._manifest_path("org/repo", "model.gguf")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\xff\xfe\x00binary garbage")
+
+        # The contract is "corrupt manifests read as absent", so listing must
+        # return rather than propagate the decode failure.
+        assert registry.list_installed() == []


### PR DESCRIPTION
## Problem

Text file I/O without `encoding=` decodes with the machine's locale, so a file holding anything outside cp1252 raises `UnicodeDecodeError` on Windows and passes on macOS and Linux. Only one CI cell in nine ever goes red, which is how the index drift guard in #686 shipped a Windows-only failure.

## The sites that bite

`runtime/lock.py` and `providers/fleet/swap_manager.py` serialize filesystem paths into JSON and YAML, and `modelhub/registry.py` writes the model manifest through a text-mode `NamedTemporaryFile`. A non-ASCII home directory or model name breaks all three on Windows today. 23 sites in `src/` now name utf-8; the rest read `/sys`, `/proc` and cgroup files, which are ASCII, so those are correct rather than urgent.

## The gate

Lives in `check_style_rules.py`, not ruff. Ruff has the rule as `PLW1514` but only under preview, which turns on 900 unrelated findings across `RUF052`, `RUF029`, `RUF069` and others. It is scoped to added lines, matching the code-smell check beside it: whole-tree enforcement is 732 sites, nearly all `tmp_path` writes in tests that cannot fail.

Two details it has to get right. `NamedTemporaryFile` defaults to `w+b`, so it is binary until a text mode says otherwise, the reverse of `open`. And a bare `.open` attribute needs a `Path(...)` receiver or a mode-shaped first argument, because `os.open` returns a descriptor and `webbrowser.open` takes a URL, and neither accepts an encoding to add.

## Exception contracts

`UnicodeDecodeError` is a `ValueError` but not a `JSONDecodeError`, so eight except clauses that promised a default on an unreadable file crashed instead. A manifest that is not UTF-8 took down the whole installed-model scan. `sessions/store.py` decoded in its for-loop, outside the try that exists to skip a torn final line, so a crash mid-write leaving a partial multi-byte character defeated exactly that resilience.

## subprocess

Text mode makes subprocess decode its pipes with the locale's encoding too, so the rule covers it: six calls read GPU tool output, engine diagnostics and pip output that way. `capture_output` alone keeps the pipes as bytes and is left alone.
