### PR TITLE
Queue a mid-answer model switch instead of killing the answer

### DIFF
--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -137,8 +137,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         "/cancel",
         "_cmd_cancel",
         help_text="Cancel any in-flight operations",
-        # Cancelling the live turn is the whole point; gating it on not
-        # streaming left it dead exactly when it is wanted.
+        # Stopping the live turn is the point, so it must reach a live stream.
         allowed_while_streaming=True,
     ),
     SlashCommand("/clear", "_cmd_clear", help_text="Clear the conversation"),

--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -18,6 +18,10 @@ class SlashCommand:
     aliases: tuple[str, ...] = ()
     args_hint: str = ""
     help_text: str = ""
+    # Reachable from the command bar while an answer is streaming. Off by
+    # default: a command that touches the index, the fleet or the transcript
+    # would race the live turn.
+    allowed_while_streaming: bool = False
 
 
 COMMANDS: tuple[SlashCommand, ...] = (
@@ -27,6 +31,8 @@ COMMANDS: tuple[SlashCommand, ...] = (
         aliases=(),
         args_hint="[name]",
         help_text="Switch chat model (no arg opens the catalog)",
+        # The chat screen queues a mid-answer switch, so this never cuts a turn.
+        allowed_while_streaming=True,
     ),
     SlashCommand(
         "/add",
@@ -127,7 +133,14 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand("/help", "_cmd_help", aliases=("/h",), help_text="Show the slash-command catalog"),
     SlashCommand("/version", "_cmd_version", help_text="Show the lilbee version"),
-    SlashCommand("/cancel", "_cmd_cancel", help_text="Cancel any in-flight operations"),
+    SlashCommand(
+        "/cancel",
+        "_cmd_cancel",
+        help_text="Cancel any in-flight operations",
+        # Cancelling the live turn is the whole point; gating it on not
+        # streaming left it dead exactly when it is wanted.
+        allowed_while_streaming=True,
+    ),
     SlashCommand("/clear", "_cmd_clear", help_text="Clear the conversation"),
     SlashCommand("/sessions", "_cmd_sessions", help_text="Open the sessions drawer"),
     SlashCommand("/quit", "_cmd_quit", aliases=("/q", "/exit"), help_text="Exit lilbee"),
@@ -150,6 +163,18 @@ def get_command(name: str) -> SlashCommand:
         if cmd.name == name:
             return cmd
     raise KeyError(name)
+
+
+def runs_while_streaming(name: str) -> bool:
+    """Whether *name* (command or alias) may be submitted mid-answer.
+
+    Unknown names are False so the streaming gate keeps rejecting them; the
+    unknown-command toast is the caller's job.
+    """
+    for cmd in COMMANDS:
+        if name == cmd.name or name in cmd.aliases:
+            return cmd.allowed_while_streaming
+    return False
 
 
 def completion_names() -> tuple[str, ...]:

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -135,6 +135,7 @@ CMD_MODEL_SET = "Model set to {name}"
 # swap and the embed/vision/rerank swaps in model_pick, which name the model in
 # their own surfaces (the chat input placeholder and warm footer for chat).
 MODEL_SWAP_APPLYING = "Switching model, loading…"
+MODEL_SWAP_QUEUED = "Switching to {name} when this answer finishes"
 MODEL_SWAP_DONE = "Now using {name}"
 MODEL_SWAP_FAILED = "Could not switch model: {error}"
 # Chat-input placeholder while a swap holds the input disabled: names the target
@@ -242,7 +243,6 @@ CMD_WIKI_WIPE_WARNING = (
 TASK_NAME_CRAWL = "Crawl {url}"
 STREAM_ERROR = "\n\n*Error: {error}*"
 STREAM_CANCELLED = "\n\n*Response cancelled.*"
-STREAM_CANCELLED_MODEL_SWITCH = "\n\n*Response cancelled: the model was switched.*"
 SYNC_STATUS_SYNCING = "Syncing..."
 SYNC_STATUS_DONE = "Synced ({count} docs)"
 SYNC_STATUS_FAILED = "Sync failed"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -355,8 +355,7 @@ class ChatScreen(Screen[None]):
         # overwrites, reset clears). Never clear it in _finalize_stream: the
         # input unblocks first, so the clear races the next turn's question.
         self._active_question: UserMessage | None = None
-        # A model switch asked for mid-answer, applied when the stream ends so
-        # the fleet restart never tears down the server feeding a live answer.
+        # A model switch asked for mid-answer, applied once the stream ends.
         self._model_switch_queued: bool = False
         self._command_handlers: dict[str, Callable[[str], None]] = self._build_command_handlers()
 
@@ -725,9 +724,7 @@ class ChatScreen(Screen[None]):
         self.remove_class("streaming")
         self.refresh_bindings()
         if self._model_switch_queued:
-            # Clear before applying: apply_model_change can re-enter through the
-            # swap-in-progress branch, and a stale flag would swap a second time
-            # at the next stream end.
+            # Cleared before the call: apply_model_change can re-enter here.
             self._model_switch_queued = False
             self.apply_model_change()
 
@@ -2073,10 +2070,10 @@ class ChatScreen(Screen[None]):
         restart and serializes overlapping reloads, so the worker can start at
         once without waiting for other workers.
 
-        A switch requested mid-answer is queued rather than applied: restarting
-        the chat server under a live stream would kill the answer being read.
-        The queued switch runs when the stream ends, by any route -- finished,
-        cancelled, or cleared -- because they all leave the streaming state.
+        A switch requested mid-answer is queued, not applied: restarting the chat
+        server under a live stream kills the answer being read. The queued switch
+        runs on leaving the streaming state, so it covers a finished, cancelled
+        and cleared answer alike.
         """
         if self.swapping_model:
             # A swap is already loading; a second one (rapid /model, or the model
@@ -2089,7 +2086,7 @@ class ChatScreen(Screen[None]):
             from lilbee.catalog.formatting import display_label_for_ref
 
             # cfg already holds the new ref, so a second queued switch needs no
-            # extra state: the swap that runs at stream end reads the latest cfg.
+            # extra state.
             self._model_switch_queued = True
             self.app.notify(
                 msg.MODEL_SWAP_QUEUED.format(name=display_label_for_ref(cfg.chat_model))

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -355,6 +355,9 @@ class ChatScreen(Screen[None]):
         # overwrites, reset clears). Never clear it in _finalize_stream: the
         # input unblocks first, so the clear races the next turn's question.
         self._active_question: UserMessage | None = None
+        # A model switch asked for mid-answer, applied when the stream ends so
+        # the fleet restart never tears down the server feeding a live answer.
+        self._model_switch_queued: bool = False
         self._command_handlers: dict[str, Callable[[str], None]] = self._build_command_handlers()
 
     def _build_command_handlers(self) -> dict[str, Callable[[str], None]]:
@@ -721,6 +724,12 @@ class ChatScreen(Screen[None]):
     def _exit_streaming_state(self) -> None:
         self.remove_class("streaming")
         self.refresh_bindings()
+        if self._model_switch_queued:
+            # Clear before applying: apply_model_change can re-enter through the
+            # swap-in-progress branch, and a stale flag would swap a second time
+            # at the next stream end.
+            self._model_switch_queued = False
+            self.apply_model_change()
 
     def _cmd_add(self, args: str) -> None:
         from lilbee.app.ingest import source_label_taken
@@ -2056,16 +2065,18 @@ class ChatScreen(Screen[None]):
         self.streaming = False
 
     def apply_model_change(self) -> None:
-        """Swap to the new chat model without freezing the UI.
+        """Swap to the new chat model without freezing the UI or losing an answer.
 
         Reloading the fleet for the new model is a multi-second restart, so it
-        runs in a thread worker instead of on the event loop. The in-flight stream
-        is cancelled first, the input is blocked behind a "switching" state with an
-        indicator toast, and the worker reloads only the chat role. The provider
-        retires any still-busy client across the restart and serializes overlapping
-        reloads, so the worker can start at once without waiting for other workers.
-        The input re-enables once the fleet has restarted with the new model (which
-        loads on the next request).
+        runs in a thread worker instead of on the event loop. The worker reloads
+        only the chat role; the provider retires any still-busy client across the
+        restart and serializes overlapping reloads, so the worker can start at
+        once without waiting for other workers.
+
+        A switch requested mid-answer is queued rather than applied: restarting
+        the chat server under a live stream would kill the answer being read.
+        The queued switch runs when the stream ends, by any route -- finished,
+        cancelled, or cleared -- because they all leave the streaming state.
         """
         if self.swapping_model:
             # A swap is already loading; a second one (rapid /model, or the model
@@ -2075,7 +2086,15 @@ class ChatScreen(Screen[None]):
             self.notify(msg.CHAT_MODEL_SWITCHING, severity="warning", timeout=3)
             return
         if self.streaming:
-            self._cancel_inflight_stream(msg.STREAM_CANCELLED_MODEL_SWITCH)
+            from lilbee.catalog.formatting import display_label_for_ref
+
+            # cfg already holds the new ref, so a second queued switch needs no
+            # extra state: the swap that runs at stream end reads the latest cfg.
+            self._model_switch_queued = True
+            self.app.notify(
+                msg.MODEL_SWAP_QUEUED.format(name=display_label_for_ref(cfg.chat_model))
+            )
+            return
         self.swapping_model = True
         self.app.notify(msg.MODEL_SWAP_APPLYING)
         self._reload_chat_model_worker()

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -40,6 +40,7 @@ from lilbee.app.themes import DARK_THEMES
 from lilbee.app.version import get_version
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp, apply_active_model
+from lilbee.cli.tui.command_registry import runs_while_streaming
 from lilbee.cli.tui.screens.chat_helpers import (
     add_indexed_anything,
     build_add_progress_callback,
@@ -621,10 +622,10 @@ class ChatScreen(Screen[None]):
 
     def _ready_to_submit(self, text: str) -> bool:
         """Gate a submit: busy, consumed, empty, and keep-the-draft cases say no."""
-        if self._reject_submit_when_busy() or self._dismiss_overlay_on_submit() or not text:
+        if self._reject_submit_when_busy(text) or self._dismiss_overlay_on_submit() or not text:
             return False
-        if text.startswith("/"):
-            cmd = text.split()[0].lower()
+        cmd = self._slash_name(text)
+        if cmd:
             if cmd not in self._command_handlers:
                 # Keep the draft so a typo (or a stale leading slash) can be
                 # fixed in place instead of retyped.
@@ -643,12 +644,14 @@ class ChatScreen(Screen[None]):
             return False
         return True
 
-    def _reject_submit_when_busy(self) -> bool:
+    def _reject_submit_when_busy(self, text: str = "") -> bool:
         """Toast and reject a submit while a swap is loading or a stream is in flight.
 
-        Returns True when the prompt was rejected so the caller stops. The swap
+        Returns True when the submit was rejected so the caller stops. The swap
         check comes first: a prompt sent mid-swap would race a half-torn-down
-        fleet, so the user is asked to wait rather than cancel.
+        fleet, so the user is asked to wait rather than cancel. Commands the
+        registry marks ``allowed_while_streaming`` pass the streaming check, so
+        /cancel and /model stay reachable during the turn they act on.
         """
         if self.swapping_model:
             self.notify(msg.CHAT_MODEL_SWITCHING, severity="warning", timeout=3)
@@ -656,12 +659,17 @@ class ChatScreen(Screen[None]):
         if self.reloading_placement:
             self.notify(msg.FLEET_RELOADING, severity="warning", timeout=3)
             return True
-        if self.streaming:
+        if self.streaming and not runs_while_streaming(self._slash_name(text)):
             # Only one chat message may be in flight at a time; surface a toast
             # so the prompt is visibly rejected, not silently dropped.
             self.notify(msg.CHAT_BUSY, severity="warning", timeout=3)
             return True
         return False
+
+    @staticmethod
+    def _slash_name(text: str) -> str:
+        """The command word of a slash submit, or "" when *text* is not one."""
+        return text.split()[0].lower() if text.startswith("/") else ""
 
     def _pending_required_model_download(self) -> str | None:
         """Return the in-flight download's name if it's for the configured chat or embedding model.

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -496,7 +496,7 @@ class ChatScreen(Screen[None]):
 
     def run_command(self, text: str) -> None:
         """Dispatch *text* as a slash command, as if submitted from the prompt."""
-        if self._reject_submit_when_busy():
+        if self._reject_submit_when_busy(text):
             return
         self._handle_slash(text)
 

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -346,10 +346,10 @@ class ModelPickerButton(Static, can_focus=True):
     def _commit_after_change(self) -> None:
         """Repaint the label, then run the chat-screen side effect for chat swaps.
 
-        ``apply_model_pick`` already persisted the ref and (for non-chat
-        scopes) reloaded the worker. Chat swaps cancel the in-flight stream
-        and reset services here so the new chat model takes over cleanly. Works
-        regardless of which container the button is mounted in.
+        ``apply_model_pick`` already persisted the ref and (for non-chat scopes)
+        reloaded the worker. Chat swaps hand off to the chat screen, which defers
+        the reload while an answer is streaming. Works regardless of which
+        container the button is mounted in.
         """
         self._refresh()
         if self._scope != "chat":

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -3550,8 +3550,9 @@ class TestChatStreaming:
                 await pilot.pause()
                 assert inp.placeholder == msg_module.CHAT_INPUT_PLACEHOLDER_DEFAULT
 
-    async def test_model_switch_during_streaming_cancels(self, _mock_resolve, _mock_services):
-        """apply_model_change cancels any in-flight stream. Regression for the model-swap path."""
+    async def test_model_switch_during_streaming_is_queued(self, _mock_resolve, _mock_services):
+        """A switch asked for mid-answer leaves the answer streaming and defers the
+        fleet restart until the stream ends."""
         with self._patch_stream_response():
             app = ChatTestApp()
             async with app.run_test(size=(120, 40)) as pilot:
@@ -3561,9 +3562,14 @@ class TestChatStreaming:
                 await pilot.press("enter")
                 await pilot.pause()
                 assert app.screen.streaming
-                app.screen.apply_model_change()
-                await pilot.pause()
-                assert app.screen.streaming is False
+                with mock.patch.object(app.screen, "_reload_chat_model_worker") as mock_worker:
+                    app.screen.apply_model_change()
+                    await pilot.pause()
+                    assert app.screen.streaming is True
+                    mock_worker.assert_not_called()
+                    app.screen._set_streaming(False)
+                    await pilot.pause()
+                    mock_worker.assert_called_once()
 
     async def test_exit_streaming_does_not_auto_send(self, _mock_resolve, _mock_services):
         """Stream exit does not auto-fire a follow-up prompt.

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3755,6 +3755,35 @@ async def test_slash_model_typed_mid_answer_queues_the_switch():
             mock_worker.assert_not_called()
 
 
+async def test_command_palette_runs_cancel_mid_answer_too():
+    """The palette is the other entry point to the same commands; it must not
+    refuse mid-answer what the command bar allows."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen._active_assistant = None
+        screen.streaming = True
+        with patch("lilbee.cli.tui.screens.chat.get_services") as mock_services:
+            screen.run_command("/cancel")
+        assert screen.streaming is False
+        mock_services.return_value.cancel_inference.assert_called_once_with()
+
+
+async def test_command_palette_still_refuses_an_unsafe_command_mid_answer():
+    """Parity cuts both ways: the palette keeps the gate for commands that are
+    not on the allow-list."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with (
+            patch.object(screen, "_handle_slash") as mock_handle,
+            patch.object(app, "notify"),
+        ):
+            screen.run_command("/add /tmp/x")
+            mock_handle.assert_not_called()
+
+
 async def test_slash_cancel_typed_mid_answer_stops_the_stream():
     """End to end through the input: /cancel while streaming reaches the handler
     and stops the turn, instead of being toasted away as 'already answering'."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3389,10 +3389,9 @@ async def test_chat_cancel_stream_while_streaming():
         assert app.screen.streaming is False
 
 
-async def testapply_model_change_cancels_stream_when_streaming():
-    """apply_model_change cancels the stream with the model-switch note."""
-    from lilbee.cli.tui import messages as msg
-
+async def test_apply_model_change_queues_the_switch_while_streaming():
+    """A switch asked for mid-answer keeps the answer: nothing is cancelled and no
+    reload starts until the stream ends."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
@@ -3402,8 +3401,87 @@ async def testapply_model_change_cancels_stream_when_streaming():
             patch.object(screen, "_reload_chat_model_worker") as mock_worker,
         ):
             screen.apply_model_change()
-            mock_cancel.assert_called_once_with(msg.STREAM_CANCELLED_MODEL_SWITCH)
+            mock_cancel.assert_not_called()
+            mock_worker.assert_not_called()
+        assert screen._model_switch_queued is True
+        assert screen.swapping_model is False
+
+
+async def test_queued_switch_toast_names_the_model_and_says_it_waits():
+    """The queued switch is announced, so a person knows it was accepted and when
+    it lands, rather than facing an answer that ignored their click."""
+    from lilbee.cli.tui import messages as msg
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with (
+            patch.object(screen, "_reload_chat_model_worker"),
+            patch.object(app, "notify") as mock_notify,
+        ):
+            screen.apply_model_change()
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.args[0].startswith("Switching to ")
+        assert mock_notify.call_args.args[0] != msg.MODEL_SWAP_APPLYING
+
+
+async def test_queued_switch_runs_when_the_stream_ends():
+    """Leaving the streaming state applies the queued swap."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with patch.object(screen, "_reload_chat_model_worker") as mock_worker:
+            screen.apply_model_change()
+            mock_worker.assert_not_called()
+            screen.streaming = False
             mock_worker.assert_called_once()
+        assert screen._model_switch_queued is False
+        assert screen.swapping_model is True
+
+
+async def test_queued_switch_runs_when_the_user_cancels_the_stream():
+    """A cancelled answer still lands the queued switch: the user asked for the new
+    model, and cancelling the turn is not a withdrawal of that."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen._active_assistant = None
+        screen.streaming = True
+        with (
+            patch.object(screen, "_reload_chat_model_worker") as mock_worker,
+            patch("lilbee.cli.tui.screens.chat.get_services"),
+        ):
+            screen.apply_model_change()
+            screen.action_cancel_stream()
+            mock_worker.assert_called_once()
+
+
+async def test_two_queued_switches_swap_once_onto_the_latest_model():
+    """Queueing twice must not run two reloads; cfg already holds the latest ref."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with patch.object(screen, "_reload_chat_model_worker") as mock_worker:
+            screen.apply_model_change()
+            screen.apply_model_change()
+            screen.streaming = False
+            mock_worker.assert_called_once()
+
+
+async def test_stream_end_without_a_queued_switch_starts_no_reload():
+    """The common path -- an answer finishing with no switch asked for -- must not
+    swap the model."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with patch.object(screen, "_reload_chat_model_worker") as mock_worker:
+            screen.streaming = False
+            mock_worker.assert_not_called()
+        assert screen.swapping_model is False
 
 
 async def testapply_model_change_spawns_worker_off_event_loop_when_not_streaming():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3410,7 +3410,9 @@ async def test_apply_model_change_queues_the_switch_while_streaming():
 async def test_queued_switch_toast_names_the_model_and_says_it_waits():
     """The queued switch is announced, so a person knows it was accepted and when
     it lands, rather than facing an answer that ignored their click."""
+    from lilbee.catalog.formatting import display_label_for_ref
     from lilbee.cli.tui import messages as msg
+    from lilbee.core.config import cfg
 
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -3422,8 +3424,9 @@ async def test_queued_switch_toast_names_the_model_and_says_it_waits():
         ):
             screen.apply_model_change()
         assert mock_notify.call_count == 1
-        assert mock_notify.call_args.args[0].startswith("Switching to ")
-        assert mock_notify.call_args.args[0] != msg.MODEL_SWAP_APPLYING
+        sent = mock_notify.call_args.args[0]
+        assert sent == msg.MODEL_SWAP_QUEUED.format(name=display_label_for_ref(cfg.chat_model))
+        assert sent != msg.MODEL_SWAP_APPLYING
 
 
 async def test_queued_switch_runs_when_the_stream_ends():
@@ -3445,17 +3448,20 @@ async def test_queued_switch_runs_when_the_user_cancels_the_stream():
     """A cancelled answer still lands the queued switch: the user asked for the new
     model, and cancelling the turn is not a withdrawal of that."""
     app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
+    async with app.run_test(size=(120, 40)) as pilot:
         screen = app.screen
         screen._active_assistant = None
+        await pilot.press("i")
         screen.streaming = True
         with (
             patch.object(screen, "_reload_chat_model_worker") as mock_worker,
             patch("lilbee.cli.tui.screens.chat.get_services"),
         ):
             screen.apply_model_change()
-            screen.action_cancel_stream()
+            await pilot.press("ctrl+c")
+            await pilot.pause()
             mock_worker.assert_called_once()
+        assert screen.streaming is False
 
 
 async def test_two_queued_switches_swap_once_onto_the_latest_model():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3674,6 +3674,105 @@ async def test_submit_not_rejected_when_idle():
         assert screen._reject_submit_when_busy() is False
 
 
+async def test_cancel_command_reaches_the_stream_it_cancels():
+    """/cancel is submittable mid-answer. Gating it on not-streaming left the one
+    command whose job is stopping the turn dead exactly when it is wanted."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        assert screen._reject_submit_when_busy("/cancel") is False
+
+
+async def test_model_command_queues_mid_answer_instead_of_being_refused():
+    """/model is submittable mid-answer; the chat screen queues the swap."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        assert screen._reject_submit_when_busy("/model") is False
+
+
+async def test_a_prompt_is_still_rejected_mid_answer():
+    """Relaxing the gate for commands must not let a second prompt through."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with patch.object(app, "notify"):
+            assert screen._reject_submit_when_busy("tell me more") is True
+
+
+async def test_an_index_touching_command_is_still_rejected_mid_answer():
+    """/add is not on the allow-list: it would race the live turn."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with patch.object(app, "notify"):
+            assert screen._reject_submit_when_busy("/add /tmp/x") is True
+
+
+async def test_allowed_command_still_waits_out_a_model_swap():
+    """The swap hold outranks the streaming allow-list: a half-torn-down fleet
+    must not take a /model or /cancel either."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.swapping_model = True
+        with patch.object(app, "notify"):
+            assert screen._reject_submit_when_busy("/cancel") is True
+
+
+def test_runs_while_streaming_covers_aliases_and_unknown_names():
+    """Alias lookup matches the command; unknown names stay gated."""
+    from lilbee.cli.tui.command_registry import runs_while_streaming
+
+    assert runs_while_streaming("/cancel") is True
+    assert runs_while_streaming("/model") is True
+    assert runs_while_streaming("/add") is False
+    assert runs_while_streaming("/q") is False
+    assert runs_while_streaming("/nope") is False
+
+
+async def test_slash_model_typed_mid_answer_queues_the_switch():
+    """End to end through the input: typing /model while streaming reaches the
+    handler and queues, rather than toasting the user away."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        await pilot.press("i")
+        screen.streaming = True
+        inp = screen.query_one("#chat-input", ChatInput)
+        inp.value = "/model some/ref.gguf"
+        with (
+            patch.object(screen, "_reload_chat_model_worker") as mock_worker,
+            patch("lilbee.cli.tui.screens.chat.apply_active_model"),
+        ):
+            await pilot.press("enter")
+            await pilot.pause()
+            assert screen._model_switch_queued is True
+            mock_worker.assert_not_called()
+
+
+async def test_slash_cancel_typed_mid_answer_stops_the_stream():
+    """End to end through the input: /cancel while streaming reaches the handler
+    and stops the turn, instead of being toasted away as 'already answering'."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        screen._active_assistant = None
+        await pilot.press("i")
+        screen.streaming = True
+        inp = screen.query_one("#chat-input", ChatInput)
+        inp.value = "/cancel"
+        with patch("lilbee.cli.tui.screens.chat.get_services") as mock_services:
+            await pilot.press("enter")
+            await pilot.pause()
+        assert screen.streaming is False
+        mock_services.return_value.cancel_inference.assert_called_once_with()
+
+
 async def test_chat_vim_j_k_scrolls_in_normal_mode():
     """j/k scroll the chat log in normal mode."""
     app = ChatTestApp()


### PR DESCRIPTION
## Problem

Switching the chat model while an answer was streaming cancelled the stream outright and disabled the chat input for the whole fleet restart, so the app read as having died. The in-flight answer ended with "Response cancelled: the model was switched."

Separately, every slash command was refused while an answer streamed. `/cancel` was the worst case: its handler has a streaming branch that could never run from the command bar, so the one command whose job is stopping the turn was dead exactly when it was wanted.

## Measurement

The standing hypothesis was that the UI thread blocks on the provider call. It does not. Sampling the main thread in-process at 42 Hz (py-spy needs root on macOS) across a real 11s switch, the longest stall was 326 ms and the loop stayed parked in the selector for 60-79 of every 85 samples. The freeze is perceived, not real: a dead input plus an answer that stops mid-sentence.

## Queued switch

A switch asked for mid-answer is queued and applied when the stream ends, by any route (finished, cancelled, or cleared), announced with a toast naming the model. Nothing in flight is discarded.

Queueing twice swaps once: cfg already holds the latest ref, so the deferred swap needs no extra state.

Only the chat role is queued. An embed, vision or rerank swap does not restart the chat server, so it cannot kill a live answer.

## Commands during an answer

The command registry carries `allowed_while_streaming`, default off, and only the streaming check consults it. `/cancel` and `/model` opt in; anything that touches the index, the fleet or the transcript stays gated. The swap and placement holds still outrank it, so nothing reaches a half-torn-down fleet.

Both entry points get the same rule: the prompt and the command palette, whose `run_command` had been dropping the submitted text before the gate.

## Latency

Answer end to new model live: 1.88 s to a warm target, about 11 s when the target needs a cold load. The cold number is the engine restart cost, not the queue.

## Deleted

`STREAM_CANCELLED_MODEL_SWITCH` had no caller left once no answer is thrown away by a switch.

## Not covered

The input is still disabled during the swap itself, which is deliberate: it gates only prompt submission and the input box, never navigation. The fuzz harness cannot exercise any of this, because it drives an idle app with mocked services and never produces a live stream; that gap is filed separately.
