### PR TITLE
Keep possessive and adjectival NER forms out of wiki page subjects

### DIFF
--- a/src/lilbee/core/config/defaults.py
+++ b/src/lilbee/core/config/defaults.py
@@ -28,12 +28,13 @@ DEFAULT_IGNORE_DIRS = frozenset(
 
 # spaCy NER labels that map onto something wiki-shaped. Excludes
 # QUANTITY / ORDINAL / CARDINAL / DATE / TIME / MONEY / PERCENT /
-# LANGUAGE / LAW because pages for "42" or "2021" are never useful.
-# FAC (buildings / airports) and NORP (nationalities / political /
-# religious groups) are included because corpora routinely surface
-# them as wiki-worthy topics.
+# LANGUAGE / LAW because pages for "42" or "2021" are never useful, and
+# NORP (nationalities / political / religious groups) because its surfaces
+# are adjectival (Saturnian, American) and make poor page subjects; opt
+# back in via the config override. FAC (buildings / airports) stays:
+# corpora routinely surface them as wiki-worthy topics.
 DEFAULT_ALLOWED_NER_LABELS = frozenset(
-    {"PERSON", "ORG", "GPE", "LOC", "EVENT", "WORK_OF_ART", "PRODUCT", "FAC", "NORP"}
+    {"PERSON", "ORG", "GPE", "LOC", "EVENT", "WORK_OF_ART", "PRODUCT", "FAC"}
 )
 
 # Timeout for backend catalog / management HTTP calls.

--- a/src/lilbee/core/text.py
+++ b/src/lilbee/core/text.py
@@ -18,6 +18,18 @@ def collapse_whitespace(text: str) -> str:
     return _WHITESPACE_RE.sub(" ", text).strip()
 
 
+# Trailing possessive clitic on an entity surface: 's with a straight or
+# curly (U+2019) apostrophe, or the bare apostrophe of a plural possessive
+# (Voyagers'). Anchored to the end so a mid-label clitic (McDonald's
+# Corporation) stays.
+_POSSESSIVE_RE = re.compile("['\u2019]s?$")
+
+
+def strip_possessive(label: str) -> str:
+    """Drop a trailing possessive clitic from an entity surface form."""
+    return _POSSESSIVE_RE.sub("", label)
+
+
 # Characters that signal markdown-structural noise in a concept label.
 # Single source of truth for both ``is_valid_label`` (membership check)
 # and ``clean_label_for_display`` (regex strip).

--- a/src/lilbee/wiki/entity_extractor/ner_concepts.py
+++ b/src/lilbee/wiki/entity_extractor/ner_concepts.py
@@ -13,7 +13,7 @@ import re
 import threading
 from typing import TYPE_CHECKING, Any
 
-from lilbee.core.text import collapse_whitespace, is_valid_label, make_slug
+from lilbee.core.text import collapse_whitespace, is_valid_label, make_slug, strip_possessive
 from lilbee.wiki.entity_extractor.base import (
     ChunkRef,
     EntityKind,
@@ -102,6 +102,8 @@ class NerConceptsExtractor:
                     doc, ref, entity_records, allowed_ent_types, funnel, debug_enabled
                 )
 
+        _merge_possessives(entity_records)
+
         if debug_enabled:
             log.debug(
                 "ner funnel: raw_ents=%(raw_ents)d "
@@ -153,6 +155,25 @@ def _accumulate_doc_entities(
         rec = entity_records.setdefault(key, _Aggregate(label=surface, type_hint=ent.label_))
         rec.refs.add(ref)
         funnel["kept_entity_surfaces"] += 1
+
+
+def _merge_possessives(entity_records: dict[str, _Aggregate]) -> None:
+    """Fold each possessive surface into its standalone base entity, in place.
+
+    "Solar System's" and "Solar System" are one subject, but a name whose
+    canonical form carries the clitic (McDonald's) has no standalone base in
+    the corpus, so a possessive with no base aggregate stays as it is.
+    """
+    for key in list(entity_records):
+        agg = entity_records[key]
+        base = strip_possessive(agg.label)
+        if base == agg.label:
+            continue
+        base_agg = entity_records.get(make_slug(base))
+        if base_agg is None or base_agg is agg:
+            continue
+        base_agg.refs |= agg.refs
+        del entity_records[key]
 
 
 class _Aggregate:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1217,13 +1217,19 @@ class TestConceptAllowedEntTypes:
 
     def test_default_includes_core_wiki_types(self):
         c = Config()
-        for label in ("PERSON", "ORG", "GPE", "PRODUCT", "FAC", "NORP"):
+        for label in ("PERSON", "ORG", "GPE", "PRODUCT", "FAC", "EVENT"):
             assert label in c.concept_allowed_ent_types
 
     def test_default_excludes_quantitative_types(self):
         c = Config()
         for label in ("QUANTITY", "CARDINAL", "DATE", "TIME", "MONEY", "PERCENT"):
             assert label not in c.concept_allowed_ent_types
+
+    def test_default_excludes_norp(self):
+        """NORP surfaces are adjectival (Saturnian, American) and make poor
+        page subjects; a corpus that wants them opts back in via the env
+        override."""
+        assert "NORP" not in Config().concept_allowed_ent_types
 
     def test_env_override_replaces_defaults(self):
         # Replace-semantics: narrowing the set should NOT re-union with

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -446,6 +446,40 @@ class TestEntityTypeFilter:
         assert labels == {"Irv Rybicki"}
 
 
+class TestPossessiveMerge:
+    """A possessive surface is the same subject as its base form."""
+
+    def test_a_possessive_surface_merges_into_its_standalone_base(self):
+        doc_a = _FakeDoc(ents=[_FakeSpan("Solar System", "LOC")])
+        doc_b = _FakeDoc(ents=[_FakeSpan("Solar System's", "LOC")])
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"a": doc_a, "b": doc_b}):
+            result = extractor.extract([_chunk("s.txt", 0, "a"), _chunk("s.txt", 1, "b")])
+        [entity] = result
+        assert entity.label == "Solar System"
+        assert len(entity.chunk_refs) == 2
+
+    def test_a_possessive_with_no_standalone_base_keeps_its_clitic(self):
+        """McDonald's-shaped names carry the clitic canonically; without the
+        base form in the corpus there is nothing safe to merge into."""
+        doc = _FakeDoc(ents=[_FakeSpan("McDonald's", "ORG")])
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        [entity] = result
+        assert entity.label == "McDonald's"
+
+    def test_a_curly_possessive_merges_too(self):
+        doc = _FakeDoc(
+            ents=[_FakeSpan("Le Verrier", "PERSON"), _FakeSpan("Le Verrier\u2019s", "PERSON")]
+        )
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        [entity] = result
+        assert entity.label == "Le Verrier"
+
+
 class TestFunnelLogging:
     """Concept counters are absent; entity counters remain."""
 

--- a/tests/test_wiki_shared.py
+++ b/tests/test_wiki_shared.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lilbee.core.config import cfg
-from lilbee.core.text import clean_label_for_display, is_valid_label, make_slug
+from lilbee.core.text import clean_label_for_display, is_valid_label, make_slug, strip_possessive
 from lilbee.wiki.shared import (
     SUBDIR_TO_TYPE,
     WikiPageType,
@@ -98,6 +98,11 @@ class TestMakeSlug:
     def test_strips_leading_and_trailing_hyphens(self):
         assert make_slug("-well-known-") == "well-known"
 
+    def test_possessive_and_base_form_slug_apart(self):
+        # The possessive-merge pass relies on the two forms keying
+        # differently; if they ever slug alike the merge is a no-op.
+        assert make_slug("Solar System's") != make_slug("Solar System")
+
     def test_table_delimited_label_reduces_to_body(self):
         # Even if the sanity gate let this through, the slug should not
         # contain the leading double hyphen that bit bb-8b7s.
@@ -117,6 +122,29 @@ class TestMakeSlug:
         # strip. ``"---"`` must still collapse to ``""`` so the
         # ``if not slug: return None`` guard in the extractor fires.
         assert make_slug("---") == ""
+
+
+class TestStripPossessive:
+    @pytest.mark.parametrize(
+        ("label", "expected"),
+        [
+            ("Solar System's", "Solar System"),
+            ("Le Verrier\u2019s", "Le Verrier"),
+            ("Voyagers'", "Voyagers"),
+            ("Uranus\u2019", "Uranus"),
+        ],
+        ids=["straight", "curly", "plural-straight", "plural-curly"],
+    )
+    def test_strips_a_trailing_possessive_clitic(self, label: str, expected: str):
+        assert strip_possessive(label) == expected
+
+    @pytest.mark.parametrize(
+        "label",
+        ["Amazonis Planitia", "McDonald's Corporation", "O'Brien", ""],
+        ids=["plain", "clitic-mid-label", "leading-apostrophe-name", "empty"],
+    )
+    def test_leaves_everything_else_alone(self, label: str):
+        assert strip_possessive(label) == label
 
 
 class TestIsValidLabel:


### PR DESCRIPTION
## Problem
The unwritten-subject index offered "Solar System's", "Le Verrier's" and "Saturnian" beside real subjects like "Amazonis Planitia" — genuine extractions, poor page titles, and indistinguishable from good ones, so every surface listing subjects showed them.

## Possessives
spaCy entity spans carry the trailing clitic and the surface was recorded verbatim. The extractor now folds a possessive surface into its standalone base entity when the corpus extracted the base on its own, so "Solar System's" and "Solar System" become one subject with combined mentions. A name whose canonical form carries the clitic (McDonald's) has no standalone base and keeps it — stripping is never applied blind.

## Adjectivals
"Saturnian" enters as NORP, whose surfaces are adjectival by definition (nationalities, group demonyms). NORP is out of the default allowed NER label set; a corpus that wants those pages opts back in through the existing env/config override.

## Existing indexes
Already-built stub indexes keep their old entries until the next `wiki index` refresh; nothing rewrites them in place.