### PR TITLE
Show first-turn prefill progress instead of nothing

### DIFF
--- a/docs/agent-models.md
+++ b/docs/agent-models.md
@@ -6,6 +6,8 @@ Launch with `--no-mcp` to keep lilbee as the model provider but drop its MCP blo
 
 Claude Code needs a large context window: its built-in system prompt and tool schemas take tens of thousands of tokens before the first turn. Pick a chat model that serves a 64K-token window or larger (the launcher warns when the served window is smaller). `lilbee launch claude` keeps the session lean -- it loads only project-scoped settings and only lilbee's MCP server -- because a populated global Claude Code setup adds tens of thousands more tokens that no local window absorbs.
 
+The first prompt on a large model pays a long prompt-processing (prefill) delay after the launcher's warm bar finishes. An agent's first turn is ~32K tokens, and on a 100B-class model that is 30 seconds to a few minutes of compute before the first visible token; the agent shows only its spinner during it. The wait is roughly the prompt size over the model's prefill speed, and it is work, not a hang: poll `GET /api/health` and watch `chat_prefill_processed` climb toward `chat_prefill_total`. Later turns reuse the prompt cache and start far faster.
+
 ## Verified families
 
 Each family completes the loop end to end: the agent sends a prompt, the model calls `lilbee_search`, the tool runs against an indexed workspace, and the model answers from the results. How reliably a model reaches for a tool depends on the model and its size, not on lilbee.

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -545,6 +545,15 @@ class LLMProvider(Protocol):
         """
         return None
 
+    def chat_prefill_progress(self) -> tuple[int, int] | None:
+        """``(processed, total)`` prompt tokens of a chat prefill in flight, or None.
+
+        A large model's first agent turn can spend minutes in prompt processing
+        with no tokens streamed; status surfaces poll this to show the work.
+        Default ``None``: providers without a managed engine report nothing.
+        """
+        return None
+
     def warm_pending(self) -> bool:
         """Whether a warm has been requested and has not finished.
 

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -510,9 +510,14 @@ class LlamaServerClient:
         rerank_mode: RerankMode | None = None,
         inline_reasoning: bool = False,
         embed_busy_deadline_s: float | None = None,
+        on_prefill: Callable[[tuple[int, int] | None], None] | None = None,
     ) -> None:
         self._base = base_url.rstrip("/")
         self._model = model
+        # Prefill observer: called with (processed, total) per engine progress
+        # frame during a streamed chat's prompt processing, then None once the
+        # first generated frame proves the prefill is over.
+        self._on_prefill = on_prefill
         # Cold-load budget (seconds) the embed path waits out a still-warming replica
         # before dropping the input, in place of the short attempt cap. Set on the
         # EMBED-role client to the same ceiling llama-swap keeps the server alive for,
@@ -830,17 +835,35 @@ class LlamaServerClient:
         """Open one SSE chat stream and yield its frames; raises before the first frame."""
         payload = self._chat_payload(messages, tools, tool_choice, options, stream=True)
         inliner = _ThinkInliner(enabled=self._inline_reasoning)
-        with (
-            self._track(),
-            self._http.stream("POST", _CHAT_PATH, json=payload) as resp,
-        ):
-            _raise_for_status(resp)
-            with self._abortable(resp):
-                for line in resp.iter_lines():
-                    yield from _parse_sse_stream_items(line, inliner)
-            tail = inliner.finish()
-            if tail:
-                yield tail
+        on_prefill = self._on_prefill
+        prefilling = False
+        try:
+            with (
+                self._track(),
+                self._http.stream("POST", _CHAT_PATH, json=payload) as resp,
+            ):
+                _raise_for_status(resp)
+                with self._abortable(resp):
+                    for line in resp.iter_lines():
+                        if on_prefill is not None:
+                            progress = _prefill_progress(line)
+                            if progress is not None:
+                                prefilling = True
+                                on_prefill(progress)
+                        for item in _parse_sse_stream_items(line, inliner):
+                            if prefilling and on_prefill is not None:
+                                # The first real frame proves prefill is over.
+                                prefilling = False
+                                on_prefill(None)
+                            yield item
+                tail = inliner.finish()
+                if tail:
+                    yield tail
+        finally:
+            # A stream that dies or is closed mid-prefill must not leave a
+            # stale in-progress reading on the status surface.
+            if prefilling and on_prefill is not None:
+                on_prefill(None)
 
     def _chat_payload(
         self,
@@ -857,6 +880,9 @@ class LlamaServerClient:
             # include_usage makes llama-server emit a final SSE chunk carrying the
             # token usage (with an empty choices list) just before [DONE].
             payload["stream_options"] = {"include_usage": True}
+            # return_progress makes llama-server stream prompt_progress frames
+            # during prefill, so a long first turn is observable server-side.
+            payload["return_progress"] = True
         if tools is not None:
             payload["tools"] = tools
         if tool_choice is not None:
@@ -1374,6 +1400,32 @@ def _tool_call_delta_from_chunk(call: Mapping[str, Any], *, fallback_index: int)
         name=str(raw_name) if raw_name else None,
         arguments_delta=str(raw_args) if raw_args else None,
     )
+
+
+_PROMPT_PROGRESS_KEY = "prompt_progress"
+
+
+def _prefill_progress(line: str) -> tuple[int, int] | None:
+    """The ``(processed, total)`` of one SSE line's ``prompt_progress``, or None.
+
+    llama-server emits the block on streamed chats that opt in via
+    ``return_progress``; the substring pre-check keeps the extra JSON parse off
+    every ordinary token line.
+    """
+    if _PROMPT_PROGRESS_KEY not in line or not line.startswith(_DATA_PREFIX):
+        return None
+    body = line[len(_DATA_PREFIX) :].strip()
+    try:
+        obj = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    progress = obj.get(_PROMPT_PROGRESS_KEY)
+    if not isinstance(progress, Mapping):
+        return None
+    try:
+        return int(progress["processed"]), int(progress["total"])
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def _parse_sse_stream_items(

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -880,6 +880,9 @@ class FleetProvider:
         # the concurrency gate and clients; defaults until the chat group is up.
         self._chat_slots = 1
         self._chat_ctx: int | None = None
+        # Latest chat prefill progress reported by a streaming client, cleared
+        # by the same stream when generation starts or the stream ends.
+        self._chat_prefill: tuple[int, int] | None = None
         # Single-flight guard: the HTTP/MCP servers route concurrently, so two
         # first-requests must not each start a swap (double GPU allocation) or
         # tear one down mid-route. Reentrant: invalidate_load_cache nests calls.
@@ -1198,6 +1201,7 @@ class FleetProvider:
                     timeout=_request_timeout_s(launch.weights_bytes),
                     rerank_mode=launch.rerank_mode,
                     inline_reasoning=role is WorkerRole.CHAT,
+                    on_prefill=self._record_chat_prefill if role is WorkerRole.CHAT else None,
                     # A cold embed replica 429s bulk ingest until its slots load; wait
                     # out the same cold-load budget llama-swap keeps it alive for so a
                     # burst never drops files while the server is legitimately warming.
@@ -1393,6 +1397,17 @@ class FleetProvider:
         """Per-slot context the chat server runs with, or None if not up."""
         with self._lock:
             return self._chat_ctx if WorkerRole.CHAT in self._role_group else None
+
+    def chat_prefill_progress(self) -> tuple[int, int] | None:
+        """``(processed, total)`` of a chat prefill in flight, or None when idle."""
+        with self._lock:
+            return self._chat_prefill
+
+    def _record_chat_prefill(self, progress: tuple[int, int] | None) -> None:
+        """Store a stream's prefill reading. Latest writer wins across concurrent
+        streams; a live prefill rewrites itself on its next engine batch."""
+        with self._lock:
+            self._chat_prefill = progress
 
     def warm_pending(self) -> bool:
         """Whether a requested warm is still running.

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -342,6 +342,12 @@ class RoutingProvider(LLMProvider):
             return None
         return self._local.served_chat_ctx()
 
+    def chat_prefill_progress(self) -> tuple[int, int] | None:
+        """Chat prefill progress of the local engine, or None when none exists."""
+        if self._local is None:
+            return None
+        return self._local.chat_prefill_progress()
+
     def warm_pending(self) -> bool:
         """Forward to the native side; the SDK side never warms."""
         return self._get_local().warm_pending()

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -128,6 +128,7 @@ async def health() -> HealthResponse:
     """Return service health, version, and whether the chat engine is warm."""
     provider = get_services().provider
     chat_status, chat_error = _chat_status(provider)
+    prefill = provider.chat_prefill_progress()
     return HealthResponse(
         status="ok",
         version=get_version(),
@@ -135,6 +136,8 @@ async def health() -> HealthResponse:
         chat_status=chat_status,
         chat_error=chat_error,
         chat_ctx=provider.served_chat_ctx(),
+        chat_prefill_processed=prefill[0] if prefill else None,
+        chat_prefill_total=prefill[1] if prefill else None,
     )
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -221,6 +221,13 @@ class HealthResponse(BaseModel):
     chat_ctx: int | None = None
     """Per-slot context the chat engine serves, so a launcher can tell the client
     its window and the client trims history to fit. None until the engine is up."""
+    chat_prefill_processed: int | None = None
+    """Prompt tokens the chat engine has processed for a prefill in flight. A
+    large model's first agent turn can spend minutes here with nothing streamed;
+    polling this tells a working engine apart from a hung one. None when idle."""
+    chat_prefill_total: int | None = None
+    """Prompt tokens the in-flight chat prefill will process in total. None when
+    no prefill is running."""
 
 
 class CompactionInfo(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,6 +490,7 @@ def _default_provider_mock():
     # with an unknown window so the gate and the /v1/models shape stay valid.
     provider.max_concurrent_chats.return_value = 1
     provider.served_chat_ctx.return_value = None
+    provider.chat_prefill_progress.return_value = None
     # warm_progress feeds the /api/warm/stream handler (WarmProgress | None);
     # default to None (idle). Warm-stream tests override this.
     provider.warm_progress.return_value = None

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -2177,11 +2177,20 @@ def test_chat_stream_items_requests_return_progress() -> None:
     assert seen["return_progress"] is True
 
 
+def _prefill_client(handler, events: list) -> LlamaServerClient:
+    """A probed-lenient client whose constructor carries the prefill callback."""
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://gpu0")
+    client = LlamaServerClient("http://gpu0", "test-model", http=http, on_prefill=events.append)
+    client._needs_alternation = False
+    return client
+
+
 def test_chat_stream_prefill_progress_reaches_callback_not_the_frames() -> None:
     """Progress chunks drive on_prefill and never surface as stream frames.
 
-    The callback sees each (processed, total) and then None when the first
-    generated token proves prefill is over.
+    The callback sees each (processed, total) and then None at the FIRST
+    generated token, not at stream end: pulled one frame at a time, the clear
+    has already landed while later frames are still pending.
     """
     body = (
         'data: {"choices":[{"delta":{"content":""}}],'
@@ -2189,6 +2198,7 @@ def test_chat_stream_prefill_progress_reaches_callback_not_the_frames() -> None:
         'data: {"choices":[{"delta":{"content":""}}],'
         '"prompt_progress":{"total":320,"cache":0,"processed":320,"time_ms":90}}\n\n'
         'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n'
+        'data: {"choices":[{"delta":{"content":" there"}}]}\n\n'
         "data: [DONE]\n\n"
     )
 
@@ -2198,15 +2208,18 @@ def test_chat_stream_prefill_progress_reaches_callback_not_the_frames() -> None:
         return httpx.Response(404)
 
     events: list[tuple[int, int] | None] = []
-    client = _client(handler)
-    client._on_prefill = lambda progress: events.append(progress)
-    frames = list(client.chat_stream_items([{"role": "user", "content": "hi"}]))
-    assert frames == ["Hi"]
+    stream = client_iter = iter(
+        _prefill_client(handler, events).chat_stream_items([{"role": "user", "content": "hi"}])
+    )
+    first = next(client_iter)
+    assert first == "Hi"
+    assert events == [(128, 320), (320, 320), None]
+    assert list(stream) == [" there"]
     assert events == [(128, 320), (320, 320), None]
 
 
-def test_chat_stream_prefill_cleared_when_the_stream_ends_early() -> None:
-    """A stream that dies mid-prefill still reports the prefill as over."""
+def test_chat_stream_prefill_cleared_when_the_stream_ends_without_a_token() -> None:
+    """A stream that ends mid-prefill (death or truncation) still clears the reading."""
     body = (
         'data: {"choices":[{"delta":{"content":""}}],'
         '"prompt_progress":{"total":320,"cache":0,"processed":128,"time_ms":50}}\n\n'
@@ -2219,7 +2232,33 @@ def test_chat_stream_prefill_cleared_when_the_stream_ends_early() -> None:
         return httpx.Response(404)
 
     events: list[tuple[int, int] | None] = []
-    client = _client(handler)
-    client._on_prefill = lambda progress: events.append(progress)
-    list(client.chat_stream_items([{"role": "user", "content": "hi"}]))
+    list(_prefill_client(handler, events).chat_stream_items([{"role": "user", "content": "hi"}]))
     assert events == [(128, 320), None]
+
+
+class TestPrefillProgressParsing:
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            ('data: {"prompt_progress":{"total":320,"cache":0,"processed":128}}', (128, 320)),
+            ("data: not-json prompt_progress", None),
+            ('data: {"prompt_progress":"128/320"}', None),
+            ('data: {"prompt_progress":{"total":320}}', None),
+            ('data: {"prompt_progress":{"total":"a","processed":"b"}}', None),
+            ('data: {"choices":[{"delta":{"content":"hi"}}]}', None),
+            ('{"prompt_progress":{"total":320,"processed":128}}', None),
+        ],
+        ids=[
+            "well-formed",
+            "unparseable-json",
+            "non-mapping-progress",
+            "missing-processed",
+            "non-numeric-counts",
+            "ordinary-token-line",
+            "no-data-prefix",
+        ],
+    )
+    def test_parses_only_well_formed_progress_lines(self, line, expected) -> None:
+        from lilbee.providers.fleet.client import _prefill_progress
+
+        assert _prefill_progress(line) == expected

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -2161,3 +2161,65 @@ def test_abort_streams_survives_close_errors() -> None:
     client._active_streams.update({failing, healthy})
     client.abort_streams()  # must not raise
     healthy.close.assert_called_once_with()
+
+
+def test_chat_stream_items_requests_return_progress() -> None:
+    """The stream request opts into the engine's prefill-progress frames."""
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/chat/completions":
+            seen.update(json.loads(request.content))
+            return httpx.Response(200, text="data: [DONE]\n\n")
+        return httpx.Response(404)
+
+    list(_client(handler).chat_stream_items([{"role": "user", "content": "hi"}]))
+    assert seen["return_progress"] is True
+
+
+def test_chat_stream_prefill_progress_reaches_callback_not_the_frames() -> None:
+    """Progress chunks drive on_prefill and never surface as stream frames.
+
+    The callback sees each (processed, total) and then None when the first
+    generated token proves prefill is over.
+    """
+    body = (
+        'data: {"choices":[{"delta":{"content":""}}],'
+        '"prompt_progress":{"total":320,"cache":0,"processed":128,"time_ms":50}}\n\n'
+        'data: {"choices":[{"delta":{"content":""}}],'
+        '"prompt_progress":{"total":320,"cache":0,"processed":320,"time_ms":90}}\n\n'
+        'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(200, text=body)
+        return httpx.Response(404)
+
+    events: list[tuple[int, int] | None] = []
+    client = _client(handler)
+    client._on_prefill = lambda progress: events.append(progress)
+    frames = list(client.chat_stream_items([{"role": "user", "content": "hi"}]))
+    assert frames == ["Hi"]
+    assert events == [(128, 320), (320, 320), None]
+
+
+def test_chat_stream_prefill_cleared_when_the_stream_ends_early() -> None:
+    """A stream that dies mid-prefill still reports the prefill as over."""
+    body = (
+        'data: {"choices":[{"delta":{"content":""}}],'
+        '"prompt_progress":{"total":320,"cache":0,"processed":128,"time_ms":50}}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(200, text=body)
+        return httpx.Response(404)
+
+    events: list[tuple[int, int] | None] = []
+    client = _client(handler)
+    client._on_prefill = lambda progress: events.append(progress)
+    list(client.chat_stream_items([{"role": "user", "content": "hi"}]))
+    assert events == [(128, 320), None]

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -4842,3 +4842,40 @@ class TestAReplicaThatCannotLoadLeavesTheRoutingPool:
         assert "no device could allocate" in fleet._warm_errors[WorkerRole.EMBED]
         for client in clients:
             client.mark_unhealthy.assert_called_once()
+
+
+class TestChatPrefillProgress:
+    """The provider exposes the latest chat prefill progress for status surfaces."""
+
+    def test_none_before_any_prefill(self) -> None:
+        assert FleetProvider().chat_prefill_progress() is None
+
+    def test_records_and_clears_via_the_client_callback(self) -> None:
+        p = FleetProvider()
+        p._record_chat_prefill((128, 320))
+        assert p.chat_prefill_progress() == (128, 320)
+        p._record_chat_prefill((320, 320))
+        assert p.chat_prefill_progress() == (320, 320)
+        p._record_chat_prefill(None)
+        assert p.chat_prefill_progress() is None
+
+    def test_adopt_group_gives_only_the_chat_client_the_prefill_hook(self, monkeypatch) -> None:
+        launches = [_fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED)]
+        for launch in launches:
+            launch.rerank_mode = None
+            launch.model_id = launch.role
+        captured: dict[WorkerRole, object] = {}
+
+        def _capture(_endpoint, model, **kw):
+            captured[model] = kw.get("on_prefill")
+            return _fake_client()
+
+        monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: _FakeSwap())
+        monkeypatch.setattr(prov_mod, "LlamaServerClient", _capture)
+        monkeypatch.setattr(
+            planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(tuple(launches))
+        )
+        p = FleetProvider()
+        p._ensure_fleet()
+        assert captured[WorkerRole.CHAT] == p._record_chat_prefill
+        assert captured[WorkerRole.EMBED] is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3752,3 +3752,18 @@ class TestRoutingRoleReadyRemote:
         cfg.chat_model = "org/repo/chat-Q4_K_M.gguf"
         assert rp.role_ready(WorkerRole.CHAT) is False
         local.role_ready.assert_called_once_with(WorkerRole.CHAT)
+
+
+class TestRoutingChatPrefillProgress:
+    def test_is_none_without_local(self) -> None:
+        from lilbee.providers.routing_provider import RoutingProvider
+
+        assert RoutingProvider().chat_prefill_progress() is None  # _local is None
+
+    def test_forwards_to_local(self) -> None:
+        from lilbee.providers.routing_provider import RoutingProvider
+
+        rp = RoutingProvider()
+        rp._local = mock.MagicMock()
+        rp._local.chat_prefill_progress.return_value = (128, 320)
+        assert rp.chat_prefill_progress() == (128, 320)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -162,6 +162,22 @@ class TestHealth:
         mock_svc.provider.role_ready.return_value = True
         assert (await handlers.health()).chat_error is None
 
+    async def test_chat_prefill_progress_reported_while_prefilling(self, mock_svc):
+        """A long first-turn prefill is visible on health, so a polling user can
+        tell a working engine from a hung one."""
+        mock_svc.provider.role_ready.return_value = True
+        mock_svc.provider.chat_prefill_progress.return_value = (12000, 32768)
+        result = await handlers.health()
+        assert result.chat_prefill_processed == 12000
+        assert result.chat_prefill_total == 32768
+
+    async def test_chat_prefill_absent_when_nothing_is_prefilling(self, mock_svc):
+        mock_svc.provider.role_ready.return_value = True
+        mock_svc.provider.chat_prefill_progress.return_value = None
+        result = await handlers.health()
+        assert result.chat_prefill_processed is None
+        assert result.chat_prefill_total is None
+
 
 def _parse_warm_events(chunks: list[str]) -> list[dict]:
     """Pull the JSON payloads off ``warm`` SSE chunks, ignoring the [DONE] tail."""


### PR DESCRIPTION
## Problem

An agent's first turn sends ~32k tokens of prompt, and on a large model that is 30 seconds to minutes of prompt processing after the launcher's warm bar ends. Nothing surfaces it: the client shows a spinner and no lilbee surface distinguishes working from hung (measured: 49 seconds of blank pane on Devstral 2 123B).

## Fix

llama-server streams `prompt_progress` frames when a streaming request opts in via `return_progress`. The fleet client now opts in on every streamed chat; the chat role's client reports (processed, total) to the provider and the same stream clears it when generation starts or the stream ends. `/api/health` carries `chat_prefill_processed` / `chat_prefill_total`, so polling health shows the prefill climbing.

## Docs

The agent-models guide states the first-prompt prefill cost plainly and points at the health fields. The warm-wait budget already scales with model weights; its existing test covers that.

## Not covered

Prompt-cache priming of the client's static prefix (an experiment, per the issue) and any in-client rendering; opencode has no channel for prefill progress.