### PR TITLE
Publish which AMD cards each ROCm build can serve

### DIFF
--- a/.github/workflows/build-gpu-executables.yml
+++ b/.github/workflows/build-gpu-executables.yml
@@ -384,13 +384,19 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
-          # The second path exists on the ROCm cell only; upload-artifact warns
-          # for a pattern that matches nothing and uploads the rest.
-          path: |
-            dist/${{ matrix.asset_name }}
-            dist/${{ matrix.asset_name }}.gfx.txt
+          path: dist/${{ matrix.asset_name }}
           # The onefile payload is already zstd-compressed; deflating it again buys nothing.
           compression-level: 0
+
+      # Its own artifact, not a second path on the step above: that step is shared
+      # by every GPU cell, and only this one produces a manifest. attach-release-artifacts
+      # collects it with the binaries either way -- both match its `lilbee-*` pattern.
+      - name: Upload the ROCm kernel manifest as a run artifact
+        if: matrix.backend == 'rocm'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.asset_name }}.gfx.txt
+          path: dist/${{ matrix.asset_name }}.gfx.txt
 
       # workflow_call eager attach: the caller created the pre-release shell,
       # so each cell's exe appears on the release as soon as it builds.

--- a/.github/workflows/build-gpu-executables.yml
+++ b/.github/workflows/build-gpu-executables.yml
@@ -295,6 +295,7 @@ jobs:
           # find it by shape rather than by that name.
           bin_dir=$(find dist -type d -path '*lilbee_engine/bin' | head -1)
           [ -n "${bin_dir}" ] || { echo "no bundled engine found under dist/" >&2; exit 1; }
+          echo "ENGINE_BIN_DIR=${bin_dir}" >> "${GITHUB_ENV}"
           # rocBLAS also loads Tensile kernels as data, so the directory is required
           # the same way the libraries are.
           if [ "${BACKEND}" = "rocm" ]; then
@@ -318,6 +319,32 @@ jobs:
           if [ "${BACKEND}" = "rocm" ]; then
             bash tools/qa/assert_rocm_bundle_loads.sh "${bin_dir}"
           fi
+
+      # A ROCm build serves only the cards it carries rocBLAS kernels for, and
+      # rocm_runtime.py reads those kernels back at startup to refuse a host it
+      # cannot serve. A downloader has to make the same call before it has a
+      # binary to read, so publish the list beside the binary. Generated from the
+      # bundle being shipped, so it cannot describe a different build.
+      - name: Publish the gfx targets this ROCm build ships kernels for
+        if: matrix.backend == 'rocm'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.release_tag || inputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          manifest="dist/${{ matrix.asset_name }}.gfx.txt"
+          for kernels in "${ENGINE_BIN_DIR}"/rocblas/library/TensileLibrary_lazy_gfx*.dat; do
+            name="${kernels##*/}"
+            name="${name#TensileLibrary_lazy_}"
+            echo "${name%.dat}"
+          done | sort -u > "${manifest}"
+          # An empty manifest reads as "supports nothing" and would turn every AMD
+          # host away, so a bundle with no kernels fails the cell instead.
+          [ -s "${manifest}" ] || { echo "the bundle carries no rocBLAS kernels" >&2; exit 1; }
+          cat "${manifest}"
+          [ -z "${TAG}" ] || gh release upload "${TAG}" "${manifest}" --clobber
 
       - name: Smoke test
         # GPU cells run on GPU-less runners: the bundled server links the vendor
@@ -357,7 +384,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
-          path: dist/${{ matrix.asset_name }}
+          # The second path exists on the ROCm cell only; upload-artifact warns
+          # for a pattern that matches nothing and uploads the rest.
+          path: |
+            dist/${{ matrix.asset_name }}
+            dist/${{ matrix.asset_name }}.gfx.txt
           # The onefile payload is already zstd-compressed; deflating it again buys nothing.
           compression-level: 0
 

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -93,6 +93,7 @@ jobs:
           lilbee-windows-x86_64-cu124.exe
           lilbee-windows-x86_64-cu125.exe
           lilbee-linux-x86_64-rocm
+          lilbee-linux-x86_64-rocm.gfx.txt
           lilbee-macos-x86_64
           lilbee-compat-macos-x86_64
           EOF


### PR DESCRIPTION
## Problem

A ROCm build only serves cards it carries rocBLAS kernels for. The engine already knows this at startup: `rocm_runtime.py` reads the bundled kernels and refuses to start on a card they do not cover, rather than aborting mid-answer at the first matrix multiply. Anything choosing a build before it has one to read cannot make that call. The list is not guessable either: it is computed at build time from what the pinned ROCm toolchain accepts, which is why gfx906 is in the wanted list in `cmake_args.sh` but absent from what the build actually ships.

## Solution

The ROCm cell writes `lilbee-linux-x86_64-rocm.gfx.txt` from the rocBLAS kernels in the bundle it just built, and uploads it with the binary in both the release and dispatch paths. It is generated from the artifact being shipped, so it cannot describe a different build.

A bundle carrying no kernels fails the cell. An empty manifest would read as "supports nothing" and turn every AMD host away.

`verify-release.yml` lists the manifest among the assets a release must carry, so a release cannot ship the ROCm binary without it.

Existing releases were backfilled from their own ROCm wheels, whose zip central directory names the same kernel files.