### PR TITLE
Self-heal the onefile cache and gate frozen charset detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ dev = [
     # still need it: the pin test reads its metadata, and the local source
     # below makes it a workspace path rather than an index lookup.
     "lilbee-engine",
+    # The self-check-extras charset probe and its tests call chardet directly;
+    # without this, chardet only arrives via the crawler extra, and the bare
+    # `uv sync --locked` CI test env cannot run those tests.
+    "chardet>=7",
     "hypothesis>=6.100",
     "mypy>=1.19.1",
     "packaging>=24",

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -349,6 +349,33 @@ def self_check_cmd(
 
 _SELF_CHECK_EXTRAS = ("litellm", "crawl4ai", "spacy", "graspologic_native")
 
+# The name of the functional charset-detection leg in self-check-extras output.
+_CHARSET_PROBE = "charset_detection"
+
+
+def _probe_charset_detection() -> str | None:
+    """Run the real chardet pipeline; return an error string when it is broken.
+
+    A bare `import chardet` passes even when the frozen bundle is broken:
+    chardet imports `chardet.models` (and loads its `.bin` data) lazily on the
+    first `detect()` call, and the crawl path only reaches that call for a
+    response without a charset header. This probe forces the full detection
+    pipeline offline, so the release gate fails deterministically when a
+    frozen build cannot detect charsets.
+    """
+    # Any failure below means the bundle is broken; the caller reports the
+    # error and fails the check, so nothing is swallowed.
+    try:
+        import chardet
+
+        sample = "字符集检测自检文本 用于验证冻结构建" * 8
+        result = chardet.detect(sample.encode("gb18030"))
+        if not result.get("encoding"):
+            return f"chardet.detect returned no encoding: {result!r}"
+        return None
+    except Exception as exc:
+        return str(exc)
+
 
 def self_check_extras_cmd() -> None:
     """Verify optional extras (crawler, litellm, graph) are bundled and importable."""
@@ -363,10 +390,16 @@ def self_check_extras_cmd() -> None:
             results[f"{name}_error"] = str(exc)
             failed.append(name)
 
+    probe_error = _probe_charset_detection()
+    results[_CHARSET_PROBE] = probe_error is None
+    if probe_error is not None:
+        results[f"{_CHARSET_PROBE}_error"] = probe_error
+        failed.append(_CHARSET_PROBE)
+
     if cfg.json_mode:
         json_output({"ok": not failed, **results})
     else:
-        for name in _SELF_CHECK_EXTRAS:
+        for name in (*_SELF_CHECK_EXTRAS, _CHARSET_PROBE):
             ok = results.get(name) is True
             tag = (
                 f"[{theme.ACCENT}]ok[/{theme.ACCENT}]"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5488,9 +5488,19 @@ class TestSelfCheckExtras:
         return _stub
 
     def test_all_extras_present_json(self) -> None:
-        with mock.patch(
-            "lilbee.cli.commands.setup.importlib.import_module",
-            side_effect=self._import_module_stub(missing=set()),
+        # The probe is stubbed (the import_module patch reaches chardet's own
+        # importlib machinery) and patched first, because mock.patch resolves
+        # its target through importlib.import_module. The real pipeline is
+        # covered by test_charset_probe_runs_real_detection.
+        with (
+            mock.patch(
+                "lilbee.cli.commands.setup._probe_charset_detection",
+                return_value=None,
+            ),
+            mock.patch(
+                "lilbee.cli.commands.setup.importlib.import_module",
+                side_effect=self._import_module_stub(missing=set()),
+            ),
         ):
             result = runner.invoke(app, ["--json", "self-check-extras"])
         assert result.exit_code == 0, result.output
@@ -5501,12 +5511,87 @@ class TestSelfCheckExtras:
             "crawl4ai": True,
             "spacy": True,
             "graspologic_native": True,
+            "charset_detection": True,
         }
 
-    def test_one_extra_missing_exits_nonzero_json(self) -> None:
+    def test_charset_probe_runs_real_detection(self) -> None:
+        """The probe runs the real chardet pipeline, including the lazy
+        chardet.models import that frozen builds have shipped broken.
+
+        Calls the probe directly rather than the command: the unmocked
+        command imports the known-heavy extras (crawl4ai, litellm, spacy),
+        and a real crawl4ai import leaves its submodules in sys.modules,
+        which breaks the crawler tests' top-level-only module injection.
+        """
+        from lilbee.cli.commands import setup as setup_module
+
+        assert setup_module._probe_charset_detection() is None
+
+    def test_probe_reports_missing_encoding(self) -> None:
+        from lilbee.cli.commands import setup as setup_module
+
+        with mock.patch("chardet.detect", return_value={"encoding": None}):
+            error = setup_module._probe_charset_detection()
+        assert error is not None
+        assert "no encoding" in error
+
+    def test_probe_reports_detection_exception(self) -> None:
+        from lilbee.cli.commands import setup as setup_module
+
         with mock.patch(
-            "lilbee.cli.commands.setup.importlib.import_module",
-            side_effect=self._import_module_stub(missing={"crawl4ai"}),
+            "chardet.detect",
+            side_effect=ImportError("cannot import name 'BigramProfile' from 'chardet.models'"),
+        ):
+            error = setup_module._probe_charset_detection()
+        assert error is not None
+        assert "BigramProfile" in error
+
+    def test_charset_probe_failure_exits_nonzero_json(self) -> None:
+        with (
+            mock.patch(
+                "lilbee.cli.commands.setup._probe_charset_detection",
+                return_value="cannot import name 'BigramProfile' from 'chardet.models'",
+            ),
+            mock.patch(
+                "lilbee.cli.commands.setup.importlib.import_module",
+                side_effect=self._import_module_stub(missing=set()),
+            ),
+        ):
+            result = runner.invoke(app, ["--json", "self-check-extras"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+        assert payload["ok"] is False
+        assert payload["charset_detection"] is False
+        assert "BigramProfile" in payload["charset_detection_error"]
+
+    def test_charset_probe_failure_human_mode_reports_failure(self) -> None:
+        with (
+            mock.patch(
+                "lilbee.cli.commands.setup._probe_charset_detection",
+                return_value="chardet.detect returned no encoding",
+            ),
+            mock.patch(
+                "lilbee.cli.commands.setup.importlib.import_module",
+                side_effect=self._import_module_stub(missing=set()),
+            ),
+        ):
+            result = runner.invoke(app, ["self-check-extras"])
+        assert result.exit_code == 1, result.output
+        assert "charset_detection" in result.output
+        assert "MISSING" in result.output
+
+    def test_one_extra_missing_exits_nonzero_json(self) -> None:
+        with (
+            # Patched first: mock.patch resolves its target through
+            # importlib.import_module, which the next patch replaces.
+            mock.patch(
+                "lilbee.cli.commands.setup._probe_charset_detection",
+                return_value=None,
+            ),
+            mock.patch(
+                "lilbee.cli.commands.setup.importlib.import_module",
+                side_effect=self._import_module_stub(missing={"crawl4ai"}),
+            ),
         ):
             result = runner.invoke(app, ["--json", "self-check-extras"])
         assert result.exit_code == 1, result.output
@@ -5519,9 +5604,17 @@ class TestSelfCheckExtras:
         assert payload["graspologic_native"] is True
 
     def test_one_extra_missing_human_mode_reports_failure(self) -> None:
-        with mock.patch(
-            "lilbee.cli.commands.setup.importlib.import_module",
-            side_effect=self._import_module_stub(missing={"spacy"}),
+        with (
+            # Patched first: mock.patch resolves its target through
+            # importlib.import_module, which the next patch replaces.
+            mock.patch(
+                "lilbee.cli.commands.setup._probe_charset_detection",
+                return_value=None,
+            ),
+            mock.patch(
+                "lilbee.cli.commands.setup.importlib.import_module",
+                side_effect=self._import_module_stub(missing={"spacy"}),
+            ),
         ):
             result = runner.invoke(app, ["self-check-extras"])
         assert result.exit_code == 1, result.output

--- a/tools/qa/artifact_smoke.sh
+++ b/tools/qa/artifact_smoke.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Core-functionality gate for a built lilbee artifact (standalone executable or
 # an installed wheel's entrypoint). Drives the user-facing surface end to end:
-# engine inference (self-check: chat + embedding), document ingest + search,
-# a RAG ask, and an http-mode crawl. Models come from a pre-populated models
+# bundled extras + charset detection (self-check-extras), engine inference
+# (self-check: chat + embedding), document ingest + search, a RAG ask, and an
+# http-mode crawl. Models come from a pre-populated models
 # directory (the ci-models mirror in CI); nothing here contacts HuggingFace.
 #
 # Reads:
@@ -26,6 +27,14 @@ chat_gguf=$(find "${models_dir}" -name 'Qwen3-0.6B-Q8_0.gguf' \( -type f -o -typ
 embed_gguf=$(find "${models_dir}" -name 'nomic-embed-text-v1.5.Q4_K_M.gguf' \( -type f -o -type l \) | head -1)
 [ -n "${chat_gguf}" ] || { echo "chat model gguf not found under ${models_dir}" >&2; exit 1; }
 [ -n "${embed_gguf}" ] || { echo "embed model gguf not found under ${models_dir}" >&2; exit 1; }
+
+# Leg 0: bundled extras import and functional charset detection. The crawl in
+# leg 4 only reaches chardet when the target response has no charset header,
+# so this leg is the deterministic check for the frozen chardet closure.
+# Skipped with the crawl leg: the check needs the crawler extra.
+if [ "${SKIP_CRAWL:-0}" != "1" ]; then
+  "${exe}" self-check-extras
+fi
 
 # Leg 1: engine inference through the same launch builder the fleet uses.
 "${exe}" self-check --chat-model-path "${chat_gguf}" --embed-model-path "${embed_gguf}"
@@ -68,4 +77,6 @@ if [ "${SKIP_CRAWL:-0}" != "1" ]; then
   echo "${crawl_out}" | grep -qi "example" || { echo "FAIL: crawled page not searchable" >&2; exit 1; }
 fi
 
-echo "ARTIFACT SMOKE PASSED: self-check, ingest, search, ask${SKIP_CRAWL:+ (crawl skipped)}"
+skipped=""
+[ "${SKIP_CRAWL:-0}" = "1" ] && skipped=" (extras and crawl skipped)"
+echo "ARTIFACT SMOKE PASSED: extras, self-check, ingest, search, ask${skipped}"

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,10 +1,9 @@
 --- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
 +++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
-@@ -446,6 +446,179 @@
- 
+@@ -447,7 +447,298 @@
  #if _NUITKA_ONEFILE_TEMP_BOOL
  static bool payload_created = false;
-+#endif
+ #endif
 +
 +// lilbee: cold-start feedback and a warm-start fast path.
 +//
@@ -47,12 +46,126 @@
 +static bool lilbee_progress_on = false;
 +static int lilbee_last_percent = -1;
 +static int lilbee_pad = 0;
-+
+ 
 +static void lilbee_stamp_path(filename_char_t *buffer, size_t size) {
 +    buffer[0] = 0;
 +    appendStringSafeFilename(buffer, payload_path, size);
 +    appendCharSafeFilename(buffer, FILENAME_SEP_CHAR, size);
 +    appendStringSafeFilename(buffer, LILBEE_STAMP_NAME, size);
++}
++
++// The manifest lists every payload entry ("<size>\t<path>" per line, -1 for
++// symlinks). The warm-start path stats each entry before trusting the cache:
++// without this, a damaged cached tree (a file deleted by a cache cleanup, or
++// a re-extraction over the shared {VERSION} dir interrupted mid-write when
++// switching binary variants) is reused on every later launch, because the
++// stamp alone only proves the payload size. Stock Nuitka re-verifies the CRC32
++// of every file on every launch and self-heals; the stat sweep restores that
++// self-healing for missing and resized files at microseconds instead of
++// seconds. A same-size content change still slips through until a cold pass
++// runs; only the full CRC path can catch that, and paying it per launch is
++// what this fast path exists to avoid.
++#define LILBEE_MANIFEST_NAME ".lilbee-bootstrap-manifest"
++
++// Defined further down; needed on the first-ever run before any file lands.
++static bool createContainingDirectory(filename_char_t const *path);
++
++static FILE *lilbee_manifest_handle = NULL;
++
++static void lilbee_manifest_paths(filename_char_t *final_buffer, filename_char_t *tmp_buffer, size_t size) {
++    final_buffer[0] = 0;
++    appendStringSafeFilename(final_buffer, payload_path, size);
++    appendCharSafeFilename(final_buffer, FILENAME_SEP_CHAR, size);
++    appendStringSafeFilename(final_buffer, LILBEE_MANIFEST_NAME, size);
++
++    tmp_buffer[0] = 0;
++    appendStringSafeFilename(tmp_buffer, final_buffer, size);
++    appendStringSafeFilename(tmp_buffer, ".tmp", size);
++}
++
++static void lilbee_manifest_begin(void) {
++    static filename_char_t manifest[4096];
++    static filename_char_t manifest_tmp[4096];
++    lilbee_manifest_paths(manifest, manifest_tmp, sizeof(manifest) / sizeof(filename_char_t));
++
++    // A stale manifest must not survive an extraction that fails to commit:
++    // the stamp is rewritten unconditionally at the end, and a stamp that
++    // matches an old manifest would validate the wrong file set.
++    unlink(manifest);
++    // On the first-ever run the payload directory does not exist yet.
++    createContainingDirectory(manifest_tmp);
++    lilbee_manifest_handle = fopen(manifest_tmp, "wb");
++}
++
++static void lilbee_manifest_note(filename_char_t const *target_path, long long file_size) {
++    if (lilbee_manifest_handle != NULL) {
++        fprintf(lilbee_manifest_handle, "%lld\t%s\n", file_size, target_path);
++    }
++}
++
++static void lilbee_manifest_commit(void) {
++    if (lilbee_manifest_handle == NULL) {
++        return;
++    }
++    fclose(lilbee_manifest_handle);
++    lilbee_manifest_handle = NULL;
++
++    static filename_char_t manifest[4096];
++    static filename_char_t manifest_tmp[4096];
++    lilbee_manifest_paths(manifest, manifest_tmp, sizeof(manifest) / sizeof(filename_char_t));
++    rename(manifest_tmp, manifest);
++}
++
++// True when every manifest entry is still present with its recorded size.
++static bool lilbee_manifest_matches(void) {
++    static filename_char_t manifest[4096];
++    static filename_char_t manifest_tmp[4096];
++    lilbee_manifest_paths(manifest, manifest_tmp, sizeof(manifest) / sizeof(filename_char_t));
++
++    FILE *handle = fopen(manifest, "rb");
++    if (handle == NULL) {
++        return false;
++    }
++
++    static char line[4200];
++    bool ok = true;
++    unsigned long entries = 0;
++
++    while (fgets(line, sizeof(line), handle) != NULL) {
++        char *sep = strchr(line, '\t');
++        if (sep == NULL) {
++            ok = false;
++            break;
++        }
++        *sep = 0;
++        char *path = sep + 1;
++        size_t length = strlen(path);
++        while (length > 0 && (path[length - 1] == '\n' || path[length - 1] == '\r')) {
++            path[--length] = 0;
++        }
++
++        long long recorded_size = strtoll(line, NULL, 10);
++        struct stat entry_stat;
++
++        if (recorded_size < 0) {
++            // Symlink: presence is all the payload records.
++            if (lstat(path, &entry_stat) != 0) {
++                ok = false;
++                break;
++            }
++        } else if (stat(path, &entry_stat) != 0 || !S_ISREG(entry_stat.st_mode) ||
++                   entry_stat.st_size != (off_t)recorded_size) {
++            ok = false;
++            break;
++        }
++
++        entries += 1;
++    }
++
++    fclose(handle);
++
++    // An empty manifest proves nothing; force the cold path.
++    return ok && entries > 0;
 +}
 +
 +// True when the stamp records this payload's size; fills first_filename from it.
@@ -82,6 +195,10 @@
 +        stamped_main[--length] = 0;
 +    }
 +    if (length == 0 || access(stamped_main, X_OK) != 0) {
++        return false;
++    }
++
++    if (!lilbee_manifest_matches()) {
 +        return false;
 +    }
 +
@@ -177,10 +294,12 @@
 +    fputs(keep_logo ? "\033[?25l" : "\033[?25h", stderr);
 +    fflush(stderr);
 +}
- #endif
- 
++#endif
++
  #define MAX_CREATED_DIRS 1024
-@@ -1151,6 +1324,13 @@
+ static filename_char_t *created_dir_paths[MAX_CREATED_DIRS];
+ int created_dir_count = 0;
+@@ -1151,6 +1442,13 @@
      wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
  #endif
  
@@ -194,7 +313,7 @@
      if (process_role == NULL) {
  #if defined(_WIN32)
          bool_res = SetConsoleCtrlHandler(ourConsoleCtrlHandler, true);
-@@ -1169,6 +1349,7 @@
+@@ -1169,6 +1467,7 @@
  #endif
  
  #if _NUITKA_ONEFILE_HAS_PAYLOAD_BOOL == 1
@@ -202,24 +321,35 @@
      NUITKA_PRINT_TIMING("ONEFILE: Checking header for compression.");
  
      char header[3];
-@@ -1202,6 +1383,11 @@
+@@ -1202,6 +1501,12 @@
  
      NUITKA_PRINT_TIMING("ONEFILE: Entering decompression.");
  
 +#if !defined(_WIN32) && !defined(__MSYS__)
 +    unsigned char const *lilbee_payload_start = payload_current;
 +    lilbee_progress_begin();
++    lilbee_manifest_begin();
 +#endif
 +
  #if _NUITKA_ONEFILE_TEMP_BOOL
      payload_created = true;
  #endif
-@@ -1336,10 +1522,22 @@
+@@ -1252,6 +1557,8 @@
+                 fatalErrorTempFileCreate(target_path);
+             }
+ 
++            lilbee_manifest_note(target_path, -1);
++
+             continue;
+         }
+ #endif
+@@ -1336,10 +1643,26 @@
                  fatalErrorTempFiles();
              }
          }
 +
 +#if !defined(_WIN32) && !defined(__MSYS__)
++        lilbee_manifest_note(target_path, (long long)file_size);
 +        lilbee_progress_update((unsigned long long)(payload_current - lilbee_payload_start), payload_size);
 +#endif
      }
@@ -230,6 +360,9 @@
 +    // argc == 1 means no user arguments: the child launches the TUI, whose splash
 +    // repaints this wordmark in place.
 +    lilbee_progress_end(argc == 1);
++    // The manifest lands before the stamp: the stamp is the commit point, so
++    // a crash between the two leaves a stamp-less cache that cold-starts.
++    lilbee_manifest_commit();
 +    lilbee_stamp_write(first_filename);
 +#endif
 +    }

--- a/uv.lock
+++ b/uv.lock
@@ -3,15 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "(python_full_version >= '3.15' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32')",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "(python_full_version == '3.14.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32')",
     "python_full_version == '3.14.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
     "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
     "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
     "(python_full_version < '3.12' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'win32')",
     "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
 ]
@@ -1879,6 +1879,7 @@ release = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "chardet" },
     { name = "httpx" },
     { name = "hypothesis" },
     { name = "lilbee-engine" },
@@ -1938,6 +1939,7 @@ provides-extras = ["engine", "litellm", "graph", "crawler", "cuda12", "release"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "chardet", specifier = ">=7" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "lilbee-engine", directory = "packaging/engine-wheel" },
@@ -4046,9 +4048,9 @@ version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "(python_full_version >= '3.15' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'win32')",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "(python_full_version == '3.14.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'win32')",
     "python_full_version == '3.14.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",


### PR DESCRIPTION
## Problem

Frozen Linux builds fail every crawl that runs charset detection with "cannot import name 'BigramProfile' from 'chardet.models'", and the state survives re-downloads of the binary. The shipped binaries are packaged correctly: the failure lives in the onefile cache. Our bootstrap patch's warm-start stamp trusts the cached extraction on payload size alone, which disables stock Nuitka's per-launch CRC sweep — once a tree under ~/.cache/lilbee/{VERSION} loses or half-overwrites a file (the dir is shared by all variants of one version, so an interrupted variant switch is enough; so is a cache cleanup or disk pressure), every later launch reuses the broken tree.

## Cache self-healing

Cold extraction now writes a manifest of every payload entry (size and path, tmp+rename, committed before the stamp). Warm start stats each entry; any missing or resized file forces the cold CRC repair pass. Validated on macOS and Linux: cold, warm fast path, delete-heal, truncate-heal.

## Deterministic gate coverage

The smoke's crawl only reaches the lazy chardet.models import when the target answers without a charset header, and example.com's header varies by edge. self-check-extras now runs a real chardet.detect() on GB18030 bytes, and artifact_smoke.sh runs it as leg 0, so a broken frozen chardet fails the gate regardless of any crawl target's headers.

## Recovery on affected hosts

`rm -rf ~/.cache/lilbee/<version>` clears the pinned state today; binaries with this fix heal on the next launch instead.