### PR TITLE
Extend runtime CPU-variant dispatch to the Linux/Windows CPU engines and the Linux Vulkan engine

### DIFF
--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -274,6 +274,10 @@ fi
 # user's machine. An ICD-less build host cannot load the backend live (its reg
 # returns null without a driver), so assert the module's link closure resolves.
 if [ "${backend}" = "vulkan" ] && [ "$(uname -s)" = "Linux" ] && [ -z "${target_arch}" ]; then
+  compgen -G "${pkg_bin_dir}/libggml-vulkan.so*" >/dev/null || {
+    echo "no libggml-vulkan.so in ${pkg_bin_dir}: the vulkan cell produced no backend" >&2
+    exit 1
+  }
   for vk_module in "${pkg_bin_dir}"/libggml-vulkan.so*; do
     unresolved=$(ldd "${vk_module}" | grep "not found" || true)
     if [ -n "${unresolved}" ]; then

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -270,23 +270,18 @@ if [ -n "${_can_exec}" ] && [ -z "${target_arch}" ]; then
 fi
 
 # The vulkan module only loads via dlopen now, so the exec above proves nothing
-# about it: a module that cannot resolve is a silent CPU fallback on the user's
-# machine. Assert the loader reports it. No GPU is needed; a loaded module with
-# zero devices still registers and logs.
+# about it, and a module that cannot resolve is a silent CPU fallback on the
+# user's machine. An ICD-less build host cannot load the backend live (its reg
+# returns null without a driver), so assert the module's link closure resolves.
 if [ "${backend}" = "vulkan" ] && [ "$(uname -s)" = "Linux" ] && [ -z "${target_arch}" ]; then
-  devices_log=$("${pkg_bin_dir}/llama-server" --list-devices 2>&1) || {
-    printf '%s\n' "${devices_log}" >&2
-    echo "llama-server --list-devices failed" >&2
-    exit 1
-  }
-  case "${devices_log}" in
-    *"loaded vulkan backend"*) ;;
-    *)
-      printf '%s\n' "${devices_log}" >&2
-      echo "the vulkan backend module did not load from ${pkg_bin_dir}" >&2
+  for vk_module in "${pkg_bin_dir}"/libggml-vulkan.so*; do
+    unresolved=$(ldd "${vk_module}" | grep "not found" || true)
+    if [ -n "${unresolved}" ]; then
+      echo "$(basename "${vk_module}") does not resolve from the bundle:" >&2
+      echo "${unresolved}" >&2
       exit 1
-      ;;
-  esac
+    fi
+  done
 fi
 
 # Build the two Go engine helpers into the same wheel bin/. llama-swap is the


### PR DESCRIPTION
## Problem

Every x86_64 engine except the Intel Mac standalone ships capped at the 2011 AVX baseline. The Linux Vulkan standalone and the cpu wheels leave AVX2/FMA/BMI2, AVX-512 and AMX unused on modern CPUs, and the CPU still does real work on GPU builds under partial offload and embedding fallback.

## Solution

The cpu_Linux, cpu_Windows and vulkan_Linux cells now build `GGML_CPU_ALL_VARIANTS` + `GGML_BACKEND_DL`: one CPU-backend module per x86 feature level (x64 through sapphirerapids, AMX included) beside the binary, best one picked at startup. The x64/sse42 variants sit below the old floor, so pre-AVX CPUs stay covered.

## Vulkan loader is bundled

Under `GGML_BACKEND_DL` nothing links libvulkan, so a missing loader becomes a silent CPU fallback instead of a startup failure. The SDK's `libvulkan.so.1` now ships beside the binary; ICDs still come from the host driver, and the binary starts on distros without libvulkan1.

## Gates

The variant-count guard runs on every dispatch cell; the vulkan module must exist and resolve by ldd from the bundle; the wheel gate requires variant modules and the loader in dispatch-cell wheels. Each gate was run against the input it rejects.

## Verified on hardware

On an RTX 4090 machine (Zen 3 host) the loader picked the haswell variant, the GPU enumerated through the bundled loader, and all 33 layers offloaded. Without the bundled loader on a libvulkan-less host the engine silently enumerates no devices, which is exactly what the gates now reject.

## Not covered

vulkan_Windows, cu12x, rocm and sycl stay AVX-capped; each converts only with an on-target run proving offload still works.
