### PR TITLE
Size a tight chat split per device instead of as a single card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ format-check:
 
 typecheck:
 	uv run mypy src/lilbee/
+	# The GPU QA tools read lilbee's own types, so they rot silently when one
+	# changes: multi_gpu_smoke crashed on its first check from #540 until this
+	# was added. The rest of tools/qa/ is not clean yet and is not listed.
+	uv run mypy tools/qa/placement_matrix/ tools/qa/multi_gpu_smoke.py
 
 test:
 	uv run pytest --cov=lilbee --cov-report=term-missing -v -n logical --dist loadgroup

--- a/src/lilbee/providers/fleet/ctx.py
+++ b/src/lilbee/providers/fleet/ctx.py
@@ -12,16 +12,16 @@ from pathlib import Path
 
 from lilbee.core.config.enums import KvCacheType
 from lilbee.providers.engine_params import chat_ctx_ceiling
+from lilbee.providers.fleet.placement import _vram_proportional_split
 from lilbee.providers.fleet.vram import estimate_instance_footprint, usable_vram_fraction
 from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTUM
 
 # Extra VRAM held back on the busiest card on top of the gguf-parser estimate.
 # In --split-mode layer, gguf-parser ignores --main-gpu and so under-models the
 # compute graph + logits that real llama.cpp concentrates on the main device.
-# Default 0 (trust the estimate); raise once measured on a multi-GPU pod. This
-# matters more than it used to: a split chat may now serve several full windows
-# where it once served one, so the unclaimed headroom that happened to cushion
-# this skew is what those extra windows are spending.
+# Measured on 2x4090 (70B Q4_K_M, ctx 5888): the main device lands 0.26 GiB over
+# its estimate, an order of magnitude inside the usable_vram_fraction already held
+# back per card, so the reserve stays 0.
 _MAIN_GPU_SKEW_RESERVE_BYTES = 0
 
 
@@ -52,6 +52,11 @@ def fit_split_ctx(
     the per-device check below against real free bytes, not the placement
     reserve. Falls to the floor when even the floor overflows; plan_launches
     refuses a chat launch left at a window below the minimum grounded prompt.
+
+    An empty *ratio* is the tight placement, which launches without one so the
+    engine runs its own fit pass. It is also the estimator's only device-count
+    signal, so size against a headroom-proportional one here: without it
+    gguf-parser reports the whole model as a single card and nothing fits.
     """
     headrooms = [
         int(free * usable_vram_fraction()) - _MAIN_GPU_SKEW_RESERVE_BYTES
@@ -59,6 +64,9 @@ def fit_split_ctx(
     ]
     if min(headrooms) <= 0:
         return _DYNAMIC_CTX_FLOOR
+    if not ratio and len(per_device_free_bytes) > 1:
+        by_position = {i: float(free) for i, free in enumerate(per_device_free_bytes)}
+        ratio = _vram_proportional_split(list(by_position), by_position)
     # Bound the per-slot search by the planned working context, not just the model's
     # trained max: filling VRAM to that max OOM'd large tensor-split models under
     # load (a 235B took the full 262144-token ctx and crashed). The caller passes the

--- a/tests/test_fleet_ctx.py
+++ b/tests/test_fleet_ctx.py
@@ -132,3 +132,47 @@ class TestFitSplitCtx:
         monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _peak_estimator(lambda c: c))
         result = _fit(Path("/m.gguf"), slots=1, per_device_free_bytes=[40000, 10000])
         assert result <= int(10000 * 0.9)
+
+    def test_a_tight_group_is_sized_per_device_not_as_one_card(self, monkeypatch) -> None:
+        # A tight placement launches with no ratio so the engine runs its own fit
+        # pass, and the estimator reads the ratio as its device count. Passing the
+        # emptiness on made it size the whole model as a single card, which no
+        # card's headroom holds, so every context down to the floor was rejected
+        # and a 70B on two 24 GiB cards was refused a window it measurably serves.
+        seen: list[tuple[int, ...]] = []
+
+        def fake(_model_path: Path, **kw: object) -> GgufVramEstimate:
+            ratio: tuple[int, ...] = kw["tensor_split"]  # type: ignore[assignment]
+            seen.append(ratio)
+            # Weights split across the cards, plus KV proportional to the context.
+            per_device = tuple(20 * _GB + int(kw["ctx"]) * int(kw["slots"]) for _ in ratio)
+            return GgufVramEstimate(
+                vram_bytes=sum(per_device),
+                ram_bytes=0,
+                unified_bytes=0,
+                per_device_vram=per_device,
+            )
+
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 32768)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", fake)
+        result = _fit(
+            Path("/m.gguf"), slots=1, ratio=(), per_device_free_bytes=[24 * _GB, 24 * _GB]
+        )
+        assert seen and all(len(r) == 2 for r in seen)
+        assert result > _DYNAMIC_CTX_FLOOR
+
+    def test_a_single_card_keeps_its_empty_ratio(self, monkeypatch) -> None:
+        # One card is not a split; deriving a ratio there would make the estimator
+        # report a breakdown the launch never asks for.
+        seen: list[tuple[int, ...]] = []
+
+        def fake(_model_path: Path, **kw: object) -> GgufVramEstimate:
+            seen.append(kw["tensor_split"])  # type: ignore[arg-type]
+            return GgufVramEstimate(
+                vram_bytes=1, ram_bytes=0, unified_bytes=0, per_device_vram=(1,)
+            )
+
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 8192)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", fake)
+        _fit(Path("/m.gguf"), slots=1, ratio=(), per_device_free_bytes=[24 * _GB])
+        assert seen and all(r == () for r in seen)

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -17,6 +17,7 @@ from lilbee.providers.fleet.devices import (
     FleetDevice,
     visible_env,
 )
+from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.placement import InstancePlan, ModelPlacementInput, Placement
 from lilbee.providers.fleet.vram import GgufVramEstimate
 from lilbee.providers.roles import RerankMode, WorkerRole
@@ -3421,3 +3422,69 @@ class TestDeviceProbeEmptyRetry:
         )
         planning_mod.resolve_devices(Path("/x"))
         assert calls["n"] == 1  # no GPU present, empty is authoritative
+
+
+class TestATightSplitSizesPerDeviceButLaunchesWithoutARatio:
+    """The tight group's two halves disagree on purpose.
+
+    The launch withholds ``--tensor-split`` so the engine runs its own fit pass
+    and can spill what does not fit (see test_tight_split_lets_the_engine_fit).
+    The estimate cannot: the ratio is its only device-count signal, and without
+    one gguf-parser sizes the whole model as a single card, so the context fit
+    rejects every window down to its floor and the chat launch is refused.
+    """
+
+    # 40 GiB of weights over two 23 GiB cards: one shard clears the 0.9 headroom,
+    # the whole model on one card does not. That gap is what the fit turns on.
+    _WEIGHTS = 40 * _GB
+    _KV_PER_TOKEN = 65536
+
+    @classmethod
+    def _tight_chat_launch(cls, monkeypatch) -> tuple[InstanceLaunch, list[tuple[int, ...]]]:
+        seen: list[tuple[int, ...]] = []
+
+        def _capture(_path, **kwargs) -> GgufVramEstimate:
+            ratio: tuple[int, ...] = kwargs.get("tensor_split", ())
+            seen.append(ratio)
+            # gguf-parser reports one entry per split proportion, and with no
+            # proportions it sizes the instance as a single device.
+            shards = len(ratio) or 1
+            kv = int(kwargs["ctx"]) * int(kwargs["slots"]) * cls._KV_PER_TOKEN
+            per_device = tuple((cls._WEIGHTS + kv) // shards for _ in range(shards))
+            return GgufVramEstimate(
+                vram_bytes=sum(per_device),
+                ram_bytes=0,
+                unified_bytes=sum(per_device),
+                per_device_vram=per_device,
+            )
+
+        monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _capture)
+        monkeypatch.setattr("lilbee.providers.fleet.ctx.estimate_instance_footprint", _capture)
+        monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+        monkeypatch.setattr(planning_mod, "_weights_bytes", lambda _p: 40 * _GB)
+        monkeypatch.setattr(
+            planning_mod.engine_params, "resolve_model_path", lambda _r: Path("/m/m.gguf")
+        )
+        by_index = {
+            0: FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB),
+            1: FleetDevice("CUDA", 1, "gpu", 24 * _GB, 23 * _GB),
+        }
+        # devices without a ratio is what _place_tight emits.
+        plan = InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=())
+        launch = planning_mod._launch_for(plan, "ref", Path("/bin/llama-server"), by_index)
+        return launch, seen
+
+    def test_the_estimate_gets_a_two_card_ratio(self, monkeypatch) -> None:
+        _launch, seen = self._tight_chat_launch(monkeypatch)
+        assert seen, "the context fit never estimated"
+        assert all(len(ratio) == 2 for ratio in seen), seen
+
+    def test_the_launch_still_withholds_the_flag(self, monkeypatch) -> None:
+        launch, _seen = self._tight_chat_launch(monkeypatch)
+        assert "--tensor-split" not in launch.argv
+
+    def test_the_window_clears_the_floor(self, monkeypatch) -> None:
+        from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR
+
+        launch, _seen = self._tight_chat_launch(monkeypatch)
+        assert launch.ctx > _DYNAMIC_CTX_FLOOR

--- a/tests/test_placement_matrix.py
+++ b/tests/test_placement_matrix.py
@@ -12,12 +12,31 @@ from __future__ import annotations
 import ast
 
 import pytest
-from tools.qa.placement_matrix import observe
-from tools.qa.placement_matrix.cells import Cell, ModelSpec, build_matrix, iter_pairs
+from tools.qa.placement_matrix import observe, oracles
+from tools.qa.placement_matrix.cells import (
+    Cell,
+    ModelSpec,
+    build_matrix,
+    iter_pairs,
+    pair_by_room,
+)
 from tools.qa.placement_matrix.oracles import Observation, compare, judge
 
 _GB = 1024**3
 _MODEL = ModelSpec(key="m", ref="org/repo/m.gguf", probes="test")
+
+_PLANNED_PAYLOAD = {
+    "planned": True,
+    "total_free_bytes": 48 * _GB,
+    "min_usable_ctx": 2160,
+    "refusal": None,
+    "ctx": 5888,
+    "slots": 1,
+    "argv": ["llama-server", "--ctx-size", "5888"],
+    "env": {"CUDA_VISIBLE_DEVICES": "0,1"},
+    "est_by_device": {"CUDA0": 20 * _GB},
+    "weights_bytes": 42 * _GB,
+}
 
 
 def _observation(**overrides: object) -> Observation:
@@ -247,3 +266,171 @@ class TestThePlanScriptStaysInSyncWithLilbee:
         from lilbee.providers.fleet.planning import FleetPlan
 
         assert {"launches", "skipped_unusable_ctx"} <= set(FleetPlan.__dataclass_fields__)
+
+
+class TestTheHarnessCannotReportGreenOnNothing:
+    """Each of these was a way a cell could pass without proving anything."""
+
+    def test_an_errored_cell_is_a_failure_not_an_absence(self) -> None:
+        # A cell that raised used to be printed and dropped, so a run whose cells
+        # all crashed merged into a report with nothing to complain about.
+        errored = _observation(error="RuntimeError: planner produced no decision")
+        assert [f.rule for f in judge(errored)] == ["cell-errored"]
+
+    def test_a_load_with_no_readback_is_not_a_passed_estimate(self) -> None:
+        # Silence from the log parser is indistinguishable from an accurate
+        # estimate, which is how a stale parser becomes invisible.
+        blind = _observation(est_by_device={"CUDA0": 20 * _GB}, actual_by_device={})
+        assert any(f.rule == "readback-missing" for f in judge(blind))
+        seeing = _observation(
+            est_by_device={"CUDA0": 20 * _GB}, actual_by_device={"CUDA0": 20 * _GB}
+        )
+        assert not any(f.rule == "readback-missing" for f in judge(seeing))
+
+    def test_a_contended_load_is_flagged(self) -> None:
+        contended = _observation(vram_was_idle=False)
+        assert any(f.rule == "load-measured-alone" for f in judge(contended))
+        assert not any(f.rule == "load-measured-alone" for f in judge(_observation()))
+
+    def test_a_refusal_no_pin_can_test_proves_nothing(self) -> None:
+        # If a num_ctx pin produces no launch either, the refusal was never
+        # actually contradicted, and recording it as honest is a free pass.
+        untestable = _observation(
+            planned=False,
+            loaded=False,
+            sustained=False,
+            refusal="only a 512-token context",
+            forced_planned=False,
+        )
+        assert any(f.rule == "refusal-is-testable" for f in judge(untestable))
+
+
+class TestPairsAreOrderedByRoomNotByName:
+    """The monotonic check reads 'the roomier side must not serve less', so the
+    direction has to come from the knob, never from the order a pair arrived in."""
+
+    def test_more_cards_is_the_roomier_side(self) -> None:
+        one, two = Cell(model=_MODEL, cards=1), Cell(model=_MODEL, cards=2)
+        assert pair_by_room(one, two) == (one, two, "cards")
+        assert pair_by_room(two, one) == (one, two, "cards")
+
+    def test_more_ballast_is_the_tighter_side(self) -> None:
+        # A resident tenant is VRAM chat does not get, so the ballasted cell is
+        # tighter even though its id sorts second.
+        free = Cell(model=_MODEL, cards=2, ballast_gib=(0, 0))
+        held = Cell(model=_MODEL, cards=2, ballast_gib=(8, 0))
+        assert pair_by_room(free, held) == (held, free, "free VRAM")
+        assert pair_by_room(held, free) == (held, free, "free VRAM")
+
+    def test_a_higher_usable_fraction_is_roomier(self) -> None:
+        tight = Cell(model=_MODEL, cards=2, usable_fraction=0.75)
+        roomy = Cell(model=_MODEL, cards=2, usable_fraction=0.9)
+        assert pair_by_room(roomy, tight) == (tight, roomy, "usable VRAM")
+
+    def test_identical_cells_are_not_comparable(self) -> None:
+        assert pair_by_room(Cell(model=_MODEL, cards=2), Cell(model=_MODEL, cards=2)) is None
+
+    def test_every_generated_pair_is_orderable(self) -> None:
+        # iter_pairs promises one differing knob; pair_by_room must handle each.
+        for left, right in iter_pairs(build_matrix(max_cards=3).cells):
+            assert pair_by_room(left, right) is not None
+
+
+class TestTheSustainCheckCannotBeFooled:
+    """A 200 is not a served window. These are the shapes that would otherwise
+    pass: a truncated prompt, and a model that answered with almost nothing."""
+
+    @staticmethod
+    def _reply(monkeypatch, prompt_tokens: int, completion_tokens: int, status: int = 200):
+        class _Response:
+            status_code = status
+
+            @staticmethod
+            def json() -> dict[str, object]:
+                return {
+                    "usage": {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                    }
+                }
+
+        monkeypatch.setattr(observe.httpx, "post", lambda *a, **k: _Response())
+
+    def test_a_filled_window_sustains(self, monkeypatch) -> None:
+        self._reply(monkeypatch, prompt_tokens=5283, completion_tokens=256)
+        sustained, generated, prompted = observe._sustains_full_window(5888)
+        assert sustained
+        assert (generated, prompted) == (256, 5283)
+
+    def test_a_truncated_prompt_does_not_sustain(self, monkeypatch) -> None:
+        # The server quietly took 500 tokens of a 5888-token window.
+        self._reply(monkeypatch, prompt_tokens=500, completion_tokens=256)
+        assert observe._sustains_full_window(5888)[0] is False
+
+    def test_an_almost_empty_answer_does_not_sustain(self, monkeypatch) -> None:
+        self._reply(monkeypatch, prompt_tokens=5283, completion_tokens=1)
+        assert observe._sustains_full_window(5888)[0] is False
+
+    def test_a_non_ok_status_does_not_sustain(self, monkeypatch) -> None:
+        self._reply(monkeypatch, prompt_tokens=5283, completion_tokens=256, status=500)
+        assert observe._sustains_full_window(5888)[0] is False
+
+
+class TestThePlanPayloadIsParsedStrictly:
+    """A key the planner stopped emitting must raise, not arrive as a zero that
+    reads like a real measurement."""
+
+    def test_a_full_payload_parses(self) -> None:
+        decision = observe.PlanDecision.from_payload(_PLANNED_PAYLOAD)
+        assert decision.ctx == 5888
+        assert decision.argv == ("llama-server", "--ctx-size", "5888")
+
+    @pytest.mark.parametrize("missing", ["ctx", "argv", "slots", "weights_bytes"])
+    def test_a_missing_field_raises(self, missing: str) -> None:
+        payload = {k: v for k, v in _PLANNED_PAYLOAD.items() if k != missing}
+        with pytest.raises(KeyError):
+            observe.PlanDecision.from_payload(payload)
+
+    def test_a_refusal_needs_no_launch_fields(self) -> None:
+        decision = observe.PlanDecision.from_payload(
+            {
+                "planned": False,
+                "total_free_bytes": 48 * _GB,
+                "min_usable_ctx": 2160,
+                "refusal": "only a 512-token context",
+            }
+        )
+        assert decision.planned is False
+        assert decision.ctx == 0
+
+
+class TestMergedResultsCannotBeMisread:
+    """Shards are merged across pods and possibly across commits, so a stale or
+    foreign result file must not load as a set of plausible defaults."""
+
+    def test_a_result_round_trips(self) -> None:
+        observation = _observation()
+        assert Observation.from_json(observation.to_json()) == observation
+
+    def test_a_result_carries_its_schema(self) -> None:
+        assert _observation().to_json()["schema"] == oracles.SCHEMA_VERSION
+
+    def test_another_schema_is_refused(self) -> None:
+        payload = _observation().to_json()
+        payload["schema"] = oracles.SCHEMA_VERSION + 1
+        with pytest.raises(ValueError, match="schema"):
+            Observation.from_json(payload)
+
+    def test_an_unversioned_result_is_refused(self) -> None:
+        payload = _observation().to_json()
+        del payload["schema"]
+        with pytest.raises(ValueError, match="schema"):
+            Observation.from_json(payload)
+
+    def test_an_unknown_field_is_refused(self) -> None:
+        # A field this version does not know means the writer measured something
+        # this reader would silently ignore.
+        payload = _observation().to_json()
+        payload["measured_something_new"] = True
+        with pytest.raises(ValueError, match="unknown fields"):
+            Observation.from_json(payload)

--- a/tests/test_placement_matrix.py
+++ b/tests/test_placement_matrix.py
@@ -10,6 +10,7 @@ on a pod.
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 
 import pytest
 from tools.qa.placement_matrix import observe, oracles
@@ -434,3 +435,32 @@ class TestMergedResultsCannotBeMisread:
         payload["measured_something_new"] = True
         with pytest.raises(ValueError, match="unknown fields"):
             Observation.from_json(payload)
+
+
+class TestTheEngineIsAskedToReportWhatItAllocated:
+    """The per-device report only exists at the verbosity lilbee asks for, so a
+    harness that spawns without it reads every load as an unparseable log."""
+
+    def test_the_harness_uses_lilbees_own_log_environment(self) -> None:
+        from lilbee.providers.fleet.readback import (
+            ENV_ARG_LOG_VERBOSITY,
+            ENV_LOG_VERBOSITY,
+            LOAD_REPORT_VERBOSITY,
+            engine_log_env,
+        )
+
+        env = engine_log_env(Path("/tmp/matrix"), "cell")
+        assert env[ENV_LOG_VERBOSITY] == LOAD_REPORT_VERBOSITY
+        assert env[ENV_ARG_LOG_VERBOSITY] == LOAD_REPORT_VERBOSITY
+        source = Path(observe.__file__).read_text()
+        assert "engine_log_env(log_dir, model_id)" in source
+        assert "engine_log_path(log_dir, model_id)" in source
+
+    def test_host_buffers_are_excluded_by_lilbees_own_predicate(self) -> None:
+        # The engine labels host-pinned memory CUDA_Host, which a "CPU"/"HOST"
+        # prefix test misses, so the estimate check demanded a charge for it.
+        from lilbee.providers.fleet.readback import _is_host_device
+
+        assert _is_host_device("CUDA_Host")
+        assert not _is_host_device("CUDA0")
+        assert "_is_host_device(label)" in Path(observe.__file__).read_text()

--- a/tests/test_placement_matrix.py
+++ b/tests/test_placement_matrix.py
@@ -1,0 +1,249 @@
+"""Tests for the placement matrix harness itself.
+
+The harness half that touches GPUs cannot run in CI; the half that decides pass
+or fail can, and is the half worth testing. Each oracle is driven with a
+fabricated observation that should trip it and one that should not, so a rule
+that stopped being able to fail is caught here rather than by a green matrix run
+on a pod.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+from tools.qa.placement_matrix import observe
+from tools.qa.placement_matrix.cells import Cell, ModelSpec, build_matrix, iter_pairs
+from tools.qa.placement_matrix.oracles import Observation, compare, judge
+
+_GB = 1024**3
+_MODEL = ModelSpec(key="m", ref="org/repo/m.gguf", probes="test")
+
+
+def _observation(**overrides: object) -> Observation:
+    base = {
+        "cell_id": "cell",
+        "model_key": "m",
+        "cards": 2,
+        "total_free_bytes": 48 * _GB,
+        "weights_bytes": 40 * _GB,
+        "planned": True,
+        "ctx": 8192,
+        "slots": 1,
+        "argv": ("llama-server", "--ctx-size", "8192"),
+        "loaded": True,
+        "sustained": True,
+    }
+    base.update(overrides)
+    return Observation(**base)  # type: ignore[arg-type]
+
+
+class TestShardingSplitsTheMatrixCleanly:
+    """A shard that overlaps another duplicates pod time; one that drops cells
+    reports a pass for something nobody ran."""
+
+    def test_shards_are_disjoint_and_cover_everything(self) -> None:
+        matrix = build_matrix(max_cards=4)
+        for count in (1, 2, 3, 5, 7):
+            shards = [matrix.shard(i, count) for i in range(count)]
+            seen = [cell.id for shard in shards for cell in shard]
+            assert sorted(seen) == sorted(cell.id for cell in matrix.cells)
+            assert len(seen) == len(set(seen))
+
+    def test_an_invalid_shard_is_refused(self) -> None:
+        matrix = build_matrix(max_cards=2)
+        for index, count in ((0, 0), (2, 2), (-1, 3)):
+            with pytest.raises(ValueError):
+                matrix.shard(index, count)
+
+    def test_cell_ids_are_unique(self) -> None:
+        # The id is the result filename; a collision silently overwrites a result.
+        cells = build_matrix(max_cards=4).cells
+        assert len({cell.id for cell in cells}) == len(cells)
+
+
+class TestPairsDifferByExactlyOneKnob:
+    """A metamorphic comparison is only meaningful when one thing changed."""
+
+    def test_every_pair_differs_in_one_dimension(self) -> None:
+        cells = build_matrix(max_cards=3).cells
+        pairs = list(iter_pairs(cells))
+        assert pairs
+        for left, right in pairs:
+            differing = sum(
+                (
+                    left.cards != right.cards,
+                    left.ballast_gib != right.ballast_gib,
+                    left.usable_fraction != right.usable_fraction,
+                    left.ctx_target != right.ctx_target,
+                )
+            )
+            assert differing == 1
+            assert left.model.key == right.model.key
+
+
+class TestTheOraclesCanFail:
+    """Each rule, driven once with an observation that must trip it and once with
+    one that must not."""
+
+    def test_a_plan_that_does_not_load_fails(self) -> None:
+        assert any(f.rule == "plan-loads" for f in judge(_observation(loaded=False)))
+        assert not any(f.rule == "plan-loads" for f in judge(_observation()))
+
+    def test_a_plan_that_loads_but_cannot_serve_fails(self) -> None:
+        failures = judge(_observation(sustained=False))
+        assert any(f.rule == "plan-sustains" for f in failures)
+        assert not any(f.rule == "plan-sustains" for f in judge(_observation()))
+
+    def test_a_refusal_contradicted_by_a_forced_launch_fails(self) -> None:
+        # The 70B-on-2x4090 bug: refused as unservable, yet a pin serves.
+        refused = _observation(
+            planned=False,
+            loaded=False,
+            sustained=False,
+            refusal="only a 512-token context",
+            min_usable_ctx=2160,
+            forced_loaded=True,
+            forced_sustained=True,
+        )
+        assert any(f.rule == "refusal-is-real" for f in judge(refused))
+        honest = _observation(
+            planned=False,
+            loaded=False,
+            sustained=False,
+            refusal="only a 512-token context",
+            forced_loaded=False,
+            forced_sustained=False,
+        )
+        assert not any(f.rule == "refusal-is-real" for f in judge(honest))
+
+    def test_an_under_estimate_fails(self) -> None:
+        under = _observation(
+            est_by_device={"CUDA0": 10 * _GB}, actual_by_device={"CUDA0": 20 * _GB}
+        )
+        assert any(f.rule == "estimate-not-under" for f in judge(under))
+        close = _observation(
+            est_by_device={"CUDA0": 20 * _GB}, actual_by_device={"CUDA0": 20 * _GB}
+        )
+        assert not any(f.rule.startswith("estimate") for f in judge(close))
+
+    def test_a_wild_over_estimate_fails(self) -> None:
+        over = _observation(est_by_device={"CUDA0": 30 * _GB}, actual_by_device={"CUDA0": 20 * _GB})
+        assert any(f.rule == "estimate-not-wildly-over" for f in judge(over))
+
+    def test_an_uncharged_device_fails(self) -> None:
+        missing = _observation(
+            est_by_device={"CUDA0": 20 * _GB},
+            actual_by_device={"CUDA0": 20 * _GB, "CUDA1": 20 * _GB},
+        )
+        assert any(f.rule == "estimate-covers-devices" for f in judge(missing))
+
+    def test_an_oversize_model_that_fails_to_spill_fails(self) -> None:
+        # Weights beyond total VRAM must load by spilling; this is the invariant a
+        # pinned tensor split breaks, because the engine abandons its own fit pass.
+        oversize = _observation(weights_bytes=100 * _GB, total_free_bytes=48 * _GB, loaded=False)
+        assert any(f.rule == "oversize-spills" for f in judge(oversize))
+        spilled = _observation(weights_bytes=100 * _GB, total_free_bytes=48 * _GB)
+        assert not any(f.rule == "oversize-spills" for f in judge(spilled))
+
+    def test_a_tight_group_carrying_a_ratio_fails(self) -> None:
+        pinned = _observation(tight=True, argv=("llama-server", "--tensor-split", "21,21"))
+        assert any(f.rule == "tight-group-has-no-ratio" for f in judge(pinned))
+        free = _observation(tight=True, argv=("llama-server", "--ctx-size", "8192"))
+        assert not any(f.rule == "tight-group-has-no-ratio" for f in judge(free))
+
+    def test_a_skipped_cell_is_judged_on_nothing(self) -> None:
+        assert judge(_observation(loaded=False, sustained=False, skipped="needs 4 cards")) == []
+
+
+class TestMonotonicity:
+    """More room must never serve less. These need no expected value, only two
+    runs whose order is known, which is what makes them able to catch a
+    configuration nobody wrote an expectation for."""
+
+    def test_a_smaller_window_on_more_cards_fails(self) -> None:
+        low = _observation(cell_id="one-card", ctx=8192)
+        high = _observation(cell_id="two-cards", ctx=4096)
+        assert any(f.rule == "monotonic-ctx" for f in compare(low, high, "cards"))
+
+    def test_an_equal_or_larger_window_passes(self) -> None:
+        low = _observation(cell_id="one-card", ctx=4096)
+        high = _observation(cell_id="two-cards", ctx=8192)
+        assert compare(low, high, "cards") == []
+
+    def test_a_refusal_on_the_roomier_side_fails(self) -> None:
+        low = _observation(cell_id="tight", ctx=4096)
+        high = _observation(cell_id="roomy", planned=False, loaded=False, sustained=False)
+        assert any(f.rule == "monotonic-service" for f in compare(low, high, "cards"))
+
+    def test_a_skipped_partner_is_not_a_violation(self) -> None:
+        low = _observation(cell_id="a", ctx=8192)
+        high = _observation(cell_id="b", ctx=1, skipped="needs 4 cards")
+        assert compare(low, high, "cards") == []
+
+
+class TestTheMatrixReachesEveryBranch:
+    def test_single_and_multi_card_cells_exist(self) -> None:
+        cells = build_matrix((_MODEL,), max_cards=4).cells
+        assert {cell.cards for cell in cells} == {1, 2, 3, 4}
+
+    def test_uneven_capacity_is_exercised_above_one_card(self) -> None:
+        cells = build_matrix((_MODEL,), max_cards=2).cells
+        assert any(cell.ballast_gib and cell.cards > 1 for cell in cells)
+        assert not any(cell.ballast_gib for cell in cells if cell.cards == 1)
+
+    def test_a_cell_id_survives_a_round_trip_through_json(self) -> None:
+        cell = Cell(model=_MODEL, cards=2, ballast_gib=(8, 0))
+        observation = _observation(cell_id=cell.id)
+        assert Observation.from_json(observation.to_json()) == observation
+
+
+class TestThePlanScriptStaysInSyncWithLilbee:
+    """The planner is driven as source text in a child process, so a renamed
+    lilbee symbol would surface as a failed pod run rather than a red test."""
+
+    @staticmethod
+    def _attributes_of(root: str) -> set[str]:
+        tree = ast.parse(observe._PLAN_SCRIPT)
+        return {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == root
+        }
+
+    def test_the_script_compiles(self) -> None:
+        compile(observe._PLAN_SCRIPT, "<plan>", "exec")
+
+    def test_every_config_field_it_sets_exists(self) -> None:
+        from lilbee.core.config import cfg
+
+        named = self._attributes_of("cfg")
+        assert named
+        assert not [field for field in named if not hasattr(cfg, field)]
+
+    def test_every_planner_function_it_calls_exists(self) -> None:
+        from lilbee.providers.fleet import planning
+
+        named = self._attributes_of("planning")
+        assert named
+        assert not [name for name in named if not hasattr(planning, name)]
+
+    def test_every_engine_params_function_it_calls_exists(self) -> None:
+        from lilbee.providers import engine_params
+
+        named = self._attributes_of("engine_params")
+        assert named
+        assert not [name for name in named if not hasattr(engine_params, name)]
+
+    def test_the_launch_fields_it_reads_exist(self) -> None:
+        from lilbee.providers.fleet.launch import InstanceLaunch
+
+        read = {"ctx", "slots", "argv", "env_overrides", "est_vram_by_device", "weights_bytes"}
+        assert read <= set(InstanceLaunch.__dataclass_fields__)
+
+    def test_the_plan_fields_it_reads_exist(self) -> None:
+        from lilbee.providers.fleet.planning import FleetPlan
+
+        assert {"launches", "skipped_unusable_ctx"} <= set(FleetPlan.__dataclass_fields__)

--- a/tools/qa/PLACEMENT_MATRIX.md
+++ b/tools/qa/PLACEMENT_MATRIX.md
@@ -23,6 +23,11 @@ Per cell (one model on one hardware shape):
 | `estimate-covers-devices` | every device the engine used was charged for |
 | `oversize-spills` | a model larger than the GPUs loads by spilling, not by dying |
 | `tight-group-has-no-ratio` | a best-effort placement leaves the split to the engine |
+| `readback-missing` | a load whose per-device report was unreadable, so nothing was checked |
+| `load-measured-alone` | another process held VRAM at launch, so the numbers describe a contended box |
+| `refusal-is-testable` | a refusal a `num_ctx` pin could not contradict, which proves nothing |
+| `cell-errored` | the cell raised; a crash is a failure, never an absent result |
+| `result-unreadable` | a merged result this harness cannot read, rather than one silently dropped |
 
 Across pairs of cells differing in exactly one knob, with no expected value
 needed — only an order that must hold:
@@ -59,7 +64,17 @@ python -m tools.qa.placement_matrix report --out results/
 ```
 
 Exit code is non-zero on any violation, and also when nothing ran — a matrix
-that produced no results must not read as a pass.
+that produced no results must not read as a pass. A cell that raises is written
+out as a failed result rather than dropped, so a run whose cells all crashed
+cannot merge into a clean report.
+
+Results carry a schema version. Shards are merged across pods and possibly
+across commits, so a file written by a different version is reported rather than
+loaded with today's defaults, which would show fields nobody measured.
+
+"Sustained" means the token counts came back, not that the request returned 200:
+a round has to generate what it asked for and occupy most of the window, so a
+silently truncated prompt or a one-token answer fails.
 
 Useful flags: `--resume` (skip cells already recorded, so a reclaimed pod picks
 up where it stopped), `--models tiny tight-split` (subset by key), `--max-cards`.

--- a/tools/qa/PLACEMENT_MATRIX.md
+++ b/tools/qa/PLACEMENT_MATRIX.md
@@ -1,0 +1,96 @@
+# Placement matrix
+
+End-to-end validation of model placement against real hardware. Unit tests cover
+the planner's arithmetic; this covers whether the plan is *true* — whether what
+the planner promised actually loads, serves, and stays inside the memory it was
+charged.
+
+It exists because placement bugs are invisible to static review. A refusal that
+should have been a launch, and a launch that should have been a refusal, both
+look like correct code.
+
+## What it checks
+
+Per cell (one model on one hardware shape):
+
+| Rule | Invariant |
+|---|---|
+| `plan-loads` | a plan is a promise the launch loads |
+| `plan-sustains` | the published window survives consecutive full-window requests |
+| `refusal-is-real` | a refusal must not be contradicted by forcing `num_ctx` |
+| `estimate-not-under` | no device allocates materially more than it was charged |
+| `estimate-not-wildly-over` | over-charging costs context elsewhere |
+| `estimate-covers-devices` | every device the engine used was charged for |
+| `oversize-spills` | a model larger than the GPUs loads by spilling, not by dying |
+| `tight-group-has-no-ratio` | a best-effort placement leaves the split to the engine |
+
+Across pairs of cells differing in exactly one knob, with no expected value
+needed — only an order that must hold:
+
+| Rule | Invariant |
+|---|---|
+| `monotonic-ctx` | more cards or more free VRAM never serves a smaller window |
+| `monotonic-service` | the roomier side is never the one that gets refused |
+
+`refusal-is-real` and `tight-group-has-no-ratio` each correspond to a real bug
+this repo has shipped or nearly shipped. A rule that never caught anything is a
+candidate for deletion, not a badge.
+
+## Running it
+
+Serial, on whatever the box has:
+
+```bash
+python -m tools.qa.placement_matrix run --out results/
+```
+
+Across pods, one shard each, then merge. Shards are disjoint and jointly cover
+the matrix (asserted in `tests/test_placement_matrix.py`):
+
+```bash
+# pod 0                              # pod 1
+... run --out results/ --shard 0/4   ... run --out results/ --shard 1/4
+```
+
+Copy every pod's `results/` into one directory and judge the union:
+
+```bash
+python -m tools.qa.placement_matrix report --out results/
+```
+
+Exit code is non-zero on any violation, and also when nothing ran — a matrix
+that produced no results must not read as a pass.
+
+Useful flags: `--resume` (skip cells already recorded, so a reclaimed pod picks
+up where it stopped), `--models tiny tight-split` (subset by key), `--max-cards`.
+
+## Hardware
+
+Cells declare how many GPUs they need; a host runs only what it can and records
+the rest as skipped, so a heterogeneous set of pods can share one matrix. Card
+counts are produced by masking `CUDA_VISIBLE_DEVICES`, so a single 4-GPU box
+covers the 1-, 2-, 3- and 4-card layouts rather than needing four machines.
+
+Cells that ask for a resident tenant (uneven capacity) are skipped unless the
+host supports allocating ballast; they are declared in the matrix so the gap is
+visible rather than absent.
+
+## Models
+
+One per decision boundary. Adding a model that reaches a branch already covered
+costs a download and proves nothing.
+
+| Key | Boundary |
+|---|---|
+| `tiny` | single card with room to spare; multi-slot |
+| `kv-starved` | weights fit one 24 GiB card, a usable context does not: forces a split |
+| `tight-split` | needs two 24 GiB cards, lands in the tight group, serves anyway |
+| `spill` | exceeds the box: must load by spilling to system memory; also MoE |
+| `embed` | co-tenant whose reservation is held back from chat |
+
+`spill` is a 133 GiB download and is the only cell that exercises
+`oversize-spills`. Run at least once per release on a box it genuinely exceeds;
+`--models` skips it the rest of the time.
+
+Pull the models before running; the harness plans and launches, it does not
+download.

--- a/tools/qa/multi_gpu_smoke.py
+++ b/tools/qa/multi_gpu_smoke.py
@@ -75,7 +75,7 @@ def _check_enumeration() -> None:
 
     binary = resolve_llama_server()
     print(f"[1] binary: {binary}")
-    devices = probe_devices(binary)
+    devices = probe_devices(binary).devices
     print(f"[1] llama-server --list-devices: {len(devices)} device(s)")
     for dev in devices:
         print(f"      {dev.backend}{dev.index}: {dev.name} free={dev.free_bytes // 1024**2} MiB")

--- a/tools/qa/placement_matrix/__main__.py
+++ b/tools/qa/placement_matrix/__main__.py
@@ -16,7 +16,12 @@ import json
 import sys
 from pathlib import Path
 
-from tools.qa.placement_matrix.cells import DEFAULT_MODELS, build_matrix, iter_pairs
+from tools.qa.placement_matrix.cells import (
+    DEFAULT_MODELS,
+    build_matrix,
+    iter_pairs,
+    pair_by_room,
+)
 from tools.qa.placement_matrix.observe import gpu_count, run_cell
 from tools.qa.placement_matrix.oracles import Failure, Observation, compare, judge_all
 
@@ -49,41 +54,49 @@ def _run(args: argparse.Namespace) -> int:
             observation = run_cell(cell, workdir=out, available_cards=cards)
         except Exception as exc:  # a crashed cell is a result, not a reason to stop
             print(f"  ERROR        {cell.id}: {type(exc).__name__}: {exc}")
-            continue
+            observation = Observation(
+                cell_id=cell.id,
+                model_key=cell.model.key,
+                cards=cell.cards,
+                total_free_bytes=0,
+                weights_bytes=0,
+                planned=False,
+                error=f"{type(exc).__name__}: {exc}",
+            )
         target.write_text(json.dumps(observation.to_json(), indent=2))
     return _report(args)
 
 
 def _report(args: argparse.Namespace) -> int:
     out = Path(args.out)
-    observations = [
-        Observation.from_json(json.loads(path.read_text()))
-        for path in sorted(out.glob("*.json"))
-        if not path.name.endswith(".engine.log")
-    ]
+    observations: list[Observation] = []
+    unreadable: list[Failure] = []
+    for path in sorted(out.glob("*.json")):
+        try:
+            observations.append(Observation.from_json(json.loads(path.read_text())))
+        except (ValueError, TypeError) as exc:
+            # Loud, not skipped: a result the merge cannot read is missing coverage,
+            # and dropping it quietly shrinks the matrix into a pass.
+            unreadable.append(Failure("result-unreadable", path.name, str(exc)))
     by_id = {o.cell_id: o for o in observations}
-    failures: list[Failure] = judge_all(observations)
+    failures: list[Failure] = [*unreadable, *judge_all(observations)]
 
     matrix = build_matrix(DEFAULT_MODELS, max_cards=args.max_cards)
-    for low, high in iter_pairs(matrix.cells):
-        left, right = by_id.get(low.id), by_id.get(high.id)
-        if left is None or right is None:
+    for left, right in iter_pairs(matrix.cells):
+        ordered = pair_by_room(left, right)
+        if ordered is None:
             continue
-        if low.cards != high.cards:
-            knob = "cards"
-        elif low.usable_fraction != high.usable_fraction:
-            knob = "usable VRAM"
-        elif low.ballast_gib != high.ballast_gib:
-            knob, left, right = "free VRAM", right, left
-        else:
+        tighter, roomier, knob = ordered
+        observed_tighter, observed_roomier = by_id.get(tighter.id), by_id.get(roomier.id)
+        if observed_tighter is None or observed_roomier is None:
             continue
-        failures.extend(compare(left, right, knob))
+        failures.extend(compare(observed_tighter, observed_roomier, knob))
 
     ran = [o for o in observations if not o.skipped]
     print(f"\n{len(ran)} cells judged, {len(observations) - len(ran)} skipped")
     for failure in sorted(failures, key=lambda f: (f.rule, f.cell_id)):
         print(f"  FAIL [{failure.rule}] {failure.cell_id}: {failure.detail}")
-    if not ran:
+    if not ran and not unreadable:
         # Green on nothing is how a matrix that never ran reads as a pass.
         print("  NOTHING RAN: no cell produced a judgeable result")
         return 1

--- a/tools/qa/placement_matrix/__main__.py
+++ b/tools/qa/placement_matrix/__main__.py
@@ -1,0 +1,108 @@
+"""Run the placement matrix, or judge results a previous run wrote.
+
+Sharding and resume are what let the same command run serially on one box or in
+parallel across pods: each shard writes one JSON per cell into --out, and the
+report merges whatever is there.
+
+    python -m tools.qa.placement_matrix run --out results/          # everything this host can
+    python -m tools.qa.placement_matrix run --out results/ --shard 0/4
+    python -m tools.qa.placement_matrix report --out results/       # merge and judge
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tools.qa.placement_matrix.cells import DEFAULT_MODELS, build_matrix, iter_pairs
+from tools.qa.placement_matrix.observe import gpu_count, run_cell
+from tools.qa.placement_matrix.oracles import Failure, Observation, compare, judge_all
+
+
+def _parse_shard(value: str) -> tuple[int, int]:
+    index, _, count = value.partition("/")
+    return int(index), int(count)
+
+
+def _run(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    models = tuple(m for m in DEFAULT_MODELS if not args.models or m.key in args.models)
+    matrix = build_matrix(models, max_cards=args.max_cards)
+    cells = matrix.cells
+    if args.shard:
+        index, count = _parse_shard(args.shard)
+        cells = matrix.shard(index, count)
+    cards = gpu_count()
+    print(f"{len(cells)} cells, {cards} GPUs visible, writing to {out}")
+    for model in models:
+        print(f"  {model.key}: {model.probes}")
+    for cell in cells:
+        target = out / f"{cell.id}.json"
+        if args.resume and target.exists():
+            print(f"  skip (done)  {cell.id}")
+            continue
+        print(f"  run          {cell.id}", flush=True)
+        try:
+            observation = run_cell(cell, workdir=out, available_cards=cards)
+        except Exception as exc:  # a crashed cell is a result, not a reason to stop
+            print(f"  ERROR        {cell.id}: {type(exc).__name__}: {exc}")
+            continue
+        target.write_text(json.dumps(observation.to_json(), indent=2))
+    return _report(args)
+
+
+def _report(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    observations = [
+        Observation.from_json(json.loads(path.read_text()))
+        for path in sorted(out.glob("*.json"))
+        if not path.name.endswith(".engine.log")
+    ]
+    by_id = {o.cell_id: o for o in observations}
+    failures: list[Failure] = judge_all(observations)
+
+    matrix = build_matrix(DEFAULT_MODELS, max_cards=args.max_cards)
+    for low, high in iter_pairs(matrix.cells):
+        left, right = by_id.get(low.id), by_id.get(high.id)
+        if left is None or right is None:
+            continue
+        if low.cards != high.cards:
+            knob = "cards"
+        elif low.usable_fraction != high.usable_fraction:
+            knob = "usable VRAM"
+        elif low.ballast_gib != high.ballast_gib:
+            knob, left, right = "free VRAM", right, left
+        else:
+            continue
+        failures.extend(compare(left, right, knob))
+
+    ran = [o for o in observations if not o.skipped]
+    print(f"\n{len(ran)} cells judged, {len(observations) - len(ran)} skipped")
+    for failure in sorted(failures, key=lambda f: (f.rule, f.cell_id)):
+        print(f"  FAIL [{failure.rule}] {failure.cell_id}: {failure.detail}")
+    if not ran:
+        # Green on nothing is how a matrix that never ran reads as a pass.
+        print("  NOTHING RAN: no cell produced a judgeable result")
+        return 1
+    if not failures:
+        print("  no invariant violations")
+    return 1 if failures else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="placement_matrix", description=__doc__)
+    parser.add_argument("command", choices=("run", "report"))
+    parser.add_argument("--out", required=True, help="directory of per-cell result JSON")
+    parser.add_argument("--shard", help="k/N: run only this shard of the matrix")
+    parser.add_argument("--max-cards", type=int, default=4)
+    parser.add_argument("--models", nargs="*", default=[], help="model keys to include")
+    parser.add_argument("--resume", action="store_true", help="skip cells already recorded")
+    args = parser.parse_args(argv)
+    return _run(args) if args.command == "run" else _report(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/qa/placement_matrix/cells.py
+++ b/tools/qa/placement_matrix/cells.py
@@ -1,0 +1,164 @@
+"""The matrix of placement configurations to exercise, and how to split it up.
+
+A cell is one (model, visible cards, resident tenant, config) combination. Cells
+are generated deterministically so a run can be sharded across pods and merged,
+and each carries the hardware it needs so a pod runs only what it can.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+
+_GB = 1024**3
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """A model in the matrix and the placement branch it exists to reach."""
+
+    key: str
+    ref: str
+    probes: str
+    """Which placement branch this model exists to reach; printed by a run."""
+    role: str = "chat"
+
+
+# One model per decision boundary. Adding a model that reaches a branch already
+# covered costs a download and proves nothing new.
+DEFAULT_MODELS: tuple[ModelSpec, ...] = (
+    ModelSpec(
+        key="tiny",
+        ref="Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf",
+        probes="single card with room to spare; multi-slot",
+    ),
+    ModelSpec(
+        key="kv-starved",
+        ref="Qwen/Qwen3-14B-GGUF/Qwen3-14B-Q8_0.gguf",
+        probes="weights fit one 24GiB card, a usable context does not: forces a split",
+    ),
+    ModelSpec(
+        key="tight-split",
+        ref="bartowski/Llama-3.3-70B-Instruct-GGUF/Llama-3.3-70B-Instruct-Q4_K_M.gguf",
+        probes="needs two 24GiB cards and lands in the tight group that serves anyway",
+    ),
+    ModelSpec(
+        key="spill",
+        # Sharded; the first part is the ref, siblings are resolved beside it.
+        ref=("unsloth/Qwen3-235B-A22B-GGUF/Q4_K_M/Qwen3-235B-A22B-Q4_K_M-00001-of-00003.gguf"),
+        probes="exceeds the box: must load by spilling to system memory, and is MoE",
+    ),
+    ModelSpec(
+        key="embed",
+        ref="nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf",
+        probes="co-tenant whose reservation is held back from chat",
+        role="embed",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One placement configuration to plan, launch and judge."""
+
+    model: ModelSpec
+    cards: int
+    """How many GPUs to expose (CUDA_VISIBLE_DEVICES is masked to this many)."""
+    ballast_gib: tuple[int, ...] = ()
+    """VRAM a fake tenant holds on each visible card, so capacity goes uneven."""
+    usable_fraction: float = 0.9
+    ctx_target: int = 16384
+    with_embed: bool = False
+    """Place the embedding model beside chat, so chat is charged its reservation."""
+
+    @property
+    def id(self) -> str:
+        """Stable identifier: the result filename, and how shards stay disjoint."""
+        ballast = "-".join(str(g) for g in self.ballast_gib) or "0"
+        return (
+            f"{self.model.key}__c{self.cards}__b{ballast}"
+            f"__f{self.usable_fraction:g}__t{self.ctx_target}"
+            f"__{'embed' if self.with_embed else 'solo'}"
+        )
+
+
+@dataclass(frozen=True)
+class Matrix:
+    """The cells a run will attempt, in a deterministic order."""
+
+    cells: tuple[Cell, ...] = field(default_factory=tuple)
+
+    def shard(self, index: int, count: int) -> tuple[Cell, ...]:
+        """Cells for shard *index* of *count*, disjoint and jointly covering."""
+        if count < 1 or not 0 <= index < count:
+            raise ValueError(f"shard {index}/{count} is not a valid split")
+        return self.cells[index::count]
+
+
+def build_matrix(
+    models: Sequence[ModelSpec] = DEFAULT_MODELS,
+    *,
+    max_cards: int = 4,
+    fractions: Sequence[float] = (0.9,),
+    ctx_targets: Sequence[int] = (16384,),
+) -> Matrix:
+    """Every combination worth planning, ordered so shards interleave evenly.
+
+    Card counts run 1..*max_cards* because the split decision changes with the
+    count, and ballast is applied to the first card only: an uneven pair is the
+    case a proportional ratio exists for, and an even one never exercises it.
+    """
+    chat = [m for m in models if m.role == "chat"]
+    has_embed = any(m.role == "embed" for m in models)
+    cells: list[Cell] = []
+    for model in chat:
+        for cards in range(1, max_cards + 1):
+            for fraction in fractions:
+                for ctx_target in ctx_targets:
+                    cells.append(
+                        Cell(
+                            model=model,
+                            cards=cards,
+                            usable_fraction=fraction,
+                            ctx_target=ctx_target,
+                        )
+                    )
+                    if cards > 1:
+                        cells.append(
+                            Cell(
+                                model=model,
+                                cards=cards,
+                                ballast_gib=(8,) + (0,) * (cards - 1),
+                                usable_fraction=fraction,
+                                ctx_target=ctx_target,
+                            )
+                        )
+                    if has_embed:
+                        cells.append(
+                            Cell(
+                                model=model,
+                                cards=cards,
+                                usable_fraction=fraction,
+                                ctx_target=ctx_target,
+                                with_embed=True,
+                            )
+                        )
+    return Matrix(cells=tuple(cells))
+
+
+def iter_pairs(cells: Sequence[Cell]) -> Iterator[tuple[Cell, Cell]]:
+    """Cells differing in exactly one knob, which is what a metamorphic check needs."""
+    for left in cells:
+        for right in cells:
+            if left.id >= right.id or left.model.key != right.model.key:
+                continue
+            if left.with_embed != right.with_embed:
+                continue
+            differing = [
+                left.cards != right.cards,
+                left.ballast_gib != right.ballast_gib,
+                left.usable_fraction != right.usable_fraction,
+                left.ctx_target != right.ctx_target,
+            ]
+            if sum(differing) == 1:
+                yield left, right

--- a/tools/qa/placement_matrix/cells.py
+++ b/tools/qa/placement_matrix/cells.py
@@ -146,6 +146,30 @@ def build_matrix(
     return Matrix(cells=tuple(cells))
 
 
+def pair_by_room(left: Cell, right: Cell) -> tuple[Cell, Cell, str] | None:
+    """``(tighter, roomier, knob)`` for a pair, or ``None`` if they are not comparable.
+
+    Ordered by the knob's own value rather than by the order the pair arrived in:
+    a monotonic check reads "the roomier side must not serve less", so getting the
+    direction from something incidental would invert the assertion silently.
+    """
+    if left.cards != right.cards:
+        return _ordered(left, right, left.cards < right.cards, "cards")
+    if left.usable_fraction != right.usable_fraction:
+        return _ordered(left, right, left.usable_fraction < right.usable_fraction, "usable VRAM")
+    if left.ballast_gib != right.ballast_gib:
+        # A resident tenant is VRAM the chat model does not get, so more ballast
+        # is the tighter side.
+        return _ordered(left, right, sum(left.ballast_gib) > sum(right.ballast_gib), "free VRAM")
+    if left.ctx_target != right.ctx_target:
+        return _ordered(left, right, left.ctx_target < right.ctx_target, "target context")
+    return None
+
+
+def _ordered(left: Cell, right: Cell, left_is_tighter: bool, knob: str) -> tuple[Cell, Cell, str]:
+    return (left, right, knob) if left_is_tighter else (right, left, knob)
+
+
 def iter_pairs(cells: Sequence[Cell]) -> Iterator[tuple[Cell, Cell]]:
     """Cells differing in exactly one knob, which is what a metamorphic check needs."""
     for left in cells:

--- a/tools/qa/placement_matrix/observe.py
+++ b/tools/qa/placement_matrix/observe.py
@@ -1,0 +1,255 @@
+"""Run one cell on real hardware and record what happened.
+
+The planner is invoked in a child process rather than in-process: planning warms
+up a fleet, and a warm-up racing the launch under test allocates the VRAM the
+launch is being measured for. Everything here returns an Observation; nothing
+here decides pass or fail (see oracles.py).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+from tools.qa.placement_matrix.cells import Cell
+from tools.qa.placement_matrix.oracles import Observation
+
+_GB = 1024**3
+_PORT = 8412
+_BASE_URL = f"http://127.0.0.1:{_PORT}"
+_LOAD_TIMEOUT_S = 1800
+_ROUNDS = 3
+_GENERATION_TOKENS = 256
+# Measured against Llama 3.3 70B: the filler phrase runs about this many tokens
+# per repeat, which is only used to size a prompt near the window.
+_TOKENS_PER_FILLER = 10.1
+_FILLER = "The quick brown fox jumps over the lazy dog. "
+
+_PLAN_SCRIPT = """
+import json, sys
+from lilbee.core.config import cfg
+cfg.chat_model = sys.argv[1]
+cfg.usable_vram_fraction = float(sys.argv[2])
+cfg.chat_n_ctx_target = int(sys.argv[3])
+if sys.argv[4] == "none":
+    cfg.embedding_model = "__absent__/__absent__.gguf"
+if sys.argv[5] != "none":
+    cfg.num_ctx = int(sys.argv[5])
+from lilbee.providers import engine_params
+from lilbee.providers.fleet import planning
+plan = planning.plan_all_launches()
+chat = next((l for l in plan.launches if l.role.value == "chat"), None)
+devices = planning.resolve_devices(planning.resolve_llama_server())
+out = {
+    "refusal": next((v for k, v in plan.skipped_unusable_ctx.items() if k.value == "chat"), None),
+    "min_usable_ctx": engine_params.min_usable_chat_ctx(),
+    "total_free_bytes": sum(d.free_bytes for d in devices),
+    "device_count": len(devices),
+}
+if chat is not None:
+    out.update(
+        planned=True, ctx=chat.ctx, slots=chat.slots, argv=list(chat.argv),
+        env=chat.env_overrides, est_by_device=dict(chat.est_vram_by_device),
+        weights_bytes=chat.weights_bytes,
+    )
+else:
+    out["planned"] = False
+print("<<<PLAN>>>" + json.dumps(out))
+"""
+
+
+def _plan(cell: Cell, env: dict[str, str], *, force_ctx: int | None = None) -> dict[str, object]:
+    """The planner's decision for this cell, from a clean child process."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _PLAN_SCRIPT,
+            cell.model.ref,
+            str(cell.usable_fraction),
+            str(cell.ctx_target),
+            "embed" if cell.with_embed else "none",
+            "none" if force_ctx is None else str(force_ctx),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=1800,
+        check=False,
+    )
+    marker = result.stdout.rfind("<<<PLAN>>>")
+    if marker < 0:
+        raise RuntimeError(
+            f"planner produced no decision: {result.stdout[-2000:]}{result.stderr[-2000:]}"
+        )
+    return json.loads(result.stdout[marker + len("<<<PLAN>>>") :])
+
+
+def _smi(field: str) -> list[str]:
+    """One nvidia-smi per-GPU column, or an empty list where there is no driver."""
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", f"--query-gpu={field}", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def gpu_count() -> int:
+    """How many GPUs this host exposes."""
+    return len(_smi("index"))
+
+
+def _smi_used_bytes() -> list[int]:
+    return [int(v) * 1024 * 1024 for v in _smi("memory.used") if v.isdigit()]
+
+
+def _wait_for_idle_vram(limit_bytes: int = 512 * 1024 * 1024, timeout_s: int = 180) -> None:
+    """Block until nothing else holds VRAM, so a load is measured alone."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        used = _smi_used_bytes()
+        if not used or max(used) < limit_bytes:
+            return
+        time.sleep(3)
+
+
+def _serve_and_measure(
+    argv: list[str], env: dict[str, str], ctx: int, log_path: Path
+) -> tuple[bool, bool, dict[str, int]]:
+    """Load the launch, fill its window repeatedly, and read back per-device use.
+
+    Returns ``(loaded, sustained, actual_by_device)``.
+    """
+    from lilbee.providers.fleet.readback import parse_device_buffers
+
+    _wait_for_idle_vram()
+    with log_path.open("wb") as log:
+        proc = subprocess.Popen(
+            [*argv, "--port", str(_PORT)], stdout=log, stderr=subprocess.STDOUT, env=env
+        )
+        try:
+            loaded = _await_health(proc)
+            if not loaded:
+                return False, False, {}
+            time.sleep(5)
+            actual = {
+                label: size
+                for label, size in parse_device_buffers(
+                    log_path.read_text(errors="replace")
+                ).items()
+                if not label.upper().startswith(("CPU", "HOST"))
+            }
+            return True, _sustains_full_window(ctx), actual
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=120)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def _await_health(proc: subprocess.Popen[bytes]) -> bool:
+    deadline = time.time() + _LOAD_TIMEOUT_S
+    while time.time() < deadline and proc.poll() is None:
+        try:
+            if httpx.get(f"{_BASE_URL}/health", timeout=5).status_code == httpx.codes.OK:
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(3)
+    return False
+
+
+def _sustains_full_window(ctx: int) -> bool:
+    """Consecutive requests that fill the served window, which is where a
+    load-time fit that was too generous shows up."""
+    gen = min(_GENERATION_TOKENS, max(64, ctx // 4))
+    repeats = max(1, int((ctx - gen - 80) / _TOKENS_PER_FILLER))
+    body = {
+        "messages": [{"role": "user", "content": _FILLER * repeats + "\n\nSummarize."}],
+        "max_tokens": gen,
+        "temperature": 0.0,
+        "ignore_eos": True,
+    }
+    for _ in range(_ROUNDS):
+        try:
+            response = httpx.post(f"{_BASE_URL}/v1/chat/completions", json=body, timeout=1800)
+            if response.status_code != httpx.codes.OK:
+                return False
+            response.json()
+        except (httpx.HTTPError, ValueError):
+            return False
+    return True
+
+
+def run_cell(cell: Cell, *, workdir: Path, available_cards: int) -> Observation:
+    """Plan, launch and measure one cell, or record why it was skipped."""
+    base = Observation(
+        cell_id=cell.id,
+        model_key=cell.model.key,
+        cards=cell.cards,
+        total_free_bytes=0,
+        weights_bytes=0,
+        planned=False,
+    )
+    if cell.cards > available_cards:
+        return _replace(base, skipped=f"needs {cell.cards} cards, host has {available_cards}")
+    if any(cell.ballast_gib):
+        return _replace(base, skipped="ballast tenants are not supported on this host")
+
+    env = {
+        **os.environ,
+        "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(cell.cards)),
+        "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
+    }
+    decision = _plan(cell, env)
+    argv: tuple[str, ...] = tuple(decision.get("argv") or ())
+    observed = _replace(
+        base,
+        total_free_bytes=int(decision.get("total_free_bytes", 0)),  # type: ignore[arg-type]
+        weights_bytes=int(decision.get("weights_bytes", 0)),  # type: ignore[arg-type]
+        planned=bool(decision.get("planned")),
+        refusal=decision.get("refusal"),
+        ctx=int(decision.get("ctx", 0)),  # type: ignore[arg-type]
+        slots=int(decision.get("slots", 0)),  # type: ignore[arg-type]
+        argv=argv,
+        est_by_device=dict(decision.get("est_by_device") or {}),
+        min_usable_ctx=int(decision.get("min_usable_ctx", 0)),  # type: ignore[arg-type]
+        # Only the tight placement leaves a multi-card group without a ratio.
+        tight=cell.cards > 1 and "--tensor-split" not in argv,
+    )
+    launch_env = {**env, **dict(decision.get("env") or {})}
+    if observed.planned:
+        loaded, sustained, actual = _serve_and_measure(
+            list(observed.argv), launch_env, observed.ctx, workdir / f"{cell.id}.engine.log"
+        )
+        return _replace(observed, loaded=loaded, sustained=sustained, actual_by_device=actual)
+
+    # Refused: the claim is that no usable window exists. Force one and find out.
+    forced = _plan(cell, env, force_ctx=observed.min_usable_ctx)
+    if not forced.get("planned"):
+        return _replace(observed, forced_loaded=False, forced_sustained=False)
+    loaded, sustained, _actual = _serve_and_measure(
+        list(forced["argv"]),  # type: ignore[arg-type]
+        {**env, **dict(forced.get("env", {}))},  # type: ignore[arg-type]
+        int(forced["ctx"]),  # type: ignore[arg-type]
+        workdir / f"{cell.id}.forced.log",
+    )
+    return _replace(observed, forced_loaded=loaded, forced_sustained=sustained)
+
+
+def _replace(observation: Observation, **changes: object) -> Observation:
+    from dataclasses import replace
+
+    return replace(observation, **changes)  # type: ignore[arg-type]

--- a/tools/qa/placement_matrix/observe.py
+++ b/tools/qa/placement_matrix/observe.py
@@ -13,11 +13,56 @@ import os
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import Any
 
 import httpx
 from tools.qa.placement_matrix.cells import Cell
 from tools.qa.placement_matrix.oracles import Observation
+
+
+@dataclass(frozen=True)
+class PlanDecision:
+    """What the planner decided for one cell, parsed rather than read loosely.
+
+    Every field is required or explicitly defaulted here, so a key the planner
+    stopped emitting raises instead of arriving as a plausible zero.
+    """
+
+    planned: bool
+    total_free_bytes: int
+    min_usable_ctx: int
+    refusal: str | None = None
+    ctx: int = 0
+    slots: int = 0
+    argv: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+    est_by_device: dict[str, int] = field(default_factory=dict)
+    weights_bytes: int = 0
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> PlanDecision:
+        planned = bool(payload["planned"])
+        decision = cls(
+            planned=planned,
+            total_free_bytes=int(payload["total_free_bytes"]),
+            min_usable_ctx=int(payload["min_usable_ctx"]),
+            refusal=payload["refusal"],
+        )
+        if not planned:
+            return decision
+        return replace(
+            decision,
+            ctx=int(payload["ctx"]),
+            slots=int(payload["slots"]),
+            argv=tuple(str(a) for a in payload["argv"]),
+            env={str(k): str(v) for k, v in payload["env"].items()},
+            est_by_device={str(k): int(v) for k, v in payload["est_by_device"].items()},
+            weights_bytes=int(payload["weights_bytes"]),
+        )
+
 
 _GB = 1024**3
 _PORT = 8412
@@ -29,6 +74,8 @@ _GENERATION_TOKENS = 256
 # per repeat, which is only used to size a prompt near the window.
 _TOKENS_PER_FILLER = 10.1
 _FILLER = "The quick brown fox jumps over the lazy dog. "
+# A round has to occupy most of the window, or it is not evidence the window works.
+_MIN_WINDOW_FILL = 0.8
 
 _PLAN_SCRIPT = """
 import json, sys
@@ -63,7 +110,7 @@ print("<<<PLAN>>>" + json.dumps(out))
 """
 
 
-def _plan(cell: Cell, env: dict[str, str], *, force_ctx: int | None = None) -> dict[str, object]:
+def _plan(cell: Cell, env: dict[str, str], *, force_ctx: int | None = None) -> PlanDecision:
     """The planner's decision for this cell, from a clean child process."""
     result = subprocess.run(
         [
@@ -87,7 +134,7 @@ def _plan(cell: Cell, env: dict[str, str], *, force_ctx: int | None = None) -> d
         raise RuntimeError(
             f"planner produced no decision: {result.stdout[-2000:]}{result.stderr[-2000:]}"
         )
-    return json.loads(result.stdout[marker + len("<<<PLAN>>>") :])
+    return PlanDecision.from_payload(json.loads(result.stdout[marker + len("<<<PLAN>>>") :]))
 
 
 def _smi(field: str) -> list[str]:
@@ -114,34 +161,48 @@ def _smi_used_bytes() -> list[int]:
     return [int(v) * 1024 * 1024 for v in _smi("memory.used") if v.isdigit()]
 
 
-def _wait_for_idle_vram(limit_bytes: int = 512 * 1024 * 1024, timeout_s: int = 180) -> None:
-    """Block until nothing else holds VRAM, so a load is measured alone."""
+def _wait_for_idle_vram(limit_bytes: int = 512 * 1024 * 1024, timeout_s: int = 180) -> bool:
+    """Block until nothing else holds VRAM; False if it never went idle.
+
+    Reported rather than swallowed: a load that raced another tenant produced
+    memory numbers describing that tenant, and a silent proceed makes those
+    numbers indistinguishable from a clean measurement.
+    """
     deadline = time.time() + timeout_s
     while time.time() < deadline:
         used = _smi_used_bytes()
         if not used or max(used) < limit_bytes:
-            return
+            return True
         time.sleep(3)
+    return False
+
+
+@dataclass(frozen=True)
+class ServeResult:
+    """What one launch did once it was up."""
+
+    loaded: bool
+    sustained: bool = False
+    actual_by_device: dict[str, int] = field(default_factory=dict)
+    vram_was_idle: bool = True
+    generated_tokens: int = 0
+    prompt_tokens: int = 0
 
 
 def _serve_and_measure(
     argv: list[str], env: dict[str, str], ctx: int, log_path: Path
-) -> tuple[bool, bool, dict[str, int]]:
-    """Load the launch, fill its window repeatedly, and read back per-device use.
-
-    Returns ``(loaded, sustained, actual_by_device)``.
-    """
+) -> ServeResult:
+    """Load the launch, fill its window repeatedly, and read back per-device use."""
     from lilbee.providers.fleet.readback import parse_device_buffers
 
-    _wait_for_idle_vram()
+    was_idle = _wait_for_idle_vram()
     with log_path.open("wb") as log:
         proc = subprocess.Popen(
             [*argv, "--port", str(_PORT)], stdout=log, stderr=subprocess.STDOUT, env=env
         )
         try:
-            loaded = _await_health(proc)
-            if not loaded:
-                return False, False, {}
+            if not _await_health(proc):
+                return ServeResult(loaded=False, vram_was_idle=was_idle)
             time.sleep(5)
             actual = {
                 label: size
@@ -150,7 +211,15 @@ def _serve_and_measure(
                 ).items()
                 if not label.upper().startswith(("CPU", "HOST"))
             }
-            return True, _sustains_full_window(ctx), actual
+            sustained, generated, prompted = _sustains_full_window(ctx)
+            return ServeResult(
+                loaded=True,
+                sustained=sustained,
+                actual_by_device=actual,
+                vram_was_idle=was_idle,
+                generated_tokens=generated,
+                prompt_tokens=prompted,
+            )
         finally:
             proc.terminate()
             try:
@@ -171,9 +240,13 @@ def _await_health(proc: subprocess.Popen[bytes]) -> bool:
     return False
 
 
-def _sustains_full_window(ctx: int) -> bool:
-    """Consecutive requests that fill the served window, which is where a
-    load-time fit that was too generous shows up."""
+def _sustains_full_window(ctx: int) -> tuple[bool, int, int]:
+    """Consecutive requests that fill the served window.
+
+    Returns ``(sustained, generated_tokens, prompt_tokens)``. A 200 with an empty
+    completion, or a prompt the server quietly truncated, is not a served window,
+    so the token counts are checked rather than the status code alone.
+    """
     gen = min(_GENERATION_TOKENS, max(64, ctx // 4))
     repeats = max(1, int((ctx - gen - 80) / _TOKENS_PER_FILLER))
     body = {
@@ -182,15 +255,22 @@ def _sustains_full_window(ctx: int) -> bool:
         "temperature": 0.0,
         "ignore_eos": True,
     }
+    generated = prompted = 0
     for _ in range(_ROUNDS):
         try:
             response = httpx.post(f"{_BASE_URL}/v1/chat/completions", json=body, timeout=1800)
             if response.status_code != httpx.codes.OK:
-                return False
-            response.json()
+                return False, generated, prompted
+            usage = response.json().get("usage") or {}
         except (httpx.HTTPError, ValueError):
-            return False
-    return True
+            return False, generated, prompted
+        generated = int(usage.get("completion_tokens", 0))
+        prompted = int(usage.get("prompt_tokens", 0))
+        # The point of the round is that the window was really occupied: a
+        # truncated prompt or a one-token answer is a pass the harness must not give.
+        if generated < gen or prompted + generated < ctx * _MIN_WINDOW_FILL:
+            return False, generated, prompted
+    return True, generated, prompted
 
 
 def run_cell(cell: Cell, *, workdir: Path, available_cards: int) -> Observation:
@@ -204,9 +284,9 @@ def run_cell(cell: Cell, *, workdir: Path, available_cards: int) -> Observation:
         planned=False,
     )
     if cell.cards > available_cards:
-        return _replace(base, skipped=f"needs {cell.cards} cards, host has {available_cards}")
+        return replace(base, skipped=f"needs {cell.cards} cards, host has {available_cards}")
     if any(cell.ballast_gib):
-        return _replace(base, skipped="ballast tenants are not supported on this host")
+        return replace(base, skipped="ballast tenants are not supported on this host")
 
     env = {
         **os.environ,
@@ -214,42 +294,51 @@ def run_cell(cell: Cell, *, workdir: Path, available_cards: int) -> Observation:
         "CUDA_DEVICE_ORDER": "PCI_BUS_ID",
     }
     decision = _plan(cell, env)
-    argv: tuple[str, ...] = tuple(decision.get("argv") or ())
-    observed = _replace(
+    observed = replace(
         base,
-        total_free_bytes=int(decision.get("total_free_bytes", 0)),  # type: ignore[arg-type]
-        weights_bytes=int(decision.get("weights_bytes", 0)),  # type: ignore[arg-type]
-        planned=bool(decision.get("planned")),
-        refusal=decision.get("refusal"),
-        ctx=int(decision.get("ctx", 0)),  # type: ignore[arg-type]
-        slots=int(decision.get("slots", 0)),  # type: ignore[arg-type]
-        argv=argv,
-        est_by_device=dict(decision.get("est_by_device") or {}),
-        min_usable_ctx=int(decision.get("min_usable_ctx", 0)),  # type: ignore[arg-type]
+        total_free_bytes=decision.total_free_bytes,
+        weights_bytes=decision.weights_bytes,
+        planned=decision.planned,
+        refusal=decision.refusal,
+        ctx=decision.ctx,
+        slots=decision.slots,
+        argv=decision.argv,
+        est_by_device=decision.est_by_device,
+        min_usable_ctx=decision.min_usable_ctx,
         # Only the tight placement leaves a multi-card group without a ratio.
-        tight=cell.cards > 1 and "--tensor-split" not in argv,
+        tight=cell.cards > 1 and "--tensor-split" not in decision.argv,
     )
-    launch_env = {**env, **dict(decision.get("env") or {})}
-    if observed.planned:
-        loaded, sustained, actual = _serve_and_measure(
-            list(observed.argv), launch_env, observed.ctx, workdir / f"{cell.id}.engine.log"
+    if decision.planned:
+        served = _serve_and_measure(
+            list(decision.argv),
+            {**env, **decision.env},
+            decision.ctx,
+            workdir / f"{cell.id}.engine.log",
         )
-        return _replace(observed, loaded=loaded, sustained=sustained, actual_by_device=actual)
+        return replace(
+            observed,
+            loaded=served.loaded,
+            sustained=served.sustained,
+            actual_by_device=served.actual_by_device,
+            vram_was_idle=served.vram_was_idle,
+            generated_tokens=served.generated_tokens,
+            prompt_tokens=served.prompt_tokens,
+        )
 
     # Refused: the claim is that no usable window exists. Force one and find out.
-    forced = _plan(cell, env, force_ctx=observed.min_usable_ctx)
-    if not forced.get("planned"):
-        return _replace(observed, forced_loaded=False, forced_sustained=False)
-    loaded, sustained, _actual = _serve_and_measure(
-        list(forced["argv"]),  # type: ignore[arg-type]
-        {**env, **dict(forced.get("env", {}))},  # type: ignore[arg-type]
-        int(forced["ctx"]),  # type: ignore[arg-type]
+    forced = _plan(cell, env, force_ctx=decision.min_usable_ctx)
+    if not forced.planned:
+        return replace(observed, forced_planned=False)
+    served = _serve_and_measure(
+        list(forced.argv),
+        {**env, **forced.env},
+        forced.ctx,
         workdir / f"{cell.id}.forced.log",
     )
-    return _replace(observed, forced_loaded=loaded, forced_sustained=sustained)
-
-
-def _replace(observation: Observation, **changes: object) -> Observation:
-    from dataclasses import replace
-
-    return replace(observation, **changes)  # type: ignore[arg-type]
+    return replace(
+        observed,
+        forced_planned=True,
+        forced_loaded=served.loaded,
+        forced_sustained=served.sustained,
+        vram_was_idle=served.vram_was_idle,
+    )

--- a/tools/qa/placement_matrix/observe.py
+++ b/tools/qa/placement_matrix/observe.py
@@ -190,13 +190,26 @@ class ServeResult:
 
 
 def _serve_and_measure(
-    argv: list[str], env: dict[str, str], ctx: int, log_path: Path
+    argv: list[str], env: dict[str, str], ctx: int, log_dir: Path, model_id: str
 ) -> ServeResult:
-    """Load the launch, fill its window repeatedly, and read back per-device use."""
-    from lilbee.providers.fleet.readback import parse_device_buffers
+    """Load the launch, fill its window repeatedly, and read back per-device use.
 
+    The engine's log environment comes from lilbee's own ``engine_log_env``, and
+    the report is read from the file it names. Spawning without it prints no
+    per-device buffers at all (the default verbosity omits them), which would
+    make every cell look like an engine whose log format had changed.
+    """
+    from lilbee.providers.fleet.readback import (
+        _is_host_device,
+        engine_log_env,
+        engine_log_path,
+        parse_device_buffers,
+    )
+
+    env = {**env, **engine_log_env(log_dir, model_id)}
+    report_path = engine_log_path(log_dir, model_id)
     was_idle = _wait_for_idle_vram()
-    with log_path.open("wb") as log:
+    with (log_dir / f"{model_id}.stdout.log").open("wb") as log:
         proc = subprocess.Popen(
             [*argv, "--port", str(_PORT)], stdout=log, stderr=subprocess.STDOUT, env=env
         )
@@ -204,12 +217,13 @@ def _serve_and_measure(
             if not _await_health(proc):
                 return ServeResult(loaded=False, vram_was_idle=was_idle)
             time.sleep(5)
+            report = report_path.read_text(errors="replace") if report_path.exists() else ""
+            # lilbee's own predicate, not a prefix guess: the engine labels
+            # host-pinned memory CUDA_Host, which no "CPU"/"HOST" test catches.
             actual = {
                 label: size
-                for label, size in parse_device_buffers(
-                    log_path.read_text(errors="replace")
-                ).items()
-                if not label.upper().startswith(("CPU", "HOST"))
+                for label, size in parse_device_buffers(report).items()
+                if not _is_host_device(label)
             }
             sustained, generated, prompted = _sustains_full_window(ctx)
             return ServeResult(
@@ -310,10 +324,7 @@ def run_cell(cell: Cell, *, workdir: Path, available_cards: int) -> Observation:
     )
     if decision.planned:
         served = _serve_and_measure(
-            list(decision.argv),
-            {**env, **decision.env},
-            decision.ctx,
-            workdir / f"{cell.id}.engine.log",
+            list(decision.argv), {**env, **decision.env}, decision.ctx, workdir, cell.id
         )
         return replace(
             observed,
@@ -330,10 +341,7 @@ def run_cell(cell: Cell, *, workdir: Path, available_cards: int) -> Observation:
     if not forced.planned:
         return replace(observed, forced_planned=False)
     served = _serve_and_measure(
-        list(forced.argv),
-        {**env, **forced.env},
-        forced.ctx,
-        workdir / f"{cell.id}.forced.log",
+        list(forced.argv), {**env, **forced.env}, forced.ctx, workdir, f"{cell.id}.forced"
     )
     return replace(
         observed,

--- a/tools/qa/placement_matrix/oracles.py
+++ b/tools/qa/placement_matrix/oracles.py
@@ -1,0 +1,224 @@
+"""What must be true of a placement, judged from a recorded observation.
+
+Pure functions over :class:`Observation`, deliberately separated from the code
+that produces one: the half that needs GPUs cannot be tested in CI, and the half
+that decides pass or fail is the half worth testing. Every verdict here is
+checked against fabricated observations in tests/test_placement_matrix.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+
+_GB = 1024**3
+
+
+@dataclass(frozen=True)
+class Observation:
+    """What one cell did on real hardware."""
+
+    cell_id: str
+    model_key: str
+    cards: int
+    total_free_bytes: int
+    weights_bytes: int
+    planned: bool
+    """The planner emitted a chat launch."""
+    refusal: str | None = None
+    ctx: int = 0
+    slots: int = 0
+    argv: tuple[str, ...] = ()
+    tight: bool = False
+    est_by_device: dict[str, int] = field(default_factory=dict)
+    actual_by_device: dict[str, int] = field(default_factory=dict)
+    loaded: bool = False
+    sustained: bool = False
+    """Served consecutive requests that filled the served window."""
+    forced_loaded: bool | None = None
+    """Refused cells only: did a forced num_ctx launch load anyway."""
+    forced_sustained: bool | None = None
+    min_usable_ctx: int = 0
+    skipped: str | None = None
+
+    def to_json(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, payload: dict[str, object]) -> Observation:
+        fields = {f for f in cls.__dataclass_fields__}
+        return cls(**{k: v for k, v in payload.items() if k in fields})  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True)
+class Failure:
+    """One violated invariant, named by the rule that caught it."""
+
+    rule: str
+    cell_id: str
+    detail: str
+
+
+# A per-device estimate may exceed reality (conservative) by this much before it
+# is worth reporting; under-estimating by any margin is what OOMs a card.
+_OVER_ESTIMATE_TOLERANCE = 2 * _GB
+_UNDER_ESTIMATE_TOLERANCE = 512 * 1024 * 1024
+
+
+def judge(observation: Observation) -> list[Failure]:
+    """Every invariant violated by one cell."""
+    if observation.skipped:
+        return []
+    checks = (
+        _served_plans_load,
+        _served_plans_sustain,
+        _refusals_are_real,
+        _estimates_bracket_reality,
+        _oversize_models_spill,
+        _tight_groups_let_the_engine_fit,
+    )
+    return [failure for check in checks for failure in check(observation)]
+
+
+def _served_plans_load(o: Observation) -> list[Failure]:
+    """A plan is a promise the launch loads."""
+    if o.planned and not o.loaded:
+        return [Failure("plan-loads", o.cell_id, "planner emitted a launch that failed to load")]
+    return []
+
+
+def _served_plans_sustain(o: Observation) -> list[Failure]:
+    """Loading is not serving: the window the planner published must be usable."""
+    if o.planned and o.loaded and not o.sustained:
+        return [
+            Failure(
+                "plan-sustains",
+                o.cell_id,
+                f"loaded at ctx={o.ctx} but could not sustain a full window",
+            )
+        ]
+    return []
+
+
+def _refusals_are_real(o: Observation) -> list[Failure]:
+    """A refusal claims no usable window exists, so forcing one must not work.
+
+    This is the general form of the 70B-on-2x4090 bug: the fit said 512 tokens
+    while a pinned 4096 loaded and answered.
+    """
+    if o.planned or o.refusal is None or o.forced_loaded is None:
+        return []
+    if o.forced_loaded and o.forced_sustained:
+        return [
+            Failure(
+                "refusal-is-real",
+                o.cell_id,
+                f"refused as unservable, but a forced {o.min_usable_ctx}-token window "
+                "loaded and sustained",
+            )
+        ]
+    return []
+
+
+def _estimates_bracket_reality(o: Observation) -> list[Failure]:
+    """Per device, what was charged has to resemble what was allocated."""
+    if not (o.loaded and o.est_by_device and o.actual_by_device):
+        return []
+    failures = []
+    for device, actual in o.actual_by_device.items():
+        estimated = o.est_by_device.get(device)
+        if estimated is None:
+            failures.append(
+                Failure("estimate-covers-devices", o.cell_id, f"{device} was never charged")
+            )
+            continue
+        if actual - estimated > _UNDER_ESTIMATE_TOLERANCE:
+            failures.append(
+                Failure(
+                    "estimate-not-under",
+                    o.cell_id,
+                    f"{device} allocated {actual / _GB:.2f} GiB against an estimate of "
+                    f"{estimated / _GB:.2f} GiB",
+                )
+            )
+        elif estimated - actual > _OVER_ESTIMATE_TOLERANCE:
+            failures.append(
+                Failure(
+                    "estimate-not-wildly-over",
+                    o.cell_id,
+                    f"{device} was charged {estimated / _GB:.2f} GiB for "
+                    f"{actual / _GB:.2f} GiB, which costs context elsewhere",
+                )
+            )
+    return failures
+
+
+def _oversize_models_spill(o: Observation) -> list[Failure]:
+    """A model larger than the GPUs is served by spilling, not refused or OOMed.
+
+    The tight placement's whole promise. It is also what breaks the moment the
+    launch pins a tensor split, because the engine abandons its own fit pass.
+    """
+    if o.weights_bytes <= o.total_free_bytes or not o.planned:
+        return []
+    if not o.loaded:
+        return [
+            Failure(
+                "oversize-spills",
+                o.cell_id,
+                f"weights {o.weights_bytes / _GB:.1f} GiB exceed {o.total_free_bytes / _GB:.1f} "
+                "GiB of VRAM and the load failed instead of spilling to system memory",
+            )
+        ]
+    return []
+
+
+def _tight_groups_let_the_engine_fit(o: Observation) -> list[Failure]:
+    """A tight group must not carry --tensor-split; the engine has to fit it."""
+    if o.tight and o.cards > 1 and "--tensor-split" in o.argv:
+        return [
+            Failure(
+                "tight-group-has-no-ratio",
+                o.cell_id,
+                "a best-effort placement pinned a tensor split, which aborts the "
+                "engine's fit pass and offloads every layer",
+            )
+        ]
+    return []
+
+
+def compare(low: Observation, high: Observation, knob: str) -> list[Failure]:
+    """Metamorphic check: more room must never serve a smaller window.
+
+    Needs no oracle, only two runs whose order is known, which is what makes it
+    able to catch configurations nobody thought to write an expectation for.
+    """
+    if low.skipped or high.skipped:
+        return []
+    if not (low.planned and high.planned):
+        # A refusal on the roomier side while the tighter side serves is itself wrong.
+        if high.planned and not low.planned and low.refusal:
+            return []
+        if low.planned and not high.planned:
+            return [
+                Failure(
+                    "monotonic-service",
+                    high.cell_id,
+                    f"more {knob} than {low.cell_id}, yet chat was refused",
+                )
+            ]
+        return []
+    if high.ctx < low.ctx:
+        return [
+            Failure(
+                "monotonic-ctx",
+                high.cell_id,
+                f"more {knob} than {low.cell_id} but a smaller window ({high.ctx} < {low.ctx})",
+            )
+        ]
+    return []
+
+
+def judge_all(observations: Sequence[Observation]) -> list[Failure]:
+    """Per-cell invariants for every observation, most severe first by rule name."""
+    return [failure for observation in observations for failure in judge(observation)]

--- a/tools/qa/placement_matrix/oracles.py
+++ b/tools/qa/placement_matrix/oracles.py
@@ -8,10 +8,15 @@ checked against fabricated observations in tests/test_placement_matrix.py.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
+from typing import Any
 
 _GB = 1024**3
+# Bumped whenever a field changes meaning. Results are merged across pods and
+# possibly across commits, and a stale file read with today's defaults would
+# report a field nobody measured (an unmeasured idle box reads as idle).
+SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -40,14 +45,36 @@ class Observation:
     forced_sustained: bool | None = None
     min_usable_ctx: int = 0
     skipped: str | None = None
+    error: str | None = None
+    """The cell raised instead of producing a verdict; never silently dropped."""
+    forced_planned: bool | None = None
+    """Refused cells only: whether a num_ctx pin even produced a launch to try."""
+    vram_was_idle: bool = True
+    """False when another process still held VRAM at launch, which taints the load."""
+    generated_tokens: int = 0
+    prompt_tokens: int = 0
 
-    def to_json(self) -> dict[str, object]:
-        return asdict(self)
+    def to_json(self) -> dict[str, Any]:
+        return {"schema": SCHEMA_VERSION, **asdict(self)}
 
     @classmethod
-    def from_json(cls, payload: dict[str, object]) -> Observation:
-        fields = {f for f in cls.__dataclass_fields__}
-        return cls(**{k: v for k, v in payload.items() if k in fields})  # type: ignore[arg-type]
+    def from_json(cls, payload: Mapping[str, Any]) -> Observation:
+        """Parse one recorded cell, refusing anything this harness cannot read.
+
+        Strict in both directions: a result from another schema, or one carrying a
+        field this version does not know, is an error rather than a set of
+        defaults that would look like measurements.
+        """
+        schema = payload.get("schema")
+        if schema != SCHEMA_VERSION:
+            raise ValueError(
+                f"result was written by schema {schema!r}, this harness reads {SCHEMA_VERSION}"
+            )
+        known = set(cls.__dataclass_fields__)
+        unknown = set(payload) - known - {"schema"}
+        if unknown:
+            raise ValueError(f"result carries unknown fields {sorted(unknown)}")
+        return cls(**{k: v for k, v in payload.items() if k in known})
 
 
 @dataclass(frozen=True)
@@ -66,7 +93,13 @@ _UNDER_ESTIMATE_TOLERANCE = 512 * 1024 * 1024
 
 
 def judge(observation: Observation) -> list[Failure]:
-    """Every invariant violated by one cell."""
+    """Every invariant violated by one cell.
+
+    An errored cell is a failure, not an absence: a run whose cells all raised
+    would otherwise merge into a report with nothing to complain about.
+    """
+    if observation.error:
+        return [Failure("cell-errored", observation.cell_id, observation.error)]
     if observation.skipped:
         return []
     checks = (
@@ -74,10 +107,44 @@ def judge(observation: Observation) -> list[Failure]:
         _served_plans_sustain,
         _refusals_are_real,
         _estimates_bracket_reality,
+        _readback_was_readable,
         _oversize_models_spill,
         _tight_groups_let_the_engine_fit,
+        _the_load_was_measured_alone,
     )
     return [failure for check in checks for failure in check(observation)]
+
+
+def _readback_was_readable(o: Observation) -> list[Failure]:
+    """A load with no per-device report leaves the estimate check with nothing.
+
+    Silent, it is indistinguishable from an accurate estimate, which is how a
+    parser that stopped matching the engine's log format becomes invisible.
+    """
+    if o.loaded and o.est_by_device and not o.actual_by_device:
+        return [
+            Failure(
+                "readback-missing",
+                o.cell_id,
+                "the engine reported no per-device memory where lilbee reads it, so "
+                "the estimate could not be checked at all",
+            )
+        ]
+    return []
+
+
+def _the_load_was_measured_alone(o: Observation) -> list[Failure]:
+    """A load racing another tenant measures that tenant, not the plan."""
+    if o.loaded and not o.vram_was_idle:
+        return [
+            Failure(
+                "load-measured-alone",
+                o.cell_id,
+                "another process still held VRAM at launch, so this cell's memory "
+                "numbers describe a contended box",
+            )
+        ]
+    return []
 
 
 def _served_plans_load(o: Observation) -> list[Failure]:
@@ -106,7 +173,18 @@ def _refusals_are_real(o: Observation) -> list[Failure]:
     This is the general form of the 70B-on-2x4090 bug: the fit said 512 tokens
     while a pinned 4096 loaded and answered.
     """
-    if o.planned or o.refusal is None or o.forced_loaded is None:
+    if o.planned or o.refusal is None:
+        return []
+    if o.forced_planned is False:
+        return [
+            Failure(
+                "refusal-is-testable",
+                o.cell_id,
+                "a num_ctx pin produced no launch either, so the refusal could not be "
+                "contradicted and this cell proves nothing",
+            )
+        ]
+    if o.forced_loaded is None:
         return []
     if o.forced_loaded and o.forced_sustained:
         return [


### PR DESCRIPTION
## Problem
A tight (best-effort) placement hands a model several cards without a tensor-split ratio on purpose: the launch withholds `--tensor-split` so llama.cpp runs its own fit pass and can spill what does not fit. That ratio is also the only signal gguf-parser has for how many devices to report, so passing the emptiness through to the context fit sized the whole model as a single card. On two 24 GiB cards a 70B was charged 39.9 GiB against a 20.8 GiB headroom, so every probe down to the 512-token floor failed, and #688's refusal then declined a model that a `num_ctx` pin loads and answers with.

## Solution
`fit_split_ctx` derives a headroom-proportional ratio from the per-device free bytes it already receives when the caller passes none.

## The launch argv is deliberately unchanged
A tight group must not carry `--tensor-split`: the engine abandons its own fit pass when the split is user-set, and a negative `n_gpu_layers` then offloads every layer. Sizing needs the device count; the launch must not have it.

## Validated on hardware
2x4090 with Llama 3.3 70B Q4_K_M: serves at 5888 tokens with no pin and no `--tensor-split` in the argv, five consecutive full-window requests at 5795/5888 tokens, VRAM flat at 20.81/20.69 GiB. The refusal still fires when nothing fits. The main-GPU skew reserve stays 0 for a measured reason now: the main device lands 0.26 GiB over its estimate, about a ninth of the `usable_vram_fraction` already held back.

## Placement matrix
A shardable harness that judges plans against real hardware rather than reading them: a plan must load and sustain a full window, a refusal must not be contradicted by forcing the window it called impossible, estimates must bracket what the engine allocated, an oversize model must load by spilling, and a tight group must not pin a split. Pairs differing in one knob add monotonicity checks that need no expected value, only an order. Judging is split from touching hardware, so every rule is unit-tested in CI without a GPU, including that it can fail.

## Not covered
The matrix has not been run on hardware yet. CPU spill, uneven cards (ballast cells always skip) and 3-4 card layouts are unmeasured by anything here.
