### PR TITLE
Point the site and README at the two graded reels

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ One model serves as many agents as you want to run. These reels show four workin
 
 ![four agents at once on Qwen3 Coder Next, reading and searching this repository through lilbee](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.gif)
 
-Qwen3 Coder Next on one RTX 5090, at 130 tokens/sec on a single stream.
+Qwen3 Coder Next, 45GB across three RTX 4090s, holding all four agents for the full reel.
 
-![four agents at once on MiniMax M2.7, investigating lilbee's engine lifecycle](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.gif)
+![four agents at once on Devstral Small 2 24B, working the same four tasks](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.gif)
 
-The same shape carrying a large model: MiniMax M2.7 across three A100s, at 60.9 tokens/sec on a single stream and 103.3 aggregate across three concurrent agents.
+The same four tasks on Devstral Small 2 24B. It answers one of them in eighteen seconds, which is where the reel ends.
 
 It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 

--- a/README.md
+++ b/README.md
@@ -219,11 +219,15 @@ Ask it something with a real answer at stake and you get the answer, not a parap
 
 `lilbee launch opencode`, `lilbee launch hermes`, and `lilbee launch claude` set up lilbee's local models in your agent in one command. For opencode and hermes, lilbee registers itself as a provider and an MCP server in the agent's own config and leaves your existing setup intact; for Claude Code, lilbee serves an Anthropic-compatible API and points the session at it by env, without touching Claude Code's settings. Each launch warms a model and opens the agent pointed at it. No API keys, no provider setup, and nothing leaves your machine. Tool-calling works across many GGUF families; [docs/agent-models.md](docs/agent-models.md) has the verified list and how the QA harness measures it.
 
-One model serves as many agents as you want to run. These reels show four working at once against a single local model, each on its own task: finding and fixing the bug behind a failing test, refactoring duplicated logic out of two functions, and searching the indexed project with `lilbee_search`.
+One model serves as many agents as you want to run. These reels show four working at once against a single local model, each in its own worktree, reading and searching this repository through lilbee.
 
-![four agents at once on Qwen3 Coder 30B A3B, each fixing, refactoring or searching through lilbee](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.gif)
+![four agents at once on Qwen3 Coder Next, reading and searching this repository through lilbee](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.gif)
 
-![four agents at once on MiniMax M2.7, writing Python functions through lilbee](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.gif)
+Qwen3 Coder Next on one RTX 5090, at 130 tokens/sec on a single stream.
+
+![four agents at once on MiniMax M2.7, investigating lilbee's engine lifecycle](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.gif)
+
+The same shape carrying a large model: MiniMax M2.7 across three A100s, at 60.9 tokens/sec on a single stream and 103.3 aggregate across three concurrent agents.
 
 It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 

--- a/site/index.html
+++ b/site/index.html
@@ -384,16 +384,16 @@
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-launchoc" aria-labelledby="tutorial-tab-launchoc" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">Four agents at once against a single local model (Qwen3 Coder 30B A3B): finding and fixing the bug behind a failing test, refactoring duplicated logic out of two functions, and searching the indexed project with <code>lilbee_search</code>.</p>
+          <p class="tutorial-caption">Four agents at once against a single local model (Qwen3 Coder Next) on one RTX 5090, each in its own worktree, reading and searching this repository through lilbee. 130 tokens/sec on a single stream.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-launchhm" aria-labelledby="tutorial-tab-launchhm" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">The same four-up shape on MiniMax M2.7, each pane writing a small Python function through lilbee.</p>
+          <p class="tutorial-caption">The same four-up shape on MiniMax M2.7 across three A100s, each pane investigating a different way the engine acquisition ladder can fail. 60.9 tokens/sec on a single stream, 103.3 aggregate across three concurrent agents.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-memory" aria-labelledby="tutorial-tab-memory" hidden>

--- a/site/index.html
+++ b/site/index.html
@@ -249,7 +249,7 @@
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-index"    aria-controls="tutorial-pane-index"    aria-selected="false" tabindex="-1">agent: index</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-godot"    aria-controls="tutorial-pane-godot"    aria-selected="false" tabindex="-1">agent: godot</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchoc" aria-controls="tutorial-pane-launchoc" aria-selected="false" tabindex="-1">agents: qwen3 coder</button>
-              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchhm" aria-controls="tutorial-pane-launchhm" aria-selected="false" tabindex="-1">agents: minimax</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchhm" aria-controls="tutorial-pane-launchhm" aria-selected="false" tabindex="-1">agents: devstral</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-memory" aria-controls="tutorial-pane-memory" aria-selected="false" tabindex="-1">memory</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-wiki" aria-controls="tutorial-pane-wiki" aria-selected="false" tabindex="-1">wiki</button>
             </div>
@@ -386,14 +386,14 @@
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">Four agents at once against a single local model (Qwen3 Coder Next) on one RTX 5090, each in its own worktree, reading and searching this repository through lilbee. 130 tokens/sec on a single stream.</p>
+          <p class="tutorial-caption">Four agents at once against a single local model, Qwen3 Coder Next, 45GB across three RTX 4090s. Each works in its own clone of this repository through lilbee.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-launchhm" aria-labelledby="tutorial-tab-launchhm" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">The same four-up shape on MiniMax M2.7 across three A100s, each pane investigating a different way the engine acquisition ladder can fail. 60.9 tokens/sec on a single stream, 103.3 aggregate across three concurrent agents.</p>
+          <p class="tutorial-caption">The same four tasks on Devstral Small 2 24B. It answers one of them in eighteen seconds, which is where the reel ends.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-memory" aria-labelledby="tutorial-tab-memory" hidden>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -434,7 +434,7 @@
 
       <section class="tutorial-section" id="agents-qwen3-coder">
         <h4><a href="#agents-qwen3-coder">Four agents on one local model</a></h4>
-        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder Next on a single RTX 5090, each in its own worktree, reading and searching this repository through lilbee. The model holds 130 tokens/sec on a single stream.</p>
+        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder Next, 45GB across three RTX 4090s, each in its own clone of this repository through lilbee.</p>
         <div class="tutorial-clip">
           <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.png">
             <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4" type="video/mp4">
@@ -443,13 +443,13 @@
         </div>
       </section>
 
-      <section class="tutorial-section" id="agents-minimax">
-        <h4><a href="#agents-minimax">The same, on MiniMax M2.7</a></h4>
-        <p>The same four-up shape on MiniMax M2.7 across three A100s. Each pane investigates a different way the engine acquisition ladder can fail when two processes race. The model holds 60.9 tokens/sec on a single stream, and 103.3 aggregate across three concurrent agents.</p>
+      <section class="tutorial-section" id="agents-devstral">
+        <h4><a href="#agents-devstral">The same, on Devstral Small 2 24B</a></h4>
+        <p>The same four tasks on Devstral Small 2 24B. It answers one of them in eighteen seconds, which is where the reel ends.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.mp4">four agents on MiniMax M2.7 (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.mp4">four agents on Devstral Small 2 24B (MP4)</a>
           </video>
         </div>
       </section>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -434,22 +434,22 @@
 
       <section class="tutorial-section" id="agents-qwen3-coder">
         <h4><a href="#agents-qwen3-coder">Four agents on one local model</a></h4>
-        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder 30B A3B: finding and fixing the bug behind a failing test, refactoring duplicated logic out of two functions, and searching the indexed project with <code>lilbee_search</code>.</p>
+        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder Next on a single RTX 5090, each in its own worktree, reading and searching this repository through lilbee. The model holds 130 tokens/sec on a single stream.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen3-coder.mp4">four agents on Qwen3 Coder (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4">four agents on Qwen3 Coder Next (MP4)</a>
           </video>
         </div>
       </section>
 
       <section class="tutorial-section" id="agents-minimax">
         <h4><a href="#agents-minimax">The same, on MiniMax M2.7</a></h4>
-        <p>The same four-up shape on a different local model, each pane writing a small Python function through lilbee.</p>
+        <p>The same four-up shape on MiniMax M2.7 across three A100s. Each pane investigates a different way the engine acquisition ladder can fail when two processes race. The model holds 60.9 tokens/sec on a single stream, and 103.3 aggregate across three concurrent agents.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax-m27.mp4">four agents on MiniMax M2.7 (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-minimax.mp4">four agents on MiniMax M2.7 (MP4)</a>
           </video>
         </div>
       </section>


### PR DESCRIPTION
## Problem

The README, the landing page and the tutorial reference the retired MiniMax and Qwen3 Coder 30B reels. PR #715 replaces those assets on gh-pages with the two graded reels, so the old references break the moment it merges.

## Solution

Repoint the README, site/index.html and site/tutorial/index.html at agents-coder-next and agents-devstral: asset URLs, poster frames, the tab label and the tutorial anchor. Captions now name the hardware (Qwen3 Coder Next, 45GB across three RTX 4090s) and the Devstral 18-second answer. Merges together with #715.