### PR TITLE
Link an accepted draft into the wiki

### DIFF
--- a/src/lilbee/wiki/drafts.py
+++ b/src/lilbee/wiki/drafts.py
@@ -31,6 +31,7 @@ from lilbee.wiki.citations import (
     strip_citation_block,
     verify_citation,
 )
+from lilbee.wiki.generation import rewrite_links_across_wiki
 from lilbee.wiki.index import update_wiki_index
 from lilbee.wiki.page import index_wiki_page, indexable_chunks
 from lilbee.wiki.shared import (
@@ -454,6 +455,10 @@ def accept_draft(
                 "re-run accept once the index is writable"
             )
         update_wiki_index(config)
+        # Same link pass a build runs. An accepted draft is a published page,
+        # and without this it arrives with no [[links]] and sits alone in the
+        # graph, the way a page written on request did before #710.
+        rewrite_links_across_wiki([], config, wiki_root)
         draft.unlink()
     log.info("Accepted draft %s -> %s (%d chunks indexed)", slug, target, reindexed)
     return AcceptResult(

--- a/src/lilbee/wiki/generation.py
+++ b/src/lilbee/wiki/generation.py
@@ -197,7 +197,9 @@ def _augment_surface_map_with_existing_pages(
             surface_to_slug.setdefault(spaced, slug)
 
 
-def rewrite_links_across_wiki(entities: list[ExtractedEntity], config: Config) -> None:
+def rewrite_links_across_wiki(
+    entities: list[ExtractedEntity], config: Config, wiki_root: Path | None = None
+) -> None:
     """Rewrite ``[[slug]]`` links on every page under ``wiki/`` content subdirs.
 
     A page never receives a link to itself: the rewriter takes the
@@ -209,7 +211,10 @@ def rewrite_links_across_wiki(entities: list[ExtractedEntity], config: Config) -
     compiled once per build and reused across pages.
     """
     surface_to_slug = _entity_surface_map(entities)
-    wiki_root = config.data_root / config.wiki_dir
+    # Callers that were handed a root use it: accept publishes into the root it
+    # was given, which is not always the one the config points at.
+    if wiki_root is None:
+        wiki_root = config.data_root / config.wiki_dir
     _augment_surface_map_with_existing_pages(surface_to_slug, wiki_root)
     rewriter = compile_rewriter(surface_to_slug)
     if rewriter is None:

--- a/tests/test_wiki_drafts.py
+++ b/tests/test_wiki_drafts.py
@@ -218,6 +218,28 @@ class TestAcceptDraft:
         assert not (wiki_root / WikiSubdir.DRAFTS / "brakes.md").exists()
         assert "new brakes body" in (wiki_root / WikiSubdir.CONCEPTS / "brakes.md").read_text()
 
+    def test_an_accepted_draft_is_linked_into_the_wiki(self, tmp_path: Path) -> None:
+        """An accepted draft is a published page. Without the link pass it
+        arrived with no ``[[links]]`` and sat alone in the graph."""
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / WikiSubdir.ENTITIES / "mars.md", "Mars is the fourth planet.\n")
+        _write(
+            wiki_root / WikiSubdir.ENTITIES / "olympus-mons.md",
+            "old body mentioning nothing\n",
+        )
+        _write(
+            wiki_root / WikiSubdir.DRAFTS / "olympus-mons.md",
+            _draft_content("Olympus Mons is a volcano on mars."),
+        )
+        store = MagicMock()
+        with patch("lilbee.wiki.drafts.index_wiki_page", return_value=1):
+            accept_draft("olympus-mons", wiki_root, store)
+
+        published = (wiki_root / WikiSubdir.ENTITIES / "olympus-mons.md").read_text(
+            encoding="utf-8"
+        )
+        assert "[[mars]]" in published, "the accepted page reached the wiki with no links"
+
     def test_accepts_into_summaries_when_no_published_counterpart(self, tmp_path: Path) -> None:
         wiki_root = tmp_path / "wiki"
         _write(wiki_root / WikiSubdir.DRAFTS / "fresh.md", _draft_content("fresh body"))


### PR DESCRIPTION
## Problem

#710 fixed pages written on request. Accepting a draft is the other way a page reaches the wiki, and it had the same gap: `accept_draft` writes the published body, registers citations, re-indexes, and never links it. So a page that arrives through the drafts queue carries no `[[links]]` and sits alone in the graph.

Found while writing #710's end-to-end test: with no embedder the faithfulness score is 0, every generated page is quarantined to `drafts/`, and accepting it later is what should link it.

## Fix

`accept_draft` runs the same pass, after the page is published and before the draft is deleted.

`rewrite_links_across_wiki` gains an optional `wiki_root`. `accept_draft` is handed a root and publishes into it, which is not always the one the config points at; deriving the root from config would have walked the wrong tree wherever those differ.

## Tests

One, and it fails without the fix with "the accepted page reached the wiki with no links". Two neighbours on disk, a draft that names one of them, accept, then assert the published page gained the link.

`make check` green: 12492 passed, 100% coverage.
