### PR TITLE
Dispatch the engine's CPU variant at runtime on the CPU cells and vulkan Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,10 +301,8 @@ jobs:
 
       # Intel Mac: `uv sync` can't run here -- stock lancedb 0.34.0 ships no
       # macosx_x86_64 wheel. Resolve it from the +compat index (PEP 440 drop-in),
-      # then install the rest of [release] fresh from PyPI. CMAKE_ARGS + deployment
-      # target hold any throwaway llama-cpp-python sdist build at the cpu/x86_64
-      # baseline; the dedicated step below builds the llama-cpp-python that actually
-      # ships. The cell stays soft so an install failure never blocks the fan-out.
+      # then install the rest of [release] fresh from PyPI. The cell stays soft
+      # so an install failure never blocks the fan-out.
       #
       # --python-platform resolves wheels for the x86_64 target instead of the
       # runner. Without it uv picks the newest wheel the macOS 15 image accepts
@@ -317,8 +315,6 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_floor }}
         run: |
           set -euxo pipefail
-          eval "$(BACKEND=cpu TARGET_ARCH=x86_64 tools/wheel-build/cmake_args.sh)"
-          export CMAKE_ARGS
           uv venv
           uv pip install --python-platform x86_64-apple-darwin \
             --extra-index-url https://lilbee.sh/compat/ \
@@ -342,16 +338,6 @@ jobs:
             uv pip install 'nuitka[onefile]>=4.0,<5' pip
             check
           fi
-
-      # Nuitka bundles these dylibs, and dyld enforces each one's minos separately
-      # from the launcher's, so one dep built on a newer runner silently ships a
-      # binary that dies at load. Fail here rather than on the user's Mac.
-      - name: Verify macOS floor
-        if: runner.os == 'macOS'
-        shell: bash
-        env:
-          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_floor }}
-        run: bash tools/wheel-build/check_macos_floor.sh
 
       # compat cell only: swap the synced stock lancedb for the pre-Haswell build.
       # --no-deps leaves the rest of the venv intact, so nothing leaves this cell.
@@ -377,6 +363,19 @@ jobs:
           cache-env: ${{ matrix.container || matrix.os }}
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_floor }}
+
+      # Nuitka bundles these dylibs, and dyld enforces each one's minos separately
+      # from the launcher's, so one dep built on a newer runner silently ships a
+      # binary that dies at load. Fail here rather than on the user's Mac. Runs
+      # after the engine bundle and the compat lancedb swap so the engine's
+      # dlopen'd modules and the swapped wheel are scanned too, including engines
+      # restored from cache or mirror.
+      - name: Verify macOS floor
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_floor }}
+        run: bash tools/wheel-build/check_macos_floor.sh
 
       - name: Build executable
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,7 @@ jobs:
           # to the x86_64 target rather than the runner, so the deps come in at their
           # oldest macOS build (pyarrow's 12.0 is the binding one) and reach every
           # Ivy Bridge / Haswell Mac, which cap at macOS 12. The engine picks its
-          # CPU variant at runtime (see cmake_args.sh), so AVX2 Macs are not held
-          # to the deps' AVX floor.
+          # CPU variant at runtime (see cmake_args.sh).
           - os: macos-15-intel
             asset_name: lilbee-macos-x86_64
             backend: cpu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,10 @@ jobs:
           # the Intel image can queue longer than the arm64 pool -- this asset must
           # never block the release fan-out. The install below pins wheel resolution
           # to the x86_64 target rather than the runner, so the deps come in at their
-          # oldest macOS build (pyarrow's 12.0 is the binding one) and the AVX
-          # baseline reaches every Ivy Bridge / Haswell Mac, which cap at macOS 12.
+          # oldest macOS build (pyarrow's 12.0 is the binding one) and reach every
+          # Ivy Bridge / Haswell Mac, which cap at macOS 12. The engine picks its
+          # CPU variant at runtime (see cmake_args.sh), so AVX2 Macs are not held
+          # to the deps' AVX floor.
           - os: macos-15-intel
             asset_name: lilbee-macos-x86_64
             backend: cpu

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -93,9 +93,11 @@ jobs:
           lilbee-windows-x86_64-cu124.exe
           lilbee-windows-x86_64-cu125.exe
           lilbee-linux-x86_64-rocm
+          lilbee-macos-x86_64
+          lilbee-compat-macos-x86_64
           EOF
-          [ "${missing}" -eq 0 ] || { echo "a continue-on-error GPU build cell dropped its artifact"; exit 1; }
-          echo "every expected CUDA asset is present"
+          [ "${missing}" -eq 0 ] || { echo "a continue-on-error build cell dropped its artifact"; exit 1; }
+          echo "every expected soft-cell asset is present"
 
   # The packaging fan-outs are dispatched fire-and-forget and finish after the RC
   # run this workflow triggers on, so their artifacts are still arriving when the

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Same `lilbee` command after install. The crash is from [lancedb](https://lancedb
 
 ### Linux runtime requirements
 
-The Linux x86_64 wheel and binary link the Vulkan loader at runtime. Most desktop distros (Ubuntu 22.04+, Pop!\_OS, Mint) ship `libvulkan1`; bare Arch / Fedora / Alpine images don't, and `lilbee self-check` fails with `cannot open shared object file: libvulkan.so.1`. Install it once: `sudo pacman -S vulkan-icd-loader` (Arch / Manjaro), `sudo dnf install vulkan-loader` (Fedora, RHEL), or `sudo apt-get install libvulkan1` (Debian, Ubuntu).
+The Linux x86_64 wheel and binary bundle the Vulkan loader, so they start on any distro. GPU detection still reads adapters through the system loader, though: without `libvulkan1` lilbee treats the machine as CPU-only. Most desktop distros (Ubuntu 22.04+, Pop!\_OS, Mint) ship it; on bare Arch / Fedora / Alpine images install it once: `sudo pacman -S vulkan-icd-loader` (Arch / Manjaro), `sudo dnf install vulkan-loader` (Fedora, RHEL), or `sudo apt-get install libvulkan1` (Debian, Ubuntu).
 
 ### Optional extras
 

--- a/tests/test_assert_engine_bundle.py
+++ b/tests/test_assert_engine_bundle.py
@@ -32,6 +32,9 @@ _ROCM_RUNTIME = (
     "libhipblas.so.3",
     "rocblas/library/TensileLibrary.dat",
 )
+# What a runtime-dispatch cell ships instead of a single libggml-cpu.
+_LINUX_VARIANTS = ("libggml-cpu-x64.so", "libggml-cpu-haswell.so", "libggml-cpu-sapphirerapids.so")
+_WINDOWS_VARIANTS = ("ggml-cpu-x64.dll", "ggml-cpu-haswell.dll")
 
 
 def _wheel(tmp_path: Path, name: str, bin_files: tuple[str, ...]) -> Path:
@@ -97,7 +100,7 @@ def test_non_cuda_wheel_passes(tmp_path: Path) -> None:
     wheel = _wheel(
         tmp_path,
         "lilbee_engine-1.0-1.cpu-py3-none-manylinux_2_17_x86_64.whl",
-        ("llama-server", "libggml-cpu.so"),
+        ("llama-server", *_LINUX_VARIANTS),
     )
     assert acb.check(wheel) == []
 
@@ -296,7 +299,71 @@ def test_a_non_rocm_wheel_is_not_asked_for_the_rocm_runtime(tmp_path: Path) -> N
     wheel = _wheel(
         tmp_path,
         "lilbee_engine-1.0-1.vulkan-py3-none-manylinux_2_17_x86_64.whl",
-        ("llama-server", "libggml-vulkan.so"),
+        ("llama-server", "libggml-vulkan.so", "libvulkan.so.1", *_LINUX_VARIANTS),
+    )
+    assert acb.check(wheel) == []
+
+
+def test_cpu_linux_wheel_with_a_single_cpu_library_is_rejected(tmp_path: Path) -> None:
+    # The pre-dispatch shape: one libggml-cpu.so carrying only the AVX baseline.
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cpu-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cpu.so"),
+    )
+    problems = acb.check(wheel)
+    assert len(problems) == 1
+    assert "libggml-cpu-<variant>.so" in problems[0]
+
+
+def test_cpu_windows_wheel_needs_variant_modules(tmp_path: Path) -> None:
+    single = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cpu-py3-none-win_amd64.whl",
+        ("llama-server.exe", "ggml-cpu.dll"),
+    )
+    problems = acb.check(single)
+    assert len(problems) == 1
+    assert "ggml-cpu-<variant>.dll" in problems[0]
+
+    dispatched = _wheel(
+        tmp_path,
+        "ok-1.0-1.cpu-py3-none-win_amd64.whl",
+        ("llama-server.exe", *_WINDOWS_VARIANTS),
+    )
+    assert acb.check(dispatched) == []
+
+
+def test_a_lone_variant_module_is_rejected(tmp_path: Path) -> None:
+    # One variant means the build host's instruction set, not runtime dispatch.
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cpu-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cpu-haswell.so"),
+    )
+    problems = acb.check(wheel)
+    assert len(problems) == 1
+    assert "libggml-cpu-<variant>.so" in problems[0]
+
+
+def test_vulkan_linux_wheel_without_the_loader_is_rejected(tmp_path: Path) -> None:
+    # Under GGML_BACKEND_DL a missing loader is a silent CPU fallback, not a
+    # startup failure, so only the payload can prove the loader ships.
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.vulkan-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-vulkan.so", *_LINUX_VARIANTS),
+    )
+    problems = acb.check(wheel)
+    assert len(problems) == 1
+    assert "libvulkan.so.1" in problems[0]
+
+
+def test_vulkan_windows_wheel_is_not_asked_for_variants_or_loader(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.vulkan-py3-none-win_amd64.whl",
+        ("llama-server.exe", "ggml-vulkan.dll", "ggml-cpu.dll"),
     )
     assert acb.check(wheel) == []
 
@@ -356,14 +423,16 @@ _ROCM_PAYLOAD = (
 _ROCM_WHEEL = "lilbee_engine-0.1-1.rocm-py3-none-manylinux_2_17_x86_64.whl"
 
 
-def test_a_wheel_too_big_to_upload_is_a_problem(tmp_path, monkeypatch):
+def test_a_wheel_too_big_to_upload_is_a_problem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """GitHub caps one artifact at 2 GiB, and a bundled ROCm engine is the one near it."""
     wheel = _wheel(tmp_path, _ROCM_WHEEL, _ROCM_PAYLOAD)
     monkeypatch.setattr(acb, "WHEEL_SIZE_LIMIT", 1)
     assert any("exceeds the" in p for p in acb.check(wheel))
 
 
-def test_a_wheel_within_the_limit_passes(tmp_path):
+def test_a_wheel_within_the_limit_passes(tmp_path: Path) -> None:
     """The common case must not pay for the check with a false failure."""
     wheel = _wheel(tmp_path, _ROCM_WHEEL, _ROCM_PAYLOAD)
     assert acb.check(wheel) == []

--- a/tests/test_cmake_args_cpu_dispatch.py
+++ b/tests/test_cmake_args_cpu_dispatch.py
@@ -1,0 +1,81 @@
+"""The macOS x86_64 CPU cell builds runtime CPU dispatch; every other x86 cell
+keeps the single-variant AVX cap, and no cell downloads server-UI assets.
+
+cmake caches an unknown ``-D`` instead of failing, so a dropped or renamed flag
+here builds successfully and ships the wrong engine. These tests pin the emitted
+flag set; ``build_llama_server.sh`` separately asserts the variant modules exist
+in the built bundle.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="the script under test is POSIX shell, Linux-only in CI"
+)
+
+_SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "tools/wheel-build/cmake_args.sh"
+
+
+def _flags(backend: str, runner_os: str, target_arch: str) -> list[str]:
+    """The CMAKE_ARGS the script emits for one build cell."""
+    result = subprocess.run(
+        ["bash", str(_SCRIPT), "--print"],
+        capture_output=True,
+        text=True,
+        env={
+            "BACKEND": backend,
+            "RUNNER_OS": runner_os,
+            "TARGET_ARCH": target_arch,
+            "PATH": "/usr/bin:/bin",
+        },
+        check=True,
+    )
+    return result.stdout.split()
+
+
+def test_macos_x86_64_cpu_builds_runtime_dispatch() -> None:
+    flags = _flags("cpu", "macOS", "x86_64")
+    assert "-DGGML_BACKEND_DL=ON" in flags
+    assert "-DGGML_CPU_ALL_VARIANTS=ON" in flags
+    # The AVX cap and variant dispatch are mutually exclusive: capping the
+    # variants would rebuild the single-baseline engine under a new name.
+    assert "-DGGML_AVX2=OFF" not in flags
+
+
+def test_macos_arm64_cpu_stays_single_variant() -> None:
+    flags = _flags("cpu", "macOS", "arm64")
+    assert "-DGGML_BACKEND_DL=ON" not in flags
+    assert "-DGGML_CPU_ALL_VARIANTS=ON" not in flags
+
+
+@pytest.mark.parametrize(
+    ("backend", "runner_os"),
+    [("cpu", "Linux"), ("vulkan", "Linux"), ("vulkan", "Windows"), ("cu121", "Linux")],
+)
+def test_gpu_and_linux_cells_keep_the_avx_cap(backend: str, runner_os: str) -> None:
+    flags = _flags(backend, runner_os, "x86_64")
+    assert "-DGGML_AVX=ON" in flags
+    assert "-DGGML_AVX2=OFF" in flags
+    assert "-DGGML_CPU_ALL_VARIANTS=ON" not in flags
+
+
+@pytest.mark.parametrize(
+    ("backend", "runner_os", "target_arch"),
+    [
+        ("cpu", "macOS", "x86_64"),
+        ("cpu", "macOS", "arm64"),
+        ("metal", "macOS", "arm64"),
+        ("cpu", "Linux", "x86_64"),
+        ("vulkan", "Windows", "x86_64"),
+    ],
+)
+def test_no_cell_downloads_ui_assets(backend: str, runner_os: str, target_arch: str) -> None:
+    flags = _flags(backend, runner_os, target_arch)
+    assert "-DLLAMA_BUILD_UI=OFF" in flags
+    assert "-DLLAMA_USE_PREBUILT_UI=OFF" in flags

--- a/tests/test_cmake_args_cpu_dispatch.py
+++ b/tests/test_cmake_args_cpu_dispatch.py
@@ -1,5 +1,4 @@
-"""Pin cmake_args.sh flag emission per build cell; cmake ignores an unknown
-``-D``, so a dropped flag builds successfully with the wrong engine."""
+"""Pin cmake_args.sh flag emission for every build cell."""
 
 from __future__ import annotations
 
@@ -10,8 +9,20 @@ import sys
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="the script under test is POSIX shell, Linux-only in CI"
+    sys.platform == "win32", reason="the script under test is POSIX shell"
 )
+
+# Every x86_64 cell, split by CPU strategy. The union plus _ARM_CELLS is the
+# script's whole case table; a new cell must join one of these lists.
+_DISPATCH_CELLS = [("cpu", "macOS"), ("cpu", "Linux"), ("cpu", "Windows"), ("vulkan", "Linux")]
+_CAPPED_CELLS = [
+    ("vulkan", "Windows"),
+    *[(f"cu12{n}", os) for n in range(1, 6) for os in ("Linux", "Windows")],
+    ("rocm", "Linux"),
+    ("sycl", "Linux"),
+    ("sycl", "Windows"),
+]
+_ARM_CELLS = [("cpu", "macOS", "arm64"), ("metal", "macOS", "arm64")]
 
 _SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "tools/wheel-build/cmake_args.sh"
 
@@ -21,7 +32,7 @@ def _flags(backend: str, runner_os: str, target_arch: str) -> list[str]:
     result = subprocess.run(
         ["bash", str(_SCRIPT), "--print"],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         env={
             "BACKEND": backend,
             "RUNNER_OS": runner_os,
@@ -33,12 +44,18 @@ def _flags(backend: str, runner_os: str, target_arch: str) -> list[str]:
     return result.stdout.split()
 
 
-def test_macos_x86_64_cpu_builds_runtime_dispatch() -> None:
-    flags = _flags("cpu", "macOS", "x86_64")
+@pytest.mark.parametrize(("backend", "runner_os"), _DISPATCH_CELLS)
+def test_converted_x86_cells_build_runtime_dispatch(backend: str, runner_os: str) -> None:
+    flags = _flags(backend, runner_os, "x86_64")
     assert "-DGGML_BACKEND_DL=ON" in flags
     assert "-DGGML_CPU_ALL_VARIANTS=ON" in flags
     # An AVX cap on a dispatch build would cap every variant.
     assert "-DGGML_AVX2=OFF" not in flags
+
+
+def test_vulkan_linux_dispatch_keeps_the_vulkan_backend() -> None:
+    flags = _flags("vulkan", "Linux", "x86_64")
+    assert "-DGGML_VULKAN=ON" in flags
 
 
 def test_macos_arm64_cpu_stays_single_variant() -> None:
@@ -47,11 +64,8 @@ def test_macos_arm64_cpu_stays_single_variant() -> None:
     assert "-DGGML_CPU_ALL_VARIANTS=ON" not in flags
 
 
-@pytest.mark.parametrize(
-    ("backend", "runner_os"),
-    [("cpu", "Linux"), ("vulkan", "Linux"), ("vulkan", "Windows"), ("cu121", "Linux")],
-)
-def test_gpu_and_linux_cells_keep_the_avx_cap(backend: str, runner_os: str) -> None:
+@pytest.mark.parametrize(("backend", "runner_os"), _CAPPED_CELLS)
+def test_deferred_gpu_cells_keep_the_avx_cap(backend: str, runner_os: str) -> None:
     flags = _flags(backend, runner_os, "x86_64")
     assert "-DGGML_AVX=ON" in flags
     assert "-DGGML_AVX2=OFF" in flags
@@ -60,13 +74,7 @@ def test_gpu_and_linux_cells_keep_the_avx_cap(backend: str, runner_os: str) -> N
 
 @pytest.mark.parametrize(
     ("backend", "runner_os", "target_arch"),
-    [
-        ("cpu", "macOS", "x86_64"),
-        ("cpu", "macOS", "arm64"),
-        ("metal", "macOS", "arm64"),
-        ("cpu", "Linux", "x86_64"),
-        ("vulkan", "Windows", "x86_64"),
-    ],
+    [(b, o, "x86_64") for b, o in _DISPATCH_CELLS + _CAPPED_CELLS] + _ARM_CELLS,
 )
 def test_no_cell_downloads_ui_assets(backend: str, runner_os: str, target_arch: str) -> None:
     flags = _flags(backend, runner_os, target_arch)

--- a/tests/test_cmake_args_cpu_dispatch.py
+++ b/tests/test_cmake_args_cpu_dispatch.py
@@ -1,11 +1,5 @@
-"""The macOS x86_64 CPU cell builds runtime CPU dispatch; every other x86 cell
-keeps the single-variant AVX cap, and no cell downloads server-UI assets.
-
-cmake caches an unknown ``-D`` instead of failing, so a dropped or renamed flag
-here builds successfully and ships the wrong engine. These tests pin the emitted
-flag set; ``build_llama_server.sh`` separately asserts the variant modules exist
-in the built bundle.
-"""
+"""Pin cmake_args.sh flag emission per build cell; cmake ignores an unknown
+``-D``, so a dropped flag builds successfully with the wrong engine."""
 
 from __future__ import annotations
 
@@ -43,8 +37,7 @@ def test_macos_x86_64_cpu_builds_runtime_dispatch() -> None:
     flags = _flags("cpu", "macOS", "x86_64")
     assert "-DGGML_BACKEND_DL=ON" in flags
     assert "-DGGML_CPU_ALL_VARIANTS=ON" in flags
-    # The AVX cap and variant dispatch are mutually exclusive: capping the
-    # variants would rebuild the single-baseline engine under a new name.
+    # An AVX cap on a dispatch build would cap every variant.
     assert "-DGGML_AVX2=OFF" not in flags
 
 

--- a/tools/qa/assert_engine_bundle.py
+++ b/tools/qa/assert_engine_bundle.py
@@ -69,6 +69,17 @@ BACKEND_LIBRARY = {
     "sycl": "ggml-sycl",
     "vulkan": "ggml-vulkan",
 }
+# Cells built with GGML_CPU_ALL_VARIANTS ship the CPU backend as one module per
+# x86 feature level, picked at runtime. A single module is the flag not taking
+# effect: the fallback lib carries only the build host's instruction set.
+DISPATCH_CELLS = {("cpu", "linux"), ("cpu", "win_amd64"), ("vulkan", "linux")}
+_VARIANT_FORMS = {
+    "linux": ("libggml-cpu-<variant>.so", r"libggml-cpu-.+\.so(\.[\d.]+)?"),
+    "win_amd64": ("ggml-cpu-<variant>.dll", r"ggml-cpu-.+\.dll"),
+}
+# The loader the vulkan module dlopens under GGML_BACKEND_DL. Nothing links it,
+# so a missing loader is a silent CPU fallback, visible only in the payload.
+_VULKAN_LOADER = ("libvulkan.so.1", r"libvulkan\.so\.[\d.]+")
 # How each platform spells a shared library, and how a version lands in the name:
 # ``libggml-hip.so.0.15.1`` on Linux, ``libggml-metal.0.15.1.dylib`` on macOS.
 # Matching the versioned form matters because the engine links by SONAME, so that
@@ -103,6 +114,9 @@ def _missing_backend_library(
     name: str, backend: str, platform: str, entries: list[str]
 ) -> str | None:
     """The problem with *entries* not holding *backend*'s ggml library, if it doesn't."""
+    if backend == "cpu" and (backend, platform) in DISPATCH_CELLS:
+        # A dispatch cell has no single libggml-cpu; the variant check owns it.
+        return None
     library = "ggml-cuda" if backend.startswith("cu") else BACKEND_LIBRARY.get(backend)
     form = _LIBRARY_FORMS.get(platform)
     if library is None or form is None:
@@ -114,6 +128,32 @@ def _missing_backend_library(
         f"{name}: {backend} wheel is missing {display} from {BIN_DIR} "
         f"(the build produced no {backend} backend, so this engine runs on CPU)"
     )
+
+
+def _missing_dispatch_modules(
+    name: str, backend: str, platform: str, entries: list[str]
+) -> list[str]:
+    """The problems with *entries* not holding a runtime-dispatch CPU backend."""
+    if (backend, platform) not in DISPATCH_CELLS:
+        return []
+    problems = []
+    display, pattern = _VARIANT_FORMS[platform]
+    variants = [e for e in entries if re.fullmatch(pattern, e)]
+    if len(variants) < 2:
+        problems.append(
+            f"{name}: {backend} wheel has {len(variants)} {display} modules in {BIN_DIR} "
+            f"(runtime CPU dispatch needs at least two; a single module carries only "
+            f"the build host's instruction set)"
+        )
+    if backend == "vulkan" and platform == "linux":
+        loader_display, loader_pattern = _VULKAN_LOADER
+        if not any(re.fullmatch(loader_pattern, e) for e in entries):
+            problems.append(
+                f"{name}: vulkan wheel is missing {loader_display} from {BIN_DIR} "
+                f"(the vulkan module dlopens the loader; without it the engine "
+                f"silently runs on CPU)"
+            )
+    return problems
 
 
 def _oversized(wheel: Path) -> str | None:
@@ -151,6 +191,8 @@ def check(wheel: Path, backend: str | None = None) -> list[str]:
     missing = _missing_backend_library(name, backend, platform, entries) if backend else None
     if missing:
         problems.append(missing)
+    if backend:
+        problems.extend(_missing_dispatch_modules(name, backend, platform, entries))
 
     if backend == "rocm" and platform == "linux" and not missing:
         # Only worth asking once the backend is actually there: a wheel with no

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -69,10 +69,12 @@ done
 # the engine wheel still succeeds (resolver falls back to PATH).
 LLAMA_SERVER_FLAGS=()
 if uv run --no-sync python -c "import lilbee_engine" >/dev/null 2>&1; then
-    # --include-package pulls the __init__.py and, on Linux, the .so libraries
-    # (Nuitka classifies a bare .so as an extension module and places it beside
-    # the binary). --include-package-data ships the executables (llama-server,
-    # llama-swap, gguf-parser) as data.
+    # --include-package pulls the __init__.py and every bin/*.so: the Linux
+    # ggml/llama libraries and the macOS libggml-cpu-<variant>.so CPU-dispatch
+    # modules (Nuitka classifies a bare .so as an extension module on both
+    # platforms and places it beside the binary verbatim).
+    # --include-package-data ships the executables (llama-server, llama-swap,
+    # gguf-parser) as data.
     LLAMA_SERVER_FLAGS+=(--include-package=lilbee_engine)
     LLAMA_SERVER_FLAGS+=(--include-package-data=lilbee_engine)
     # Platform gap: --include-package-data keeps the extensionless executables on
@@ -80,9 +82,9 @@ if uv run --no-sync python -c "import lilbee_engine" >/dev/null 2>&1; then
     # Windows .exe executables (Nuitka routes those through its DLL/program
     # handling, discarding what nothing it scans references) -- shipping a server
     # that cannot start or is not found. Force every engine file in verbatim with
-    # --include-data-files (rpath and exec bit preserved), EXCEPT Linux .so: those
-    # are Python extension modules Nuitka already includes via --include-package,
-    # and data-files-ing a .so FATALs with an extension/data conflict.
+    # --include-data-files (rpath and exec bit preserved), EXCEPT .so: those are
+    # already included via --include-package above, and data-files-ing a .so
+    # FATALs with an extension/data conflict.
     ENGINE_BIN=$(uv run --no-sync python -c "import lilbee_engine, pathlib; print(pathlib.Path(lilbee_engine.__file__).parent / 'bin')")
     for _f in "${ENGINE_BIN}"/*; do
         [ -f "${_f}" ] || continue

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -69,9 +69,10 @@ done
 # the engine wheel still succeeds (resolver falls back to PATH).
 LLAMA_SERVER_FLAGS=()
 if uv run --no-sync python -c "import lilbee_engine" >/dev/null 2>&1; then
-    # --include-package pulls the __init__.py and every bin/*.so, Linux libs and
-    # macOS libggml-cpu-<variant>.so alike (Nuitka places a bare .so beside the
-    # binary verbatim). --include-package-data ships the executables as data.
+    # --include-package pulls the __init__.py and every bin/*.so, the
+    # libggml-cpu-<variant>.so dispatch modules alike (Nuitka places a bare .so
+    # beside the binary verbatim); versioned .so.N files and the bundled
+    # libvulkan.so.1 ride --include-package-data along with the executables.
     LLAMA_SERVER_FLAGS+=(--include-package=lilbee_engine)
     LLAMA_SERVER_FLAGS+=(--include-package-data=lilbee_engine)
     # Platform gap: --include-package-data keeps the extensionless executables on

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -69,12 +69,9 @@ done
 # the engine wheel still succeeds (resolver falls back to PATH).
 LLAMA_SERVER_FLAGS=()
 if uv run --no-sync python -c "import lilbee_engine" >/dev/null 2>&1; then
-    # --include-package pulls the __init__.py and every bin/*.so: the Linux
-    # ggml/llama libraries and the macOS libggml-cpu-<variant>.so CPU-dispatch
-    # modules (Nuitka classifies a bare .so as an extension module on both
-    # platforms and places it beside the binary verbatim).
-    # --include-package-data ships the executables (llama-server, llama-swap,
-    # gguf-parser) as data.
+    # --include-package pulls the __init__.py and every bin/*.so, Linux libs and
+    # macOS libggml-cpu-<variant>.so alike (Nuitka places a bare .so beside the
+    # binary verbatim). --include-package-data ships the executables as data.
     LLAMA_SERVER_FLAGS+=(--include-package=lilbee_engine)
     LLAMA_SERVER_FLAGS+=(--include-package-data=lilbee_engine)
     # Platform gap: --include-package-data keeps the extensionless executables on

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -274,6 +274,10 @@ fi
 # user's machine. An ICD-less build host cannot load the backend live (its reg
 # returns null without a driver), so assert the module's link closure resolves.
 if [ "${backend}" = "vulkan" ] && [ "$(uname -s)" = "Linux" ] && [ -z "${target_arch}" ]; then
+  compgen -G "${pkg_bin_dir}/libggml-vulkan.so*" >/dev/null || {
+    echo "no libggml-vulkan.so in ${pkg_bin_dir}: the vulkan cell produced no backend" >&2
+    exit 1
+  }
   for vk_module in "${pkg_bin_dir}"/libggml-vulkan.so*; do
     unresolved=$(ldd "${vk_module}" | grep "not found" || true)
     if [ -n "${unresolved}" ]; then

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -144,6 +144,20 @@ while IFS= read -r -d '' lib; do
 done < <(find "${src}/server-build" \( -name CMakeFiles -o -name CMakeScratch -o -path '*vulkan-shaders-gen-prefix*' \) -prune -o \
   \( -type f -o -type l \) \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -print0)
 
+# The macOS x86_64 CPU cell builds GGML_CPU_ALL_VARIANTS (see cmake_args.sh). That
+# flag is a cached -D like any other: cmake ignores an unknown spelling instead of
+# failing, and the fallback single libggml-cpu would carry the AVX2 the build host
+# supports -- a SIGILL on the pre-Haswell Macs this cell exists for, invisible on
+# an AVX2 runner. Count the variant modules instead of trusting the flag.
+if [ "${backend}" = "cpu" ] && [ "$(uname -s)" = "Darwin" ] && [ "${target_arch:-$(uname -m)}" = "x86_64" ]; then
+  variant_count=$(find "${pkg_bin_dir}" -name 'libggml-cpu-*.so' | wc -l)
+  if [ "${variant_count}" -lt 2 ]; then
+    echo "found ${variant_count} libggml-cpu-<variant>.so in ${pkg_bin_dir}:" \
+      "GGML_CPU_ALL_VARIANTS did not take effect" >&2
+    exit 1
+  fi
+fi
+
 # A CUDA build links the CUDA 12 runtime dynamically, and those libraries live in the
 # toolkit, never in the build output copied above. Only libcuda / nvcuda comes from the
 # driver; cudart, cublas and cublasLt do not, so they ship beside the binary like every

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -145,14 +145,23 @@ done < <(find "${src}/server-build" \( -name CMakeFiles -o -name CMakeScratch -o
   \( -type f -o -type l \) \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -print0)
 
 # cmake ignores an unknown -D, and a variant-less fallback would carry the build
-# host's AVX2. Verify the mac x86_64 dispatch modules actually exist.
-if [ "${backend}" = "cpu" ] && [ "$(uname -s)" = "Darwin" ] && [ "${target_arch:-$(uname -m)}" = "x86_64" ]; then
-  variant_count=$(find "${pkg_bin_dir}" -name 'libggml-cpu-*.so' | wc -l)
+# host's AVX2. Verify the dispatch modules actually exist on every dispatch cell.
+if [[ "${CMAKE_ARGS}" == *"-DGGML_CPU_ALL_VARIANTS=ON"* ]]; then
+  variant_count=$(find "${pkg_bin_dir}" \( -name 'libggml-cpu-*.so' -o -name 'ggml-cpu-*.dll' \) | wc -l)
   if [ "${variant_count}" -lt 2 ]; then
-    echo "found ${variant_count} libggml-cpu-<variant>.so in ${pkg_bin_dir}:" \
+    echo "found ${variant_count} ggml-cpu variant modules in ${pkg_bin_dir}:" \
       "GGML_CPU_ALL_VARIANTS did not take effect" >&2
     exit 1
   fi
+fi
+
+# Under GGML_BACKEND_DL nothing links libvulkan: the vulkan module dlopens it, and
+# a missing loader is a silent CPU fallback instead of a startup failure. Bundle
+# the SDK's loader beside the binary; ICDs still come from the host's driver.
+if [ "${backend}" = "vulkan" ] && [ "$(uname -s)" = "Linux" ]; then
+  vulkan_loader="${VULKAN_SDK:-/opt/vulkan/x86_64}/lib/libvulkan.so.1"
+  [ -e "${vulkan_loader}" ] || { echo "no Vulkan loader at ${vulkan_loader}" >&2; exit 1; }
+  cp -L "${vulkan_loader}" "${pkg_bin_dir}/"
 fi
 
 # A CUDA build links the CUDA 12 runtime dynamically, and those libraries live in the
@@ -164,8 +173,9 @@ fi
 # Both platforms broke without this, in different ways. On Windows cudart is a hard
 # import of the process, so llama-server.exe died before binding its port with a
 # "cudart64_12.dll was not found" dialog. On Linux the backend is a DT_NEEDED of
-# libggml.so.0, since GGML_BACKEND_DL is off (see cmake_args.sh), so a missing runtime
-# is a loader failure at startup rather than a silent fall back to CPU.
+# libggml.so.0, since the cu12x cells build without GGML_BACKEND_DL (see
+# cmake_args.sh), so a missing runtime is a loader failure at startup rather than a
+# silent fall back to CPU.
 #
 # ROCm gets the same treatment further down, for the same reason and with the same
 # goal: an AMD user should need a driver and nothing else, exactly as an NVIDIA one
@@ -257,6 +267,26 @@ case "${backend}" in
 esac
 if [ -n "${_can_exec}" ] && [ -z "${target_arch}" ]; then
   "${pkg_bin_dir}/llama-server" --version
+fi
+
+# The vulkan module only loads via dlopen now, so the exec above proves nothing
+# about it: a module that cannot resolve is a silent CPU fallback on the user's
+# machine. Assert the loader reports it. No GPU is needed; a loaded module with
+# zero devices still registers and logs.
+if [ "${backend}" = "vulkan" ] && [ "$(uname -s)" = "Linux" ] && [ -z "${target_arch}" ]; then
+  devices_log=$("${pkg_bin_dir}/llama-server" --list-devices 2>&1) || {
+    printf '%s\n' "${devices_log}" >&2
+    echo "llama-server --list-devices failed" >&2
+    exit 1
+  }
+  case "${devices_log}" in
+    *"loaded vulkan backend"*) ;;
+    *)
+      printf '%s\n' "${devices_log}" >&2
+      echo "the vulkan backend module did not load from ${pkg_bin_dir}" >&2
+      exit 1
+      ;;
+  esac
 fi
 
 # Build the two Go engine helpers into the same wheel bin/. llama-swap is the

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -270,23 +270,18 @@ if [ -n "${_can_exec}" ] && [ -z "${target_arch}" ]; then
 fi
 
 # The vulkan module only loads via dlopen now, so the exec above proves nothing
-# about it: a module that cannot resolve is a silent CPU fallback on the user's
-# machine. Assert the loader reports it. No GPU is needed; a loaded module with
-# zero devices still registers and logs.
+# about it, and a module that cannot resolve is a silent CPU fallback on the
+# user's machine. An ICD-less build host cannot load the backend live (its reg
+# returns null without a driver), so assert the module's link closure resolves.
 if [ "${backend}" = "vulkan" ] && [ "$(uname -s)" = "Linux" ] && [ -z "${target_arch}" ]; then
-  devices_log=$("${pkg_bin_dir}/llama-server" --list-devices 2>&1) || {
-    printf '%s\n' "${devices_log}" >&2
-    echo "llama-server --list-devices failed" >&2
-    exit 1
-  }
-  case "${devices_log}" in
-    *"loaded vulkan backend"*) ;;
-    *)
-      printf '%s\n' "${devices_log}" >&2
-      echo "the vulkan backend module did not load from ${pkg_bin_dir}" >&2
+  for vk_module in "${pkg_bin_dir}"/libggml-vulkan.so*; do
+    unresolved=$(ldd "${vk_module}" | grep "not found" || true)
+    if [ -n "${unresolved}" ]; then
+      echo "$(basename "${vk_module}") does not resolve from the bundle:" >&2
+      echo "${unresolved}" >&2
       exit 1
-      ;;
-  esac
+    fi
+  done
 fi
 
 # Build the two Go engine helpers into the same wheel bin/. llama-swap is the

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -144,11 +144,8 @@ while IFS= read -r -d '' lib; do
 done < <(find "${src}/server-build" \( -name CMakeFiles -o -name CMakeScratch -o -path '*vulkan-shaders-gen-prefix*' \) -prune -o \
   \( -type f -o -type l \) \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -print0)
 
-# The macOS x86_64 CPU cell builds GGML_CPU_ALL_VARIANTS (see cmake_args.sh). That
-# flag is a cached -D like any other: cmake ignores an unknown spelling instead of
-# failing, and the fallback single libggml-cpu would carry the AVX2 the build host
-# supports -- a SIGILL on the pre-Haswell Macs this cell exists for, invisible on
-# an AVX2 runner. Count the variant modules instead of trusting the flag.
+# cmake ignores an unknown -D, and a variant-less fallback would carry the build
+# host's AVX2. Verify the mac x86_64 dispatch modules actually exist.
 if [ "${backend}" = "cpu" ] && [ "$(uname -s)" = "Darwin" ] && [ "${target_arch:-$(uname -m)}" = "x86_64" ]; then
   variant_count=$(find "${pkg_bin_dir}" -name 'libggml-cpu-*.so' | wc -l)
   if [ "${variant_count}" -lt 2 ]; then

--- a/tools/wheel-build/cmake_args.sh
+++ b/tools/wheel-build/cmake_args.sh
@@ -34,36 +34,16 @@ esac
 #                     instruction" on weaker pool members.
 #
 # GPU cells cap the single libggml-cpu.so at AVX baseline (Sandy Bridge
-# 2011+). Explicitly disable AVX2 / FMA / F16C / BMI2 / AVX512 / VNNI
-# so ggml's CMake (which auto-enables those when GGML_NATIVE=OFF on a
-# build host that supports them) doesn't bake them in. The resulting
-# wheel runs on any x86_64 CPU from 2011 forward — a Sandy Bridge Xeon
-# E5-2609 included. Those users are on GPU paths for chat and only hit
-# CPU for embedding fallback, where the AVX2 loss is negligible.
-#
-# The macOS x86_64 CPU cell instead builds GGML_CPU_ALL_VARIANTS +
-# GGML_BACKEND_DL: one libggml-cpu-<variant>.so per x86 feature level
-# (x64 through sapphirerapids) beside the binary, and libllama itself
-# calls ggml_backend_load_all() at backend init to pick the best one
-# at runtime. Chat runs entirely on CPU there, and the AVX cap
-# costs Haswell+ Macs ~2x prompt speed (measured on a Broadwell 2015
-# MBP: 14.6 -> 34.1 tok/s prompt, 11.7 -> 17.6 gen; the loader picked
-# the haswell variant). The x64/sse42 variants sit below the AVX cap,
-# so the pre-AVX compat tail is covered by the same bundle.
-#
-# An earlier GGML_CPU_ALL_VARIANTS attempt was reverted (44aea6bd1)
-# because the then-shipped llama-cpp-python binding never loads DL
-# backends. The engine runtime is llama-server now, which does. The
-# GPU cells stay single-variant: under GGML_BACKEND_DL the GPU
-# backends also become DL modules, and that bundling is unvalidated.
-#
-# arm64: NEON is mandatory in ARMv8 so a single baseline variant covers
-# every aarch64 system.
-# LLAMA_BUILD_UI=OFF + LLAMA_USE_PREBUILT_UI=OFF: no npm/vite UI build
-# (flaky on Windows runners) and no HF-bucket asset download; the
-# bucket keeps only its newest revision, so the pinned fetch 404s on
-# any uncached rebuild (b1 is already gone). lilbee never serves the
-# web UI; the server builds with an empty asset table.
+# 2011+); each extension is explicitly OFF because ggml's CMake
+# auto-enables whatever the build host supports.
+# The macOS x86_64 CPU cell builds runtime dispatch instead: one
+# libggml-cpu-<variant>.so per x86 feature level, loaded best-match at
+# backend init. GGML_BACKEND_DL would split GPU backends into DL modules
+# too, so the GPU cells stay single-variant.
+# arm64: NEON is mandatory in ARMv8; one variant covers all aarch64.
+# LLAMA_BUILD_UI=OFF + LLAMA_USE_PREBUILT_UI=OFF: no npm UI build, no HF
+# asset download (the pinned bucket revision is pruned upstream); lilbee
+# never serves the server web UI.
 ui_off="-DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF"
 common_x86="${ui_off} -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF"
 dispatch_x86="${ui_off} -DGGML_NATIVE=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"

--- a/tools/wheel-build/cmake_args.sh
+++ b/tools/wheel-build/cmake_args.sh
@@ -33,13 +33,21 @@ esac
 #                     runners would otherwise crash with "Illegal
 #                     instruction" on weaker pool members.
 #
-# GPU cells cap the single libggml-cpu.so at AVX baseline (Sandy Bridge
-# 2011+); each extension is explicitly OFF because ggml's CMake
-# auto-enables whatever the build host supports.
-# The macOS x86_64 CPU cell builds runtime dispatch instead: one
-# libggml-cpu-<variant>.so per x86 feature level, loaded best-match at
-# backend init. GGML_BACKEND_DL would split GPU backends into DL modules
-# too, so the GPU cells stay single-variant.
+# The cpu cells and vulkan_Linux build runtime dispatch: one
+# libggml-cpu-<variant> module per x86 feature level (x64 through
+# sapphirerapids, AMX included), loaded best-match at backend init.
+# build_llama_server.sh counts the variant modules and, on vulkan_Linux,
+# bundles the Vulkan loader: under GGML_BACKEND_DL a missing
+# libvulkan.so.1 is a silent CPU fallback, not a startup failure.
+# The remaining GPU cells cap their single CPU backend library (.so/.dll)
+# at AVX baseline (Sandy Bridge 2011+); each extension is explicitly OFF
+# because ggml's CMake auto-enables whatever the build host supports. GGML_BACKEND_DL
+# splits their GPU backends into DL modules too, so each converts only
+# with an on-target run proving offload still works (vulkan_Windows:
+# Nuitka handling of DL .dlls untested; cu12x: the CUDA runtime copy
+# assumes the backend is a DT_NEEDED of libggml; rocm: the runtime
+# bundler and its ld.so gate assume a linked backend; sycl: never
+# validated on hardware).
 # arm64: NEON is mandatory in ARMv8; one variant covers all aarch64.
 # LLAMA_BUILD_UI=OFF + LLAMA_USE_PREBUILT_UI=OFF: no npm UI build, no HF
 # asset download (the pinned bucket revision is pruned upstream); lilbee
@@ -96,19 +104,18 @@ rocm_buildable_targets() {
 
 case "${backend}_${runner_os}" in
   cpu_Linux)
-    args="${common_x86} -DGGML_CUDA=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_VULKAN=OFF"
+    args="${dispatch_x86} -DGGML_CUDA=OFF -DGGML_METAL=OFF -DGGML_BLAS=OFF -DGGML_VULKAN=OFF"
     ;;
   cpu_macOS)
     if [ "${target_arch}" = "x86_64" ]; then
-      # Disable OpenSSL find_package: arm64 runner has no x86_64 libssl,
-      # so cpp-httplib's TLS code fails to link. We don't ship llama-server.
+      # OpenSSL off: an arm64 cross-build has no x86_64 libssl to link.
       args="${dispatch_x86} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_BLAS=OFF -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON"
     else
       args="${common_arm} -DGGML_METAL=OFF -DGGML_BLAS=OFF"
     fi
     ;;
   cpu_Windows)
-    args="${common_x86} -DGGML_CUDA=OFF -DGGML_VULKAN=OFF -DGGML_BLAS=OFF"
+    args="${dispatch_x86} -DGGML_CUDA=OFF -DGGML_VULKAN=OFF -DGGML_BLAS=OFF"
     ;;
   metal_macOS)
     if [ "${target_arch}" = "x86_64" ]; then
@@ -117,10 +124,15 @@ case "${backend}_${runner_os}" in
     fi
     args="${common_arm} -DGGML_METAL=ON -DGGML_BLAS=OFF"
     ;;
-  vulkan_Linux|vulkan_Windows)
+  vulkan_Linux)
     # Vulkan is cross-vendor (NVIDIA, AMD, Intel Arc). Single Vulkan-built
-    # wheel covers the GPU users on Linux/Windows. CUDA stays off here — a
-    # CUDA-built wheel is a separate variant on the extra-index publish.
+    # wheel covers the GPU users. CUDA stays off here; a CUDA-built wheel
+    # is a separate variant on the extra-index publish.
+    args="${dispatch_x86} -DGGML_VULKAN=ON -DGGML_CUDA=OFF -DGGML_BLAS=OFF"
+    ;;
+  vulkan_Windows)
+    # Same backend split as vulkan_Linux, still AVX-capped: Nuitka ships DL
+    # .dll modules through --include-data-files, unvalidated with variants.
     args="${common_x86} -DGGML_VULKAN=ON -DGGML_CUDA=OFF -DGGML_BLAS=OFF"
     ;;
   cu121_Linux|cu121_Windows|cu122_Linux|cu122_Windows|cu123_Linux|cu123_Windows|cu124_Linux|cu124_Windows|cu125_Linux|cu125_Windows)

--- a/tools/wheel-build/cmake_args.sh
+++ b/tools/wheel-build/cmake_args.sh
@@ -33,35 +33,41 @@ esac
 #                     runners would otherwise crash with "Illegal
 #                     instruction" on weaker pool members.
 #
-# Why we don't use GGML_CPU_ALL_VARIANTS + GGML_BACKEND_DL:
-#   The DL-based runtime variant dispatch builds correctly but
-#   llama-cpp-python's Python binding does not call
-#   ggml_backend_load_all_from_path at startup, so no CPU backend is
-#   registered at runtime and Llama(model_path=...) fails with
-#   "Failed to load model from file" (no compute device available).
-#   Confirmed in b443. The DL split is a llama.cpp-only mechanism;
-#   adopting it requires a llama-cpp-python upstream change.
-#
-# Instead: cap the single libggml-cpu.so at AVX baseline (Sandy Bridge
+# GPU cells cap the single libggml-cpu.so at AVX baseline (Sandy Bridge
 # 2011+). Explicitly disable AVX2 / FMA / F16C / BMI2 / AVX512 / VNNI
 # so ggml's CMake (which auto-enables those when GGML_NATIVE=OFF on a
 # build host that supports them) doesn't bake them in. The resulting
 # wheel runs on any x86_64 CPU from 2011 forward — a Sandy Bridge Xeon
-# E5-2609 included.
+# E5-2609 included. Those users are on GPU paths for chat and only hit
+# CPU for embedding fallback, where the AVX2 loss is negligible.
 #
-# Modern users (Haswell+) lose ~10–20% CPU perf vs. an AVX2-tuned wheel,
-# but they're typically on GPU paths (Vulkan / CUDA) for chat and only
-# hit CPU for embedding fallback, where the loss is negligible. Users
-# who want the absolute fastest CPU path can install from the per-CUDA
-# extra-index — those wheels target a specific GPU and don't care about
-# CPU portability.
+# The macOS x86_64 CPU cell instead builds GGML_CPU_ALL_VARIANTS +
+# GGML_BACKEND_DL: one libggml-cpu-<variant>.so per x86 feature level
+# (x64 through sapphirerapids) beside the binary, and libllama itself
+# calls ggml_backend_load_all() at backend init to pick the best one
+# at runtime. Chat runs entirely on CPU there, and the AVX cap
+# costs Haswell+ Macs ~2x prompt speed (measured on a Broadwell 2015
+# MBP: 14.6 -> 34.1 tok/s prompt, 11.7 -> 17.6 gen; the loader picked
+# the haswell variant). The x64/sse42 variants sit below the AVX cap,
+# so the pre-AVX compat tail is covered by the same bundle.
+#
+# An earlier GGML_CPU_ALL_VARIANTS attempt was reverted (44aea6bd1)
+# because the then-shipped llama-cpp-python binding never loads DL
+# backends. The engine runtime is llama-server now, which does. The
+# GPU cells stay single-variant: under GGML_BACKEND_DL the GPU
+# backends also become DL modules, and that bundling is unvalidated.
 #
 # arm64: NEON is mandatory in ARMv8 so a single baseline variant covers
 # every aarch64 system.
-# LLAMA_BUILD_UI=OFF: skip the npm/vite server-UI build (flaky on Windows
-# runners); assets fall back to the prebuilt HF bucket download.
-common_x86="-DLLAMA_BUILD_UI=OFF -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF"
-common_arm="-DLLAMA_BUILD_UI=OFF -DGGML_NATIVE=OFF"
+# LLAMA_BUILD_UI=OFF + LLAMA_USE_PREBUILT_UI=OFF: no npm/vite UI build
+# (flaky on Windows runners) and no HF-bucket asset download; the
+# bucket keeps only its newest revision, so the pinned fetch 404s on
+# any uncached rebuild (b1 is already gone). lilbee never serves the
+# web UI; the server builds with an empty asset table.
+ui_off="-DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF"
+common_x86="${ui_off} -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF"
+dispatch_x86="${ui_off} -DGGML_NATIVE=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"
+common_arm="${ui_off} -DGGML_NATIVE=OFF"
 
 # Every AMD target lilbee wants to ship for: gfx906 (MI50), gfx908 (MI100),
 # gfx90a (MI200), gfx942 (MI300), gfx950 (MI350), gfx1030 (RDNA2), gfx1100/1101/1102
@@ -116,7 +122,7 @@ case "${backend}_${runner_os}" in
     if [ "${target_arch}" = "x86_64" ]; then
       # Disable OpenSSL find_package: arm64 runner has no x86_64 libssl,
       # so cpp-httplib's TLS code fails to link. We don't ship llama-server.
-      args="${common_x86} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_BLAS=OFF -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON"
+      args="${dispatch_x86} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_METAL=OFF -DGGML_BLAS=OFF -DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON"
     else
       args="${common_arm} -DGGML_METAL=OFF -DGGML_BLAS=OFF"
     fi


### PR DESCRIPTION
## Problem
Every x86_64 engine ships capped at the AVX baseline so pre-AVX2 machines don't crash. Haswell+ CPUs lose AVX2/FMA/F16C/AVX512/AMX on every CPU-bound path: all chat on the Intel Mac standalone, and embedding, CPU fallback, and partial offload on the others. Measured on a 2015 Broadwell MacBook Pro: prompt processing 14.6 tok/s where AVX2 delivers 34.1.

## Solution
cpu_macOS x86_64, cpu_Linux, cpu_Windows, and vulkan_Linux build GGML_CPU_ALL_VARIANTS + GGML_BACKEND_DL: one CPU module per x86 feature level (x64 through sapphirerapids), best match loaded at backend init. The x64/sse42 variants sit below the old AVX floor, so pre-AVX hardware is covered by the same bundle. An earlier ALL_VARIANTS attempt was reverted because llama-cpp-python never loads DL backends; the runtime is llama-server now, which does.

## Deferred cells
vulkan_Windows, cu12x, rocm, and sycl keep the AVX cap: under BACKEND_DL their GPU backends become DL modules too, and each needs an on-target validation (reasons per cell recorded in cmake_args.sh).

## Vulkan loader
Under BACKEND_DL nothing links libvulkan, so a missing loader silently degrades to CPU. The vulkan_Linux bundle now ships the SDK loader beside the binary; the wheel gate requires it.

## Guards
cmake ignores an unknown -D, so a renamed flag would silently ship a single AVX2-hot module (the rocm wheel once shipped as CPU-only this way). build_llama_server.sh fails any dispatch bundle with fewer than two variant modules; assert_engine_bundle.py enforces the dispatch layout on the wheels; verify-release's soft-cell tripwire now also requires the two Intel Mac assets so a failed guard can't quietly thin the release.

## Also fixed
The engine build no longer downloads server-UI assets (the pinned HF bucket revision is pruned upstream; any uncached rebuild 404s), the macOS floor check moved after the engine bundle so the dlopen'd modules are minos-scanned, and the Intel Mac install step stops exporting engine CMAKE_ARGS into pip.