### PR TITLE
Point the Devstral reel captions at the 123B recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ One model serves as many agents as you want to run. These reels show four workin
 
 Qwen3 Coder Next, 45GB across three RTX 4090s, holding all four agents for the full reel.
 
-![four agents at once on Devstral Small 2 24B, working the same four tasks](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.gif)
+![four agents at once on Devstral 2 123B, working the same four tasks](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b.gif)
 
-The same four tasks on Devstral Small 2 24B. It answers one of them in eighteen seconds, which is where the reel ends.
+The same four tasks on Devstral 2 123B, 70GB across two A100 80GB cards. A model this size streams about 14 tokens a second, and the reel runs at that speed.
 
 It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 

--- a/site/index.html
+++ b/site/index.html
@@ -391,9 +391,9 @@
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-launchhm" aria-labelledby="tutorial-tab-launchhm" hidden>
           <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">The same four tasks on Devstral Small 2 24B. It answers one of them in eighteen seconds, which is where the reel ends.</p>
+          <p class="tutorial-caption">The same four tasks on Devstral 2 123B, 70GB across two A100 80GB cards. A model this size streams about 14 tokens a second, and the reel runs at that speed.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-memory" aria-labelledby="tutorial-tab-memory" hidden>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -443,13 +443,13 @@
         </div>
       </section>
 
-      <section class="tutorial-section" id="agents-devstral">
-        <h4><a href="#agents-devstral">The same, on Devstral Small 2 24B</a></h4>
-        <p>The same four tasks on Devstral Small 2 24B. It answers one of them in eighteen seconds, which is where the reel ends.</p>
+      <section class="tutorial-section" id="agents-devstral-123b">
+        <h4><a href="#agents-devstral-123b">The same, on Devstral 2 123B</a></h4>
+        <p>The same four tasks on Devstral 2 123B, 70GB across two A100 80GB cards. A model this size streams about 14 tokens a second, and the reel runs at that speed.</p>
         <div class="tutorial-clip">
-          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.png">
-            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.mp4" type="video/mp4">
-            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral.mp4">four agents on Devstral Small 2 24B (MP4)</a>
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b.mp4">four agents on Devstral 2 123B (MP4)</a>
           </video>
         </div>
       </section>


### PR DESCRIPTION
## Problem

The README, landing page and tutorial reference the retired agents-devstral assets, which the reel-replacement PR deletes from gh-pages.

## Solution

Repoint all three at agents-devstral-123b and rewrite the captions for the new recording: Devstral 2 123B, 70GB across two A100 80GB cards, playing at its real ~14 tokens a second. The tutorial anchor follows the asset name. Merges together with the gh-pages swap.