### PR TITLE
Show the 70B auto-split as the big-model demo, and defer the rest behind posters

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,11 +353,11 @@ Either way, your files and the index stay on your computer. Only what you ask an
 
 ## Run a model bigger than one card
 
-When a chat model won't fit on a single GPU, lilbee spreads it across the ones you have. It sizes each role's memory with gguf-parser, keeps headroom on every card, and tensor-splits the chat model across the fewest GPUs that fit, with the embedder, reranker, and vision models placed alongside it behind a load-balancing router. This is automatic: ask a question and the model loads split across your cards, answering from your own indexed source.
+When a chat model won't fit on a single GPU, lilbee spreads it across the ones you have. It sizes each role's memory with gguf-parser, keeps headroom on every card, and tensor-splits the chat model across the fewest GPUs that fit, with the embedder, reranker, and vision models placed alongside it behind a load-balancing router. This is automatic: ask a question and the model loads split across your cards, answering from your own indexed source. Here a 70B is spread across three consumer cards and answers a mechanic's question from an indexed car manual, citing the page it came from.
+
+![a 70B spread across three cards without being asked, answering from an indexed manual with a citation](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-auto-placement.gif)
 
 You can also place it by hand. The placement editor pins each role to the cards you choose, previews the fit before anything loads, and applies it live. Ask for a layout that can't fit and it tells you the exact shortfall instead of failing at load time.
-
-![the placement editor: a too-small layout refused with the exact shortfall, then spread across the cards and applied](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.gif)
 
 ## TUI
 

--- a/site/index.html
+++ b/site/index.html
@@ -413,14 +413,14 @@
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-gpuauto" aria-labelledby="tutorial-tab-gpuauto" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-auto.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-auto-placement.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
           <p class="tutorial-caption">Automatic placement: lilbee spreads the models across every GPU on its own — one big chat model tensor-split across all the cards, the embedder copied to each — then answers a grounded question while the per-card load bars move live.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-gpumanual" aria-labelledby="tutorial-tab-gpumanual" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-manual.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
           <p class="tutorial-caption">Manual placement: press <code>ctrl+g</code> for the drawer, pin each role to the cards you want — split, copy, or a single pinned instance — preview the fit, then chat against that exact fleet.</p>
         </div>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -349,9 +349,9 @@
         <h4><a href="#placement-auto">Automatic placement</a></h4>
         <p>With more than one GPU, lilbee spreads the models across all of them on its own: the chat model is tensor-split across every card so it fits, and the embedder is copied to each. It then answers a grounded question while the per-card load bars move live.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-auto.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-auto.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-auto.mp4">automatic GPU placement (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-auto-placement.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-auto-placement.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-auto-placement.mp4">automatic GPU placement (MP4)</a>
           </video>
         </div>
       </section>
@@ -360,9 +360,9 @@
         <h4><a href="#placement-manual">Manual placement</a></h4>
         <p>Press <kbd>ctrl+g</kbd> for the placement drawer and pin each role to the cards you want. Each role shows what it is: a chat model <em>split</em> across cards, an embedder <em>copied</em> per card, a reranker on a <em>single</em> card. Preview the fit, apply, then chat against that exact fleet.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-manual.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-manual.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/placement-manual.mp4">manual GPU placement (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.mp4">manual GPU placement (MP4)</a>
           </video>
         </div>
       </section>


### PR DESCRIPTION
## Problem

The "Run a model bigger than one card" section had no automatic-placement image: the old one was removed because its alt text claimed a model too big for one card while showing an 8B, which fits on one card with room to spare.

Separately, the README pulled 72.7 MB of animated gifs on open.

## The big-model demo

The new auto-placement reel shows what the prose claims: a 70B spread across three consumer cards, answering a mechanic's three-part question from an indexed car manual and citing the page it came from. Generation runs at the speed it actually arrives.

Manual placement keeps its paragraph but loses its image for now. That reel does not read: the placement grid never visibly changes, so lilbee refusing an impossible layout appears as an effect with no cause. It returns once re-shot to show the pin being made before the refusal lands.

## Deferred loading

Twenty-two reels are now mp4 with a poster and `preload="none"`, each inside a `<details>`. Nothing but the poster is fetched until someone presses play.

| | on open |
|---|---|
| before | 72.7 MB |
| after | 11.9 MB |
| if every reel is played | 35.6 MB |

Collapsing alone would not have done this. GitHub adds no `loading="lazy"` to README images -- none of the 48 on the rendered page carry it -- and browsers fetch images inside a closed `<details>` anyway, since the content is in the DOM whether or not it is painted. The wrappers are for skimming; `preload="none"` saves the bytes.

Three stay as autoplaying gifs: the hero, and the two launch clips whose side-by-side comparison is the point of showing them together.

## Site

The placement tabs pointed at older assets under different filenames and now point at these reels.

## Worth checking on review

`<video>` renders on github.com but is stripped by some README mirrors, PyPI's among them. If this README is reused as the PyPI description, those 22 demos will show as nothing there.
