### PR TITLE
Keep the setup wizard off a chat screen that cannot chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ markers = [
     "no_warm_default: opt out of the launch tests' default chat-warm fixture",
     "live_picks: opt out of the seeded SAMPLE_PICKS and resolve picks for real",
     "real_hf_client: opt out of the global hf_client.fetch_models stub (tests the client itself)",
+    "first_run: opt out of the sealed fresh-install probe (the TUI opens its setup wizard)",
 ]
 
 [tool.coverage.run]

--- a/scripts/qa/tui_nav_eval.py
+++ b/scripts/qa/tui_nav_eval.py
@@ -73,7 +73,7 @@ def _isolated_env(tmp: Path):
     set_services(mock_svc)
     try:
         with (
-            mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+            mock.patch("lilbee.cli.tui.app.models_ready", return_value=True),
             mock.patch(
                 "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True
             ),

--- a/src/lilbee/app/setup_state.py
+++ b/src/lilbee/app/setup_state.py
@@ -10,17 +10,26 @@ from lilbee.providers.model_ref import parse_model_ref
 log = logging.getLogger(__name__)
 
 
-def needs_setup() -> bool:
-    """True when the setup wizard should run: fresh data dir or unresolved models.
+def is_fresh_install() -> bool:
+    """True when this lilbee has no data directory yet, so nothing has run here."""
+    if cfg.lancedb_dir.is_dir():
+        return False
+    log.debug("fresh install: lancedb_dir missing (%s)", cfg.lancedb_dir)
+    return True
 
-    Remote-prefixed refs (ollama/lm_studio/API) are validated against current
-    state instead of probed on disk: an ``ollama/`` ref whose litellm extra is
-    missing or whose server is down is unusable and must route the user to
-    setup, not be assumed live.
+
+def models_ready() -> bool:
+    """True when the chat and embedding refs both resolve to something usable now.
+
+    This is the question chat depends on: without both, there is no engine to
+    answer a prompt. Remote-prefixed refs (ollama/lm_studio/API) are validated
+    against current state instead of probed on disk: an ``ollama/`` ref whose
+    litellm extra is missing or whose server is down is unusable and must route
+    the user to setup, not be assumed live.
+
+    Does disk reads and, for local-server refs, an HTTP probe, so callers run it
+    off the UI thread.
     """
-    if not cfg.lancedb_dir.is_dir():
-        log.debug("needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)
-        return True
     from lilbee.modelhub.model_manager import ValidationResult, validate_persisted_model
     from lilbee.providers.base import ProviderError
     from lilbee.providers.engine_params import resolve_model_path
@@ -28,12 +37,17 @@ def needs_setup() -> bool:
     for label, model in (("chat", cfg.chat_model), ("embedding", cfg.embedding_model)):
         if parse_model_ref(model).is_remote:
             if validate_persisted_model(model) != ValidationResult.OK:
-                log.debug("needs_setup: remote %s model %r not usable", label, model)
-                return True
+                log.debug("models_ready: remote %s model %r not usable", label, model)
+                return False
             continue
         try:
             resolve_model_path(model)
         except (ProviderError, KeyError, ValueError) as exc:
-            log.debug("needs_setup: %s model %r unresolved: %s", label, model, exc)
-            return True
-    return False
+            log.debug("models_ready: %s model %r unresolved: %s", label, model, exc)
+            return False
+    return True
+
+
+def needs_setup() -> bool:
+    """True when the setup wizard should run: fresh data dir or unresolved models."""
+    return is_fresh_install() or not models_ready()

--- a/src/lilbee/app/setup_state.py
+++ b/src/lilbee/app/setup_state.py
@@ -1,10 +1,9 @@
 """The two questions the TUI asks before it hands anyone a screen.
 
-``models_ready`` is what chat depends on; ``is_fresh_install`` is why a brand
-new lilbee still meets the setup wizard. They are kept apart because folding
-the data-dir check into the chat gate would lock chat behind an ingest that
-cannot be started from anywhere else. ``LilbeeApp.settle_setup_state`` composes
-them.
+``models_ready`` gates chat; ``is_fresh_install`` gates the first-run wizard.
+Folding the data dir into the chat gate would lock chat behind an ingest that
+only chat can start, so they stay apart. ``LilbeeApp.settle_setup_state``
+composes them.
 """
 
 from __future__ import annotations

--- a/src/lilbee/app/setup_state.py
+++ b/src/lilbee/app/setup_state.py
@@ -1,4 +1,11 @@
-"""Whether the first-run setup wizard has to run before anything can load."""
+"""The two questions the TUI asks before it hands anyone a screen.
+
+``models_ready`` is what chat depends on; ``is_fresh_install`` is why a brand
+new lilbee still meets the setup wizard. They are kept apart because folding
+the data-dir check into the chat gate would lock chat behind an ingest that
+cannot be started from anywhere else. ``LilbeeApp.settle_setup_state`` composes
+them.
+"""
 
 from __future__ import annotations
 
@@ -46,8 +53,3 @@ def models_ready() -> bool:
             log.debug("models_ready: %s model %r unresolved: %s", label, model, exc)
             return False
     return True
-
-
-def needs_setup() -> bool:
-    """True when the setup wizard should run: fresh data dir or unresolved models."""
-    return is_fresh_install() or not models_ready()

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -368,5 +368,6 @@ def browse_cmd(
         raise typer.Exit(1)
 
     from lilbee.cli.tui import run_tui
+    from lilbee.cli.tui.messages import CATALOG_VIEW
 
-    run_tui(initial_view="Catalog")
+    run_tui(initial_view=CATALOG_VIEW)

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -18,7 +18,7 @@ from textual.screen import Screen
 from textual.signal import Signal
 from textual.widgets import Input, TextArea
 
-from lilbee.app.services import get_services
+from lilbee.app.services import get_services, peek_services
 from lilbee.app.settings import apply_settings_update
 from lilbee.app.setup_state import is_fresh_install, models_ready
 from lilbee.app.themes import DARK_THEMES
@@ -94,7 +94,7 @@ def _make_sessions() -> Screen:
 # has no factory). The active set + order + wiki gate come from msg.get_nav_views,
 # so the view universe lives in exactly one place (messages.ALL_NAV_VIEWS).
 _VIEW_FACTORIES: dict[str, Callable[[], Screen]] = {
-    "Catalog": _make_catalog,
+    msg.CATALOG_VIEW: _make_catalog,
     "Status": _make_status,
     "Settings": _make_settings,
     "Tasks": _make_tasks,
@@ -198,10 +198,8 @@ class LilbeeApp(App[None]):
         self._previous_view: str | None = None
         self._switching = False
         self._theme_index = 0
-        # Whether a chat and an embedding model both resolve; the Chat view is
-        # only entered while this holds. The startup gate settles it before any
-        # screen is handed over, so the permissive default is only ever read by
-        # a host that never boots the gate.
+        # A chat and an embedding model both resolve; gates the Chat view.
+        # The startup gate settles it before handing over any screen.
         self.models_are_ready = True
         # Names of non-Chat screens already installed via install_screen.
         # Subsequent visits switch by name to reuse the same instance,
@@ -295,9 +293,8 @@ class LilbeeApp(App[None]):
     def reveal_chat(self) -> None:
         """Swap the startup gate for the chat screen once the engine has settled.
 
-        No readiness guard here: the gate settles that answer before it hands
-        over, and routes to setup itself when there is setup to do, so this is
-        only ever reached for an app that can serve.
+        Reached only for an app that can serve: the gate settles readiness
+        first, and routes to setup itself when there is any.
         """
         self.switch_screen(_CHAT_SCREEN_NAME)
         if self._initial_view and self._initial_view != msg.DEFAULT_VIEW:
@@ -309,10 +306,9 @@ class LilbeeApp(App[None]):
     def settle_setup_state(self) -> bool:
         """Answer the setup questions, run setup if there is any, and say so.
 
-        Called from the startup gate's boot thread and blocking by design: the
-        answer decides whether the handover goes to chat at all, so the gate
-        settles it rather than racing it against a default. Returns whether
-        setup took the screen, which is the gate's cue not to hand over.
+        Blocks the calling thread until the answer is recorded on the UI
+        thread, so a handover ordered after it cannot read a stale flag.
+        Returns whether setup took the screen.
         """
         ready = models_ready()
         setup_to_do = not ready or is_fresh_install()
@@ -323,11 +319,24 @@ class LilbeeApp(App[None]):
     def refresh_models_ready(self) -> None:
         """Re-answer readiness off the UI thread, leaving the user where they are.
 
-        Only the boot probe presents the wizard: re-presenting it from the path
-        that runs when a model lands -- which is how the wizard is closed --
-        would be a trap.
+        Never presents the wizard: this runs when a model lands, which is how
+        the wizard is closed.
         """
-        call_from_thread(self, self._apply_setup_state, models_ready(), False)
+        ready = models_ready()
+        if ready and peek_services() is None:
+            # Setup finished after the gate stepped aside, so nothing has built
+            # the container yet and this thread is the one that should.
+            self.adopt_services()
+        call_from_thread(self, self._apply_setup_state, ready, False)
+
+    def adopt_services(self) -> None:
+        """Build the services container and subscribe this app to it.
+
+        Never call from the UI thread: building spawns the role servers. Two
+        workers can reach here at once during boot; the listeners only add to
+        and discard from a set, so a double subscription changes nothing.
+        """
+        self._wire_worker_pool_notifications(get_services())
 
     def _apply_setup_state(self, ready: bool, open_setup: bool) -> None:
         """Record the readiness answer, then run setup when the boot probe asked."""
@@ -338,22 +347,18 @@ class LilbeeApp(App[None]):
     def _recheck_models_on_model_change(self, payload: tuple[str, object]) -> None:
         """Re-answer readiness whenever a model role is reassigned.
 
-        Every write lands on the settings boundary, so this one subscription
-        covers the wizard, the catalog, the settings editor and ``/set``
-        alike -- including a download that assigns its model on completion,
-        long after the screen that started it went away.
+        Every model write lands on the settings boundary, a download included,
+        so one subscription covers every surface that assigns one.
         """
         key, _value = payload
         if key in MODEL_ROLE_FIELDS:
             self.refresh_models_ready()
 
     def open_setup(self) -> None:
-        """Show the setup wizard over the catalog, so closing it lands somewhere useful.
+        """Show the setup wizard over the catalog.
 
-        A dismissable wizard leaves the user on whatever is underneath it.
-        Underneath a first-run chat screen that is a prompt with no engine
-        behind it and no route back, so the catalog -- the other place models
-        are installed -- takes that spot.
+        The wizard is dismissable, so what sits under it is where Escape
+        lands: the catalog, never a chat screen with no engine behind it.
         """
         from lilbee.cli.tui.screens.setup import SetupWizard
 
@@ -361,16 +366,14 @@ class LilbeeApp(App[None]):
             return
         if self._switching:
             # switch_view drops a switch that arrives mid-transition, which
-            # would leave the wizard sitting on whatever screen the other
-            # switch was leaving. Retry on the next frame instead: paced by
-            # the display, so a transition that never settles costs a repaint
-            # rather than a spinning message pump.
+            # would leave the wizard over the screen that switch was leaving.
+            # Retrying on the next frame is paced by the display, not a spin.
             self.call_after_refresh(self.open_setup)
             return
         self.switch_view(msg.CATALOG_VIEW)
         self.push_screen(SetupWizard())
 
-    def wire_worker_pool_notifications(self, services: Services) -> None:
+    def _wire_worker_pool_notifications(self, services: Services) -> None:
         """Surface worker spawn lifecycle in the bottom TaskBar.
 
         Worker spawns happen on the pool runtime thread, not the TUI's main
@@ -379,11 +382,8 @@ class LilbeeApp(App[None]):
         in-flight roles instead of one toast per role; the chat surface is
         for user content, not implementation detail.
 
-        Takes the container rather than reaching for it: the startup gate calls
-        this from its boot thread once it has one. Subscribing from the mount
-        path meant calling ``get_services()`` there, which built the whole
-        container on the UI thread ahead of the gate -- the exact work the gate
-        exists to move off it.
+        Takes the container instead of reaching for one: reaching for it builds
+        it, which is ``adopt_services``' job and never the UI thread's.
         """
 
         def _on_spawning(role: WorkerRole) -> None:
@@ -610,7 +610,7 @@ class LilbeeApp(App[None]):
             self._previous_view = self.active_view
 
         awaitable: AwaitComplete | None = None
-        if view_name == "Chat":
+        if view_name == msg.DEFAULT_VIEW:
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             if not isinstance(self.screen, ChatScreen):
@@ -724,7 +724,7 @@ class LilbeeApp(App[None]):
 
     def action_open_catalog(self) -> None:
         """Jump to the model catalog (m key)."""
-        self.switch_view("Catalog")
+        self.switch_view(msg.CATALOG_VIEW)
 
     def action_open_chat(self) -> None:
         """Jump to Chat (c key), the counterpart to t / m for the busiest view."""
@@ -840,7 +840,7 @@ class LilbeeApp(App[None]):
         from lilbee.cli.tui.screens.chat import ChatScreen
 
         if not isinstance(self.screen, ChatScreen):
-            self.switch_view("Chat")
+            self.switch_view(msg.DEFAULT_VIEW)
         # Defer the prompt focus until after switch_view's call_later
         # _finish has updated active_view, so the chat input is mounted
         # and ready when we prefill it.
@@ -889,7 +889,7 @@ class LilbeeApp(App[None]):
                 chat._run_sync()
                 return
             if attempts > 0:
-                self.switch_view("Chat")
+                self.switch_view(msg.DEFAULT_VIEW)
                 self.set_timer(0.05, lambda: _start(attempts - 1))
 
         self.call_later(_start)

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -20,6 +20,7 @@ from textual.widgets import Input, TextArea
 
 from lilbee.app.services import get_services
 from lilbee.app.settings import apply_settings_update
+from lilbee.app.setup_state import is_fresh_install, models_ready
 from lilbee.app.themes import DARK_THEMES
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
@@ -196,6 +197,11 @@ class LilbeeApp(App[None]):
         self._previous_view: str | None = None
         self._switching = False
         self._theme_index = 0
+        # Whether a chat and an embedding model both resolve. Chat is only
+        # entered while this holds; it is answered off the UI thread (the
+        # probe reads disk and can call a local model server), so it starts
+        # permissive and the boot check corrects it.
+        self.models_are_ready = True
         # Names of non-Chat screens already installed via install_screen.
         # Subsequent visits switch by name to reuse the same instance,
         # so Footer / signal / worker wiring runs once per session.
@@ -223,6 +229,7 @@ class LilbeeApp(App[None]):
         # test observe app-level signals without booting the startup gate, whose
         # wait is a timing window that wedges loaded CI runners.
         self.settings_changed_signal.subscribe(self, self._fan_out_provider_availability)
+        self.settings_changed_signal.subscribe(self, self._recheck_models_on_model_change)
         if self._test_skip_auto_init:
             return
         # Paint the gate before any other work so the terminal is never blank
@@ -244,6 +251,10 @@ class LilbeeApp(App[None]):
         self._sync_theme_index_to_current()
 
         self._wire_worker_pool_notifications()
+        # Started here rather than from the chat screen's mount: the answer
+        # decides whether chat is entered at all, so it must not depend on
+        # chat having been entered first.
+        self.refresh_models_ready(present_setup=True)
         # Chat's import graph is the TUI's heaviest; loading it here would hold
         # the first frame back for seconds on a cold disk, leaving the terminal
         # blank exactly where the gate should be. Paint first, then load.
@@ -287,12 +298,69 @@ class LilbeeApp(App[None]):
 
     def reveal_chat(self) -> None:
         """Swap the startup gate for the chat screen once the engine has settled."""
+        if not self.models_are_ready:
+            self.open_setup()
+            return
         self.switch_screen(_CHAT_SCREEN_NAME)
         if self._initial_view and self._initial_view != msg.DEFAULT_VIEW:
             self.switch_view(self._initial_view)
         # Cheap detection only: filesystem walk + hash compare. The user
         # initiates sync explicitly via S or the command palette.
         self.task_bar.start_detect_pending()
+
+    @work(thread=True, name="models_ready", exit_on_error=False)
+    def refresh_models_ready(self, *, present_setup: bool = False) -> None:
+        """Re-answer whether chat has models to run, off the UI thread.
+
+        ``present_setup`` also opens the wizard when there is setup to do,
+        which is what the first launch of a lilbee wants. Every other caller
+        only refreshes the answer: re-opening the wizard from the path that
+        runs when it closes would be a trap.
+        """
+        ready = models_ready()
+        show = present_setup and (not ready or is_fresh_install())
+        call_from_thread(self, self._apply_models_ready, ready, show)
+
+    def _apply_models_ready(self, ready: bool, present_setup: bool) -> None:
+        """Record the readiness answer and, on the first launch, run setup."""
+        self.models_are_ready = ready
+        if present_setup:
+            self.open_setup()
+
+    def _recheck_models_on_model_change(self, payload: tuple[str, object]) -> None:
+        """Re-answer readiness whenever a model role is reassigned.
+
+        Every write lands on the settings boundary, so this one subscription
+        covers the wizard, the catalog, the settings editor and ``/set``
+        alike -- including a download that assigns its model on completion,
+        long after the screen that started it went away.
+        """
+        key, _value = payload
+        if key in MODEL_ROLE_FIELDS:
+            self.refresh_models_ready()
+
+    def open_setup(self) -> None:
+        """Show the setup wizard over the catalog, so closing it lands somewhere useful.
+
+        A dismissable wizard leaves the user on whatever is underneath it.
+        Underneath a first-run chat screen that is a prompt with no engine
+        behind it and no route back, so the catalog -- the other place models
+        are installed -- takes that spot.
+        """
+        from lilbee.cli.tui.screens.setup import SetupWizard
+
+        if isinstance(self.screen, SetupWizard):
+            return
+        if self._switching:
+            # switch_view drops a switch that arrives mid-transition, which
+            # would leave the wizard sitting on whatever screen the other
+            # switch was leaving. Retry on the next frame instead: paced by
+            # the display, so a transition that never settles costs a repaint
+            # rather than a spinning message pump.
+            self.call_after_refresh(self.open_setup)
+            return
+        self.switch_view(msg.CATALOG_VIEW)
+        self.push_screen(SetupWizard())
 
     def _wire_worker_pool_notifications(self) -> None:
         """Surface worker spawn lifecycle in the bottom TaskBar.
@@ -338,8 +406,8 @@ class LilbeeApp(App[None]):
             reason = canon.reason or msg.MODEL_REASON_DEFAULT
 
             if canon.original == canon.effective:
-                # Nothing to fall back to: keep the ref and let the chat screen's
-                # needs_setup open the SetupWizard, which is the single voice for
+                # Nothing to fall back to: keep the ref and let the readiness
+                # check open the SetupWizard, which is the single voice for
                 # "pick a model." A toast here just duplicates the wizard (on first
                 # launch the default refs aren't downloaded yet), so log the reason
                 # as a breadcrumb but don't surface it.
@@ -500,6 +568,20 @@ class LilbeeApp(App[None]):
             return
         self.exit()
 
+    def _view_is_refused(self, view_name: str) -> bool:
+        """True when *view_name* cannot be entered now, having handled the refusal."""
+        if view_name == msg.DEFAULT_VIEW and not self.models_are_ready:
+            # Chat with no model behind it is a prompt that cannot answer, so
+            # the Chat route is a route into setup until one resolves.
+            self.open_setup()
+            return True
+        if view_name == msg.SESSIONS_VIEW and not cfg.sessions_enabled:
+            # The tab stays visible so the feature is discoverable, but opening it
+            # while off shows why rather than an empty list.
+            self._notify_sessions_disabled()
+            return True
+        return view_name != msg.DEFAULT_VIEW and get_views().get(view_name) is None
+
     def switch_view(self, view_name: str) -> None:
         """Switch to a named view, installing each screen at most once.
 
@@ -507,14 +589,7 @@ class LilbeeApp(App[None]):
         keypresses can't corrupt the screen stack. ``active_view`` is updated
         after the switch completes.
         """
-        if self._switching:
-            return
-        if view_name == msg.SESSIONS_VIEW and not cfg.sessions_enabled:
-            # The tab stays visible so the feature is discoverable, but opening it
-            # while off shows why rather than an empty list.
-            self._notify_sessions_disabled()
-            return
-        if view_name != "Chat" and get_views().get(view_name) is None:
+        if self._switching or self._view_is_refused(view_name):
             return
         self._switching = True
         if view_name != self.active_view:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -31,6 +31,7 @@ from lilbee.core.config import cfg
 from lilbee.providers.roles import WorkerRole
 
 if TYPE_CHECKING:
+    from lilbee.app.services import Services
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
@@ -250,7 +251,6 @@ class LilbeeApp(App[None]):
         self.theme = persisted if persisted in self.available_themes else _DEFAULT_THEME
         self._sync_theme_index_to_current()
 
-        self._wire_worker_pool_notifications()
         # Chat's import graph is the TUI's heaviest; loading it here would hold
         # the first frame back for seconds on a cold disk, leaving the terminal
         # blank exactly where the gate should be. Paint first, then load.
@@ -370,7 +370,7 @@ class LilbeeApp(App[None]):
         self.switch_view(msg.CATALOG_VIEW)
         self.push_screen(SetupWizard())
 
-    def _wire_worker_pool_notifications(self) -> None:
+    def wire_worker_pool_notifications(self, services: Services) -> None:
         """Surface worker spawn lifecycle in the bottom TaskBar.
 
         Worker spawns happen on the pool runtime thread, not the TUI's main
@@ -378,6 +378,12 @@ class LilbeeApp(App[None]):
         before mutating controller state. A single TaskBar hint covers all
         in-flight roles instead of one toast per role; the chat surface is
         for user content, not implementation detail.
+
+        Takes the container rather than reaching for it: the startup gate calls
+        this from its boot thread once it has one. Subscribing from the mount
+        path meant calling ``get_services()`` there, which built the whole
+        container on the UI thread ahead of the gate -- the exact work the gate
+        exists to move off it.
         """
 
         def _on_spawning(role: WorkerRole) -> None:
@@ -386,7 +392,7 @@ class LilbeeApp(App[None]):
         def _on_spawned(role: WorkerRole) -> None:
             self.call_from_thread(self.task_bar.mark_role_spawned, role.value)
 
-        get_services().add_pool_listener(on_spawning=_on_spawning, on_spawned=_on_spawned)
+        services.add_pool_listener(on_spawning=_on_spawning, on_spawned=_on_spawned)
 
     def canonicalize_persisted_models(self) -> None:
         """Swap stale persisted refs to a working fallback, persist, and log once.

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -197,10 +197,10 @@ class LilbeeApp(App[None]):
         self._previous_view: str | None = None
         self._switching = False
         self._theme_index = 0
-        # Whether a chat and an embedding model both resolve. Chat is only
-        # entered while this holds; it is answered off the UI thread (the
-        # probe reads disk and can call a local model server), so it starts
-        # permissive and the boot check corrects it.
+        # Whether a chat and an embedding model both resolve; the Chat view is
+        # only entered while this holds. The startup gate settles it before any
+        # screen is handed over, so the permissive default is only ever read by
+        # a host that never boots the gate.
         self.models_are_ready = True
         # Names of non-Chat screens already installed via install_screen.
         # Subsequent visits switch by name to reuse the same instance,
@@ -251,10 +251,6 @@ class LilbeeApp(App[None]):
         self._sync_theme_index_to_current()
 
         self._wire_worker_pool_notifications()
-        # Started here rather than from the chat screen's mount: the answer
-        # decides whether chat is entered at all, so it must not depend on
-        # chat having been entered first.
-        self.refresh_models_ready(present_setup=True)
         # Chat's import graph is the TUI's heaviest; loading it here would hold
         # the first frame back for seconds on a cold disk, leaving the terminal
         # blank exactly where the gate should be. Paint first, then load.
@@ -297,10 +293,12 @@ class LilbeeApp(App[None]):
         gate.start_boot()
 
     def reveal_chat(self) -> None:
-        """Swap the startup gate for the chat screen once the engine has settled."""
-        if not self.models_are_ready:
-            self.open_setup()
-            return
+        """Swap the startup gate for the chat screen once the engine has settled.
+
+        No readiness guard here: the gate settles that answer before it hands
+        over, and routes to setup itself when there is setup to do, so this is
+        only ever reached for an app that can serve.
+        """
         self.switch_screen(_CHAT_SCREEN_NAME)
         if self._initial_view and self._initial_view != msg.DEFAULT_VIEW:
             self.switch_view(self._initial_view)
@@ -308,23 +306,33 @@ class LilbeeApp(App[None]):
         # initiates sync explicitly via S or the command palette.
         self.task_bar.start_detect_pending()
 
-    @work(thread=True, name="models_ready", exit_on_error=False)
-    def refresh_models_ready(self, *, present_setup: bool = False) -> None:
-        """Re-answer whether chat has models to run, off the UI thread.
+    def settle_setup_state(self) -> bool:
+        """Answer the setup questions, run setup if there is any, and say so.
 
-        ``present_setup`` also opens the wizard when there is setup to do,
-        which is what the first launch of a lilbee wants. Every other caller
-        only refreshes the answer: re-opening the wizard from the path that
-        runs when it closes would be a trap.
+        Called from the startup gate's boot thread and blocking by design: the
+        answer decides whether the handover goes to chat at all, so the gate
+        settles it rather than racing it against a default. Returns whether
+        setup took the screen, which is the gate's cue not to hand over.
         """
         ready = models_ready()
-        show = present_setup and (not ready or is_fresh_install())
-        call_from_thread(self, self._apply_models_ready, ready, show)
+        setup_to_do = not ready or is_fresh_install()
+        call_from_thread(self, self._apply_setup_state, ready, setup_to_do)
+        return setup_to_do
 
-    def _apply_models_ready(self, ready: bool, present_setup: bool) -> None:
-        """Record the readiness answer and, on the first launch, run setup."""
+    @work(thread=True, name="setup_state", exit_on_error=False)
+    def refresh_models_ready(self) -> None:
+        """Re-answer readiness off the UI thread, leaving the user where they are.
+
+        Only the boot probe presents the wizard: re-presenting it from the path
+        that runs when a model lands -- which is how the wizard is closed --
+        would be a trap.
+        """
+        call_from_thread(self, self._apply_setup_state, models_ready(), False)
+
+    def _apply_setup_state(self, ready: bool, open_setup: bool) -> None:
+        """Record the readiness answer, then run setup when the boot probe asked."""
         self.models_are_ready = ready
-        if present_setup:
+        if open_setup:
             self.open_setup()
 
     def _recheck_models_on_model_change(self, payload: tuple[str, object]) -> None:

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -97,7 +97,7 @@ class LilbeeCommandProvider(Provider):
             return
         if cmd.args_hint.startswith("<"):
             # Needs an argument: land in the chat prompt for Tab completion.
-            app.switch_view("Chat")
+            app.switch_view(msg.DEFAULT_VIEW)
             chat.insert_slash_command(cmd.name)
         else:
             # Complete as-is: dispatch like a submitted prompt. Handlers that

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -40,7 +40,7 @@ class LilbeeCommandProvider(Provider):
         app = self._app
         commands: list[tuple[str, str, Any]] = [
             ("Open chat", "Ask questions about your knowledge base", app.action_open_chat),
-            ("Open catalog", "Browse and install models", lambda: app.switch_view("Catalog")),
+            ("Open catalog", "Browse and install models", app.action_open_catalog),
             ("Run setup wizard", "Configure chat and embedding models", self._action_setup),
             ("Open status", "Knowledge base status", lambda: app.switch_view("Status")),
             ("Open settings", "View and change settings", lambda: app.switch_view("Settings")),

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -552,6 +552,7 @@ COMPAT_MODAL_BODY = (
     "so loading after download will probably fail. Pull anyway?"
 )
 DEFAULT_VIEW = "Chat"
+CATALOG_VIEW = "Catalog"
 WIKI_VIEW = "Wiki"
 FLEET_VIEW = "Fleet"
 SESSIONS_VIEW = "Sessions"
@@ -616,7 +617,7 @@ FLEET_HELP_TOOLTIP = (
 # factory map from get_nav_views().
 ALL_NAV_VIEWS: tuple[str, ...] = (
     DEFAULT_VIEW,
-    "Catalog",
+    CATALOG_VIEW,
     "Status",
     "Settings",
     "Tasks",

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -35,7 +35,6 @@ from textual.worker import get_current_worker as _get_worker
 
 from lilbee.app.services import get_services, reset_store
 from lilbee.app.settings_map import SETTINGS_MAP
-from lilbee.app.setup_state import needs_setup
 from lilbee.app.themes import DARK_THEMES
 from lilbee.app.version import get_version
 from lilbee.cli.tui import messages as msg
@@ -414,22 +413,6 @@ class ChatScreen(Screen[None]):
     def on_mount(self) -> None:
         self._update_input_style()
         self.app.settings_changed_signal.subscribe(self, self._on_settings_changed)
-        self._setup_check_worker()
-
-    @work(thread=True, name="chat_setup_check", exit_on_error=False)
-    def _setup_check_worker(self) -> None:
-        """Run ``needs_setup`` off the UI thread; push the wizard if needed."""
-        if not needs_setup():
-            return
-        call_from_thread(self, self._push_setup_wizard)
-
-    def _push_setup_wizard(self) -> None:
-        """Push the SetupWizard if the screen is still mounted."""
-        if not self.is_mounted:
-            return
-        from lilbee.cli.tui.screens.setup import SetupWizard
-
-        self.app.push_screen(SetupWizard(), self._on_setup_complete)
 
     def on_show(self) -> None:
         """Called when screen becomes visible."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1060,7 +1060,7 @@ class ChatScreen(Screen[None]):
     def _cmd_catalog(self, _args: str) -> None:
         # switch_view already installs and navigates to the managed Catalog view;
         # a push_screen on top would stack a second, orphaned CatalogScreen.
-        self.app.switch_view("Catalog")
+        self.app.switch_view(msg.CATALOG_VIEW)
 
     def _cmd_delete(self, args: str) -> None:
         """Run /delete in a worker so the chat screen stays interactive."""

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -12,7 +12,7 @@ from textual.screen import Screen
 from textual.widgets import ProgressBar, Static
 from textual.worker import get_current_worker
 
-from lilbee.app.services import get_services, peek_services
+from lilbee.app.services import peek_services
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.runtime.bee_logo import BEE_LINES
@@ -65,12 +65,10 @@ class StartupGate(Screen[None]):
     def start_boot(self) -> None:
         """Work out what the app can serve, off the UI thread, then hand over.
 
-        One path, even when the container is already built (a second TUI in the
-        same process, a test host): the setup answer decides whether the
-        handover goes to chat at all, so there is nothing to fast-path past.
-        The thread hop also keeps the screen switch out of the mount that
-        started it -- start_boot runs at the tail of the app's on_mount, and
-        switching screens from inside on_mount stalls Textual.
+        One path even when the container is already built (a second TUI in the
+        same process, a test host): the setup answer still decides whether the
+        handover happens. The thread hop also keeps the screen switch out of
+        on_mount, which stalls Textual.
         """
         self._boot_worker()
 
@@ -78,20 +76,14 @@ class StartupGate(Screen[None]):
     def _boot_worker(self) -> None:
         """Settle the refs, settle the setup answer, build the container, hand over.
 
-        Canonicalization runs first (it can swap a stale ref to a working
-        fallback, which decides whether setup is needed) and runs here rather
-        than on the mount path: its disk reads and server probes would sit
-        between the terminal handover and the TUI's first frame. An already
-        built container (a second TUI in the same process, a test host) has
-        nothing left to settle, so it skips straight to the setup answer.
+        Canonicalization runs first: it can swap a stale ref for a working one,
+        which decides the setup answer. An already built container skips it.
 
         ``settle_setup_state`` blocks until the app has recorded the answer, so
-        a handover can never read a readiness flag that has yet to be written.
+        the handover cannot read a readiness flag that has yet to be written.
 
-        Building the container is the reason this screen exists: it constructs
-        every singleton and spawns the role servers, so it belongs on this
-        thread, behind the loading bar. The app subscribes to the container it
-        gets back rather than reaching for one of its own on the mount path.
+        Building the container spawns the role servers, so it belongs on this
+        thread, behind the loading bar.
         """
         try:
             if peek_services() is None:
@@ -100,7 +92,7 @@ class StartupGate(Screen[None]):
                 # Setup owns the screen now, and the app has already routed
                 # there; handing over as well would land on top of it.
                 return
-            self.app.wire_worker_pool_notifications(get_services())
+            self.app.adopt_services()
         except Exception as exc:
             # Any failure to prepare the app leaves the user with no engine.
             # Show it and hand them the rest of the TUI rather than a dead screen.

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -82,11 +82,16 @@ class StartupGate(Screen[None]):
         fallback, which decides whether setup is needed) and runs here rather
         than on the mount path: its disk reads and server probes would sit
         between the terminal handover and the TUI's first frame. An already
-        built container has nothing left to settle, so it skips straight to the
-        setup answer.
+        built container (a second TUI in the same process, a test host) has
+        nothing left to settle, so it skips straight to the setup answer.
 
         ``settle_setup_state`` blocks until the app has recorded the answer, so
         a handover can never read a readiness flag that has yet to be written.
+
+        Building the container is the reason this screen exists: it constructs
+        every singleton and spawns the role servers, so it belongs on this
+        thread, behind the loading bar. The app subscribes to the container it
+        gets back rather than reaching for one of its own on the mount path.
         """
         try:
             if peek_services() is None:
@@ -95,7 +100,7 @@ class StartupGate(Screen[None]):
                 # Setup owns the screen now, and the app has already routed
                 # there; handing over as well would land on top of it.
                 return
-            get_services()
+            self.app.wire_worker_pool_notifications(get_services())
         except Exception as exc:
             # Any failure to prepare the app leaves the user with no engine.
             # Show it and hand them the rest of the TUI rather than a dead screen.

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -13,7 +13,6 @@ from textual.widgets import ProgressBar, Static
 from textual.worker import get_current_worker
 
 from lilbee.app.services import get_services, peek_services
-from lilbee.app.setup_state import needs_setup
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.runtime.bee_logo import BEE_LINES
@@ -64,32 +63,37 @@ class StartupGate(Screen[None]):
         self.refresh()
 
     def start_boot(self) -> None:
-        """Reveal chat at once when services already exist, else build them off-thread.
+        """Work out what the app can serve, off the UI thread, then hand over.
 
-        A container that is already built (a second TUI in the same process, a
-        test host) has nothing to wait for, so painting a loading screen would be
-        a lie. The handover is deferred a frame because start_boot runs at the
-        tail of the app's on_mount, and switching screens from inside on_mount
-        stalls Textual.
+        One path, even when the container is already built (a second TUI in the
+        same process, a test host): the setup answer decides whether the
+        handover goes to chat at all, so there is nothing to fast-path past.
+        The thread hop also keeps the screen switch out of the mount that
+        started it -- start_boot runs at the tail of the app's on_mount, and
+        switching screens from inside on_mount stalls Textual.
         """
-        if peek_services() is not None:
-            self.call_after_refresh(self._release)
-            return
         self._boot_worker()
 
     @work(thread=True, name="startup_gate", exit_on_error=False)
     def _boot_worker(self) -> None:
-        """Settle the model refs, build the services container, then hand over.
+        """Settle the refs, settle the setup answer, build the container, hand over.
 
         Canonicalization runs first (it can swap a stale ref to a working
         fallback, which decides whether setup is needed) and runs here rather
         than on the mount path: its disk reads and server probes would sit
-        between the terminal handover and the TUI's first frame.
+        between the terminal handover and the TUI's first frame. An already
+        built container has nothing left to settle, so it skips straight to the
+        setup answer.
+
+        ``settle_setup_state`` blocks until the app has recorded the answer, so
+        a handover can never read a readiness flag that has yet to be written.
         """
         try:
-            self.app.canonicalize_persisted_models()
-            if needs_setup():
-                self._marshal(self._release)
+            if peek_services() is None:
+                self.app.canonicalize_persisted_models()
+            if self.app.settle_setup_state():
+                # Setup owns the screen now, and the app has already routed
+                # there; handing over as well would land on top of it.
                 return
             get_services()
         except Exception as exc:

--- a/tests/_lilbee_app_test_host.py
+++ b/tests/_lilbee_app_test_host.py
@@ -71,9 +71,9 @@ async def await_chat(app, pilot) -> object:
 def ready_services():
     """Bind a mock container whose chat role is ready, so the startup gate releases at once.
 
-    Also pins ``needs_setup`` False: the chat screen's setup-check worker runs
-    on a real thread, so an unpinned True pushes the SetupWizard over whatever
-    screen the test just pushed, on a slow runner's schedule.
+    Also pins ``models_ready`` True: the app's readiness worker runs on a real
+    thread, so an unpinned False routes the test to the catalog and opens the
+    SetupWizard over it, on a slow runner's schedule.
     """
     from unittest.mock import MagicMock, patch
 
@@ -83,7 +83,7 @@ def ready_services():
     services.provider.role_ready.return_value = True
     set_services(services)
     try:
-        with patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
+        with patch("lilbee.cli.tui.app.models_ready", return_value=True):
             yield services
     finally:
         set_services(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,21 @@ def _sealed_engine_resolution(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _sealed_fresh_install_probe(request, monkeypatch):
+    """Seal the TUI's fresh-install probe so every machine behaves like a set-up one.
+
+    ``is_fresh_install`` answers from ``cfg.lancedb_dir``, which outside an
+    isolated data dir is the developer's real platform path: present on one
+    machine, absent on the next, and it decides whether the app opens its setup
+    wizard over whatever screen a test is driving. Tests that exercise the
+    first-run path opt out with ``@pytest.mark.first_run``.
+    """
+    if "first_run" in {m.name for m in request.node.iter_markers()}:
+        return
+    monkeypatch.setattr("lilbee.cli.tui.app.is_fresh_install", lambda: False)
+
+
+@pytest.fixture(autouse=True)
 def _reset_services_after_test():
     """Drop any Services container ``set_services()`` left around.
 

--- a/tests/test_bottom_bar_affordances.py
+++ b/tests/test_bottom_bar_affordances.py
@@ -60,8 +60,8 @@ def _mock_services():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.needs_setup",
-            return_value=False,
+            "lilbee.cli.tui.app.models_ready",
+            return_value=True,
         ),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",

--- a/tests/test_bottom_bars_stacking.py
+++ b/tests/test_bottom_bars_stacking.py
@@ -54,7 +54,7 @@ def _mock_services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_chat_input_wrap.py
+++ b/tests/test_chat_input_wrap.py
@@ -42,7 +42,7 @@ def _chat_ready_env():
     cfg.embedding_model = TEST_EMBED_REF
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     with (
-        mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.app.models_ready", return_value=True),
         mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True),
     ):
         yield

--- a/tests/test_chat_memory_commands.py
+++ b/tests/test_chat_memory_commands.py
@@ -47,7 +47,7 @@ def _patch_chat_setup():
     from lilbee.cli.tui.widgets.model_bar import ModelBar
 
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
         patch.object(ModelBar, "_scan_models"),
     ):

--- a/tests/test_chat_sessions.py
+++ b/tests/test_chat_sessions.py
@@ -29,7 +29,7 @@ def _services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
         patch("lilbee.cli.tui.widgets.model_bar.ModelBar.on_mount"),
     ):

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -1,4 +1,4 @@
-"""Tests for needs_setup: the wizard shows on fresh data dirs."""
+"""Tests for the two setup questions: is this lilbee new, and can it serve chat."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from lilbee.app.setup_state import models_ready, needs_setup
+from lilbee.app.setup_state import is_fresh_install, models_ready
 from lilbee.core.config import cfg
 from tests._lilbee_app_test_host import await_chat
 
@@ -26,15 +26,16 @@ def isolated_data_dir(tmp_path):
             setattr(cfg, field_name, getattr(snapshot, field_name))
 
 
-def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
-    """Fresh data dir must trigger the wizard even when models resolve globally."""
+def test_a_missing_lancedb_dir_is_a_fresh_install(isolated_data_dir):
+    """A fresh data dir means the wizard runs, whatever the models say."""
     assert not cfg.lancedb_dir.exists()
-    with mock.patch(
-        "lilbee.providers.engine_params.resolve_model_path",
-        return_value="/some/resolved/path",
-    ) as resolve:
-        assert needs_setup() is True
-        resolve.assert_not_called()
+    assert is_fresh_install() is True
+
+
+def test_an_existing_lancedb_dir_is_not_a_fresh_install(isolated_data_dir):
+    """A lilbee that has already stored something must not re-run first-run setup."""
+    cfg.lancedb_dir.mkdir(parents=True)
+    assert is_fresh_install() is False
 
 
 def test_models_ready_ignores_a_fresh_data_dir(isolated_data_dir):
@@ -43,7 +44,7 @@ def test_models_ready_ignores_a_fresh_data_dir(isolated_data_dir):
     ``models_ready`` is what keeps the user out of the chat screen, so it must
     answer only the question chat depends on. Folding the fresh-data-dir check
     into it would lock chat behind an ingest that cannot be run from anywhere
-    but chat. The wizard still runs on a fresh dir -- that is ``needs_setup``.
+    but chat. The wizard still runs on a fresh dir -- that is is_fresh_install.
     """
     assert not cfg.lancedb_dir.exists()
     cfg.chat_model = "owner/chat-GGUF/chat.Q4_K_M.gguf"
@@ -53,11 +54,11 @@ def test_models_ready_ignores_a_fresh_data_dir(isolated_data_dir):
         return_value="/some/resolved/path",
     ):
         assert models_ready() is True
-        assert needs_setup() is True
+        assert is_fresh_install() is True
 
 
-def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir):
-    """Initialized data dir plus resolvable native models skips the wizard."""
+def test_models_ready_when_the_native_refs_resolve(isolated_data_dir):
+    """Resolvable native chat and embedding refs mean chat has an engine."""
     cfg.lancedb_dir.mkdir(parents=True)
     # Explicit native refs so the check is deterministic regardless of the
     # developer's loaded config.toml (which may hold remote refs).
@@ -67,11 +68,11 @@ def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir
         "lilbee.providers.engine_params.resolve_model_path",
         return_value="/some/resolved/path",
     ):
-        assert needs_setup() is False
+        assert models_ready() is True
 
 
-def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
-    """Unresolvable native chat/embedding model still triggers the wizard."""
+def test_models_not_ready_when_a_native_ref_is_missing(isolated_data_dir):
+    """An unresolvable native chat/embedding ref leaves chat with no engine."""
     from lilbee.providers.base import ProviderError
 
     cfg.lancedb_dir.mkdir(parents=True)
@@ -81,10 +82,10 @@ def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
         "lilbee.providers.engine_params.resolve_model_path",
         side_effect=ProviderError("no such model", provider="llama-cpp"),
     ):
-        assert needs_setup() is True
+        assert models_ready() is False
 
 
-def test_needs_setup_skips_native_probe_for_usable_remote_models(isolated_data_dir):
+def test_readiness_skips_the_native_probe_for_usable_remote_models(isolated_data_dir):
     """ollama/ and API-prefixed models bypass the llama-cpp registry check.
 
     The native resolver only knows about GGUFs, so a usable remote ref
@@ -103,11 +104,11 @@ def test_needs_setup_skips_native_probe_for_usable_remote_models(isolated_data_d
         ),
         mock.patch("lilbee.providers.engine_params.resolve_model_path") as resolve,
     ):
-        assert needs_setup() is False
+        assert models_ready() is True
         resolve.assert_not_called()
 
 
-def test_needs_setup_true_when_remote_model_unusable(isolated_data_dir):
+def test_models_not_ready_when_a_remote_ref_is_unusable(isolated_data_dir):
     """An unusable remote ref (litellm missing, server down, no key) opens the wizard.
 
     Regression: this used to be skipped on the assumption that remote refs
@@ -123,20 +124,16 @@ def test_needs_setup_true_when_remote_model_unusable(isolated_data_dir):
         "lilbee.modelhub.model_manager.validate_persisted_model",
         return_value=ValidationResult.UNKNOWN,
     ):
-        assert needs_setup() is True
+        assert models_ready() is False
 
 
-def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
+def test_a_file_at_the_lancedb_path_is_a_fresh_install(isolated_data_dir):
     """A stray file at the lancedb path is not a real data directory."""
     cfg.lancedb_dir.parent.mkdir(parents=True, exist_ok=True)
     cfg.lancedb_dir.write_text("not a directory")
     assert cfg.lancedb_dir.exists()
     assert not cfg.lancedb_dir.is_dir()
-    with mock.patch(
-        "lilbee.providers.engine_params.resolve_model_path",
-        return_value="/some/resolved/path",
-    ):
-        assert needs_setup() is True
+    assert is_fresh_install() is True
 
 
 @pytest.fixture

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -6,8 +6,7 @@ from unittest import mock
 
 import pytest
 
-from lilbee.app.setup_state import needs_setup
-from lilbee.cli.tui.screens.chat import ChatScreen
+from lilbee.app.setup_state import models_ready, needs_setup
 from lilbee.core.config import cfg
 from tests._lilbee_app_test_host import await_chat
 
@@ -38,20 +37,23 @@ def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
         resolve.assert_not_called()
 
 
-def test_push_setup_wizard_no_op_when_unmounted():
-    """``_push_setup_wizard`` short-circuits when the screen is no longer mounted.
+def test_models_ready_ignores_a_fresh_data_dir(isolated_data_dir):
+    """A fresh lilbee whose models resolve can still chat.
 
-    The setup-check worker may race a view switch: by the time the worker
-    finishes, the chat screen is already gone. Ensure the push is gated
-    on ``is_mounted`` so we don't push onto whatever screen is now on top.
+    ``models_ready`` is what keeps the user out of the chat screen, so it must
+    answer only the question chat depends on. Folding the fresh-data-dir check
+    into it would lock chat behind an ingest that cannot be run from anywhere
+    but chat. The wizard still runs on a fresh dir -- that is ``needs_setup``.
     """
-    screen = ChatScreen.__new__(ChatScreen)
-    ChatScreen.is_mounted = property(lambda self: False)
-    try:
-        # If the guard breaks, this would AttributeError on ``self.app``.
-        screen._push_setup_wizard()
-    finally:
-        del ChatScreen.is_mounted
+    assert not cfg.lancedb_dir.exists()
+    cfg.chat_model = "owner/chat-GGUF/chat.Q4_K_M.gguf"
+    cfg.embedding_model = "owner/embed-GGUF/embed.Q8_0.gguf"
+    with mock.patch(
+        "lilbee.providers.engine_params.resolve_model_path",
+        return_value="/some/resolved/path",
+    ):
+        assert models_ready() is True
+        assert needs_setup() is True
 
 
 def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir):
@@ -163,8 +165,8 @@ async def test_chat_screen_cached_across_navigation(isolated_data_dir, mock_serv
 
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.needs_setup",
-            return_value=False,
+            "lilbee.cli.tui.app.models_ready",
+            return_value=True,
         ),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -45,7 +45,7 @@ def _warming_services():
     services.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
     set_services(services)
     with (
-        mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.app.models_ready", return_value=True),
         mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True),
     ):
         yield services

--- a/tests/test_context_chip.py
+++ b/tests/test_context_chip.py
@@ -27,7 +27,7 @@ def _services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
         patch("lilbee.cli.tui.widgets.model_bar.ModelBar.on_mount"),
     ):

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -641,9 +641,9 @@ class TestAppCanonicalizeFallbackNotice:
         and the reason is logged, but no toast fires.
 
         This is the first-launch case: the default refs aren't downloaded
-        yet and there's nothing to fall back to. The chat screen's
-        ``needs_setup`` keys off the same unresolved state and opens the
-        SetupWizard, which is the single voice for "pick a model." A toast
+        yet and there's nothing to fall back to. The app's readiness check
+        keys off the same unresolved state and opens the SetupWizard, which
+        is the single voice for "pick a model." A toast
         here just duplicates the wizard (its text literally says "Opening
         setup"), so it's suppressed; the WARNING log stays as a breadcrumb.
         """

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -368,8 +368,8 @@ def test_protocol_defaults_for_drop_and_role_ready():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.needs_setup",
-            return_value=False,
+            "lilbee.cli.tui.app.models_ready",
+            return_value=True,
         ),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",

--- a/tests/test_screen_navigation_repaint.py
+++ b/tests/test_screen_navigation_repaint.py
@@ -51,7 +51,7 @@ def _mock_services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_setup_gate_routing.py
+++ b/tests/test_setup_gate_routing.py
@@ -1,0 +1,207 @@
+"""Chat is not reachable while its models cannot resolve.
+
+A fresh install has model refs configured but nothing on disk, so the chat
+screen has no engine behind it. Every route into chat lands on the catalog
+with the setup wizard over it, which makes Escape leave the user somewhere
+models can be installed rather than on a prompt that cannot answer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from lilbee.cli.tui.app import LilbeeApp
+from lilbee.cli.tui.screens.catalog import CatalogScreen
+from lilbee.cli.tui.screens.chat import ChatScreen
+from lilbee.cli.tui.screens.setup import SetupWizard
+from tests._lilbee_app_test_host import LilbeeAppHost
+
+_WAIT_TIMEOUT_S = 60.0
+_POLL_S = 0.02
+
+
+def _no_models():
+    """Pin the app's readiness probe to "nothing resolves", as on a fresh install."""
+    return patch("lilbee.cli.tui.app.models_ready", return_value=False)
+
+
+def _patch_setup_scan():
+    return patch(
+        "lilbee.cli.tui.screens.setup._scan_installed_models",
+        return_value=([], []),
+    )
+
+
+def _patch_setup_ram(ram_gb: float = 16.0):
+    return patch("lilbee.cli.tui.screens.setup.get_system_ram_gb", return_value=ram_gb)
+
+
+async def _push_a_screen(app) -> None:
+    """Stand in for the startup gate: a view switch replaces a *pushed* screen."""
+    from textual.screen import Screen
+
+    await app.push_screen(Screen())
+
+
+async def _wait_for(pilot, predicate, what: str):
+    """Pump until *predicate* holds, or fail naming what never happened."""
+    deadline = time.monotonic() + _WAIT_TIMEOUT_S
+    while time.monotonic() < deadline:
+        await pilot.pause()
+        if predicate():
+            return
+        await asyncio.sleep(_POLL_S)
+    raise AssertionError(f"{what} never happened")
+
+
+@pytest.mark.asyncio
+async def test_escaping_the_wizard_lands_on_the_catalog_not_a_dead_chat() -> None:
+    """Escape must leave a surface that works, never a chat with no engine."""
+    app = LilbeeApp()
+    with _no_models(), _patch_setup_scan(), _patch_setup_ram():
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _wait_for(
+                pilot,
+                lambda: isinstance(app.screen, SetupWizard),
+                "the setup wizard",
+            )
+            # The wizard is layered over the catalog, so dismissing it reveals
+            # the place models are installed.
+            assert not any(isinstance(s, ChatScreen) for s in app.screen_stack)
+
+            await pilot.press("escape")
+            await _wait_for(
+                pilot,
+                lambda: not isinstance(app.screen, SetupWizard),
+                "the wizard dismissal",
+            )
+            assert isinstance(app.screen, CatalogScreen)
+            assert not any(isinstance(s, ChatScreen) for s in app.screen_stack)
+
+
+@pytest.mark.asyncio
+async def test_navigating_to_chat_without_models_re_presents_setup() -> None:
+    """The Chat view is a route into setup while no model resolves."""
+    app = LilbeeApp()
+    with _no_models(), _patch_setup_scan(), _patch_setup_ram():
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _wait_for(
+                pilot,
+                lambda: isinstance(app.screen, SetupWizard),
+                "the setup wizard",
+            )
+            await pilot.press("escape")
+            await _wait_for(
+                pilot,
+                lambda: isinstance(app.screen, CatalogScreen),
+                "the catalog",
+            )
+
+            app.switch_view("Chat")
+            await _wait_for(
+                pilot,
+                lambda: isinstance(app.screen, SetupWizard),
+                "the setup wizard re-presenting",
+            )
+            assert app.active_view != "Chat"
+            assert not any(isinstance(s, ChatScreen) for s in app.screen_stack)
+
+
+@pytest.mark.asyncio
+async def test_reveal_chat_hands_the_first_run_to_setup() -> None:
+    """The gate's handover is a route into chat, so it answers to the same gate."""
+    app = LilbeeAppHost()
+    async with app.run_test(size=(120, 40)):
+        app.models_are_ready = False
+        with patch.object(LilbeeApp, "open_setup") as open_setup:
+            app.reveal_chat()
+        open_setup.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_setup_waits_for_an_in_flight_view_switch() -> None:
+    """A wizard pushed mid-switch would sit on the screen the switch is leaving."""
+    app = LilbeeAppHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _push_a_screen(app)
+        app._switching = True
+        app.open_setup()
+        await pilot.pause()
+        assert not isinstance(app.screen, SetupWizard)
+
+        app._switching = False
+        await _wait_for(
+            pilot,
+            lambda: isinstance(app.screen, SetupWizard),
+            "the deferred wizard",
+        )
+        assert isinstance(app.screen_stack[-2], CatalogScreen)
+
+
+@pytest.mark.asyncio
+async def test_setup_is_not_re_opened_over_itself() -> None:
+    """Two routes into setup landing at once must not stack two wizards."""
+    app = LilbeeAppHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _push_a_screen(app)
+        with _patch_setup_scan(), _patch_setup_ram():
+            app.open_setup()
+            await _wait_for(
+                pilot,
+                lambda: isinstance(app.screen, SetupWizard),
+                "the setup wizard",
+            )
+            depth = len(app.screen_stack)
+            app.open_setup()
+            await pilot.pause()
+            assert len(app.screen_stack) == depth
+
+
+@pytest.mark.asyncio
+async def test_a_model_reassignment_re_answers_readiness() -> None:
+    """A model landing anywhere -- wizard, catalog, /set -- unblocks chat."""
+    app = LilbeeAppHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        with patch.object(LilbeeApp, "refresh_models_ready") as refresh:
+            app.settings_changed_signal.publish(("chat_model", "owner/repo/model.gguf"))
+            await pilot.pause()
+            refresh.assert_called_once_with()
+            refresh.reset_mock()
+            app.settings_changed_signal.publish(("theme", "rose-pine"))
+            await pilot.pause()
+            refresh.assert_not_called()
+
+
+def test_readiness_worker_presents_setup_only_when_there_is_setup_to_do() -> None:
+    """The probe runs off the UI thread; the answer decides whether setup shows."""
+    body = LilbeeApp.refresh_models_ready.__wrapped__
+    for ready, fresh, expected in (
+        (True, False, (True, False)),  # nothing to do
+        (False, False, (False, True)),  # no models: show the wizard
+        (True, True, (True, True)),  # models, but this lilbee is brand new
+    ):
+        app = LilbeeApp()
+        with (
+            patch("lilbee.cli.tui.app.models_ready", return_value=ready),
+            patch("lilbee.cli.tui.app.is_fresh_install", return_value=fresh),
+            patch("lilbee.cli.tui.app.call_from_thread") as marshal,
+        ):
+            body(app, present_setup=True)
+        assert marshal.call_args.args[2:] == expected
+
+
+def test_readiness_worker_only_refreshes_when_setup_is_not_being_presented() -> None:
+    """The path that runs when the wizard closes must never re-open it."""
+    body = LilbeeApp.refresh_models_ready.__wrapped__
+    app = LilbeeApp()
+    with (
+        patch("lilbee.cli.tui.app.models_ready", return_value=False),
+        patch("lilbee.cli.tui.app.is_fresh_install", return_value=True),
+        patch("lilbee.cli.tui.app.call_from_thread") as marshal,
+    ):
+        body(app)
+    assert marshal.call_args.args[2:] == (False, False)

--- a/tests/test_setup_gate_routing.py
+++ b/tests/test_setup_gate_routing.py
@@ -59,6 +59,38 @@ async def _wait_for(pilot, predicate, what: str):
 
 
 @pytest.mark.asyncio
+async def test_the_handover_waits_for_the_readiness_answer() -> None:
+    """The gate must not hand over to chat while the answer is still outstanding.
+
+    The probe reads disk and can call a local model server, so it takes real
+    time. A handover that races it reads whatever the readiness flag happened
+    to hold and flashes up the very chat screen this gate exists to prevent,
+    before the wizard replaces it. Sample the stack the whole way through:
+    chat must never appear on it, not merely be gone by the end.
+    """
+    seen: set[str] = set()
+
+    def _slow_probe() -> bool:
+        time.sleep(0.5)
+        return False
+
+    app = LilbeeApp()
+    with (
+        patch("lilbee.cli.tui.app.models_ready", side_effect=_slow_probe),
+        _patch_setup_scan(),
+        _patch_setup_ram(),
+    ):
+        async with app.run_test(size=(120, 40)) as pilot:
+
+            def _sample_until_wizard() -> bool:
+                seen.update(type(screen).__name__ for screen in app.screen_stack)
+                return isinstance(app.screen, SetupWizard)
+
+            await _wait_for(pilot, _sample_until_wizard, "the setup wizard")
+    assert ChatScreen.__name__ not in seen, f"chat was on screen during boot: {sorted(seen)}"
+
+
+@pytest.mark.asyncio
 async def test_escaping_the_wizard_lands_on_the_catalog_not_a_dead_chat() -> None:
     """Escape must leave a surface that works, never a chat with no engine."""
     app = LilbeeApp()
@@ -112,13 +144,22 @@ async def test_navigating_to_chat_without_models_re_presents_setup() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reveal_chat_hands_the_first_run_to_setup() -> None:
-    """The gate's handover is a route into chat, so it answers to the same gate."""
+async def test_settling_runs_setup_before_it_returns_to_the_gate() -> None:
+    """The answer is recorded and acted on before the gate is told what to do.
+
+    Driven from a worker thread, as the gate drives it: the marshalled apply
+    has to have landed by the time the call returns, or the gate could hand
+    over against a flag nobody has written yet.
+    """
     app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)):
-        app.models_are_ready = False
-        with patch.object(LilbeeApp, "open_setup") as open_setup:
-            app.reveal_chat()
+        with (
+            patch("lilbee.cli.tui.app.models_ready", return_value=False),
+            patch.object(LilbeeApp, "open_setup") as open_setup,
+        ):
+            took_the_screen = await asyncio.to_thread(app.settle_setup_state)
+        assert took_the_screen is True
+        assert app.models_are_ready is False
         open_setup.assert_called_once_with()
 
 
@@ -176,9 +217,8 @@ async def test_a_model_reassignment_re_answers_readiness() -> None:
             refresh.assert_not_called()
 
 
-def test_readiness_worker_presents_setup_only_when_there_is_setup_to_do() -> None:
-    """The probe runs off the UI thread; the answer decides whether setup shows."""
-    body = LilbeeApp.refresh_models_ready.__wrapped__
+def test_settling_runs_setup_only_when_there_is_setup_to_do() -> None:
+    """A brand new lilbee sees the wizard even when its models already resolve."""
     for ready, fresh, expected in (
         (True, False, (True, False)),  # nothing to do
         (False, False, (False, True)),  # no models: show the wizard
@@ -190,12 +230,12 @@ def test_readiness_worker_presents_setup_only_when_there_is_setup_to_do() -> Non
             patch("lilbee.cli.tui.app.is_fresh_install", return_value=fresh),
             patch("lilbee.cli.tui.app.call_from_thread") as marshal,
         ):
-            body(app, present_setup=True)
+            assert app.settle_setup_state() is expected[1]
         assert marshal.call_args.args[2:] == expected
 
 
-def test_readiness_worker_only_refreshes_when_setup_is_not_being_presented() -> None:
-    """The path that runs when the wizard closes must never re-open it."""
+def test_a_later_refresh_never_re_opens_the_wizard() -> None:
+    """The refresh path runs when a model lands, which is how the wizard closes."""
     body = LilbeeApp.refresh_models_ready.__wrapped__
     app = LilbeeApp()
     with (

--- a/tests/test_setup_gate_routing.py
+++ b/tests/test_setup_gate_routing.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.screens.catalog import CatalogScreen
 from lilbee.cli.tui.screens.chat import ChatScreen
@@ -133,13 +134,14 @@ async def test_navigating_to_chat_without_models_re_presents_setup() -> None:
                 "the catalog",
             )
 
-            app.switch_view("Chat")
+            # The user's own route into chat: the c key, not the method behind it.
+            await pilot.press("c")
             await _wait_for(
                 pilot,
                 lambda: isinstance(app.screen, SetupWizard),
                 "the setup wizard re-presenting",
             )
-            assert app.active_view != "Chat"
+            assert app.active_view != msg.DEFAULT_VIEW
             assert not any(isinstance(s, ChatScreen) for s in app.screen_stack)
 
 
@@ -245,3 +247,45 @@ def test_a_later_refresh_never_re_opens_the_wizard() -> None:
     ):
         body(app)
     assert marshal.call_args.args[2:] == (False, False)
+
+
+def test_models_landing_after_setup_builds_the_container_off_the_ui_thread() -> None:
+    """First run reaches chat with no container, and building one is not UI work."""
+    body = LilbeeApp.refresh_models_ready.__wrapped__
+    app = LilbeeApp()
+    with (
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
+        patch("lilbee.cli.tui.app.peek_services", return_value=None),
+        patch.object(LilbeeApp, "adopt_services") as adopt,
+        patch("lilbee.cli.tui.app.call_from_thread"),
+    ):
+        body(app)
+    adopt.assert_called_once_with()
+
+
+def test_a_container_that_already_exists_is_not_adopted_again() -> None:
+    """Swapping a model on a running app must not stack another subscription."""
+    body = LilbeeApp.refresh_models_ready.__wrapped__
+    app = LilbeeApp()
+    with (
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
+        patch("lilbee.cli.tui.app.peek_services", return_value=object()),
+        patch.object(LilbeeApp, "adopt_services") as adopt,
+        patch("lilbee.cli.tui.app.call_from_thread"),
+    ):
+        body(app)
+    adopt.assert_not_called()
+
+
+def test_a_model_that_still_does_not_resolve_builds_nothing() -> None:
+    """Half a setup is not a reason to spawn role servers."""
+    body = LilbeeApp.refresh_models_ready.__wrapped__
+    app = LilbeeApp()
+    with (
+        patch("lilbee.cli.tui.app.models_ready", return_value=False),
+        patch("lilbee.cli.tui.app.peek_services", return_value=None),
+        patch.object(LilbeeApp, "adopt_services") as adopt,
+        patch("lilbee.cli.tui.app.call_from_thread"),
+    ):
+        body(app)
+    adopt.assert_not_called()

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -189,9 +189,9 @@ async def test_gate_hands_nothing_over_when_setup_takes_the_screen(monkeypatch):
 async def test_gate_settles_setup_before_it_hands_over(monkeypatch):
     """An already built container still waits on the setup answer.
 
-    The container is built on the app's mount path, so this is the path every
-    launch takes. Handing over first and asking afterwards flashes up the very
-    chat screen the answer exists to withhold.
+    Nothing is left to build for a second TUI in the same process, which is the
+    one case that used to skip the worker entirely. Handing over first and
+    asking afterwards flashes up the very chat screen the answer withholds.
     """
     from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
@@ -301,6 +301,58 @@ async def test_first_run_hands_over_when_setup_is_required(tmp_path, monkeypatch
             await pilot.pause()
             await asyncio.sleep(0.02)
         assert not isinstance(app.screen, StartupGate)
+
+
+async def test_the_container_is_built_behind_the_gate(monkeypatch):
+    """The app must not build the services container on its mount path.
+
+    ``get_services`` constructs every singleton and spawns the role servers.
+    Building it from ``on_mount`` blocks the first frame with the work the gate
+    exists to hide, and leaves the gate with nothing to wait for: its boot
+    worker, and the canonicalization that only runs there, never run at all.
+    """
+    import threading
+
+    from lilbee.app.services import peek_services, set_services
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from tests._async_wait import wait_until
+
+    set_services(None)
+    container = mock.MagicMock()
+    monkeypatch.setattr(gate_mod, "get_services", lambda: container)
+    # An app with nothing to set up, so the gate runs its whole boot.
+    monkeypatch.setattr("lilbee.cli.tui.app.models_ready", lambda: True)
+
+    at_start_boot: list[object] = []
+    real_start_boot = StartupGate.start_boot
+
+    def _spy_start_boot(self):
+        at_start_boot.append(peek_services())
+        return real_start_boot(self)
+
+    monkeypatch.setattr(StartupGate, "start_boot", _spy_start_boot)
+
+    canonicalized: list[str] = []
+    monkeypatch.setattr(
+        LilbeeApp,
+        "canonicalize_persisted_models",
+        lambda self: canonicalized.append(threading.current_thread().name),
+    )
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await wait_until(
+            pilot,
+            lambda: bool(canonicalized) and container.add_pool_listener.called,
+            max_pauses=200,
+        )
+
+    assert at_start_boot == [None], "the mount path built the container ahead of the gate"
+    assert canonicalized, "the gate's boot worker never ran, so the refs were never settled"
+    assert canonicalized[0] != threading.main_thread().name, "boot work ran on the UI thread"
+    assert container.add_pool_listener.called, "the app subscribed to some other container"
 
 
 async def test_gate_composes_and_styles_its_widgets(monkeypatch):

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -195,7 +195,6 @@ async def test_gate_settles_setup_before_it_hands_over(monkeypatch):
     app.settle_setup_state.side_effect = lambda: order.append("settle") or False
     app.reveal_chat.side_effect = lambda: order.append("reveal")
     monkeypatch.setattr(gate_mod, "peek_services", lambda: mock.MagicMock())
-    monkeypatch.setattr(gate_mod, "get_services", mock.Mock())
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -243,31 +243,32 @@ async def test_stopping_is_true_when_the_worker_is_cancelled():
         assert gate._stopping() is True
 
 
+@pytest.mark.first_run
 async def test_first_run_hands_over_when_setup_is_required(tmp_path, monkeypatch):
     """Regression: an unmounted gate must not be mistaken for a torn-down one.
 
     ``push_screen`` returns an AwaitMount. Left unawaited, the boot worker could
     reach ``_stopping`` before the gate mounted, silently drop the handover, and
-    strand a first-run user on the loading screen forever.
+    strand a first-run user on the loading screen forever. A first run lands on
+    setup rather than on chat, so the assertion is that the gate steps aside at
+    all, not which screen takes its place.
     """
     import asyncio
     import time
 
     from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
     from lilbee.core.config import cfg
 
     monkeypatch.setattr(cfg, "lancedb_dir", tmp_path / "missing")  # forces needs_setup
-    revealed = mock.MagicMock()
-    monkeypatch.setattr(LilbeeApp, "reveal_chat", revealed)
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline and not revealed.called:
+        while time.monotonic() < deadline and isinstance(app.screen, StartupGate):
             await pilot.pause()
             await asyncio.sleep(0.02)
-
-    revealed.assert_called_once_with()
+        assert not isinstance(app.screen, StartupGate)
 
 
 async def test_gate_composes_and_styles_its_widgets(monkeypatch):

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -126,24 +126,21 @@ async def test_gate_releases_once_services_build_even_with_a_cold_engine(monkeyp
     first waits inside its own answer bubble. Holding the screen for the load
     would re-block every launch that the lazy path exists to unblock.
     """
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
-
-    provider = mock.MagicMock()
-    provider.role_ready.return_value = False  # engine is stone cold
-    services = mock.MagicMock()
-    services.provider = provider
-    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
+    order: list[str] = []
+    app.adopt_services.side_effect = lambda: order.append("adopt")
+    app.reveal_chat.side_effect = lambda: order.append("reveal")
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
         StartupGate._boot_worker.__wrapped__(gate)
-    app.reveal_chat.assert_called_once_with()
-    provider.role_ready.assert_not_called()
+    # The container, then the handover -- nothing in between asks the engine
+    # whether it has finished loading.
+    assert order == ["adopt", "reveal"]
 
 
 async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
@@ -169,13 +166,10 @@ async def test_gate_hands_nothing_over_when_setup_takes_the_screen(monkeypatch):
     Chat is not reachable while setup is outstanding, and the container is not
     worth building against models that do not resolve.
     """
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
     app.settle_setup_state.return_value = True
-    built = mock.Mock()
-    monkeypatch.setattr(gate_mod, "get_services", built)
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
@@ -183,7 +177,7 @@ async def test_gate_hands_nothing_over_when_setup_takes_the_screen(monkeypatch):
     ):
         StartupGate._boot_worker.__wrapped__(gate)
     app.reveal_chat.assert_not_called()
-    built.assert_not_called()
+    app.adopt_services.assert_not_called()
 
 
 async def test_gate_settles_setup_before_it_hands_over(monkeypatch):
@@ -215,11 +209,10 @@ async def test_gate_settles_setup_before_it_hands_over(monkeypatch):
 
 async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
     """A container that cannot be built must show the error, not hang the screen."""
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "get_services", mock.Mock(side_effect=OSError("disk gone")))
+    app.adopt_services.side_effect = OSError("disk gone")
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
@@ -315,13 +308,12 @@ async def test_the_container_is_built_behind_the_gate(monkeypatch):
 
     from lilbee.app.services import peek_services, set_services
     from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
     from tests._async_wait import wait_until
 
     set_services(None)
     container = mock.MagicMock()
-    monkeypatch.setattr(gate_mod, "get_services", lambda: container)
+    monkeypatch.setattr("lilbee.cli.tui.app.get_services", lambda: container)
     # An app with nothing to set up, so the gate runs its whole boot.
     monkeypatch.setattr("lilbee.cli.tui.app.models_ready", lambda: True)
 

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -98,6 +98,9 @@ def _gate_with_app():
     app = mock.MagicMock()
     app.call_from_thread.side_effect = lambda fn, *a: fn(*a)
     app.screen = gate  # the gate owns the screen, as it does in production
+    # An app with nothing to set up, so the gate reaches its handover. Tests
+    # about the setup route say so by flipping this.
+    app.settle_setup_state.return_value = False
     return gate, app
 
 
@@ -127,7 +130,6 @@ async def test_gate_releases_once_services_build_even_with_a_cold_engine(monkeyp
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
 
     provider = mock.MagicMock()
     provider.role_ready.return_value = False  # engine is stone cold
@@ -161,13 +163,17 @@ async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
     app.reveal_chat.assert_called_once_with()
 
 
-async def test_gate_reveals_chat_when_setup_is_required(monkeypatch):
-    """With no models installed the wizard owns the flow, so the gate steps aside."""
+async def test_gate_hands_nothing_over_when_setup_takes_the_screen(monkeypatch):
+    """Setup owns the screen, so the gate must not hand over on top of it.
+
+    Chat is not reachable while setup is outstanding, and the container is not
+    worth building against models that do not resolve.
+    """
     from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: True)
+    app.settle_setup_state.return_value = True
     built = mock.Mock()
     monkeypatch.setattr(gate_mod, "get_services", built)
     with (
@@ -176,8 +182,35 @@ async def test_gate_reveals_chat_when_setup_is_required(monkeypatch):
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
         StartupGate._boot_worker.__wrapped__(gate)
-    app.reveal_chat.assert_called_once_with()
+    app.reveal_chat.assert_not_called()
     built.assert_not_called()
+
+
+async def test_gate_settles_setup_before_it_hands_over(monkeypatch):
+    """An already built container still waits on the setup answer.
+
+    The container is built on the app's mount path, so this is the path every
+    launch takes. Handing over first and asking afterwards flashes up the very
+    chat screen the answer exists to withhold.
+    """
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    order: list[str] = []
+    app.settle_setup_state.side_effect = lambda: order.append("settle") or False
+    app.reveal_chat.side_effect = lambda: order.append("reveal")
+    monkeypatch.setattr(gate_mod, "peek_services", lambda: mock.MagicMock())
+    monkeypatch.setattr(gate_mod, "get_services", mock.Mock())
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    assert order == ["settle", "reveal"]
+    # Nothing to settle in the refs: that work belongs to the build it skipped.
+    app.canonicalize_persisted_models.assert_not_called()
 
 
 async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
@@ -186,7 +219,6 @@ async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
     monkeypatch.setattr(gate_mod, "get_services", mock.Mock(side_effect=OSError("disk gone")))
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
@@ -260,7 +292,7 @@ async def test_first_run_hands_over_when_setup_is_required(tmp_path, monkeypatch
     from lilbee.cli.tui.screens.startup_gate import StartupGate
     from lilbee.core.config import cfg
 
-    monkeypatch.setattr(cfg, "lancedb_dir", tmp_path / "missing")  # forces needs_setup
+    monkeypatch.setattr(cfg, "lancedb_dir", tmp_path / "missing")  # a fresh install
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
@@ -351,45 +383,33 @@ async def test_gate_hands_over_when_it_still_owns_the_screen():
     app.reveal_chat.assert_called_once_with()
 
 
-async def test_built_services_defer_the_handover_off_on_mount(monkeypatch):
+@pytest.mark.parametrize("container", [None, "built"])
+async def test_start_boot_always_takes_the_worker(monkeypatch, container):
     """Regression: switching screens inside on_mount stalled Textual.
 
-    start_boot runs at the tail of LilbeeApp.on_mount. Calling reveal_chat straight
-    from there switches screens mid-mount; defer it a frame instead.
+    start_boot runs at the tail of LilbeeApp.on_mount, so it must not hand over
+    inline. There is no longer a fast path for an already built container
+    either: the setup answer decides whether the handover happens at all, and
+    it is not a question the UI thread can afford to ask.
     """
     from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate = StartupGate()
-    monkeypatch.setattr(gate_mod, "peek_services", lambda: mock.MagicMock())
+    services = None if container is None else mock.MagicMock()
+    monkeypatch.setattr(gate_mod, "peek_services", lambda: services)
 
+    worker_calls: list = []
     deferred: list = []
     released: list = []
+    monkeypatch.setattr(gate, "_boot_worker", lambda: worker_calls.append(True), raising=False)
     monkeypatch.setattr(gate, "call_after_refresh", deferred.append, raising=False)
     monkeypatch.setattr(gate, "_release", lambda: released.append(True), raising=False)
 
     gate.start_boot()
 
-    assert released == [], "the handover must not run inside on_mount"
-    assert deferred == [gate._release]
-
-
-async def test_start_boot_builds_services_when_none_exist(monkeypatch):
-    """Without a container the gate takes the worker path, not the fast path."""
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-
-    gate = StartupGate()
-    monkeypatch.setattr(gate_mod, "peek_services", lambda: None)
-
-    worker_calls: list = []
-    deferred: list = []
-    monkeypatch.setattr(gate, "_boot_worker", lambda: worker_calls.append(True), raising=False)
-    monkeypatch.setattr(gate, "call_after_refresh", deferred.append, raising=False)
-
-    gate.start_boot()
-
     assert worker_calls == [True]
+    assert released == [], "the handover must not run inside on_mount"
     assert deferred == []
 
 
@@ -401,8 +421,9 @@ async def test_boot_worker_canonicalizes_before_the_setup_check(monkeypatch):
 
     gate, app = _gate_with_app()
     order: list[str] = []
+    monkeypatch.setattr(gate_mod, "peek_services", lambda: None)
     app.canonicalize_persisted_models.side_effect = lambda: order.append("canonicalize")
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: order.append("setup") or True)
+    app.settle_setup_state.side_effect = lambda: order.append("setup") or True
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
@@ -419,7 +440,7 @@ async def test_boot_worker_surfaces_a_canonicalization_failure(monkeypatch):
 
     gate, app = _gate_with_app()
     app.canonicalize_persisted_models.side_effect = OSError("registry unreadable")
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(gate_mod, "peek_services", lambda: None)
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),

--- a/tests/test_tab_navigation.py
+++ b/tests/test_tab_navigation.py
@@ -73,8 +73,8 @@ def _mock_services() -> Any:
 def _patch_chat_setup() -> Any:
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.needs_setup",
-            return_value=False,
+            "lilbee.cli.tui.app.models_ready",
+            return_value=True,
         ),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -53,7 +53,7 @@ def _mock_services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_task_center_polling.py
+++ b/tests/test_task_center_polling.py
@@ -241,7 +241,7 @@ async def test_go_back_switches_to_chat_on_lilbee_app() -> None:
 
     with (
         ready_services(),
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
     ):
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:

--- a/tests/test_task_center_polling.py
+++ b/tests/test_task_center_polling.py
@@ -232,7 +232,7 @@ async def test_cursor_actions_move_focus() -> None:
 async def test_go_back_switches_to_chat_on_lilbee_app() -> None:
     """go-back returns to chat, so this one needs the real app with a chat screen.
 
-    ready_services + needs_setup=False make the startup gate hand over to chat
+    ready_services pins readiness True, so the startup gate hands over to chat
     deterministically, without the setup wizard racing the pushed TaskCenter.
     """
     from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -44,7 +44,7 @@ def _isolated_cfg(tmp_path):
 def _patch_chat_setup():
     """Patch out embedding model checks and model scanning so ChatScreen mounts cleanly."""
     with (
-        mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.app.models_ready", return_value=True),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -37,8 +37,8 @@ def _isolated_cfg(tmp_path):
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
-    # Simulate "already-initialized" state so needs_setup()
-    # doesn't push the SetupWizard during tests that exercise chat.
+    # Simulate "already-initialized" state so the app does not read this as
+    # a fresh install and open the SetupWizard over tests that exercise chat.
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
     for field_name in type(snapshot).model_fields:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -3433,7 +3433,7 @@ class TestChatEmbeddingReadyCoverage:
         try:
             app = ChatTestApp()
             # Keep the ChatScreen mounted; wizard routing is covered separately.
-            with mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
+            with mock.patch("lilbee.cli.tui.app.models_ready", return_value=True):
                 async with app.run_test(size=(120, 40)) as pilot:
                     await pilot.pause()
                     screen = app.screen
@@ -3458,7 +3458,7 @@ class TestChatEmbeddingReadyCoverage:
         try:
             app = ChatTestApp()
             # Keep the ChatScreen mounted; wizard routing is covered separately.
-            with mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
+            with mock.patch("lilbee.cli.tui.app.models_ready", return_value=True):
                 async with app.run_test(size=(120, 40)) as pilot:
                     await pilot.pause()
                     screen = app.screen

--- a/tests/test_tui_fleet_drawer.py
+++ b/tests/test_tui_fleet_drawer.py
@@ -339,7 +339,7 @@ async def test_normal_tab_focuses_drawer_and_enter_toggles(monkeypatch) -> None:
     try:
         cs = "lilbee.cli.tui.screens.chat.ChatScreen"
         with (
-            mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+            mock.patch("lilbee.cli.tui.app.models_ready", return_value=True),
             mock.patch(f"{cs}._embedding_ready", return_value=True),
         ):
             app = LilbeeApp()

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -452,9 +452,9 @@ def _seeded_models(monkeypatch):
     monkeypatch.setattr(cfg, "embedding_model", "fake/embed-model")
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "reranker_model", "")
-    from lilbee.cli.tui.screens import chat as chat_screen_mod
+    from lilbee.cli.tui import app as app_mod
 
-    monkeypatch.setattr(chat_screen_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(app_mod, "models_ready", lambda: True)
 
 
 async def test_chat_screen_mounts_with_bar_present(_seeded_models) -> None:

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -67,8 +67,8 @@ def _mock_services():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.needs_setup",
-            return_value=False,
+            "lilbee.cli.tui.app.models_ready",
+            return_value=True,
         ),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -41,8 +41,8 @@ def _isolated_cfg(tmp_path):
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
-    # Simulate "already-initialized" state so needs_setup()
-    # doesn't push the SetupWizard during tests that exercise chat.
+    # Simulate "already-initialized" state so the app does not read this as
+    # a fresh install and open the SetupWizard over tests that exercise chat.
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
     for field_name in type(snapshot).model_fields:

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -633,9 +633,10 @@ async def test_switching_guard_blocks_concurrent_switch():
         app._switching = False
 
 
-async def test_lilbee_app_wires_worker_pool_notifications_on_mount() -> None:
-    """``on_mount`` calls ``Services.add_pool_listener`` so server spawn
-    lifecycle surfaces as Textual notifications. Verified by replacing the
+async def test_lilbee_app_wires_worker_pool_notifications_behind_the_gate() -> None:
+    """The gate hands the app the container it built, and the app calls
+    ``Services.add_pool_listener`` on it so server spawn lifecycle surfaces as
+    Textual notifications. Verified by replacing the
     Services singleton with a provider whose ``add_spawn_listener`` records the
     callbacks, then firing them from a worker thread (call_from_thread requires a
     different thread) so their notify() bodies execute against the live app."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -103,7 +103,7 @@ def _patch_chat_setup():
     from lilbee.cli.tui.widgets.model_bar import ModelBar
 
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,
@@ -3844,7 +3844,7 @@ async def test_chat_needs_setup_false_when_models_exist():
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.cli.tui.screens.setup import SetupWizard
 
-    with patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
+    with patch("lilbee.cli.tui.app.models_ready", return_value=True):
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -6694,27 +6694,6 @@ async def test_chat_cancel_stream_with_streaming_workers(mock_svc):
         app.screen.streaming = True
         app.screen.action_cancel_stream()
         assert app.screen.streaming is False
-
-
-async def test_chat_needs_setup_true_pushes_wizard():
-    """Verify needs_setup() returning True pushes SetupWizard on mount."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
-    from lilbee.cli.tui.screens.setup import SetupWizard
-
-    class SetupTestApp(LilbeeAppHost):
-        CSS = ""
-
-        def compose(self) -> ComposeResult:
-            yield Footer()
-
-        def on_mount(self) -> None:
-            self.push_screen(ChatScreen())
-
-    app = SetupTestApp()
-    with patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=True):
-        async with app.run_test(size=(120, 40)) as _pilot:
-            await _pilot.pause()
-            assert isinstance(app.screen, SetupWizard)
 
 
 async def test_chat_on_input_submitted_slash():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -70,8 +70,8 @@ def _isolated_cfg(tmp_path):
     cfg.chat_model = TEST_LOCAL_REF
     cfg.embedding_model = TEST_EMBED_REF
     cfg.chunk_size = 512
-    # Simulate "already-initialized" state so needs_setup()
-    # doesn't push the SetupWizard during tests that exercise chat.
+    # Simulate "already-initialized" state so the app does not read this as
+    # a fresh install and open the SetupWizard over tests that exercise chat.
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
     for name in type(cfg).model_fields:
@@ -3839,7 +3839,7 @@ async def test_chat_vim_j_k_skips_in_insert_mode():
         assert inp.has_focus
 
 
-async def test_chat_needs_setup_false_when_models_exist():
+async def test_chat_stays_up_when_models_exist():
     """Resolvable models must leave the chat screen up, with no setup wizard."""
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.cli.tui.screens.setup import SetupWizard

--- a/tests/test_tui_sessions.py
+++ b/tests/test_tui_sessions.py
@@ -30,7 +30,7 @@ def _services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+        patch("lilbee.cli.tui.app.models_ready", return_value=True),
         patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
         patch("lilbee.cli.tui.widgets.model_bar.ModelBar.on_mount"),
     ):

--- a/tests/test_view_tabs_visibility.py
+++ b/tests/test_view_tabs_visibility.py
@@ -51,8 +51,8 @@ def _mock_services():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.needs_setup",
-            return_value=False,
+            "lilbee.cli.tui.app.models_ready",
+            return_value=True,
         ),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",

--- a/tools/qa/conftest.py
+++ b/tools/qa/conftest.py
@@ -463,10 +463,10 @@ def tui_with_models(
     corpus so the TUI skips the setup wizard and lands on the chat screen
     with a live model bar.
 
-    ``ChatScreen._needs_setup()`` returns True when the LanceDB dir is
-    missing *or* a configured model can't be resolved. ``lilbee_env_with_models``
-    covers the second case; seeding + ``sync`` covers the first (it creates
-    and populates the LanceDB dir), so the wizard never fires.
+    The app opens the wizard when the LanceDB dir is missing *or* a configured
+    model can't be resolved. ``lilbee_env_with_models`` covers the second case;
+    seeding + ``sync`` covers the first (it creates and populates the LanceDB
+    dir), so the wizard never fires.
     """
     seed_fixture_corpus(lilbee_data)
     sync = run_lilbee_with_env(lane, ["sync"], env=lilbee_env_with_models, timeout=SYNC_TIMEOUT)


### PR DESCRIPTION
## The bug

On a fresh install lilbee already has a chat model and an embedding model configured, pointing at files that are not on disk. It hands you the chat screen anyway. The setup wizard then opens on top of that screen, so pressing Escape drops you back onto a prompt with no engine behind it and no route to the catalog.

Going back to Chat later was worse. The chat screen is built once per session, so its setup check never ran a second time and the tab led straight to the dead screen with no wizard at all.

Under both of those: the startup gate's setup check never ran in a shipped build. The app built the services container on its own mount path, so the gate always took its already-built shortcut, and the model canonicalisation that lives on the boot path never ran.

## The fix

Chat is entered only when a chat model and an embedding model both resolve. The question is asked once, on the gate's boot thread, and settled before any screen is handed over, so there is no window where chat appears first. When a model is missing, the wizard opens over the catalog, so Escape lands where models are installed.

The answer is refreshed whenever a model is assigned, whether from the wizard, the catalog, the settings editor, `/set`, or a download that finishes minutes later.

The services container is built behind the gate on its boot thread, and the app subscribes to the one it gets back instead of building its own.

## What was deleted

The chat screen's setup check and the wizard push that went with it. The gate's second boot path. `needs_setup`, now that its two questions each have their own caller.

## Not covered

Chat's input still accepts a prompt while the engine is still starting. Reaching chat now means both models resolve, but resolving and being warm are different things, and the submit guard has no not-ready state to check. That is a separate fix, tracked on its own.
