### PR TITLE
Show the four-model agent reel set on the README and the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,19 @@ One model serves as many agents as you want to run. These reels show four workin
 
 ![four agents at once on Qwen3 Coder Next, reading and searching this repository through lilbee](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.gif)
 
-Qwen3 Coder Next, 45GB across three RTX 4090s, holding all four agents for the full reel.
+Qwen3 Coder Next, 45GB across three RTX 4090s: four agents on one model, 138 tokens a second warm.
+
+![four agents on Gemma 4 26B, its reasoning streamed as visible text](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-gemma4.gif)
+
+Gemma 4 26B is a thinking model, and lilbee streams its reasoning as visible text: every pane shows the model working through the problem before it answers.
+
+![four agents on Qwen3.6 27B, thinking out loud on the same tasks](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen36.gif)
+
+Qwen3.6 27B on the same four tasks: each agent states what it expects, then reads the code to check itself.
+
+![one agent on Devstral 2 123B, walking through lilbee's GPU placement code](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b-solo.gif)
+
+And the same setup scales up: Devstral 2 123B, 70GB across two A100 80GB cards, one agent at the model's full 14 tokens a second.
 
 It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 

--- a/site/index.html
+++ b/site/index.html
@@ -249,6 +249,9 @@
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-index"    aria-controls="tutorial-pane-index"    aria-selected="false" tabindex="-1">agent: index</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-godot"    aria-controls="tutorial-pane-godot"    aria-selected="false" tabindex="-1">agent: godot</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-launchoc" aria-controls="tutorial-pane-launchoc" aria-selected="false" tabindex="-1">agents: qwen3 coder</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-gemma4" aria-controls="tutorial-pane-gemma4" aria-selected="false" tabindex="-1">agents: gemma 4</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-qwen36" aria-controls="tutorial-pane-qwen36" aria-selected="false" tabindex="-1">agents: qwen3.6</button>
+              <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-solo123b" aria-controls="tutorial-pane-solo123b" aria-selected="false" tabindex="-1">agent: devstral 123b</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-memory" aria-controls="tutorial-pane-memory" aria-selected="false" tabindex="-1">memory</button>
               <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-wiki" aria-controls="tutorial-pane-wiki" aria-selected="false" tabindex="-1">wiki</button>
             </div>
@@ -385,7 +388,28 @@
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">Four agents at once against a single local model, Qwen3 Coder Next, 45GB across three RTX 4090s. Each works in its own clone of this repository through lilbee.</p>
+          <p class="tutorial-caption">Four agents at once against a single local model, Qwen3 Coder Next, 45GB across three RTX 4090s at 138 tokens a second. Each works in its own clone of this repository through lilbee.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-gemma4" aria-labelledby="tutorial-tab-gemma4" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-gemma4.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">The same four tasks on Gemma 4 26B, a thinking model. lilbee streams its reasoning as visible text, so every pane shows the model working through the problem before it answers.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-qwen36" aria-labelledby="tutorial-tab-qwen36" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen36.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">Qwen3.6 27B, also thinking out loud: each agent states what it expects, then reads the code to check itself.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-solo123b" aria-labelledby="tutorial-tab-solo123b" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b-solo.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">Devstral 2 123B, 70GB across two A100 80GB cards. One agent gets the model's full 14 tokens a second; a model this size trades pane count for depth.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-memory" aria-labelledby="tutorial-tab-memory" hidden>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -434,11 +434,44 @@
 
       <section class="tutorial-section" id="agents-qwen3-coder">
         <h4><a href="#agents-qwen3-coder">Four agents on one local model</a></h4>
-        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder Next, 45GB across three RTX 4090s, each in its own clone of this repository through lilbee.</p>
+        <p>One model serves as many agents as you want to run. Four work at once here against Qwen3 Coder Next, 45GB across three RTX 4090s at 138 tokens a second, each in its own clone of this repository through lilbee.</p>
         <div class="tutorial-clip">
           <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.png">
             <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4" type="video/mp4">
             <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.mp4">four agents on Qwen3 Coder Next (MP4)</a>
+          </video>
+        </div>
+      </section>
+
+      <section class="tutorial-section" id="agents-gemma4">
+        <h4><a href="#agents-gemma4">The same, on a thinking model</a></h4>
+        <p>Gemma 4 26B reasons before it answers, and lilbee streams that reasoning as visible text. Every pane shows the model working through the problem -- reading files, second-guessing itself, checking the code -- before it commits to an answer.</p>
+        <div class="tutorial-clip">
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-gemma4.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-gemma4.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-gemma4.mp4">four agents on Gemma 4 26B (MP4)</a>
+          </video>
+        </div>
+      </section>
+
+      <section class="tutorial-section" id="agents-qwen36">
+        <h4><a href="#agents-qwen36">Qwen3.6 27B, thinking out loud</a></h4>
+        <p>The same four tasks on Qwen3.6 27B: each agent states what it expects first, then reads the code to check itself.</p>
+        <div class="tutorial-clip">
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen36.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen36.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen36.mp4">four agents on Qwen3.6 27B (MP4)</a>
+          </video>
+        </div>
+      </section>
+
+      <section class="tutorial-section" id="agent-devstral-123b">
+        <h4><a href="#agent-devstral-123b">One agent on Devstral 2 123B</a></h4>
+        <p>The biggest model in the set: 70GB across two A100 80GB cards. One agent gets the model's full 14 tokens a second -- a model this size trades pane count for depth.</p>
+        <div class="tutorial-clip">
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b-solo.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b-solo.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b-solo.mp4">one agent on Devstral 2 123B (MP4)</a>
           </video>
         </div>
       </section>


### PR DESCRIPTION
## Problem

The README and site show a single agent reel; the replacement set has four.

## Solution

The README's agent section carries all four reels with hardware and speed in each caption: Qwen3 Coder Next (138 tok/s, three RTX 4090s), Gemma 4 26B and Qwen3.6 27B thinking in visible text, Devstral 2 123B as one agent at its full 14 tok/s on two A100 80GB cards. The site gains a tab per reel and matching tutorial sections.

## Ordering

Merges together with the asset PR into gh-pages, after #720/#724/#721.