### PR TITLE
Publish an OpenAPI schema that tells streaming routes apart from body routes

### DIFF
--- a/.github/actions/attach-prerelease/action.yml
+++ b/.github/actions/attach-prerelease/action.yml
@@ -1,5 +1,5 @@
 name: Attach binaries and the lilbee wheel to GH pre-release
-description: "Attach this run's standalone executables and the pure lilbee wheel to a pre-release at the given tag. Caller needs contents:write. (Per-backend engine wheels are attached separately by attach-multigpu.)"
+description: "Attach this run's standalone executables, the pure lilbee wheel, and the OpenAPI schema to a pre-release at the given tag. Caller needs contents:write. (Per-backend engine wheels are attached separately by attach-multigpu.)"
 
 inputs:
   tag:
@@ -31,10 +31,18 @@ runs:
         name: wheel-default
         path: lilbee-wheel/
 
+    # The API contract for this version. One file, so clients pin a schema
+    # instead of introspecting a source checkout.
+    - name: Download the OpenAPI schema
+      uses: actions/download-artifact@v4
+      with:
+        name: openapi-schema
+        path: schema/
+
     - name: List release assets
       shell: bash
       run: |
-        ls -lh bins/ lilbee-wheel/
+        ls -lh bins/ lilbee-wheel/ schema/
 
     - name: Create GH pre-release with binaries and the lilbee wheel
       uses: softprops/action-gh-release@v3
@@ -43,5 +51,6 @@ runs:
         files: |
           bins/*
           lilbee-wheel/*
+          schema/openapi.json
         generate_release_notes: ${{ inputs.generate-notes == 'true' }}
         prerelease: ${{ contains(inputs.version, 'a') || contains(inputs.version, 'b') || contains(inputs.version, 'rc') }}

--- a/.github/workflows/attach-release-artifacts.yml
+++ b/.github/workflows/attach-release-artifacts.yml
@@ -49,6 +49,17 @@ jobs:
           run-id: ${{ inputs.run_id }}
           github-token: ${{ github.token }}
 
+      # continue-on-error: a stranded run may not have reached the schema job;
+      # attach whatever did build.
+      - name: Download the OpenAPI schema from the run
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: openapi-schema
+          path: schema/
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
       # continue-on-error: a stranded run may not have built the optional
       # multi-gpu artifacts; attach whatever did build.
       - name: Download multi-gpu wheels from the run
@@ -78,7 +89,7 @@ jobs:
           PY
 
       - name: List assets
-        run: ls -lh bins/ default-wheels/ multigpu-wheels/ || true
+        run: ls -lh bins/ default-wheels/ multigpu-wheels/ schema/ || true
 
       - name: Attach to the GH release
         uses: softprops/action-gh-release@v3
@@ -88,5 +99,6 @@ jobs:
             bins/*
             default-wheels/*
             multigpu-wheels/*
+            schema/*
           generate_release_notes: true
           prerelease: ${{ contains(inputs.version, 'a') || contains(inputs.version, 'b') || contains(inputs.version, 'rc') }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -126,6 +126,28 @@ jobs:
       - run: make lint
       - run: make format-check
 
+  # The API contract for this version, generated from the built app so it cannot
+  # drift from the routes. Attached beside the binaries so a client pins a
+  # schema instead of introspecting a source checkout.
+  build-openapi:
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - run: uv python install 3.12
+      - run: uv sync --locked
+      - run: uv run python tools/gen_openapi.py schema/openapi.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: openapi-schema
+          path: schema/openapi.json
+          if-no-files-found: error
+
   build-default-wheels:
     needs: [resolve, create-prerelease]
     if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.create-prerelease.result != 'failure' }}
@@ -199,7 +221,7 @@ jobs:
   # release is reversible (delete + retag) so this is safe to do eagerly; the
   # irreversible step (PyPI) waits for a human to run publish.yml.
   attach-prerelease:
-    needs: [resolve, build-default-wheels, build-binaries, build-cuda]
+    needs: [resolve, build-default-wheels, build-binaries, build-cuda, build-openapi]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -147,6 +147,38 @@ jobs:
             sleep 60
           done
 
+  # The contract clients pin. Checked here because the schema is one small file
+  # from one small job: a dropped artifact, or a schema that stopped naming its
+  # SSE routes, would otherwise ship silently.
+  verify-openapi:
+    needs: [resolve]
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: The published schema parses and declares its streaming routes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'openapi.json' --dir schema/
+          python3 - <<'PY'
+          import json, pathlib, sys
+          schema = json.loads(pathlib.Path("schema/openapi.json").read_text())
+          streamed = {
+              path
+              for path, ops in schema["paths"].items()
+              for op in ops.values()
+              for response in op.get("responses", {}).values()
+              if "text/event-stream" in (response.get("content") or {})
+          }
+          missing = {"/api/ask/stream", "/api/chat/stream", "/api/sync"} - streamed
+          if missing:
+              sys.exit(f"published schema documents these as JSON, not SSE: {sorted(missing)}")
+          print(f"{len(schema['paths'])} paths, {len(streamed)} streaming")
+          PY
+
   verify-executables:
     needs: [resolve]
     timeout-minutes: 45

--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,7 @@ engine-archs:  ## Regenerate the supported-architecture list from the pinned eng
 	uv run python tools/gen_supported_archs.py
 
 docs-api:  ## Generate OpenAPI schema and Redoc static HTML
-	uv run python -c "\
-	from lilbee.server.app import create_app; \
-	import json; \
-	app = create_app(); \
-	schema = app.openapi_schema.to_schema(); \
-	open('openapi.json', 'w').write(json.dumps(schema, indent=2))"
+	uv run python tools/gen_openapi.py openapi.json
 	npx --yes @redocly/cli build-docs openapi.json -o site/api/index.html
 	rm -f openapi.json
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1243,7 +1243,7 @@ Launched by `lilbee` or `lilbee chat`. Screens: chat, task center, model catalog
 - Wiki: `GET /api/wiki`, `GET /api/wiki/{slug}`, `GET /api/wiki/{slug}/citations`, `GET /api/wiki/citations?source=`, `GET /api/wiki/status`, `POST /api/wiki/build` (add `?dry_run=true` for the JSON entity preview), `PATCH /api/wiki/update`, `POST /api/wiki/synthesize` (these three are SSE streams), `POST /api/wiki/lint`, `POST /api/wiki/prune`, `DELETE /api/wiki` (wipe; the one wiki route that answers while the wiki is disabled), `POST /api/wiki/index`, `POST /api/wiki/generate/{slug}`, `GET /api/wiki/drafts`, `GET /api/wiki/drafts/diff/{slug}`, `POST /api/wiki/drafts/accept/{slug}`, `DELETE /api/wiki/drafts/{slug}`
 - Config: `GET /api/config`, `GET /api/config/defaults`, `PATCH /api/config`
 - Status/health: `GET /api/status`, `GET /api/health`
-- Interactive docs at `/schema/redoc`; OpenAPI JSON at `/schema/openapi.json`
+- Interactive docs at `/schema/redoc`; OpenAPI JSON at `/schema/openapi.json`. Every release also attaches the same schema as an `openapi.json` asset, so a client can pin the contract for a version without running the server. Streaming routes declare `text/event-stream` on the decorator, which is where litestar reads the documented content type from.
 
 All chat-generating endpoints (`/api/ask`, `/api/chat`, both their `/stream` variants, and `POST /v1/chat/completions`) share a process-wide chat lock so only one inference call runs at a time per server. Concurrent requests queue server-side; if the wait exceeds the configured timeout the request returns 429 with a `Retry-After: 1` header.
 

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -9,8 +9,10 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 import anyio.to_thread
-from litestar import Litestar
+from litestar import Litestar, MediaType, Request, Response
 from litestar.config.cors import CORSConfig
+from litestar.exceptions import HTTPException
+from litestar.exceptions.responses import create_exception_response
 from litestar.middleware.base import DefineMiddleware
 from litestar.openapi import OpenAPIConfig
 
@@ -232,6 +234,17 @@ async def _lifespan(app: Litestar) -> AsyncIterator[None]:
             svc.provider.shutdown()
 
 
+def _json_error_response(request: Request, exc: Exception) -> Response:
+    """Answer errors as JSON even on a route whose success media type is SSE.
+
+    Litestar builds an error response with the route handler's media type, so a
+    streaming route would label a JSON error body text/event-stream.
+    """
+    response = create_exception_response(request, exc)
+    response.media_type = MediaType.JSON
+    return response
+
+
 def create_app() -> Litestar:
     """Create the Litestar application instance."""
     cors = CORSConfig(
@@ -244,6 +257,7 @@ def create_app() -> Litestar:
     return Litestar(
         lifespan=[_lifespan, mcp_session_lifespan],
         middleware=[DefineMiddleware(AuthMiddleware)],
+        exception_handlers={HTTPException: _json_error_response},
         route_handlers=[
             mcp_route,
             health_route,

--- a/src/lilbee/server/chat_completions_api/routes.py
+++ b/src/lilbee/server/chat_completions_api/routes.py
@@ -48,6 +48,7 @@ from lilbee.server.chat_dispatch.dispatch import (
     dispatch_chat_stream,
     preflight_chat_request,
 )
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 
 log = logging.getLogger(__name__)
 
@@ -120,7 +121,13 @@ async def _auth_before_request(request: Request) -> Response | None:
 async def chat_completions_endpoint(
     request: Request, data: CompletionsRequest
 ) -> Response | Stream:
-    """``/v1/chat/completions`` (stream + non-stream + tools)."""
+    """``/v1/chat/completions`` (stream + non-stream + tools).
+
+    ``stream: true`` switches the 200 response from JSON to an SSE stream of
+    chat.completion.chunk frames. The request body picks the arm, which OpenAPI
+    cannot express, so the schema declares the JSON default and this contract
+    matches OpenAI's own.
+    """
     rejection = _reject_before_dispatch(request, data)
     if rejection is not None:
         return rejection
@@ -156,7 +163,7 @@ async def chat_completions_endpoint(
             _gated_completions_stream(
                 req, guard, model=resolved_model, include_usage=include_usage
             ),
-            media_type="text/event-stream",
+            media_type=SSE_MEDIA_TYPE,
             background=BackgroundTask(guard.release),
         )
     return await _run_non_stream(req, guard, canonical_model=resolved_model)

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -26,6 +26,10 @@ from lilbee.server.chat_completions_api.errors import CompletionsErrorCode
 
 log = logging.getLogger(__name__)
 
+# Litestar documents a response's content type from the route decorator, so a
+# streaming route passes this to both the decorator and the Stream it returns.
+SSE_MEDIA_TYPE = "text/event-stream"
+
 # Machine-readable ``code`` on an SSE error event. Load-time failures use
 # SseErrorCode; failed provider calls reuse ProviderErrorKind directly; the
 # RAG chat stream reuses the wire-layer CompletionsErrorCode for typed

--- a/src/lilbee/server/routes/crawl.py
+++ b/src/lilbee/server/routes/crawl.py
@@ -8,10 +8,11 @@ from litestar.exceptions import ValidationException
 from litestar.response import Stream
 
 from lilbee.server import handlers
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 from lilbee.server.models import CrawlRequest
 
 
-@post("/api/crawl")
+@post("/api/crawl", media_type=SSE_MEDIA_TYPE)
 async def crawl_route(data: CrawlRequest) -> Stream:
     """Crawl a URL with streaming SSE progress events."""
     from lilbee.crawler import require_valid_crawl_url
@@ -29,4 +30,4 @@ async def crawl_route(data: CrawlRequest) -> Stream:
         render_mode=data.render_mode,
         include_subdomains=data.include_subdomains,
     )
-    return Stream(gen, media_type="text/event-stream")
+    return Stream(gen, media_type=SSE_MEDIA_TYPE)

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -110,12 +110,18 @@ async def documents_remove_route(data: RemoveRequest) -> DocumentRemoveResponse:
     return await handlers.delete_documents(data.names)
 
 
-@get("/api/export")
+@get("/api/export", media_type="application/octet-stream")
 async def export_route(
     fmt: Annotated[str, QueryParameter(name="format")] = "",
     source: FromQuery[str] = "",
 ) -> Response[bytes]:
-    """Download the per-page text dataset as a file (parquet by default)."""
+    """Download the per-page text dataset as a file (parquet by default).
+
+    The media type is declared on the decorator as well as on the returned
+    Response for the same reason the streaming routes declare theirs: litestar
+    documents the content type from the decorator, so without it the schema
+    promises JSON and a generated client parses a parquet file as text.
+    """
     from lilbee.app.dataset import DatasetError, export_to_bytes
 
     try:

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -17,6 +17,7 @@ from litestar.response import Stream
 from pydantic import BaseModel, Field
 
 from lilbee.server import handlers
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 from lilbee.server.models import (
     AddRequest,
     DocumentListResponse,
@@ -31,7 +32,7 @@ class RemoveRequest(BaseModel):
     names: list[str] = Field(max_length=100)
 
 
-@post("/api/sync")
+@post("/api/sync", media_type=SSE_MEDIA_TYPE)
 async def sync_route(data: SyncRequest | None = None) -> Stream:
     """Re-index changed documents with streaming SSE progress events.
 
@@ -48,11 +49,11 @@ async def sync_route(data: SyncRequest | None = None) -> Stream:
         handlers.sync_stream(
             enable_ocr=enable_ocr, force_rebuild=force_rebuild, retry_skipped=retry_skipped
         ),
-        media_type="text/event-stream",
+        media_type=SSE_MEDIA_TYPE,
     )
 
 
-@post("/api/add")
+@post("/api/add", media_type=SSE_MEDIA_TYPE)
 async def add_route(data: AddRequest) -> Stream:
     """Add files to the knowledge base with streaming SSE progress."""
     try:
@@ -63,12 +64,12 @@ async def add_route(data: AddRequest) -> Stream:
         handlers.add_files_stream(
             paths, force=force, enable_ocr=enable_ocr, ocr_timeout=ocr_timeout
         ),
-        media_type="text/event-stream",
+        media_type=SSE_MEDIA_TYPE,
         status_code=201,
     )
 
 
-@post("/api/add/upload")
+@post("/api/add/upload", media_type=SSE_MEDIA_TYPE)
 async def add_upload_route(
     data: MultipartBody[list[UploadFile]],
 ) -> Stream:
@@ -88,7 +89,7 @@ async def add_upload_route(
     cleaned = [(name, await upload.read()) for name, upload in zip(names, data, strict=True)]
     return Stream(
         handlers.add_uploads_stream(cleaned),
-        media_type="text/event-stream",
+        media_type=SSE_MEDIA_TYPE,
         status_code=201,
     )
 
@@ -131,7 +132,7 @@ async def export_route(
     )
 
 
-@post("/api/import")
+@post("/api/import", media_type=SSE_MEDIA_TYPE)
 async def import_route(
     request: Request,
     fmt: Annotated[str, QueryParameter(name="format")] = "",
@@ -150,6 +151,6 @@ async def import_route(
         raise ValidationException(str(exc)) from exc
     return Stream(
         handlers.import_stream(await request.body(), fmt),
-        media_type="text/event-stream",
+        media_type=SSE_MEDIA_TYPE,
         status_code=201,
     )

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -20,6 +20,7 @@ from litestar.status_codes import HTTP_202_ACCEPTED
 from pydantic import ValidationError
 
 from lilbee.server import handlers
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 from lilbee.server.models import (
     ConfigResponse,
     ConfigUpdateResponse,
@@ -36,10 +37,10 @@ async def health_route() -> HealthResponse:
     return await handlers.health()
 
 
-@get("/api/warm/stream")
+@get("/api/warm/stream", media_type=SSE_MEDIA_TYPE)
 async def warm_stream_route() -> Stream:
     """Stream chat-model cold-load progress as SSE for a launcher's warm indicator."""
-    return Stream(handlers.warm_stream(), media_type="text/event-stream")
+    return Stream(handlers.warm_stream(), media_type=SSE_MEDIA_TYPE)
 
 
 @get("/api/status")

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -18,6 +18,7 @@ from lilbee.catalog.types import ModelSource
 from lilbee.modelhub.role_validator import TaskMismatchError
 from lilbee.server import handlers
 from lilbee.server.handlers import ModelsResponse, format_task_mismatch
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 from lilbee.server.models import (
     ExternalModelsResponse,
     ModelsCatalogResponse,
@@ -125,7 +126,7 @@ async def models_installed_route() -> ModelsInstalledResponse:
     return await handlers.models_installed()
 
 
-@post("/api/models/pull")
+@post("/api/models/pull", media_type=SSE_MEDIA_TYPE)
 async def models_pull_route(data: PullRequest) -> Stream:
     """Pull a model with streaming SSE progress events."""
     # Validate before opening the stream so an unsupported arch is a real 409, not
@@ -141,7 +142,7 @@ async def models_pull_route(data: PullRequest) -> Stream:
         handlers.models_pull(
             data.model, source=data.source, allow_unsupported=data.allow_unsupported
         ),
-        media_type="text/event-stream",
+        media_type=SSE_MEDIA_TYPE,
     )
 
 

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -23,6 +23,7 @@ from lilbee.core.config import cfg
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 from lilbee.server.models import GpusResponse, PlacementResponse, PlacementSpecBody
 
 log = logging.getLogger(__name__)
@@ -114,7 +115,7 @@ async def gpus_route() -> GpusResponse:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
 
 
-@get("/api/gpus/stream")
+@get("/api/gpus/stream", media_type=SSE_MEDIA_TYPE)
 async def gpu_stats_stream_route() -> Stream:
     """Live per-GPU utilization + free memory as SSE for the placement view."""
     from lilbee.app.placement import get_placement
@@ -126,4 +127,4 @@ async def gpu_stats_stream_route() -> Stream:
         view = await asyncio.to_thread(get_placement)
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
-    return Stream(handlers.gpu_stats_stream(view.gpus), media_type="text/event-stream")
+    return Stream(handlers.gpu_stats_stream(view.gpus), media_type=SSE_MEDIA_TYPE)

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -31,7 +31,7 @@ from lilbee.server.chat_dispatch.dispatch import (
     ModelDoesNotSupportToolsError,
     ModelNotFoundError,
 )
-from lilbee.server.handlers.sse import sse_error
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE, sse_error
 from lilbee.server.models import (
     AskRequest,
     AskResponse,
@@ -140,7 +140,7 @@ def _slot_gated_sse(generator: AsyncGenerator[str, None], guard: ChatSlotGuard) 
     """SSE Stream whose chat slot is freed by the generator or the after-send hook."""
     return Stream(
         _gated_stream(generator, guard),
-        media_type="text/event-stream",
+        media_type=SSE_MEDIA_TYPE,
         background=BackgroundTask(guard.release),
     )
 
@@ -199,7 +199,7 @@ async def ask_route(data: AskRequest) -> AskResponse:
         await release_chat_slot()
 
 
-@post("/api/ask/stream")
+@post("/api/ask/stream", media_type=SSE_MEDIA_TYPE)
 async def ask_stream_route(data: AskRequest) -> Stream:
     """Streaming SSE version of ask, emitting token-by-token answer chunks."""
     await _acquire_chat_lock_or_raise()
@@ -239,7 +239,7 @@ async def chat_route(data: ChatRequest) -> AskResponse:
         await release_chat_slot()
 
 
-@post("/api/chat/stream")
+@post("/api/chat/stream", media_type=SSE_MEDIA_TYPE)
 async def chat_stream_route(data: ChatRequest) -> Stream:
     """Streaming SSE version of chat with conversation history."""
     await _acquire_chat_lock_or_raise()

--- a/src/lilbee/server/routes/setup.py
+++ b/src/lilbee/server/routes/setup.py
@@ -28,6 +28,7 @@ from lilbee.crawler import (
     crawler_browsers_path,
 )
 from lilbee.server.handlers import SseStream
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 
 
 @get("/setup/crawler/status")
@@ -63,10 +64,10 @@ async def _bootstrap_crawler_stream() -> AsyncGenerator[str, None]:
         yield frame
 
 
-@post("/setup/crawler")
+@post("/setup/crawler", media_type=SSE_MEDIA_TYPE)
 async def setup_crawler_route() -> Stream:
     """Stream the Chromium bootstrap subprocess as SSE events."""
-    return Stream(_bootstrap_crawler_stream(), media_type="text/event-stream")
+    return Stream(_bootstrap_crawler_stream(), media_type=SSE_MEDIA_TYPE)
 
 
 __all__ = [

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -16,13 +16,14 @@ from litestar.exceptions import ClientException, NotFoundException
 from litestar.openapi.datastructures import ResponseSpec
 from litestar.params import FromPath, FromQuery
 from litestar.response import Stream
-from litestar.status_codes import HTTP_409_CONFLICT
+from litestar.status_codes import HTTP_200_OK, HTTP_409_CONFLICT
 
 from lilbee.app import services as svc_mod
 from lilbee.core.config import cfg
 from lilbee.core.security import PathTraversalError
 from lilbee.data.store import Store
 from lilbee.server import handlers
+from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
 from lilbee.server.models import (
     DraftInfoResponse,
     WikiBuildDryRunResult,
@@ -312,9 +313,12 @@ async def wiki_wipe_route() -> WikiWipeResult:
 
 @post(
     "/api/wiki/build",
+    media_type=SSE_MEDIA_TYPE,
     responses={
-        201: ResponseSpec(
+        HTTP_200_OK: ResponseSpec(
             data_container=WikiBuildDryRunResult,
+            media_type=MediaType.JSON,
+            generate_examples=False,
             description="Entity candidates a build would cover, when dry_run=true.",
         )
     },
@@ -325,21 +329,20 @@ async def wiki_build_route(
     """Build the concept and entity wiki across all ingested sources.
 
     A build issues per-source LLM calls and embeddings and can run for a long
-    time, so the response is an SSE stream: wiki_phase and wiki_page events
-    while it runs, then a done event carrying the summary. The work runs in a
-    worker thread and holds the wiki build mutex, so a second request streams
-    its own progress only once the first run finishes.
+    time, so the response is 201 with an SSE stream: wiki_phase and wiki_page
+    events while it runs, then a done event carrying the summary. The work runs
+    in a worker thread and holds the wiki build mutex, so a second request
+    streams its own progress only once the first run finishes.
 
-    ``dry_run=true`` answers with plain JSON instead: the NER entity candidates
-    a build would cover, with no LLM call made. The dry run returns a Response
-    carrying its own media type, and the annotation says so: a union of Stream
-    and a bare model resolves the whole route to JSON, which breaks every SSE
-    client on the streaming arm.
+    ``dry_run=true`` creates nothing, so it answers 200 with plain JSON: the
+    NER entity candidates a build would cover, with no LLM call made. The two
+    arms carry different content types, so each is declared under its own
+    status code.
     """
     _require_wiki()
     if dry_run:
         return await _build_dry_run()
-    return Stream(handlers.wiki_build_stream(), media_type="text/event-stream")
+    return Stream(handlers.wiki_build_stream(), media_type=SSE_MEDIA_TYPE)
 
 
 async def _build_dry_run() -> Response[WikiBuildDryRunResult]:
@@ -352,20 +355,20 @@ async def _build_dry_run() -> Response[WikiBuildDryRunResult]:
         count=len(rows),
         note=DRY_RUN_CONCEPT_NOTE,
     )
-    return Response(result, media_type=MediaType.JSON)
+    return Response(result, media_type=MediaType.JSON, status_code=HTTP_200_OK)
 
 
-@patch("/api/wiki/update")
+@patch("/api/wiki/update", media_type=SSE_MEDIA_TYPE)
 async def wiki_update_route() -> Stream:
     """Refresh the concept and entity wiki after an ingest.
 
     A full rebuild, streamed like /api/wiki/build.
     """
     _require_wiki()
-    return Stream(handlers.wiki_build_stream(), media_type="text/event-stream")
+    return Stream(handlers.wiki_build_stream(), media_type=SSE_MEDIA_TYPE)
 
 
-@post("/api/wiki/synthesize")
+@post("/api/wiki/synthesize", media_type=SSE_MEDIA_TYPE)
 async def wiki_synthesize_route() -> Stream:
     """Generate synthesis pages for concept clusters spanning 3+ sources.
 
@@ -373,7 +376,7 @@ async def wiki_synthesize_route() -> Stream:
     can't race a build over the same on-disk wiki tree.
     """
     _require_wiki()
-    return Stream(handlers.wiki_synthesize_stream(), media_type="text/event-stream")
+    return Stream(handlers.wiki_synthesize_stream(), media_type=SSE_MEDIA_TYPE)
 
 
 @get("/api/wiki/status")

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -678,7 +678,7 @@ class TestWikiEnabled:
         assert payload["stats"]["citation_verify_rate"] == 2 / 3
 
     async def test_build_dry_run_returns_candidates_as_json(self, monkeypatch):
-        """dry_run answers with the entity candidates, not an SSE stream."""
+        """dry_run answers 200 with the entity candidates, not a 201 SSE stream."""
 
         def build_boom(*a, **kw):
             raise AssertionError("dry_run must not build")
@@ -699,7 +699,7 @@ class TestWikiEnabled:
         )
         async with AsyncTestClient(_create_app()) as client:
             resp = await client.post("/api/wiki/build?dry_run=true", headers=_h())
-        assert resp.status_code == 201
+        assert resp.status_code == 200
         payload = resp.json()
         assert payload["dry_run"] is True
         assert payload["count"] == 1

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1149,7 +1149,49 @@ class TestDocumentsRemoveRoute:
         assert resp.json()["removed"] == ["a.md"]
 
 
+SSE_ROUTES = [
+    ("get", "/api/warm/stream"),
+    ("get", "/api/gpus/stream"),
+    ("post", "/api/ask/stream"),
+    ("post", "/api/chat/stream"),
+    ("post", "/api/sync"),
+    ("post", "/api/add"),
+    ("post", "/api/add/upload"),
+    ("post", "/api/import"),
+    ("post", "/api/models/pull"),
+    ("post", "/api/crawl"),
+    ("post", "/setup/crawler"),
+    ("post", "/api/wiki/build"),
+    ("post", "/api/wiki/synthesize"),
+    ("patch", "/api/wiki/update"),
+]
+
+
 class TestOpenAPISchema:
+    @pytest.mark.parametrize(("method", "path"), SSE_ROUTES)
+    def test_streaming_routes_publish_the_sse_media_type(self, client, method, path):
+        """Litestar reads the documented content type off the decorator, not off
+        the returned Stream, so a missing media_type publishes these as JSON and
+        no client can tell an SSE route from a body route."""
+        schema = client.get("/schema/openapi.json").json()
+        operation = schema["paths"][path][method]
+        streamed = [
+            media_type
+            for response in operation["responses"].values()
+            for media_type in (response.get("content") or {})
+            if media_type == "text/event-stream"
+        ]
+        assert streamed == ["text/event-stream"]
+
+    def test_schema_serializes_to_json(self):
+        """A ResponseSpec generates examples whatever create_examples says, and
+        polyfactory fills them with live pydantic instances, which stdlib json
+        cannot encode. The published asset is dumped that way rather than served
+        through litestar's own encoder, so the dump is what has to hold."""
+        from tools.gen_openapi import render_schema
+
+        assert json.loads(render_schema())["info"]["title"] == "lilbee"
+
     def test_schema_endpoint_returns_json(self, client):
         resp = client.get("/schema/openapi.json")
         assert resp.status_code == 200
@@ -1161,13 +1203,16 @@ class TestOpenAPISchema:
     def test_dry_run_payload_stays_in_the_schema(self, client):
         """The build route's return annotation unions a Stream with a generic
         Response, which litestar does not unwrap, so the dry-run payload is
-        declared on the decorator. Without that the published schema shows an
-        empty object and the model is not registered at all. The route is
-        registered unconditionally, so this holds with the wiki disabled."""
+        declared on the decorator under its own 200. Without that the published
+        schema shows an empty object and the model is not registered at all. The
+        route is registered unconditionally, so this holds with the wiki
+        disabled."""
         schema = client.get("/schema/openapi.json").json()
-        content = schema["paths"]["/api/wiki/build"]["post"]["responses"]["201"]["content"]
+        responses = schema["paths"]["/api/wiki/build"]["post"]["responses"]
+        content = responses["200"]["content"]
         assert "WikiBuildDryRunResult" in content["application/json"]["schema"]["$ref"]
         assert "WikiBuildDryRunResult" in schema["components"]["schemas"]
+        assert set(responses["201"]["content"]) == {"text/event-stream"}
 
     def test_redoc_endpoint(self, client):
         resp = client.get("/schema/redoc")
@@ -1359,6 +1404,17 @@ class TestCrawlRoute:
     def test_post_crawl_invalid_url(self, mock_stream, client):
         resp = client.post("/api/crawl", json={"url": "ftp://bad.com"})
         assert resp.status_code == 400
+
+    @mock.patch(
+        "lilbee.server.handlers.crawl_stream",
+        side_effect=ValueError("URL must start with http:// or https://"),
+    )
+    def test_error_on_a_streaming_route_stays_json(self, mock_stream, client):
+        """Litestar builds an error response with the handler's media type, so a
+        streaming route would otherwise label a JSON error body as SSE."""
+        resp = client.post("/api/crawl", json={"url": "ftp://bad.com"})
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json()["status_code"] == 400
 
     @mock.patch("lilbee.server.handlers.crawl_stream")
     def test_post_crawl_accepts_null_max_pages(self, mock_stream, client):

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1183,6 +1183,17 @@ class TestOpenAPISchema:
         ]
         assert streamed == ["text/event-stream"]
 
+    def test_export_publishes_the_octet_stream_media_type(self, client):
+        """/api/export answers with a parquet or jsonl body. It set its media
+        type on the returned Response only, so the schema promised JSON and a
+        generated client would have parsed the bytes as text. The error arm
+        stays JSON, which is what the exception handler is for."""
+        responses = client.get("/schema/openapi.json").json()["paths"]["/api/export"]["get"][
+            "responses"
+        ]
+        assert set(responses["200"]["content"]) == {"application/octet-stream"}
+        assert set(responses["400"]["content"]) == {"application/json"}
+
     def test_schema_serializes_to_json(self):
         """A ResponseSpec generates examples whatever create_examples says, and
         polyfactory fills them with live pydantic instances, which stdlib json

--- a/tools/gen_openapi.py
+++ b/tools/gen_openapi.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Write the server's OpenAPI schema to a file.
+
+The release attaches the result as ``openapi.json`` so a client can pin the
+contract for a version without a source checkout and a venv to introspect the
+app. The docs site renders the same file through Redoc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from lilbee.server.app import create_app
+
+_DEFAULT_OUT = Path("openapi.json")
+
+
+def render_schema() -> str:
+    """Serialize the app's OpenAPI schema as indented JSON."""
+    return json.dumps(create_app().openapi_schema.to_schema(), indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("out", nargs="?", type=Path, default=_DEFAULT_OUT)
+    args = parser.parse_args()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(render_schema(), encoding="utf-8")
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug

Every SSE route set `media_type` on the `Stream` it returned, but litestar documents a response's content type from the route decorator. The schema called all fourteen streaming routes `application/json`, so nothing in it separated an event stream from a body. `/api/wiki/update` and `/api/wiki/synthesize` became streams during the wiki rework and the Obsidian plugin kept calling `.json()` on them for weeks; no schema check could have caught that.

Dumping the schema failed outright. A `ResponseSpec` generates examples whatever `create_examples` says, and polyfactory fills them with live pydantic instances that stdlib json cannot encode, so `make docs-api` has been red since the wiki models landed.

## The fix

Streaming routes declare `text/event-stream` on the decorator, from one shared constant used for the decorator and the returned `Stream` alike. The wiki build route's `ResponseSpec` stops generating examples. Errors are answered as JSON app-wide, since litestar would otherwise label an error body with the handler's streaming media type.

## Routes that only sometimes stream

`/api/wiki/build` streams unless `?dry_run=true`. The dry run creates nothing, so it answers 200 rather than 201, and each arm is now declared under its own status code.

`/v1/chat/completions` picks its arm from the request body, which OpenAPI cannot express. It stays documented as JSON, the arm you get when `stream` is unset, matching OpenAI's own contract, and the handler says what `stream: true` changes.

## Published as a release asset

Releases attach `openapi.json`, generated in CI from the built app by the same script `make docs-api` uses. `verify-release` fails if it is missing or has stopped naming its streaming routes. Downstream, obsidian-lilbee#214 can drop the script that imports the app and reads handler annotations to find the streams.

## Downloads

`/api/export` had the same fault by a different route: it serves a parquet or jsonl body and set its media type on the returned `Response`, so the schema promised JSON and a generated client would have parsed the bytes as text. It declares `application/octet-stream` now. Its error arm stays JSON, which is what the exception handler above is for.

## Not covered

`/api/source` answers JSON or raw bytes depending on `?raw=`. A media type on the decorator would mislabel the common arm, so it stays documented as JSON, the same call made for the completions route.

