### PR TITLE
Fix the black Windows first launch and downloads that stall forever

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import logging
+import os
 import signal
 import sys
 import threading
@@ -435,15 +436,40 @@ class _EngineLifecycle:
         raise SystemExit(_SIGNAL_EXIT_BASE + signum)
 
 
+_FORCE_QUIT_EXIT_CODE = 130
+
+_STOPPING_NOTE = "lilbee: stopping the engine. Press Ctrl-C again to force quit.\n"
+
+_FORCE_QUIT_NOTE = "lilbee: force quit. The engine stops with it.\n"
+
+
+def _write_exit_note(note: str) -> None:
+    """Print an exit-path status line; stderr may already be gone at exit."""
+    try:
+        sys.stderr.write(note)
+        sys.stderr.flush()
+    except (OSError, ValueError):
+        pass
+
+
 def wait_for_hard_exit_teardown() -> None:
     """Block until any teardown thread (signal-driven or exit-driven) finishes.
 
     Lets ``serve`` hold its OS locks through the fleet stop, so a successor
     cannot acquire them while this server's models still occupy memory.
+
+    An interrupt while waiting force-quits the process: waiting is the only
+    thing left, the interpreter would otherwise still join the non-daemon
+    teardown thread, and every platform's child guard reaps the engine when
+    the process dies (kill-on-close job object, pdeathsig, death pipe).
     """
-    for thread in threading.enumerate():
-        if thread.name == _HARD_EXIT_THREAD_NAME:
-            thread.join()
+    try:
+        for thread in threading.enumerate():
+            if thread.name == _HARD_EXIT_THREAD_NAME:
+                thread.join()
+    except KeyboardInterrupt:
+        _write_exit_note(_FORCE_QUIT_NOTE)
+        os._exit(_FORCE_QUIT_EXIT_CODE)
 
 
 def reset_services_on_exit() -> None:
@@ -451,12 +477,13 @@ def reset_services_on_exit() -> None:
 
     Engine release waits on the fleet build lock before it releases anything, so
     a Ctrl-C on the main thread skips the release, and atexit cannot retry: the
-    singleton is already cleared. The teardown thread is non-daemon and takes no
-    signals, so an interrupt breaks only the join here.
+    singleton is already cleared. The teardown thread is non-daemon and takes
+    no signals; the wait names what is happening and how to skip it.
     """
     if peek_services() is None:
         return
     threading.Thread(target=reset_services, name=_HARD_EXIT_THREAD_NAME).start()
+    _write_exit_note(_STOPPING_NOTE)
     wait_for_hard_exit_teardown()
 
 

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -23,6 +23,7 @@ import os
 import signal
 import sys
 import threading
+import time
 from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -440,7 +441,15 @@ _FORCE_QUIT_EXIT_CODE = 130
 
 _STOPPING_NOTE = "lilbee: stopping the engine. Press Ctrl-C again to force quit.\n"
 
+_STOPPING_NOTE_GRACE_S = 1.0
+"""Seconds a teardown may run silently; a fast exit stays as quiet as ever."""
+
 _FORCE_QUIT_NOTE = "lilbee: force quit. The engine stops with it.\n"
+
+_STRAGGLER_BUDGET_S = 5.0
+"""Seconds every leftover non-daemon thread gets, together, before the exit."""
+
+_STRAGGLER_NOTE = "lilbee: a background task would not stop; exiting anyway.\n"
 
 
 def _write_exit_note(note: str) -> None:
@@ -450,6 +459,11 @@ def _write_exit_note(note: str) -> None:
         sys.stderr.flush()
     except (OSError, ValueError):
         pass
+
+
+def _all_threads() -> list[threading.Thread]:
+    """Seam over threading.enumerate, so tests never patch the stdlib global."""
+    return threading.enumerate()
 
 
 def wait_for_hard_exit_teardown() -> None:
@@ -464,8 +478,12 @@ def wait_for_hard_exit_teardown() -> None:
     the process dies (kill-on-close job object, pdeathsig, death pipe).
     """
     try:
-        for thread in threading.enumerate():
-            if thread.name == _HARD_EXIT_THREAD_NAME:
+        for thread in _all_threads():
+            if thread.name != _HARD_EXIT_THREAD_NAME:
+                continue
+            thread.join(_STOPPING_NOTE_GRACE_S)
+            if thread.is_alive():
+                _write_exit_note(_STOPPING_NOTE)
                 thread.join()
     except KeyboardInterrupt:
         _write_exit_note(_FORCE_QUIT_NOTE)
@@ -478,13 +496,48 @@ def reset_services_on_exit() -> None:
     Engine release waits on the fleet build lock before it releases anything, so
     a Ctrl-C on the main thread skips the release, and atexit cannot retry: the
     singleton is already cleared. The teardown thread is non-daemon and takes
-    no signals; the wait names what is happening and how to skip it.
+    no signals; a wait that outlives the grace names what is happening.
     """
     if peek_services() is None:
         return
     threading.Thread(target=reset_services, name=_HARD_EXIT_THREAD_NAME).start()
-    _write_exit_note(_STOPPING_NOTE)
     wait_for_hard_exit_teardown()
+
+
+def _straggler_threads() -> list[threading.Thread]:
+    """Non-daemon threads the interpreter would join at shutdown, besides us."""
+    return [
+        thread
+        for thread in _all_threads()
+        if thread.is_alive()
+        and not thread.daemon
+        and thread is not threading.main_thread()
+        and thread is not threading.current_thread()
+    ]
+
+
+def exit_when_stragglers_would_hang() -> None:
+    """Exit rather than let interpreter shutdown join a wedged thread forever.
+
+    threading joins every non-daemon thread after atexit, so one worker
+    blocked in an unbounded network read hangs the process after all real
+    work is done. Stragglers share a short budget; whatever remains cannot
+    finish, and the child guard reaps the engine when the process dies.
+    Called from the TUI's own exit path and inert elsewhere: a test process
+    or embedding host owns its threads, and an exit would take them with it.
+    """
+    if not _state.interactive:
+        return
+    try:
+        deadline = time.monotonic() + _STRAGGLER_BUDGET_S
+        for thread in _straggler_threads():
+            thread.join(max(0.0, deadline - time.monotonic()))
+        if _straggler_threads():
+            _write_exit_note(_STRAGGLER_NOTE)
+            os._exit(0)
+    except KeyboardInterrupt:
+        _write_exit_note(_FORCE_QUIT_NOTE)
+        os._exit(_FORCE_QUIT_EXIT_CODE)
 
 
 def _teardown_for_signal(signum: int) -> None:

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
@@ -152,6 +153,28 @@ def abort_active_download() -> None:
 
 _XET_HIGH_PERFORMANCE_ENV = "HF_XET_HIGH_PERFORMANCE"
 
+_XET_DISABLE_ENV = "HF_HUB_DISABLE_XET"
+
+
+def _disable_xet_where_it_stalls() -> None:
+    """Fall back to the plain HTTP download path on Windows.
+
+    hf_xet transfers stall or deadlock on Windows (xet-core issues #446,
+    #789, #850; reproduced on the Windows verification box with hf_xet
+    1.5.2), while the plain path downloads at line speed. A user who
+    exported the variable keeps whatever they chose. huggingface_hub parses
+    the variable once at import, so the hub constant must change too; the
+    environment write covers worker subprocesses, which parse it fresh.
+    """
+    if sys.platform != "win32":
+        return
+    if _XET_DISABLE_ENV in os.environ:
+        return
+    from huggingface_hub import constants
+
+    os.environ[_XET_DISABLE_ENV] = "1"
+    constants.HF_HUB_DISABLE_XET = True
+
 
 def _apply_fast_download_mode() -> None:
     """Publish the high-performance setting to xet before it builds a session.
@@ -175,6 +198,7 @@ def _hf_download_or_translate(entry: CatalogModel, config: DownloadConfig) -> Pa
     from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 
     _apply_fast_download_mode()
+    _disable_xet_where_it_stalls()
     try:
         return Path(hf_hub_download(**config.model_dump(exclude_none=True)))
     except TaskCancelledError:

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -196,10 +196,17 @@ def _apply_fast_download_mode() -> None:
 
 
 _STALL_WINDOW_S = 60.0
-"""Seconds without a progress pulse before a transfer counts as stalled.
+"""Seconds per measurement window; a transfer below the byte floor for a
+whole window counts as stalled.
 
 Well past the hub's own 10s read timeout and its resume retries, so the
 guard only fires on transfers those mechanisms cannot wake."""
+
+_STALL_FLOOR_BYTES = 256 * 1024
+"""Minimum bytes per window for a transfer to count as alive.
+
+A wedged connection can trickle a few bytes a minute, which an any-activity
+check reads as progress; ~4 KB/s is far below any usable model download."""
 
 _STALL_POLL_S = 5.0
 
@@ -224,23 +231,31 @@ class _StallGuard:
     """Aborts a transfer that reports no bytes for the stall window.
 
     A wedged transfer blocks forever with the task showing active: hf_xet
-    can deadlock before its first byte, and a dead socket never wakes the
-    plain path's read. The guard rides the same progress stream the task
-    bar shows; when it goes quiet, the abort makes the blocked thread
-    raise, and the caller resumes from the .incomplete file.
+    can deadlock before its first byte, a dead socket never wakes the
+    plain path's read, and a dying connection can trickle bytes too slowly
+    to ever finish. The guard rides the same progress stream the task bar
+    shows; when a window passes under the byte floor, the abort makes the
+    blocked thread raise, and the caller resumes from the .incomplete file.
     """
 
-    def __init__(self, window_s: float = _STALL_WINDOW_S, poll_s: float = _STALL_POLL_S) -> None:
+    def __init__(
+        self,
+        window_s: float = _STALL_WINDOW_S,
+        poll_s: float = _STALL_POLL_S,
+        floor_bytes: int = _STALL_FLOOR_BYTES,
+    ) -> None:
         self._window_s = window_s
         self._poll_s = poll_s
-        self._last_pulse = time.monotonic()
+        self._floor_bytes = floor_bytes
+        self._window_start = time.monotonic()
+        self._window_bytes = 0
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self.fired = False
 
-    def pulse(self) -> None:
-        """Record transfer activity; called from the download thread's tqdm."""
-        self._last_pulse = time.monotonic()
+    def pulse(self, n: float = 0) -> None:
+        """Count transferred bytes; called from the download thread's tqdm."""
+        self._window_bytes += int(n)
 
     def wrap_tqdm(self, tqdm_class: Any) -> Any:
         """Subclass *tqdm_class* (or the hub's default) to pulse on every update.
@@ -256,7 +271,7 @@ class _StallGuard:
 
         class _Pulsing(base):  # type: ignore[misc, valid-type]
             def update(self, n: float = 1) -> bool | None:
-                guard.pulse()
+                guard.pulse(n)
                 super().update(n)
                 return None
 
@@ -265,7 +280,7 @@ class _StallGuard:
 
         class _PulsingTransfer(_Pulsing):
             def update_transfer(self, n: float = 1) -> bool | None:
-                guard.pulse()
+                guard.pulse(n)
                 super().update_transfer(n)
                 return None
 
@@ -278,10 +293,15 @@ class _StallGuard:
 
     def _keep_watching(self) -> bool:
         """One tick: True to keep watching, False once fired or stopped."""
-        if time.monotonic() - self._last_pulse <= self._window_s:
+        now = time.monotonic()
+        if now - self._window_start < self._window_s:
             return True
         if self._stop.is_set():
             return False  # the transfer finished while this tick was deciding
+        if self._window_bytes >= self._floor_bytes:
+            self._window_start = now
+            self._window_bytes = 0
+            return True
         self.fired = True
         _abort_stalled_transfer()
         return False
@@ -326,9 +346,9 @@ def _download_with_stall_guard(entry: CatalogModel, config: DownloadConfig) -> P
                 _STALL_RETRIES + 1,
             )
     raise RuntimeError(
-        f"Download of {entry.hf_repo} stalled {_STALL_RETRIES + 1} times with no data "
-        "arriving. Check the network connection and retry; the finished part is kept "
-        "and the download resumes where it stopped."
+        f"Download of {entry.hf_repo} stalled {_STALL_RETRIES + 1} times with almost "
+        "no data arriving. Check the network connection and retry; the finished part "
+        "is kept and the download resumes where it stopped."
     ) from last_error
 
 

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -6,6 +6,8 @@ import os
 import re
 import shutil
 import sys
+import threading
+import time
 from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
@@ -195,6 +197,136 @@ def _apply_fast_download_mode() -> None:
         os.environ.pop(_XET_HIGH_PERFORMANCE_ENV, None)
 
 
+_STALL_WINDOW_S = 60.0
+"""Seconds without a progress pulse before a transfer counts as stalled.
+
+Well past the hub's own 10s read timeout and its resume retries, so the
+guard only fires on transfers those mechanisms cannot wake."""
+
+_STALL_POLL_S = 5.0
+
+_STALL_RETRIES = 2
+
+
+def _abort_stalled_transfer() -> None:
+    """Break a wedged transfer so the blocked download thread raises.
+
+    Covers both transports: the xet session abort stops a deadlocked Rust
+    transfer (a no-op without one), and closing the hub's shared client
+    closes the plain path's socket under its blocked read. The next hub
+    call builds a fresh client.
+    """
+    from huggingface_hub.utils._http import close_session
+
+    abort_active_download()
+    close_session()
+
+
+class _StallGuard:
+    """Aborts a transfer that reports no bytes for the stall window.
+
+    A wedged transfer blocks forever with the task showing active: hf_xet
+    can deadlock before its first byte, and a dead socket never wakes the
+    plain path's read (seen on the Windows verification box, where the
+    read outlived a 15-minute stall). The guard rides the same progress
+    stream the task bar shows; when it goes quiet, the abort makes the
+    blocked thread raise, and the caller resumes from the .incomplete file.
+    """
+
+    def __init__(self, window_s: float = _STALL_WINDOW_S, poll_s: float = _STALL_POLL_S) -> None:
+        self._window_s = window_s
+        self._poll_s = poll_s
+        self._last_pulse = time.monotonic()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.fired = False
+
+    def pulse(self) -> None:
+        """Record transfer activity; called from the download thread's tqdm."""
+        self._last_pulse = time.monotonic()
+
+    def wrap_tqdm(self, tqdm_class: Any) -> Any:
+        """Subclass *tqdm_class* (or the hub's default) to pulse on every update.
+
+        ``update_transfer`` is only defined when the base has it: the hub
+        feature-detects the method, so adding it to a base that lacks it
+        would advertise a stream the base cannot aggregate.
+        """
+        from huggingface_hub.utils.tqdm import tqdm as hub_tqdm
+
+        guard = self
+        base = tqdm_class if tqdm_class is not None else hub_tqdm
+
+        class _Pulsing(base):  # type: ignore[misc, valid-type]
+            def update(self, n: float = 1) -> bool | None:
+                guard.pulse()
+                super().update(n)
+                return None
+
+        if not hasattr(base, "update_transfer"):
+            return _Pulsing
+
+        class _PulsingTransfer(_Pulsing):
+            def update_transfer(self, n: float = 1) -> bool | None:
+                guard.pulse()
+                super().update_transfer(n)
+                return None
+
+        return _PulsingTransfer
+
+    def _watch(self) -> None:
+        while not self._stop.wait(self._poll_s):
+            if time.monotonic() - self._last_pulse > self._window_s:
+                self.fired = True
+                _abort_stalled_transfer()
+                return
+
+    def __enter__(self) -> "_StallGuard":
+        self._thread = threading.Thread(
+            target=self._watch, name="download-stall-guard", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._poll_s + 1)
+
+
+def _download_with_stall_guard(entry: CatalogModel, config: DownloadConfig) -> Path:
+    """Run the transfer under the stall guard, resuming after each stall.
+
+    huggingface_hub resumes from the .incomplete file, so a retry costs only
+    the bytes since the stall. A failure with the guard quiet is a real
+    error and propagates on the first attempt; cancellation always does.
+    """
+    last_error: Exception | None = None
+    for attempt in range(_STALL_RETRIES + 1):
+        guard = _StallGuard()
+        guarded = config.model_copy(update={"tqdm_class": guard.wrap_tqdm(config.tqdm_class)})
+        try:
+            with guard:
+                return _hf_download_or_translate(entry, guarded)
+        except TaskCancelledError:
+            raise
+        except Exception as exc:
+            if not guard.fired:
+                raise
+            last_error = exc
+            log.warning(
+                "Transfer of %s stalled (attempt %d/%d); resuming.",
+                entry.hf_repo,
+                attempt + 1,
+                _STALL_RETRIES + 1,
+            )
+    raise RuntimeError(
+        f"Download of {entry.hf_repo} stalled {_STALL_RETRIES + 1} times with no data "
+        "arriving. Check the network connection and retry; the finished part is kept "
+        "and the download resumes where it stopped."
+    ) from last_error
+
+
 def _hf_download_or_translate(entry: CatalogModel, config: DownloadConfig) -> Path:
     """Run the HF download and translate every error class into a clean exception."""
     from huggingface_hub import hf_hub_download
@@ -305,7 +437,7 @@ def download_model(
             cache_dir=str(models_dir),
             tqdm_class=tracker.make_tqdm_class() if tracker else None,
         )
-        shard_path = _hf_download_or_translate(entry, config)
+        shard_path = _download_with_stall_guard(entry, config)
         shard_paths.append(shard_path)
         if tracker is not None:
             tracker.shard_done(shard_path.stat().st_size)
@@ -361,8 +493,8 @@ def download_mmproj(
     tracker = _ProgressTracker(on_progress) if on_progress else None
     log.info("Downloading mmproj %s/%s → %s", entry.hf_repo, mmproj_filename, models_dir)
     _require_disk_space(entry, models_dir, fetch_expected_file_size(entry.hf_repo, mmproj_filename))
-    # The projector gets the same error translation as the GGUF.
-    path = _hf_download_or_translate(
+    # The projector gets the same error translation and stall guard as the GGUF.
+    path = _download_with_stall_guard(
         entry,
         DownloadConfig(
             repo_id=entry.hf_repo,

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -162,11 +162,9 @@ def _disable_xet_where_it_stalls() -> None:
     """Fall back to the plain HTTP download path on Windows.
 
     hf_xet transfers stall or deadlock on Windows (xet-core issues #446,
-    #789, #850; reproduced on the Windows verification box with hf_xet
-    1.5.2), while the plain path downloads at line speed. Everywhere else
-    xet stays on deliberately: it is the fast path, and the old global
-    disable was removed once the transfer-progress stream landed. A user
-    who exported the variable keeps whatever they chose. huggingface_hub
+    #789, #850), while the plain path downloads at line speed. Everywhere
+    else xet stays on deliberately: it is the fast path. A user who
+    exported the variable keeps whatever they chose. huggingface_hub
     parses the variable once at import, so the hub constant must change
     too; the environment write covers worker subprocesses, which parse it
     fresh.
@@ -227,10 +225,9 @@ class _StallGuard:
 
     A wedged transfer blocks forever with the task showing active: hf_xet
     can deadlock before its first byte, and a dead socket never wakes the
-    plain path's read (seen on the Windows verification box, where the
-    read outlived a 15-minute stall). The guard rides the same progress
-    stream the task bar shows; when it goes quiet, the abort makes the
-    blocked thread raise, and the caller resumes from the .incomplete file.
+    plain path's read. The guard rides the same progress stream the task
+    bar shows; when it goes quiet, the abort makes the blocked thread
+    raise, and the caller resumes from the .incomplete file.
     """
 
     def __init__(self, window_s: float = _STALL_WINDOW_S, poll_s: float = _STALL_POLL_S) -> None:
@@ -276,10 +273,18 @@ class _StallGuard:
 
     def _watch(self) -> None:
         while not self._stop.wait(self._poll_s):
-            if time.monotonic() - self._last_pulse > self._window_s:
-                self.fired = True
-                _abort_stalled_transfer()
+            if not self._keep_watching():
                 return
+
+    def _keep_watching(self) -> bool:
+        """One tick: True to keep watching, False once fired or stopped."""
+        if time.monotonic() - self._last_pulse <= self._window_s:
+            return True
+        if self._stop.is_set():
+            return False  # the transfer finished while this tick was deciding
+        self.fired = True
+        _abort_stalled_transfer()
+        return False
 
     def __enter__(self) -> "_StallGuard":
         self._thread = threading.Thread(

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -161,10 +161,13 @@ def _disable_xet_where_it_stalls() -> None:
 
     hf_xet transfers stall or deadlock on Windows (xet-core issues #446,
     #789, #850; reproduced on the Windows verification box with hf_xet
-    1.5.2), while the plain path downloads at line speed. A user who
-    exported the variable keeps whatever they chose. huggingface_hub parses
-    the variable once at import, so the hub constant must change too; the
-    environment write covers worker subprocesses, which parse it fresh.
+    1.5.2), while the plain path downloads at line speed. Everywhere else
+    xet stays on deliberately: it is the fast path, and the old global
+    disable was removed once the transfer-progress stream landed. A user
+    who exported the variable keeps whatever they chose. huggingface_hub
+    parses the variable once at import, so the hub constant must change
+    too; the environment write covers worker subprocesses, which parse it
+    fresh.
     """
     if sys.platform != "win32":
         return

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -9,7 +9,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from lilbee.app.services import reset_services_on_exit
+from lilbee.app.services import exit_when_stragglers_would_hang, reset_services_on_exit
 from lilbee.cli.tui.log_routing import setup_tui_log_file
 
 
@@ -113,3 +113,4 @@ def run_tui(*, initial_view: str | None = None) -> None:
         _restore_native_stderr(stderr_redirect)
         shutdown_executor()
         reset_services_on_exit()
+        exit_when_stragglers_would_hang()

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -245,6 +245,7 @@ CMD_WIKI_WIPE_WARNING = (
 )
 TASK_NAME_CRAWL = "Crawl {url}"
 STREAM_ERROR = "\n\n*Error: {error}*"
+STREAM_DISCONNECTED = "\n\n*The engine connection dropped before the answer finished.*"
 STREAM_CANCELLED = "\n\n*Response cancelled.*"
 SYNC_STATUS_SYNCING = "Syncing..."
 SYNC_STATUS_DONE = "Synced ({count} docs)"

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -2152,7 +2152,10 @@ class CatalogScreen(Screen[None]):
         """
 
         def _adopt() -> None:
-            self.app.call_from_thread(self._adopt_first_download, model)
+            # Runs on the download worker thread, where resolving self.app
+            # raises NoActiveAppError once this screen is detached; the safe
+            # wrapper drops the hop instead of crashing the worker.
+            call_from_thread(self, self._adopt_first_download, model)
 
         if model.compat is ModelCompat.UNSUPPORTED:
 

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -2152,9 +2152,8 @@ class CatalogScreen(Screen[None]):
         """
 
         def _adopt() -> None:
-            # Runs on the download worker thread, where resolving self.app
-            # raises NoActiveAppError once this screen is detached; the safe
-            # wrapper drops the hop instead of crashing the worker.
+            # Runs on the download worker thread; the safe wrapper drops the
+            # hop on a detached screen instead of crashing the worker.
             call_from_thread(self, self._adopt_first_download, model)
 
         if model.compat is ModelCompat.UNSUPPORTED:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1604,10 +1604,14 @@ class ChatScreen(Screen[None]):
             # A deliberate cancel severs the transport, which surfaces here as a
             # stream error; the cancel already wrote its note into the bubble.
             if not self._stream_worker_cancelled():
+                # A severed engine socket names the OS error, not the problem.
+                error_text = (
+                    msg.STREAM_DISCONNECTED
+                    if isinstance(exc, ConnectionError)
+                    else msg.STREAM_ERROR.format(error=exc)
+                )
                 with contextlib.suppress(Exception):
-                    call_from_thread(
-                        self, widget.append_content, msg.STREAM_ERROR.format(error=exc)
-                    )
+                    call_from_thread(self, widget.append_content, error_text)
         finally:
             close_stream(stream)
             self._finalize_stream(widget, sources, response_parts)

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -35,11 +35,10 @@ class StartupGate(Screen[None]):
     # reveal_landing resolve without reflection.
     app: LilbeeApp  # type: ignore[assignment]
 
-    # The app reference every worker and UI hop uses. ``self.app`` reads a
+    # The app reference every worker and UI hop uses: ``self.app`` reads a
     # contextvar that plain threads never carry and then walks ``_parent``,
-    # which raises NoActiveAppError the moment the gate detaches -- seen on
-    # Windows first launches, where the crash left a dead loading screen.
-    # Captured once in on_mount, on the UI thread, where resolution is certain.
+    # which raises NoActiveAppError the moment the gate detaches. Captured
+    # once in on_mount, on the UI thread, where resolution is certain.
     _ui_app: LilbeeApp
 
     def compose(self) -> ComposeResult:

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -35,6 +35,13 @@ class StartupGate(Screen[None]):
     # reveal_landing resolve without reflection.
     app: LilbeeApp  # type: ignore[assignment]
 
+    # The app reference every worker and UI hop uses. ``self.app`` reads a
+    # contextvar that plain threads never carry and then walks ``_parent``,
+    # which raises NoActiveAppError the moment the gate detaches -- seen on
+    # Windows first launches, where the crash left a dead loading screen.
+    # Captured once in on_mount, on the UI thread, where resolution is certain.
+    _ui_app: LilbeeApp
+
     def compose(self) -> ComposeResult:
         with Vertical(id="gate-body"):
             yield Static(_LOGO, id="gate-logo")
@@ -42,13 +49,14 @@ class StartupGate(Screen[None]):
             yield Static(msg.STARTUP_PREPARING, id="gate-status")
 
     def on_mount(self) -> None:
-        """Retire the launcher's splash now that Textual is painting.
+        """Capture the app for the workers, then retire the launcher's splash.
 
         The splash animates over the blank alt-screen right up to this moment,
         so the wordmark never leaves the terminal. Dismissal waits on the
         subprocess, so it runs off-thread; the refresh afterwards repaints
         anything a final splash frame may have touched.
         """
+        self._ui_app = self.app
         self._retire_splash()
 
     @work(thread=True, name="splash_retire", exit_on_error=False)
@@ -88,9 +96,9 @@ class StartupGate(Screen[None]):
         """
         try:
             if peek_services() is None:
-                self.app.canonicalize_persisted_models()
-            self.app.settle_landing()
-            self.app.adopt_services()
+                self._ui_app.canonicalize_persisted_models()
+            self._ui_app.settle_landing()
+            self._ui_app.adopt_services()
         except Exception as exc:
             # Any failure to prepare the app leaves the user with no engine.
             # Show it and hand them the rest of the TUI rather than a dead screen.
@@ -108,11 +116,11 @@ class StartupGate(Screen[None]):
         """Hop to the UI thread, unless the app is already tearing down."""
         if self._stopping():
             return
-        self.app.call_from_thread(callback, *args)
+        self._ui_app.call_from_thread(callback, *args)
 
     def _fail(self, error: str) -> None:
         """Surface a failed start and hand the user to the rest of the TUI to fix it."""
-        self.app.notify(msg.STARTUP_FAILED.format(error=error), severity="error", timeout=8)
+        self._ui_app.notify(msg.STARTUP_FAILED.format(error=error), severity="error", timeout=8)
         self._release()
 
     def _release(self) -> None:
@@ -123,6 +131,6 @@ class StartupGate(Screen[None]):
         itself. No widget lookup here either: the gate can resolve before compose
         has mounted its children, and a missed query would strand the user.
         """
-        if self.app.screen is not self:
+        if self._ui_app.screen is not self:
             return
-        self.app.reveal_landing()
+        self._ui_app.reveal_landing()

--- a/src/lilbee/runtime/_splash_runner.py
+++ b/src/lilbee/runtime/_splash_runner.py
@@ -43,8 +43,13 @@ POLL_INTERVAL = 0.01
 _BAR_FALLOFF_DENSE = 1
 _BAR_FALLOFF_LIGHT = 2
 
-# Subprocess entry point expects exactly ``python -m ... <pipe_fd>`` (script name + 1 arg).
+# Subprocess entry point expects exactly ``python -m ... <pipe_ref>`` (script name + 1 arg).
 _EXPECTED_ARGV_LEN = 2
+
+# Console-mode bits for the legacy Windows console (Windows Terminal has VT on
+# by default, conhost does not).
+_STD_ERROR_HANDLE = -12
+_ENABLE_VT_PROCESSING = 0x0004
 
 # Sent down the pipe by ``splash.dismiss()`` when the TUI takes over the
 # terminal: the child must exit without writing anything (no frame clear, no
@@ -187,6 +192,37 @@ def poll_pipe(pipe_fd: int) -> PipeSignal:
     return _poll_pipe_posix(pipe_fd)  # pragma: no cover  POSIX-only
 
 
+def _open_pipe_ref(ref: int) -> int:
+    """Turn the argv pipe reference into a readable fd.
+
+    POSIX passes the fd itself (pass_fds keeps the number). Windows cannot
+    pass fds, so the parent sends the pipe's OS handle number and the child
+    reopens it as a fd here.
+    """
+    if sys.platform == "win32":  # pragma: no cover  Windows-only
+        import msvcrt
+
+        return msvcrt.open_osfhandle(ref, os.O_RDONLY)
+    return ref
+
+
+def _enable_vt_win32() -> None:  # pragma: no cover  Windows-only
+    """Turn on ANSI processing for the legacy console.
+
+    Skipped silently when stderr is not a console (GetConsoleMode fails);
+    the parent only starts the splash on a tty anyway.
+    """
+    if sys.platform != "win32":
+        return
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    handle = kernel32.GetStdHandle(_STD_ERROR_HANDLE)
+    mode = ctypes.c_ulong(0)
+    if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+        kernel32.SetConsoleMode(handle, mode.value | _ENABLE_VT_PROCESSING)
+
+
 def animation_loop(pipe_fd: int) -> None:
     """Run the animation, exiting when the pipe signals EOF or takeover.
 
@@ -205,7 +241,9 @@ def animation_loop(pipe_fd: int) -> None:
     got_signal = False
     pipe_signal = PipeSignal.OPEN
 
-    if sys.platform != "win32":  # pragma: no cover - POSIX-only SIGTERM handler
+    if sys.platform == "win32":  # pragma: no cover - Windows-only console setup
+        _enable_vt_win32()
+    else:  # pragma: no cover - POSIX-only SIGTERM handler
 
         def handle_term(signum: int, frame: object) -> None:
             nonlocal got_signal
@@ -262,13 +300,13 @@ def _animate_frames(
 
 
 def main() -> None:
-    """Entry point when run as ``python -m lilbee.runtime._splash_runner <pipe_fd>``."""
+    """Entry point when run as ``python -m lilbee.runtime._splash_runner <pipe_ref>``."""
     if len(sys.argv) != _EXPECTED_ARGV_LEN:
         sys.exit(1)
 
     try:
-        pipe_fd = int(sys.argv[1])
-    except ValueError:
+        pipe_fd = _open_pipe_ref(int(sys.argv[1]))
+    except (ValueError, OSError):
         sys.exit(1)
 
     try:

--- a/src/lilbee/runtime/_splash_runner.py
+++ b/src/lilbee/runtime/_splash_runner.py
@@ -50,6 +50,7 @@ _EXPECTED_ARGV_LEN = 2
 # by default, conhost does not).
 _STD_ERROR_HANDLE = -12
 _ENABLE_VT_PROCESSING = 0x0004
+_UTF8_CODEPAGE = 65001
 
 # Sent down the pipe by ``splash.dismiss()`` when the TUI takes over the
 # terminal: the child must exit without writing anything (no frame clear, no
@@ -206,21 +207,37 @@ def _open_pipe_ref(ref: int) -> int:
     return ref
 
 
-def _enable_vt_win32() -> None:  # pragma: no cover  Windows-only
-    """Turn on ANSI processing for the legacy console.
+def _setup_console_win32() -> int:  # pragma: no cover  Windows-only
+    """Make the console render this process's output: VT on, UTF-8 out.
 
-    Skipped silently when stderr is not a console (GetConsoleMode fails);
-    the parent only starts the splash on a tty anyway.
+    ANSI processing is off on the legacy console (Windows Terminal has it
+    on), and the default output codepage mangles the loading bar's block
+    characters, which the frames carry as UTF-8 bytes. Returns the previous
+    codepage so the caller can restore it; 0 when there is no console
+    (GetConsoleMode fails -- the parent only starts the splash on a tty).
     """
     if sys.platform != "win32":
-        return
+        return 0
     import ctypes
 
     kernel32 = ctypes.windll.kernel32
     handle = kernel32.GetStdHandle(_STD_ERROR_HANDLE)
     mode = ctypes.c_ulong(0)
-    if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
-        kernel32.SetConsoleMode(handle, mode.value | _ENABLE_VT_PROCESSING)
+    if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+        return 0
+    kernel32.SetConsoleMode(handle, mode.value | _ENABLE_VT_PROCESSING)
+    previous_cp = int(kernel32.GetConsoleOutputCP())
+    kernel32.SetConsoleOutputCP(_UTF8_CODEPAGE)
+    return previous_cp
+
+
+def _restore_console_win32(previous_cp: int) -> None:  # pragma: no cover  Windows-only
+    """Put the console codepage back so the parent shell keeps its own."""
+    if sys.platform != "win32" or not previous_cp:
+        return
+    import ctypes
+
+    ctypes.windll.kernel32.SetConsoleOutputCP(previous_cp)
 
 
 def animation_loop(pipe_fd: int) -> None:
@@ -241,9 +258,7 @@ def animation_loop(pipe_fd: int) -> None:
     got_signal = False
     pipe_signal = PipeSignal.OPEN
 
-    if sys.platform == "win32":  # pragma: no cover - Windows-only console setup
-        _enable_vt_win32()
-    else:  # pragma: no cover - POSIX-only SIGTERM handler
+    if sys.platform != "win32":  # pragma: no cover - POSIX-only SIGTERM handler
 
         def handle_term(signum: int, frame: object) -> None:
             nonlocal got_signal
@@ -257,11 +272,12 @@ def animation_loop(pipe_fd: int) -> None:
             pipe_signal = poll_pipe(pipe_fd)
         return got_signal or pipe_signal is not PipeSignal.OPEN
 
-    for _ in range(int(STARTUP_DELAY / POLL_INTERVAL)):
-        if should_stop():
-            return  # nothing drawn yet, nothing to clean up
-        time.sleep(POLL_INTERVAL)
+    if _stopped_during_startup_delay(should_stop):
+        return  # nothing drawn yet, nothing to clean up
 
+    previous_cp = 0
+    if sys.platform == "win32":  # pragma: no cover - Windows-only console setup
+        previous_cp = _setup_console_win32()
     try:
         os.write(fd, HIDE_CURSOR.encode())
         _animate_frames(fd, logo_frames, knight_frames, pad, frame_height, should_stop)
@@ -271,6 +287,17 @@ def animation_loop(pipe_fd: int) -> None:
         if pipe_signal is not PipeSignal.TAKEOVER:
             with contextlib.suppress(OSError):
                 os.write(fd, clear_screen(frame_height))
+        if sys.platform == "win32":  # pragma: no cover - Windows-only console restore
+            _restore_console_win32(previous_cp)
+
+
+def _stopped_during_startup_delay(should_stop: Callable[[], bool]) -> bool:
+    """Poll through the startup delay; True when the splash should not draw."""
+    for _ in range(int(STARTUP_DELAY / POLL_INTERVAL)):
+        if should_stop():
+            return True
+        time.sleep(POLL_INTERVAL)
+    return False
 
 
 def _animate_frames(

--- a/src/lilbee/runtime/_splash_runner.py
+++ b/src/lilbee/runtime/_splash_runner.py
@@ -1,8 +1,9 @@
 """Standalone splash animation process: stdlib plus the shared wordmark.
 
-Launched as a subprocess by ``splash.start()``. Reads a pipe fd from argv
-and animates until the pipe signals EOF (parent closed its write end, or
-parent died). This guarantees no orphan/zombie animation processes.
+Launched as a subprocess by ``splash.start()``. Reads a pipe reference from
+argv (the fd on POSIX, the pipe's OS handle on Windows) and animates until
+the pipe signals EOF (parent closed its write end, or parent died). This
+guarantees no orphan/zombie animation processes.
 """
 
 from __future__ import annotations

--- a/src/lilbee/runtime/splash.py
+++ b/src/lilbee/runtime/splash.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
+from typing import Any
 
 from lilbee.runtime._splash_runner import TAKEOVER_BYTE
 
@@ -39,13 +40,32 @@ _active_handle: SplashHandle | None = None
 
 def _should_skip() -> bool:
     """Return True when the splash animation should be suppressed."""
-    if sys.platform == "win32":
-        # The splash hands its child a pipe fd via pass_fds, which subprocess
-        # does not support on Windows.
-        return True
     if not os.isatty(2):
         return True
     return bool(os.environ.get("LILBEE_NO_SPLASH", ""))
+
+
+def _spawn_args(read_fd: int) -> tuple[str, dict[str, Any]]:
+    """Per-platform argv reference and Popen kwargs for the pipe's read end.
+
+    POSIX passes the fd itself; pass_fds keeps only read_fd open in the child
+    (close_fds=False would leak all open descriptors, including any held by
+    libraries). subprocess cannot pass fds on Windows, so the child gets the
+    pipe's OS handle number on argv instead and reopens it as a fd
+    (msvcrt.open_osfhandle in the runner; inherited handles keep their value
+    in the child). handle_list restricts inheritance to exactly this handle,
+    the same no-leak guarantee pass_fds gives on POSIX.
+    """
+    if sys.platform == "win32":  # pragma: no cover - Windows-only, covered on the Windows CI leg
+        import msvcrt
+
+        handle = msvcrt.get_osfhandle(read_fd)
+        os.set_handle_inheritable(handle, True)
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.lpAttributeList = {"handle_list": [handle]}
+        return str(handle), {"startupinfo": startupinfo}
+    os.set_inheritable(read_fd, True)
+    return str(read_fd), {"pass_fds": (read_fd,)}
 
 
 def start() -> SplashHandle | None:
@@ -59,18 +79,16 @@ def start() -> SplashHandle | None:
         return None
 
     read_fd, write_fd = os.pipe()
-    os.set_inheritable(read_fd, True)
+    pipe_ref, spawn_kwargs = _spawn_args(read_fd)
 
     # Trusted: sys.executable is this interpreter, module path is static,
-    # the one runtime value (read_fd) is an int from os.pipe().
-    # pass_fds keeps only read_fd open in the child (close_fds=False would
-    # leak all open descriptors, including any held by libraries).
+    # the one runtime value (pipe_ref) derives from an int from os.pipe().
     proc = subprocess.Popen(  # noqa: S603
-        [sys.executable, "-m", "lilbee.runtime._splash_runner", str(read_fd)],
-        pass_fds=(read_fd,),
+        [sys.executable, "-m", "lilbee.runtime._splash_runner", pipe_ref],
         stderr=None,
         stdout=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
+        **spawn_kwargs,
     )
 
     os.close(read_fd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,20 @@ def _raised_in_loop_selector(excinfo: pytest.ExceptionInfo) -> bool:  # type: ig
 
 
 @pytest.fixture(autouse=True)
+def _restore_interactive_intent():
+    """Snapshot the interactive-session flag around every test.
+
+    mark_interactive_session flips process state; a leak arms the TUI's
+    straggler exit inside a test worker, which then exits the worker.
+    """
+    from lilbee.app import services as services_mod
+
+    before = services_mod._state.interactive
+    yield
+    services_mod._state.interactive = before
+
+
+@pytest.fixture(autouse=True)
 def _suppress_model_scan(request, monkeypatch):
     """Prevent ModelBar._scan_models from doing real work in tests.
 

--- a/tests/integration/test_xet_download_e2e.py
+++ b/tests/integration/test_xet_download_e2e.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -40,6 +41,10 @@ pytestmark = [
     pytest.mark.skipif(
         not os.environ.get("LILBEE_E2E_DOWNLOADS"),
         reason="moves ~1.1GB; set LILBEE_E2E_DOWNLOADS=1 to run",
+    ),
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="lilbee routes Windows downloads to plain HTTP (xet stalls there)",
     ),
 ]
 

--- a/tests/test_chat_embedder_adopt.py
+++ b/tests/test_chat_embedder_adopt.py
@@ -90,6 +90,27 @@ class TestStreamResponseDispatch:
         services.searcher.ask_stream.assert_not_called()
         screen._finalize_stream.assert_called_once()
 
+    def test_a_dropped_connection_reads_as_a_dropped_connection(self):
+        """A severed engine socket (quit mid-answer, engine death) must not
+        surface the OS error text (WinError 10054) in the answer bubble."""
+        screen = self._screen()
+        widget = MagicMock()
+        services = MagicMock()
+        services.searcher.ask_stream.side_effect = ConnectionResetError(
+            10054, "An existing connection was forcibly closed by the remote host"
+        )
+        with (
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services),
+            patch(
+                "lilbee.cli.tui.screens.chat.call_from_thread",
+                side_effect=lambda _node, fn, *a, **k: fn(*a, **k),
+            ),
+        ):
+            screen._do_stream_response("q", widget, None)
+        rendered = " ".join(str(c.args) for c in widget.append_content.call_args_list)
+        assert "forcibly closed" not in rendered
+        assert msg.STREAM_DISCONNECTED.strip("\n") in rendered
+
     def test_other_error_shows_stream_error(self):
         screen = self._screen()
         widget = MagicMock()

--- a/tests/test_download_stall_guard.py
+++ b/tests/test_download_stall_guard.py
@@ -1,0 +1,213 @@
+"""The stall guard aborts and resumes transfers that stop reporting bytes.
+
+A wedged transfer blocks its worker thread forever while the task shows
+active: hf_xet can deadlock before the first byte, and a dead socket never
+wakes the plain path's read. The guard is the only mechanism that turns
+that state into a visible failure, so these tests pin its firing rule, its
+pulse plumbing, and the resume loop around it.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from lilbee.catalog import download as dl
+from lilbee.catalog.models import CatalogModel
+from lilbee.runtime.cancellation import TaskCancelledError
+
+
+def _entry() -> CatalogModel:
+    return CatalogModel(
+        hf_repo="user/repo",
+        gguf_filename="f.gguf",
+        size_gb=1.0,
+        min_ram_gb=2,
+        description="d",
+        featured=False,
+        downloads=0,
+        task="chat",
+    )
+
+
+def _config() -> dl.DownloadConfig:
+    return dl.DownloadConfig(repo_id="user/repo", filename="f.gguf", token=None)
+
+
+class TestStallGuard:
+    def test_fires_after_a_quiet_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        aborts: list[str] = []
+        monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
+
+        with dl._StallGuard(window_s=0.0, poll_s=0.01) as guard:
+            deadline = time.monotonic() + 5.0
+            while not guard.fired and time.monotonic() < deadline:
+                time.sleep(0.01)
+
+        assert guard.fired
+        assert aborts == ["abort"]
+
+    def test_does_not_fire_inside_the_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        aborts: list[str] = []
+        monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
+
+        with dl._StallGuard(window_s=60.0, poll_s=0.01) as guard:
+            time.sleep(0.05)
+
+        assert not guard.fired
+        assert aborts == []
+
+    def test_wrapped_tqdm_pulses_on_update(self) -> None:
+        guard = dl._StallGuard()
+        pulses: list[str] = []
+        guard.pulse = lambda: pulses.append("pulse")  # type: ignore[method-assign]
+
+        cls = guard.wrap_tqdm(None)
+        bar = cls(total=10, disable=True)
+        bar.update(5)
+
+        assert pulses == ["pulse"]
+
+    def test_wrapped_tqdm_pulses_on_the_transfer_stream(self) -> None:
+        """A base exposing update_transfer (the xet stream) keeps it, pulsed."""
+        calls: list[tuple[str, float]] = []
+
+        class _Base:
+            def update(self, n: float = 1) -> None:
+                calls.append(("update", n))
+
+            def update_transfer(self, n: float = 1) -> None:
+                calls.append(("update_transfer", n))
+
+        guard = dl._StallGuard()
+        pulses: list[str] = []
+        guard.pulse = lambda: pulses.append("pulse")  # type: ignore[method-assign]
+
+        bar = guard.wrap_tqdm(_Base)()
+        bar.update(3)
+        bar.update_transfer(4)
+
+        assert calls == [("update", 3), ("update_transfer", 4)]
+        assert pulses == ["pulse", "pulse"]
+
+    def test_wrapping_does_not_invent_the_transfer_stream(self) -> None:
+        """The hub feature-detects update_transfer; a base without it must not
+        grow one, or the hub would feed a stream the base cannot aggregate."""
+
+        class _Base:
+            def update(self, n: float = 1) -> None:
+                pass
+
+        cls = dl._StallGuard().wrap_tqdm(_Base)
+        assert not hasattr(cls, "update_transfer")
+
+    def test_abort_stops_xet_and_closes_the_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import huggingface_hub.utils._http as hub_http
+
+        calls: list[str] = []
+        monkeypatch.setattr(dl, "abort_active_download", lambda: calls.append("xet"))
+        monkeypatch.setattr(hub_http, "close_session", lambda: calls.append("client"))
+
+        dl._abort_stalled_transfer()
+
+        assert calls == ["xet", "client"]
+
+
+class _GuardStub:
+    """A guard whose firing is scripted, with inert plumbing."""
+
+    fired_script: bool = True
+
+    def __init__(self, *_a: object, **_k: object) -> None:
+        self.fired = False
+
+    def wrap_tqdm(self, tqdm_class: object) -> object:
+        return tqdm_class
+
+    def __enter__(self) -> _GuardStub:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.fired = self.fired_script
+
+
+class TestStallRetries:
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        outcomes: list[Exception | Path],
+        fired: bool,
+    ) -> tuple[Path | None, int]:
+        calls = {"n": 0}
+
+        def _fake_transfer(entry: CatalogModel, config: dl.DownloadConfig) -> Path:
+            outcome = outcomes[calls["n"]]
+            calls["n"] += 1
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        stub = type("_Stub", (_GuardStub,), {"fired_script": fired})
+        monkeypatch.setattr(dl, "_StallGuard", stub)
+        monkeypatch.setattr(dl, "_hf_download_or_translate", _fake_transfer)
+        return dl._download_with_stall_guard(_entry(), _config()), calls["n"]
+
+    def test_a_stall_resumes_and_finishes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        path = Path("/models/f.gguf")
+        result, attempts = self._run(
+            monkeypatch, [RuntimeError("aborted"), RuntimeError("aborted"), path], fired=True
+        )
+        assert result == path
+        assert attempts == 3
+
+    def test_a_persistent_stall_fails_with_the_resume_note(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with pytest.raises(RuntimeError, match=r"stalled.*resumes where it stopped"):
+            self._run(
+                monkeypatch,
+                [RuntimeError("a"), RuntimeError("b"), RuntimeError("c")],
+                fired=True,
+            )
+
+    def test_a_real_error_propagates_without_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with pytest.raises(RuntimeError, match="repo gone"):
+            self._run(monkeypatch, [RuntimeError("repo gone")], fired=False)
+
+    def test_cancellation_is_never_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with pytest.raises(TaskCancelledError):
+            self._run(monkeypatch, [TaskCancelledError()], fired=True)
+
+
+class TestGuardIsOnEveryTransfer:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(lambda entry: dl.download_model(entry), id="model"),
+            pytest.param(lambda entry: dl.download_mmproj(entry), id="mmproj"),
+        ],
+    )
+    def test_the_transfer_runs_under_the_guard(
+        self, call, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Both download entry points must go through the stall guard."""
+        guarded: list[str] = []
+        gguf = tmp_path / "f.gguf"
+
+        def _fake_guarded(entry: CatalogModel, config: dl.DownloadConfig) -> Path:
+            guarded.append(config.filename)
+            gguf.write_bytes(b"g")  # lands only when the transfer ran
+            return gguf
+
+        monkeypatch.setattr(dl, "_download_with_stall_guard", _fake_guarded)
+        monkeypatch.setattr(dl, "_models_dir", lambda: tmp_path)
+        monkeypatch.setattr(dl, "resolve_filename", lambda entry: "f.gguf")
+        monkeypatch.setattr(dl, "fetch_expected_file_size", lambda *a: 1)
+        monkeypatch.setattr(dl, "_resolve_mmproj_filename", lambda *a: "mmproj.gguf")
+        monkeypatch.setattr(dl, "_finalize_download", lambda entry, dest, **k: dest)
+
+        call(_entry())
+
+        assert guarded, "the transfer bypassed the stall guard"

--- a/tests/test_download_stall_guard.py
+++ b/tests/test_download_stall_guard.py
@@ -211,3 +211,34 @@ class TestGuardIsOnEveryTransfer:
         call(_entry())
 
         assert guarded, "the transfer bypassed the stall guard"
+
+
+class TestWatchTick:
+    def test_a_quiet_window_fires_the_abort(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        aborts: list[str] = []
+        monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
+        guard = dl._StallGuard(window_s=0.0)
+        guard._last_pulse -= 1.0
+
+        assert guard._keep_watching() is False
+        assert guard.fired
+        assert aborts == ["abort"]
+
+    def test_a_recent_pulse_keeps_watching(self) -> None:
+        guard = dl._StallGuard(window_s=60.0)
+        guard.pulse()
+        assert guard._keep_watching() is True
+        assert not guard.fired
+
+    def test_a_finished_transfer_is_not_aborted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The exit path can win the race against an expiring tick; the tick
+        must stand down instead of closing the next transfer's client."""
+        aborts: list[str] = []
+        monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
+        guard = dl._StallGuard(window_s=0.0)
+        guard._last_pulse -= 1.0
+        guard._stop.set()
+
+        assert guard._keep_watching() is False
+        assert not guard.fired
+        assert aborts == []

--- a/tests/test_download_stall_guard.py
+++ b/tests/test_download_stall_guard.py
@@ -41,7 +41,7 @@ class TestStallGuard:
         aborts: list[str] = []
         monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
 
-        with dl._StallGuard(window_s=0.0, poll_s=0.01) as guard:
+        with dl._StallGuard(window_s=0.0, poll_s=0.01, floor_bytes=1) as guard:
             deadline = time.monotonic() + 5.0
             while not guard.fired and time.monotonic() < deadline:
                 time.sleep(0.01)
@@ -59,16 +59,16 @@ class TestStallGuard:
         assert not guard.fired
         assert aborts == []
 
-    def test_wrapped_tqdm_pulses_on_update(self) -> None:
+    def test_wrapped_tqdm_pulses_the_byte_count(self) -> None:
         guard = dl._StallGuard()
-        pulses: list[str] = []
-        guard.pulse = lambda: pulses.append("pulse")  # type: ignore[method-assign]
+        pulses: list[float] = []
+        guard.pulse = lambda n=0: pulses.append(n)  # type: ignore[method-assign]
 
         cls = guard.wrap_tqdm(None)
         bar = cls(total=10, disable=True)
         bar.update(5)
 
-        assert pulses == ["pulse"]
+        assert pulses == [5]
 
     def test_wrapped_tqdm_pulses_on_the_transfer_stream(self) -> None:
         """A base exposing update_transfer (the xet stream) keeps it, pulsed."""
@@ -82,15 +82,15 @@ class TestStallGuard:
                 calls.append(("update_transfer", n))
 
         guard = dl._StallGuard()
-        pulses: list[str] = []
-        guard.pulse = lambda: pulses.append("pulse")  # type: ignore[method-assign]
+        pulses: list[float] = []
+        guard.pulse = lambda n=0: pulses.append(n)  # type: ignore[method-assign]
 
         bar = guard.wrap_tqdm(_Base)()
         bar.update(3)
         bar.update_transfer(4)
 
         assert calls == [("update", 3), ("update_transfer", 4)]
-        assert pulses == ["pulse", "pulse"]
+        assert pulses == [3, 4]
 
     def test_wrapping_does_not_invent_the_transfer_stream(self) -> None:
         """The hub feature-detects update_transfer; a base without it must not
@@ -214,29 +214,45 @@ class TestGuardIsOnEveryTransfer:
 
 
 class TestWatchTick:
-    def test_a_quiet_window_fires_the_abort(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_a_window_under_the_floor_fires_the_abort(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         aborts: list[str] = []
         monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
-        guard = dl._StallGuard(window_s=0.0)
-        guard._last_pulse -= 1.0
+        guard = dl._StallGuard(window_s=0.0, floor_bytes=1024)
+        guard._window_start -= 1.0
+        guard.pulse(1023)  # a trickle is not progress
 
         assert guard._keep_watching() is False
         assert guard.fired
         assert aborts == ["abort"]
 
-    def test_a_recent_pulse_keeps_watching(self) -> None:
+    def test_a_window_before_expiry_keeps_watching(self) -> None:
         guard = dl._StallGuard(window_s=60.0)
-        guard.pulse()
         assert guard._keep_watching() is True
         assert not guard.fired
+
+    def test_a_window_at_the_floor_starts_the_next_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        aborts: list[str] = []
+        monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
+        guard = dl._StallGuard(window_s=0.0, floor_bytes=1024)
+        guard._window_start -= 1.0
+        guard.pulse(1024)
+
+        assert guard._keep_watching() is True
+        assert not guard.fired
+        assert aborts == []
+        assert guard._window_bytes == 0
 
     def test_a_finished_transfer_is_not_aborted(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The exit path can win the race against an expiring tick; the tick
         must stand down instead of closing the next transfer's client."""
         aborts: list[str] = []
         monkeypatch.setattr(dl, "_abort_stalled_transfer", lambda: aborts.append("abort"))
-        guard = dl._StallGuard(window_s=0.0)
-        guard._last_pulse -= 1.0
+        guard = dl._StallGuard(window_s=0.0, floor_bytes=1024)
+        guard._window_start -= 1.0
         guard._stop.set()
 
         assert guard._keep_watching() is False

--- a/tests/test_fast_model_downloads.py
+++ b/tests/test_fast_model_downloads.py
@@ -136,3 +136,37 @@ def test_the_xet_disable_variable_name_is_the_one_the_hub_reads() -> None:
     from huggingface_hub import constants
 
     assert hasattr(constants, dl._XET_DISABLE_ENV)
+
+
+def test_the_download_path_disables_xet_before_transferring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback must land before the transfer starts, like the
+    fast-download mode above."""
+    calls: list[str] = []
+    monkeypatch.setattr(dl, "_apply_fast_download_mode", lambda: None)
+    monkeypatch.setattr(dl, "_disable_xet_where_it_stalls", lambda: calls.append("disabled"))
+
+    def _fake_download(**_kw: object) -> str:
+        calls.append("downloaded")
+        return "/tmp/file"
+
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", _fake_download)
+
+    from lilbee.catalog.models import CatalogModel
+
+    entry = CatalogModel(
+        hf_repo="user/repo",
+        gguf_filename="f.gguf",
+        size_gb=1.0,
+        min_ram_gb=2,
+        description="d",
+        featured=False,
+        downloads=0,
+        task="chat",
+    )
+    dl._hf_download_or_translate(
+        entry, dl.DownloadConfig(repo_id="user/repo", filename="f.gguf", token=None)
+    )
+
+    assert calls == ["disabled", "downloaded"]

--- a/tests/test_fast_model_downloads.py
+++ b/tests/test_fast_model_downloads.py
@@ -80,3 +80,61 @@ def test_the_download_path_applies_it_before_transferring(monkeypatch: pytest.Mo
         )
 
     assert calls == ["applied", "downloaded"]
+
+
+@pytest.mark.parametrize("platform", ["win32", "linux"], ids=["windows", "posix"])
+def test_xet_is_disabled_only_on_windows(
+    monkeypatch: pytest.MonkeyPatch, platform: str
+) -> None:
+    """hf_xet transfers stall or deadlock on Windows (xet-core #446/#789/#850),
+    so lilbee falls back to the plain HTTP path there."""
+    from huggingface_hub import constants
+
+    monkeypatch.setattr("sys.platform", platform)
+    monkeypatch.delenv(dl._XET_DISABLE_ENV, raising=False)
+    monkeypatch.setattr(constants, "HF_HUB_DISABLE_XET", False)
+
+    dl._disable_xet_where_it_stalls()
+
+    on_windows = platform == "win32"
+    assert (os.environ.get(dl._XET_DISABLE_ENV) == "1") is on_windows
+    assert constants.HF_HUB_DISABLE_XET is on_windows
+
+
+def test_an_explicit_xet_choice_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A user who exported the variable keeps whatever they chose."""
+    from huggingface_hub import constants
+
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv(dl._XET_DISABLE_ENV, "0")
+    monkeypatch.setattr(constants, "HF_HUB_DISABLE_XET", False)
+
+    dl._disable_xet_where_it_stalls()
+
+    assert os.environ[dl._XET_DISABLE_ENV] == "0"
+    assert constants.HF_HUB_DISABLE_XET is False
+
+
+def test_xet_disable_mutates_the_hub_constant_not_just_the_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """huggingface_hub parses the variable once at import, so setting the
+    environment alone after that parse changes nothing in this process."""
+    from huggingface_hub import constants
+
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.delenv(dl._XET_DISABLE_ENV, raising=False)
+    monkeypatch.setattr(constants, "HF_HUB_DISABLE_XET", False)
+
+    dl._disable_xet_where_it_stalls()
+
+    from huggingface_hub.utils._runtime import is_xet_available
+
+    assert is_xet_available() is False
+
+
+def test_the_xet_disable_variable_name_is_the_one_the_hub_reads() -> None:
+    """A rename upstream must fail here, not silently stop applying."""
+    from huggingface_hub import constants
+
+    assert hasattr(constants, dl._XET_DISABLE_ENV)

--- a/tests/test_fast_model_downloads.py
+++ b/tests/test_fast_model_downloads.py
@@ -83,9 +83,7 @@ def test_the_download_path_applies_it_before_transferring(monkeypatch: pytest.Mo
 
 
 @pytest.mark.parametrize("platform", ["win32", "linux"], ids=["windows", "posix"])
-def test_xet_is_disabled_only_on_windows(
-    monkeypatch: pytest.MonkeyPatch, platform: str
-) -> None:
+def test_xet_is_disabled_only_on_windows(monkeypatch: pytest.MonkeyPatch, platform: str) -> None:
     """hf_xet transfers stall or deadlock on Windows (xet-core #446/#789/#850),
     so lilbee falls back to the plain HTTP path there."""
     from huggingface_hub import constants

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import signal
 import threading
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -220,26 +221,48 @@ def test_a_second_interrupt_force_quits_instead_of_waiting(monkeypatch):
         name = services_mod._HARD_EXIT_THREAD_NAME
         daemon = True  # the leak-check fixture enumerates threads too
 
-        def join(self) -> None:
+        def join(self, timeout: float | None = None) -> None:
             raise KeyboardInterrupt
 
         def is_alive(self) -> bool:
             return False
 
-    monkeypatch.setattr(services_mod.threading, "enumerate", lambda: [_Interrupted()])
+    monkeypatch.setattr(services_mod, "_all_threads", lambda: [_Interrupted()])
 
     services_mod.wait_for_hard_exit_teardown()
 
     assert exits == [services_mod._FORCE_QUIT_EXIT_CODE]
 
 
-def test_exit_teardown_names_the_wait_and_the_way_out(capsys):
-    """The engine stop is silent work; the exit line says what is happening."""
+def test_a_slow_exit_names_the_wait_and_the_way_out(capsys, monkeypatch):
+    """A teardown that outlives the grace says what is happening."""
+    monkeypatch.setattr(services_mod, "_STOPPING_NOTE_GRACE_S", 0.0)
+    provider = _install_stub_services()
+    release = threading.Event()
+    provider.shutdown.side_effect = lambda: release.wait(timeout=5)
+
+    try:
+        waiter = threading.Thread(target=reset_services_on_exit)
+        waiter.start()
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if "stopping the engine" in capsys.readouterr().err:
+                break
+            time.sleep(0.01)
+        else:
+            raise AssertionError("the slow exit never named the wait")
+    finally:
+        release.set()
+        waiter.join(timeout=5)
+
+
+def test_a_fast_exit_stays_silent(capsys):
+    """A teardown inside the grace keeps the exit as quiet as it always was."""
     _install_stub_services()
 
     reset_services_on_exit()
 
-    assert "stopping the engine" in capsys.readouterr().err
+    assert "stopping the engine" not in capsys.readouterr().err
 
 
 def test_exit_note_survives_a_closed_stderr(monkeypatch):
@@ -265,3 +288,78 @@ def test_exit_teardown_without_services_starts_no_thread(monkeypatch):
     reset_services_on_exit()
 
     spawned.assert_not_called()
+
+
+class _Wedged:
+    """A non-daemon thread facade that never finishes joining."""
+
+    daemon = False
+    name = "wedged-straggler"  # the leak-check fixture reads thread names
+
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float | None = None) -> None:
+        return None
+
+
+class TestStragglerExit:
+    @pytest.fixture(autouse=True)
+    def _interactive(self, monkeypatch):
+        monkeypatch.setattr(services_mod._state, "interactive", True)
+
+    def test_a_non_interactive_process_keeps_its_threads(self, monkeypatch) -> None:
+        """A test host or library embedder owns its threads; never exit them."""
+        monkeypatch.setattr(services_mod._state, "interactive", False)
+        exits: list[int] = []
+        monkeypatch.setattr(services_mod.os, "_exit", exits.append)
+        threads = self._fake_enumerate(monkeypatch, [_Wedged()])
+
+        services_mod.exit_when_stragglers_would_hang()
+        del threads[1:]
+
+        assert exits == []
+
+    def _fake_enumerate(self, monkeypatch, extra):
+        """Patch enumerate with a mutable list, cleared before teardown so the
+        leak-check fixture never meets the fakes."""
+        threads = [threading.main_thread(), *extra]
+        monkeypatch.setattr(services_mod, "_all_threads", lambda: list(threads))
+        return threads
+
+    def test_a_wedged_thread_exits_instead_of_hanging(self, monkeypatch, capsys) -> None:
+        exits: list[int] = []
+        monkeypatch.setattr(services_mod.os, "_exit", exits.append)
+        monkeypatch.setattr(services_mod, "_STRAGGLER_BUDGET_S", 0.0)
+        threads = self._fake_enumerate(monkeypatch, [_Wedged()])
+
+        services_mod.exit_when_stragglers_would_hang()
+        del threads[1:]
+
+        assert exits == [0]
+        assert "would not stop" in capsys.readouterr().err
+
+    def test_a_clean_shutdown_exits_normally(self, monkeypatch, capsys) -> None:
+        exits: list[int] = []
+        monkeypatch.setattr(services_mod.os, "_exit", exits.append)
+        self._fake_enumerate(monkeypatch, [])
+
+        services_mod.exit_when_stragglers_would_hang()
+
+        assert exits == []
+        assert capsys.readouterr().err == ""
+
+    def test_an_interrupt_during_the_budget_force_quits(self, monkeypatch) -> None:
+        exits: list[int] = []
+        monkeypatch.setattr(services_mod.os, "_exit", exits.append)
+
+        class _Interruptible(_Wedged):
+            def join(self, timeout: float | None = None) -> None:
+                raise KeyboardInterrupt
+
+        threads = self._fake_enumerate(monkeypatch, [_Interruptible()])
+
+        services_mod.exit_when_stragglers_would_hang()
+        del threads[1:]
+
+        assert exits == [services_mod._FORCE_QUIT_EXIT_CODE]

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -210,23 +210,50 @@ def test_exit_teardown_runs_off_the_main_thread():
     assert peek_services() is None
 
 
-def test_exit_teardown_finishes_after_the_wait_is_interrupted(monkeypatch):
-    """A second Ctrl-C must abandon only the wait, never the fleet stop."""
-    provider = _install_stub_services()
-    release = threading.Event()
-    provider.shutdown.side_effect = lambda: release.wait(timeout=5)
-    monkeypatch.setattr(
-        services_mod,
-        "wait_for_hard_exit_teardown",
-        MagicMock(side_effect=KeyboardInterrupt),
-    )
+def test_a_second_interrupt_force_quits_instead_of_waiting(monkeypatch):
+    """A second Ctrl-C force-quits: the child guard reaps the engine, and the
+    interpreter would otherwise still join the non-daemon teardown thread."""
+    exits: list[int] = []
+    monkeypatch.setattr(services_mod.os, "_exit", exits.append)
 
-    with pytest.raises(KeyboardInterrupt):
-        reset_services_on_exit()
+    class _Interrupted:
+        name = services_mod._HARD_EXIT_THREAD_NAME
+        daemon = True  # the leak-check fixture enumerates threads too
 
-    release.set()
-    _join_teardown()
-    provider.shutdown.assert_called_once()
+        def join(self) -> None:
+            raise KeyboardInterrupt
+
+        def is_alive(self) -> bool:
+            return False
+
+    monkeypatch.setattr(services_mod.threading, "enumerate", lambda: [_Interrupted()])
+
+    services_mod.wait_for_hard_exit_teardown()
+
+    assert exits == [services_mod._FORCE_QUIT_EXIT_CODE]
+
+
+def test_exit_teardown_names_the_wait_and_the_way_out(capsys):
+    """The engine stop is silent work; the exit line says what is happening."""
+    _install_stub_services()
+
+    reset_services_on_exit()
+
+    assert "stopping the engine" in capsys.readouterr().err
+
+
+def test_exit_note_survives_a_closed_stderr(monkeypatch):
+    """atexit can run after stderr is gone; the note must not raise."""
+
+    class _Closed:
+        def write(self, _note: str) -> int:
+            raise ValueError("I/O operation on closed file")
+
+        def flush(self) -> None:  # pragma: no cover - never reached
+            raise ValueError
+
+    monkeypatch.setattr(services_mod.sys, "stderr", _Closed())
+    services_mod._write_exit_note("note")
 
 
 def test_exit_teardown_without_services_starts_no_thread(monkeypatch):

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from unittest.mock import patch
 
 import pytest
@@ -47,10 +46,15 @@ class TestShouldSkip:
         ):
             assert _should_skip() is False
 
-    def test_win32_always_skips(self) -> None:
-        # pass_fds is unsupported on Windows, so the splash never starts there.
-        with patch("lilbee.runtime.splash.sys.platform", "win32"):
-            assert _should_skip() is True
+    def test_win32_tty_does_not_skip(self) -> None:
+        # Windows passes the pipe as an inheritable OS handle instead of an
+        # fd, so the splash runs there like everywhere else.
+        with (
+            patch("lilbee.runtime.splash.sys.platform", "win32"),
+            patch("lilbee.runtime.splash.os.isatty", return_value=True),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            assert _should_skip() is False
 
 
 class TestStartStop:
@@ -61,7 +65,6 @@ class TestStartStop:
     def test_stop_none_is_noop(self) -> None:
         stop(None)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="splash child needs pass_fds")
     def test_start_and_stop(self) -> None:
         with patch("lilbee.runtime.splash._should_skip", return_value=False):
             handle = start()
@@ -72,7 +75,6 @@ class TestStartStop:
             assert handle.process.poll() is not None  # exited
             assert _SPLASH_FD_ENV not in os.environ
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="splash child needs pass_fds")
     def test_start_sets_env_var(self) -> None:
         with patch("lilbee.runtime.splash._should_skip", return_value=False):
             handle = start()
@@ -144,7 +146,6 @@ class TestDismiss:
         finally:
             splash_mod._active_handle = original
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="splash child needs pass_fds")
     def test_dismiss_waits_for_process_and_clears_handle(self) -> None:
         """dismiss() waits for the subprocess and clears _active_handle
         so atexit does not re-run stop() while Textual owns the terminal.

--- a/tests/test_splash_e2e.py
+++ b/tests/test_splash_e2e.py
@@ -13,10 +13,6 @@ from unittest.mock import patch
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="splash e2e exercises POSIX fd inheritance"
-)
-
 
 def _run_lilbee(
     *args: str, env_extra: dict[str, str] | None = None
@@ -84,6 +80,7 @@ class TestSplashE2ENonTTY:
 class TestSplashSubprocessLifecycle:
     """Tests that the splash subprocess starts and stops reliably."""
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="spawns the runner via pass_fds")
     def test_runner_takeover_emits_no_cursor_show(self) -> None:
         """A real runner subprocess dismissed via takeover never writes cursor-show."""
         import time

--- a/tests/test_splash_runner.py
+++ b/tests/test_splash_runner.py
@@ -388,13 +388,24 @@ def test_main_invalid_fd():
 
 
 def test_main_valid_fd():
-    """main runs animation_loop with a valid pipe fd."""
+    """main runs animation_loop with a valid pipe reference.
+
+    argv carries what the parent passes: the fd on POSIX, the pipe's OS
+    handle on Windows (fds do not survive process boundaries there).
+    """
     r, w = os.pipe()
     os.close(w)
 
+    if sys.platform == "win32":
+        import msvcrt
+
+        pipe_ref = str(msvcrt.get_osfhandle(r))
+    else:
+        pipe_ref = str(r)
+
     from lilbee.runtime._splash_runner import main
 
-    with patch("sys.argv", ["_splash_runner", str(r)]):
+    with patch("sys.argv", ["_splash_runner", pipe_ref]):
         main()
 
 

--- a/tests/test_splash_runner.py
+++ b/tests/test_splash_runner.py
@@ -426,3 +426,11 @@ def test_animation_loop_sleeps_during_startup_then_exits(monkeypatch):
     monkeypatch.setattr(sr, "poll_pipe", fake_poll)
     sr.animation_loop(0)
     assert sleeps == [sr.POLL_INTERVAL]
+
+
+def test_open_pipe_ref_returns_the_fd_on_posix(monkeypatch):
+    """POSIX passes the fd through unchanged; only Windows converts a handle."""
+    monkeypatch.setattr("sys.platform", "linux")
+    from lilbee.runtime._splash_runner import _open_pipe_ref
+
+    assert _open_pipe_ref(7) == 7

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -91,6 +91,8 @@ def _gate_with_app():
 
     ``_stopping`` needs a live worker context and a mounted screen, neither of
     which a direct call to the worker body has, so it is stubbed to "keep going".
+    The app lands in ``_ui_app`` exactly as ``on_mount`` leaves it: the workers
+    read the captured reference, never the ``app`` property.
     """
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
@@ -98,7 +100,43 @@ def _gate_with_app():
     app = mock.MagicMock()
     app.call_from_thread.side_effect = lambda fn, *a: fn(*a)
     app.screen = gate  # the gate owns the screen, as it does in production
+    gate._ui_app = app
     return gate, app
+
+
+async def test_boot_worker_never_resolves_app_from_the_thread():
+    """Regression: the boot thread has no Textual app context, so resolving
+    ``self.app`` there raised NoActiveAppError mid-boot on Windows first
+    launches and left a dead loading screen. The worker must run on the
+    reference captured at mount, even when the property cannot resolve."""
+    from textual._context import NoActiveAppError
+
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(side_effect=NoActiveAppError())),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    app.settle_landing.assert_called_once_with()
+    app.reveal_landing.assert_called_once_with()
+
+
+async def test_mount_captures_the_app_for_the_workers():
+    """on_mount runs on the UI thread, the one place ``self.app`` always
+    resolves, so that is where the workers' reference is captured."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "_retire_splash"),
+    ):
+        gate.on_mount()
+    assert gate._ui_app is app
 
 
 async def test_gate_release_reveals_chat():
@@ -108,10 +146,8 @@ async def test_gate_release_reveals_chat():
     gate = StartupGate()
     app = mock.MagicMock()
     app.screen = gate
-    with (
-        mock.patch.object(StartupGate, "query_one"),
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-    ):
+    gate._ui_app = app
+    with mock.patch.object(StartupGate, "query_one"):
         gate._release()
     app.reveal_landing.assert_called_once_with()
 
@@ -130,7 +166,6 @@ async def test_gate_releases_once_services_build_even_with_a_cold_engine(monkeyp
     app.adopt_services.side_effect = lambda: order.append("adopt")
     app.reveal_landing.side_effect = lambda: order.append("reveal")
     with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
@@ -147,10 +182,8 @@ async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
     gate = StartupGate()
     app = mock.MagicMock()
     app.screen = gate
-    with (
-        mock.patch.object(StartupGate, "query_one"),
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-    ):
+    gate._ui_app = app
+    with mock.patch.object(StartupGate, "query_one"):
         gate._fail("no such file")
     notified = [c.args[0] for c in app.notify.call_args_list if c.args]
     assert msg.STARTUP_FAILED.format(error="no such file") in notified
@@ -168,7 +201,6 @@ async def test_gate_builds_the_container_even_with_nothing_configured(monkeypatc
 
     gate, app = _gate_with_app()
     with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
@@ -194,7 +226,6 @@ async def test_gate_settles_setup_before_it_hands_over(monkeypatch):
     app.reveal_landing.side_effect = lambda: order.append("reveal")
     monkeypatch.setattr(gate_mod, "peek_services", lambda: mock.MagicMock())
     with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
@@ -211,7 +242,6 @@ async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
     gate, app = _gate_with_app()
     app.adopt_services.side_effect = OSError("disk gone")
     with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
@@ -227,10 +257,8 @@ async def test_marshal_skips_the_ui_hop_once_the_app_is_tearing_down():
 
     gate = StartupGate()
     app = mock.MagicMock()
-    with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-        mock.patch.object(StartupGate, "_stopping", return_value=True),
-    ):
+    gate._ui_app = app
+    with mock.patch.object(StartupGate, "_stopping", return_value=True):
         gate._marshal(gate._release)
     app.call_from_thread.assert_not_called()
     app.reveal_landing.assert_not_called()
@@ -402,10 +430,8 @@ async def test_gate_does_not_steal_a_screen_pushed_over_it(monkeypatch):
     gate = StartupGate()
     app = mock.MagicMock()
     app.screen = _Other()  # something else owns the screen now
-    with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-        mock.patch.object(StartupGate, "query_one"),
-    ):
+    gate._ui_app = app
+    with mock.patch.object(StartupGate, "query_one"):
         gate._release()
     app.reveal_landing.assert_not_called()
 
@@ -417,10 +443,8 @@ async def test_gate_hands_over_when_it_still_owns_the_screen():
     gate = StartupGate()
     app = mock.MagicMock()
     app.screen = gate
-    with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-        mock.patch.object(StartupGate, "query_one"),
-    ):
+    gate._ui_app = app
+    with mock.patch.object(StartupGate, "query_one"):
         gate._release()
     app.reveal_landing.assert_called_once_with()
 
@@ -467,7 +491,6 @@ async def test_boot_worker_canonicalizes_before_the_setup_check(monkeypatch):
     app.canonicalize_persisted_models.side_effect = lambda: order.append("canonicalize")
     app.settle_landing.side_effect = lambda: order.append("setup")
     with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
@@ -484,7 +507,6 @@ async def test_boot_worker_surfaces_a_canonicalization_failure(monkeypatch):
     app.canonicalize_persisted_models.side_effect = OSError("registry unreadable")
     monkeypatch.setattr(gate_mod, "peek_services", lambda: None)
     with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
@@ -499,13 +521,10 @@ async def test_gate_mount_retires_the_splash_then_repaints(monkeypatch):
     the dismissal then repaints anything a final frame touched."""
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
-    gate, app = _gate_with_app()
+    gate, _app = _gate_with_app()
     order: list[str] = []
     monkeypatch.setattr("lilbee.runtime.splash.dismiss", lambda: order.append("dismiss"))
     monkeypatch.setattr(gate, "_repaint", lambda: order.append("refresh"), raising=False)
-    with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-        mock.patch.object(StartupGate, "_stopping", return_value=False),
-    ):
+    with mock.patch.object(StartupGate, "_stopping", return_value=False):
         StartupGate._retire_splash.__wrapped__(gate)
     assert order == ["dismiss", "refresh"]

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -3654,6 +3654,7 @@ class TestRunTuiKeyboardInterrupt:
             with (
                 mock.patch("lilbee.cli.sync.shutdown_executor"),
                 mock.patch("lilbee.cli.tui.reset_services_on_exit"),
+                mock.patch("lilbee.cli.tui.exit_when_stragglers_would_hang"),
             ):
                 from lilbee.cli.tui import run_tui
 
@@ -3666,12 +3667,14 @@ class TestRunTuiKeyboardInterrupt:
             with (
                 mock.patch("lilbee.cli.sync.shutdown_executor") as mock_shutdown,
                 mock.patch("lilbee.cli.tui.reset_services_on_exit") as mock_reset,
+                mock.patch("lilbee.cli.tui.exit_when_stragglers_would_hang") as mock_straggler,
             ):
                 from lilbee.cli.tui import run_tui
 
                 run_tui()
                 mock_shutdown.assert_called_once()
                 mock_reset.assert_called_once()
+                mock_straggler.assert_called_once()
 
 
 class _ViewTabsApp(LilbeeAppHost):


### PR DESCRIPTION
## Problem
A first launch on Windows shows a black screen with no bootstrapping UI, and model downloads stall forever with the task showing active. The splash never ran on win32 (`pass_fds` does not exist there), the startup gate behind it crashed resolving `self.app` from its worker thread (`NoActiveAppError`), and a wedged transfer blocked its worker with no timeout, no error, and no way to cancel.

## Splash on Windows
The spawn branches per platform: POSIX keeps `pass_fds`; Windows passes the pipe's OS handle, made inheritable and whitelisted via `STARTUPINFO.lpAttributeList["handle_list"]`, and the runner reopens it with `msvcrt.open_osfhandle`. The runner turns on virtual terminal processing and switches the console to the UTF-8 codepage while it draws (restored on exit) so the animation renders correctly on the legacy console.

## Startup gate
The gate captures its app reference once in `on_mount`, on the UI thread; workers never resolve `self.app` from a thread again. The catalog's first-download adoption hop moves onto the thread-safe wrapper, closing the same defect class (reproduced live: it crashed on a real box when a download finished after navigating away).

## Downloads that stop moving
hf_xet stalls and deadlocks on Windows (xet-core [446](https://github.com/huggingface/xet-core/issues/446), [789](https://github.com/huggingface/xet-core/issues/789), [850](https://github.com/huggingface/xet-core/issues/850)), so the download path falls back to plain HTTP there; xet stays on everywhere else. A stall guard rides the transfer's progress stream: a window that moves under 256 KB per 60s aborts the transfer (xet session + the hub's client), resumes from the `.incomplete` file up to three attempts, then fails with an error that names the stall. This also catches a dead socket whose read outlives every hub timeout, and a connection trickling bytes too slowly to ever finish.

## Verified
macOS full gate (12674 tests, 100% coverage). Windows from source on a real Windows 11 box: test suites, splash animation, first-launch boot to the catalog, model download and adoption, clean Ctrl-C exit with a wedged transfer. CI matrix covers ubuntu, macos, and windows.

