### PR TITLE
Strip the think markers from inline reasoning content

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -964,7 +964,7 @@ The ones most users set at least once.
 | `LILBEE_RAG_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt for RAG (search-mode) answers |
 | `LILBEE_GENERAL_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt for chat-mode (ungrounded) answers |
 | `LILBEE_SHOW_REASONING` | `false` | Show the model's `<think>` reasoning tokens in chat output. Useful with Qwen3, DeepSeek-R1, and other reasoning models |
-| `LILBEE_COMPLETIONS_REASONING` | `separate` | How `/v1/chat/completions` presents thinking: `separate` (own `reasoning_content` field), `inline` (`<think>` text stays in `content`, for clients that never render `reasoning_content`), or `off` (ask the model not to think). A request's `reasoning` field overrides it per call |
+| `LILBEE_COMPLETIONS_REASONING` | `separate` | How `/v1/chat/completions` presents thinking: `separate` (own `reasoning_content` field), `inline` (thinking streams as plain `content` text, tags stripped, for clients that never render `reasoning_content`), or `off` (ask the model not to think). A request's `reasoning` field overrides it per call |
 | `LILBEE_HF_TOKEN` | *(none)* | HuggingFace access token. Avoids the unauthenticated download rate limit and unlocks gated repos. Same token can be persisted via the `System` tab in `/settings` (stored in plain text at `config.toml`). `HF_TOKEN` env var also accepted |
 
 ### Retrieval tuning

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -509,7 +509,7 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group=SettingGroup.GENERATION,
         help_text=(
             "How /v1/chat/completions presents thinking: separate "
-            "reasoning_content field, inline <think> text in content, "
+            "reasoning_content field, inline thinking as plain content text, "
             "or off (ask the model not to think)"
         ),
         choices=tuple(m.value for m in ReasoningMode),

--- a/src/lilbee/core/config/enums.py
+++ b/src/lilbee/core/config/enums.py
@@ -7,7 +7,8 @@ class ReasoningMode(StrEnum):
     """How ``/v1/chat/completions`` presents a reasoning model's thinking.
 
     ``separate`` reports thinking in ``reasoning_content`` (OpenAI-compatible).
-    ``inline`` keeps thinking in ``content`` as ``<think>`` text, for clients
+    ``inline`` streams thinking as ordinary ``content`` text with the
+    ``<think>`` markers stripped, for clients
     that never render ``reasoning_content``. ``off`` asks the model not to
     think; thinking templates honor the request and other templates ignore it.
     """

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -113,10 +113,16 @@ def canonical_to_completions_response(
     tool_calls = [_response_tool_call(b) for b in resp.content if isinstance(b, ToolUseBlock)]
     # lilbee carries a reasoning model's thinking inline as <think>...</think>; the
     # OpenAI surface reports it in its own field so agents render a clean answer.
-    # INLINE skips the split for clients that never render reasoning_content; OFF
-    # keeps it, because a template that ignores enable_thinking still thinks.
+    # INLINE streams the thinking as ordinary content for clients that never
+    # render reasoning_content -- with the tag markers stripped, because a
+    # client that ignores reasoning_content renders raw <think> text literally.
+    # OFF keeps the split, because a template that ignores enable_thinking
+    # still thinks.
     if mode is ReasoningMode.INLINE:
-        reasoning, answer = "", "".join(text_parts)
+        reasoning, answer = split_reasoning("".join(text_parts))
+        if reasoning:
+            answer = f"{reasoning}\n\n{answer}" if answer else reasoning
+        reasoning = ""
     else:
         reasoning, answer = split_reasoning("".join(text_parts))
     content: str | None = answer if answer or not tool_calls else None
@@ -152,8 +158,10 @@ class _StreamMapper:
         self._role_emitted = False
         self._tool_index_for_block: dict[int, int] = {}
         self._next_tool_index = 0
-        # INLINE forwards text untouched (thinking stays in content, and no
-        # token is ever held back for a possible tag prefix).
+        # INLINE routes thinking into content instead of reasoning_content, with
+        # the <think> markers stripped: a client that ignores reasoning_content
+        # renders raw tags literally, which is exactly what INLINE exists to
+        # avoid. The same stateful parse handles a tag split across deltas.
         self._inline = mode is ReasoningMode.INLINE
         # Splits lilbee's inline <think> text into its own delta field. Stateful
         # because a tag can arrive split across deltas.
@@ -180,9 +188,6 @@ class _StreamMapper:
 
     def block_delta(self, event: ContentBlockDelta) -> CompletionsStreamDelta | None:
         if isinstance(event.delta, TextDelta):
-            if self._inline:
-                text = event.delta.text
-                return CompletionsStreamDelta(content=text) if text else None
             return self._text_delta(self._reasoning.feed(event.delta.text))
         if isinstance(event.delta, ToolUseDelta):
             # A delta for a block we never saw start is a provider quirk, not a
@@ -198,13 +203,15 @@ class _StreamMapper:
 
     def block_stop(self) -> CompletionsStreamDelta | None:
         """Emit whatever the reasoning splitter still holds (a partial or unclosed tag)."""
-        if self._inline:
-            return None
         remaining = self._reasoning.flush()
         return self._text_delta([remaining] if remaining else [])
 
     def _text_delta(self, tokens: list[StreamToken]) -> CompletionsStreamDelta | None:
-        """One delta carrying the reasoning and answer text split out of *tokens*."""
+        """One delta carrying the parsed text: split fields, or tag-free content."""
+        if self._inline:
+            # Arrival order preserved; the parser already dropped the markers.
+            text = "".join(t.content for t in tokens)
+            return CompletionsStreamDelta(content=text) if text else None
         reasoning = "".join(t.content for t in tokens if t.is_reasoning)
         answer = "".join(t.content for t in tokens if not t.is_reasoning)
         if not reasoning and not answer:

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -1788,6 +1788,10 @@ class TestReasoningModeOnRoute:
     """The reasoning mode: request field first, then the completions_reasoning setting."""
 
     _THINKING_TEXT = "<think>weighing</think>Answer."
+    # What inline mode delivers: the thinking as ordinary content with the tag
+    # markers stripped -- a client that ignores reasoning_content renders raw
+    # <think> text literally, which is what inline exists to avoid.
+    _INLINE_TEXT = "weighing\n\nAnswer."
 
     def _thinking_provider(self, services) -> None:
         services.provider.chat.return_value = ChatResult(
@@ -1809,7 +1813,7 @@ class TestReasoningModeOnRoute:
                 },
             )
         message = resp.json()["choices"][0]["message"]
-        assert message["content"] == self._THINKING_TEXT
+        assert message["content"] == self._INLINE_TEXT
         assert "reasoning_content" not in message
 
     async def test_setting_inline_applies_without_request_field(
@@ -1830,7 +1834,7 @@ class TestReasoningModeOnRoute:
                 },
             )
         message = resp.json()["choices"][0]["message"]
-        assert message["content"] == self._THINKING_TEXT
+        assert message["content"] == self._INLINE_TEXT
 
     async def test_request_separate_overrides_inline_setting(
         self, services_with_chat_model, _auth_token, monkeypatch
@@ -1890,7 +1894,7 @@ class TestReasoningModeOnRoute:
         chunks = _sse_to_chunks(resp.content)
         deltas = [c["choices"][0]["delta"] for c in chunks if isinstance(c, dict) and c["choices"]]
         content = "".join(d.get("content") or "" for d in deltas)
-        assert content == "<think>why</think>hi"
+        assert content == "whyhi"
         assert all("reasoning_content" not in d for d in deltas)
 
     async def test_object_shaped_reasoning_still_completes(

--- a/tests/server/chat_completions_api/test_translate.py
+++ b/tests/server/chat_completions_api/test_translate.py
@@ -1222,7 +1222,9 @@ class TestStreamCreatedIsConstant:
 
 
 class TestReasoningModePresentation:
-    """``inline`` keeps thinking in ``content`` so tag-blind clients see motion;
+    """``inline`` streams thinking as content so tag-blind clients see motion --
+    with the tag markers stripped, because a client that ignores
+    reasoning_content renders raw <think> text literally (it did, on camera);
     ``off`` falls back to the separate split for templates that think anyway."""
 
     def _resp(self, text: str) -> CanonicalResponse:
@@ -1234,15 +1236,23 @@ class TestReasoningModePresentation:
             usage=CanonicalUsage(input_tokens=0, output_tokens=0),
         )
 
-    def test_inline_response_keeps_think_text_in_content(self) -> None:
+    def test_inline_response_keeps_think_text_in_content_without_tags(self) -> None:
         body = canonical_to_completions_response(
             self._resp("<think>weighing</think>Answer."),
             response_id=_RESPONSE_ID,
             mode=ReasoningMode.INLINE,
         )
         message = body.choices[0].message
-        assert message.content == "<think>weighing</think>Answer."
+        assert message.content == "weighing\n\nAnswer."
         assert message.reasoning_content is None
+
+    def test_inline_response_with_only_thinking_keeps_the_thinking(self) -> None:
+        body = canonical_to_completions_response(
+            self._resp("<think>all thought, no answer</think>"),
+            response_id=_RESPONSE_ID,
+            mode=ReasoningMode.INLINE,
+        )
+        assert body.choices[0].message.content == "all thought, no answer"
 
     def test_off_response_still_splits_leaked_thinking(self) -> None:
         # A template that ignores enable_thinking still thinks; presentation
@@ -1275,18 +1285,24 @@ class TestReasoningModePresentation:
         )
         return [c.choices[0].delta for c in chunks if c.choices]
 
-    async def test_inline_stream_carries_think_text_as_content(self) -> None:
+    async def test_inline_stream_carries_think_text_as_content_without_tags(self) -> None:
         deltas = await self._inline_deltas(["<think>", "why", "</think>", "hi"])
         content = "".join(d.content or "" for d in deltas)
-        assert content == "<think>why</think>hi"
+        assert content == "whyhi"
         assert all(d.reasoning_content is None for d in deltas)
 
-    async def test_inline_stream_does_not_buffer_partial_tags(self) -> None:
-        # The splitter buffers a possible tag prefix; inline mode must not,
-        # so every model token reaches the client the moment it arrives.
-        deltas = await self._inline_deltas(["<thi", "nk>", "hm"])
-        content_deltas = [d.content for d in deltas if d.content]
-        assert content_deltas == ["<thi", "nk>", "hm"]
+    async def test_inline_stream_strips_a_tag_split_across_deltas(self) -> None:
+        # A tag can arrive in pieces; the stateful parse must still drop it
+        # whole rather than leak a fragment like "nk>" into the content.
+        deltas = await self._inline_deltas(["<thi", "nk>", "hm", "</th", "ink>", "ok"])
+        content = "".join(d.content or "" for d in deltas)
+        assert content == "hmok"
+
+    async def test_inline_stream_flushes_an_unclosed_think_block(self) -> None:
+        # A stream cut mid-thought still delivers the thinking it carried.
+        deltas = await self._inline_deltas(["<think>", "partial thought"])
+        content = "".join(d.content or "" for d in deltas)
+        assert content == "partial thought"
 
 
 class TestReasoningRequestField:


### PR DESCRIPTION
## Problem

Inline mode forwards model text untouched, so a client that never renders reasoning_content displays literal <think></think> markers around the thinking. The first reel recorded with the mode showed them on camera.

## Solution

The stateful tag parse the separate split already uses now feeds both modes; inline joins every parsed token into content in arrival order. A tag split across deltas is dropped whole, an unclosed think block still delivers its text at stream end, and the non-streaming path rejoins thinking and answer with a blank line. Separate and off are untouched. Docs and the setting description now say tags are stripped.

Stacks on #720; merge into it or land after it.