### PR TITLE
Link a page written on request into the wiki

### DIFF
--- a/src/lilbee/wiki/batch.py
+++ b/src/lilbee/wiki/batch.py
@@ -174,7 +174,7 @@ def archive_legacy_concept_pages(
 def _unwrap_archived_links(wiki_root: Path, archived_slugs: list[str]) -> None:
     """Rewrite ``[[slug]]`` → ``slug`` (plain text) across remaining wiki pages.
 
-    The existing ``_rewrite_links_across_wiki`` path is the wrong
+    The existing ``rewrite_links_across_wiki`` path is the wrong
     tool here: it compiles an *additive* surface map, not a
     removal pass. Walk the active wiki content subdirs once per
     archived slug is acceptable because the archive count is

--- a/src/lilbee/wiki/generation.py
+++ b/src/lilbee/wiki/generation.py
@@ -197,7 +197,7 @@ def _augment_surface_map_with_existing_pages(
             surface_to_slug.setdefault(spaced, slug)
 
 
-def _rewrite_links_across_wiki(entities: list[ExtractedEntity], config: Config) -> None:
+def rewrite_links_across_wiki(entities: list[ExtractedEntity], config: Config) -> None:
     """Rewrite ``[[slug]]`` links on every page under ``wiki/`` content subdirs.
 
     A page never receives a link to itself: the rewriter takes the
@@ -312,7 +312,7 @@ def build_wiki(
             ),
         )
 
-    _rewrite_links_across_wiki(entities, config)
+    rewrite_links_across_wiki(entities, config)
     log.info("Generated %d batched wiki pages", len(pages))
     return pages
 

--- a/src/lilbee/wiki/lazy.py
+++ b/src/lilbee/wiki/lazy.py
@@ -27,6 +27,7 @@ from lilbee.runtime.progress import (
 
 from .batch import hash_existing_sources
 from .citations import resolve_multi_source_citations
+from .generation import rewrite_links_across_wiki
 from .page import (
     chunks_to_text,
     generate_page,
@@ -173,6 +174,14 @@ def generate_stub_page(
             supersedes_sources=False,
         )
         if path is not None:
+            # Link it into the wiki, the way a build does. Without this a page
+            # written on request carries no [[links]] at all while every page
+            # written by a build carries several, so it lands in the vault as an
+            # isolated node: in the wiki but not part of it, and alone in the
+            # graph. Passing no entities is deliberate; the surface map is built
+            # from the pages already on disk, which now includes this one, so
+            # the new page gains links out and its neighbours gain links back.
+            rewrite_links_across_wiki([], config)
             on_progress(
                 EventType.WIKI_PAGE,
                 WikiPageEvent(label=stub.label, pages=1, current=1, total=1),

--- a/src/lilbee/wiki/lazy.py
+++ b/src/lilbee/wiki/lazy.py
@@ -174,13 +174,10 @@ def generate_stub_page(
             supersedes_sources=False,
         )
         if path is not None:
-            # Link it into the wiki, the way a build does. Without this a page
-            # written on request carries no [[links]] at all while every page
-            # written by a build carries several, so it lands in the vault as an
-            # isolated node: in the wiki but not part of it, and alone in the
-            # graph. Passing no entities is deliberate; the surface map is built
-            # from the pages already on disk, which now includes this one, so
-            # the new page gains links out and its neighbours gain links back.
+            # The link pass a build runs; without it the page has no [[links]]
+            # and sits alone in the graph. No entities: the surface map is then
+            # built from the pages on disk, this one included, so links go both
+            # ways.
             rewrite_links_across_wiki([], config)
             on_progress(
                 EventType.WIKI_PAGE,

--- a/tests/test_wiki_lazy.py
+++ b/tests/test_wiki_lazy.py
@@ -298,9 +298,8 @@ class TestResolveStub:
 
 
 class TestGeneratedPagesJoinTheWiki:
-    """A page written on request used to carry no ``[[links]]`` at all, while
-    every page a build wrote carried several. It landed in the vault as an
-    isolated node: in the wiki, but not part of it, and alone in the graph."""
+    """A page written on request carried no ``[[links]]``, so it sat alone in
+    the graph while every page a build wrote was connected."""
 
     def _entities_dir(self) -> Path:
         d = cfg.data_root / cfg.wiki_dir / "entities"
@@ -326,8 +325,7 @@ class TestGeneratedPagesJoinTheWiki:
         assert "[[henry-ford]]" in new_page.read_text(encoding="utf-8")
 
     def test_its_neighbours_link_back_to_the_new_page(self):
-        """Links only outward would still leave the page with no backlinks, so
-        it would sit on the edge of the graph rather than inside it."""
+        """Outward links alone would leave it with no backlinks."""
         entities = self._entities_dir()
         neighbour = entities / "henry-ford.md"
         neighbour.write_text("---\n---\nHe built the model t.\n", encoding="utf-8")

--- a/tests/test_wiki_lazy.py
+++ b/tests/test_wiki_lazy.py
@@ -295,3 +295,64 @@ class TestResolveStub:
     def test_an_unknown_slug_resolves_to_none(self):
         save_stub_index({})
         assert resolve_stub("nope", cfg) is None
+
+
+class TestGeneratedPagesJoinTheWiki:
+    """A page written on request used to carry no ``[[links]]`` at all, while
+    every page a build wrote carried several. It landed in the vault as an
+    isolated node: in the wiki, but not part of it, and alone in the graph."""
+
+    def _entities_dir(self) -> Path:
+        d = cfg.data_root / cfg.wiki_dir / "entities"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_the_new_page_links_out_to_its_neighbours(self):
+        entities = self._entities_dir()
+        (entities / "henry-ford.md").write_text("---\n---\nAbout the man.\n", encoding="utf-8")
+        new_page = entities / "model-t.md"
+
+        def write_it(**kwargs):
+            new_page.write_text(
+                "---\n---\nThe Model T was built by henry ford.\n", encoding="utf-8"
+            )
+            return new_page
+
+        save_stub_index({"model-t": _stub("model-t", (("a.md", 0),))})
+        store = _store_with({"a.md": [make_search_chunk(source="a.md", chunk_index=0)]})
+        with patch("lilbee.wiki.lazy.generate_page", side_effect=write_it):
+            generate_stub_page("model-t", store, cfg)
+
+        assert "[[henry-ford]]" in new_page.read_text(encoding="utf-8")
+
+    def test_its_neighbours_link_back_to_the_new_page(self):
+        """Links only outward would still leave the page with no backlinks, so
+        it would sit on the edge of the graph rather than inside it."""
+        entities = self._entities_dir()
+        neighbour = entities / "henry-ford.md"
+        neighbour.write_text("---\n---\nHe built the model t.\n", encoding="utf-8")
+        new_page = entities / "model-t.md"
+
+        def write_it(**kwargs):
+            new_page.write_text("---\n---\nA car.\n", encoding="utf-8")
+            return new_page
+
+        save_stub_index({"model-t": _stub("model-t", (("a.md", 0),))})
+        store = _store_with({"a.md": [make_search_chunk(source="a.md", chunk_index=0)]})
+        with patch("lilbee.wiki.lazy.generate_page", side_effect=write_it):
+            generate_stub_page("model-t", store, cfg)
+
+        assert "[[model-t]]" in neighbour.read_text(encoding="utf-8")
+
+    def test_a_failed_generation_does_not_rewrite_anything(self):
+        entities = self._entities_dir()
+        neighbour = entities / "henry-ford.md"
+        original = "---\n---\nHe built the model t.\n"
+        neighbour.write_text(original, encoding="utf-8")
+
+        save_stub_index({"model-t": _stub("model-t", (("a.md", 0),))})
+        store = _store_with({"a.md": [make_search_chunk(source="a.md", chunk_index=0)]})
+        with patch("lilbee.wiki.lazy.generate_page", return_value=None):
+            generate_stub_page("model-t", store, cfg)
+
+        assert neighbour.read_text(encoding="utf-8") == original

--- a/tests/test_wiki_lazy.py
+++ b/tests/test_wiki_lazy.py
@@ -354,3 +354,67 @@ class TestGeneratedPagesJoinTheWiki:
             generate_stub_page("model-t", store, cfg)
 
         assert neighbour.read_text(encoding="utf-8") == original
+
+
+class TestGeneratingOnRequestEndToEnd:
+    """The whole path with only the model stubbed: real prompt, real citation
+    verification, real faithfulness gate, real page write, real link pass. The
+    class above patches ``generate_page``, so it proves the call happens but not
+    that a page written this way actually reaches the vault linked."""
+
+    _RESPONSE = (
+        "# Amazonis Planitia\n\n"
+        "> Amazonis Planitia is a plain on mars.[^src1]\n\n"
+        "---\n"
+        "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+        '[^src1]: a.md, excerpt: "Amazonis Planitia is a plain on mars."\n'
+    )
+
+    def _provider(self):
+        from lilbee.providers.base import ChatResult, FinishReason
+
+        provider = MagicMock()
+        provider.get_capabilities.return_value = []
+        provider.chat.return_value = ChatResult(
+            text=self._RESPONSE, tool_calls=(), finish_reason=FinishReason.STOP
+        )
+        return provider
+
+    def test_the_page_reaches_the_vault_linked_to_its_neighbours(self):
+        entities = cfg.data_root / cfg.wiki_dir / "entities"
+        entities.mkdir(parents=True, exist_ok=True)
+        neighbour = entities / "mars.md"
+        neighbour.write_text(
+            "---\n---\nMars is the fourth planet. Amazonis Planitia lies on it.\n",
+            encoding="utf-8",
+        )
+
+        text = "Amazonis Planitia is a plain on mars."
+        chunk = make_search_chunk(source="a.md", chunk_index=0, chunk=text)
+        save_stub_index({"amazonis-planitia": _stub("amazonis-planitia", (("a.md", 0),))})
+        store = _store_with({"a.md": [chunk]})
+
+        services = MagicMock()
+        services.provider = self._provider()
+        # The faithfulness score needs an embedder, which the test environment
+        # has no engine for. Left real it scores 0, the page is quarantined to
+        # drafts/, and this would silently stop testing the published path.
+        # page.py resolves services itself to embed the written body.
+        page_services = MagicMock()
+        page_services.embedder.embed_batch.side_effect = lambda chunks: [
+            [0.1] * cfg.embedding_dim for _ in chunks
+        ]
+        with (
+            patch("lilbee.wiki.lazy.get_services", return_value=services),
+            patch("lilbee.wiki.page.get_services", return_value=page_services),
+            patch("lilbee.wiki.page.check_faithfulness", return_value=1.0),
+        ):
+            path = generate_stub_page("amazonis-planitia", store, cfg)
+
+        assert path.parent.name == "entities", f"quarantined to {path.parent.name}/"
+
+        assert path is not None, "the page was not written at all"
+        body = path.read_text(encoding="utf-8")
+        assert "[^src1]" in body, "the citation did not survive verification"
+        assert "[[mars]]" in body, "the page reached the vault with no links"
+        assert "[[amazonis-planitia]]" in neighbour.read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

A page written by the full build carries `[[links]]` to related subjects. A page written on request through `POST /api/wiki/generate/{slug}` carried none.

Measured on the same server, same model, same corpus:

```
entities/saturn.md             build-time      3 wikilinks
entities/amazonis-planitia.md  written live    0 wikilinks
```

Obsidian agrees: the generated page had 0 outgoing links and 0 backlinks, so a user who fills a gap from the wiki gets a page that is in the wiki but not part of it, sitting alone in the graph while everything around it is connected.

## Cause

`build_wiki` runs the link pass over the wiki after writing pages. `generate_stub_page` writes its page and returns.

## Fix

The lazy path runs the same pass. It is called with no entities on purpose: the surface map is then built from the pages already on disk, which by that point includes the new one, so the new page gains links out and its neighbours gain links back in the same walk.

`_rewrite_links_across_wiki` becomes `rewrite_links_across_wiki`, since it now has a caller outside its own module.

## Tests

Three, and the first two fail without the fix:

- the new page links out to a neighbour already on disk
- a neighbour that names the new subject links back to it, so the page has backlinks rather than only outgoing edges
- a generation that produces no page rewrites nothing

`make check` green: 12489 passed, 100% coverage.

## Validated end to end

Added `TestGeneratingOnRequestEndToEnd`: the real prompt, the real citation verification, the real faithfulness gate, the real page write and the real link pass, with only the model stubbed. It asserts the page lands under `entities/` rather than being quarantined, keeps its citation, links out to a neighbour, and that the neighbour links back.

Without the fix it fails with "the page reached the vault with no links".

Writing it turned up two things worth knowing:

The page is quarantined to `drafts/` when the faithfulness score cannot be computed, which in a test environment with no embedder is always. Left unstubbed the test would have passed while silently never exercising the published path, so it now asserts the subdirectory explicitly.

Accepting a draft has the same gap this PR fixes: `accept_draft` publishes a page and never links it. That is a different entry point and is filed as bb-x2rrl rather than widened into this change.
