### PR TITLE
Count cache-recovered models as installed on symlink-less caches

### DIFF
--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -187,8 +187,9 @@ class ModelRegistry:
     def resolve(self, ref: str) -> Path:
         """Return the loadable GGUF path for *ref*; ``KeyError`` if not installed.
 
-        A single-file GGUF resolves to its content-hashed blob; a split GGUF to
-        its first shard's snapshot symlink (so llama.cpp finds the sibling shards).
+        A single-file GGUF resolves to its content-hashed blob (the snapshot
+        file on a cache without symlinks); a split GGUF to its first shard's
+        snapshot symlink (so llama.cpp finds the sibling shards).
 
         The canonical *ref* is ``<org>/<repo>/<file>.gguf`` resolved via the
         lilbee manifest. Two other shapes are accepted as a backwards-compat
@@ -208,10 +209,10 @@ class ModelRegistry:
         if len(shards) > 1:
             return self._resolve_split(ref, hf_repo, shards)
         manifest = self._read_manifest(hf_repo, gguf_filename)
-        if manifest is not None and manifest.blob is not None:
-            blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
-            if _blob_size_matches(blob_file, manifest.size_bytes):
-                return blob_file
+        if manifest is not None:
+            backing = self._manifest_backing_file(manifest)
+            if backing is not None:
+                return backing
         recovered = self._find_cached_gguf(hf_repo, gguf_filename)
         if recovered is not None:
             self._reregister_from_cache(hf_repo, gguf_filename, recovered)
@@ -273,11 +274,11 @@ class ModelRegistry:
             # to the slower huggingface_hub cache recovery.
             for mf in sorted(manifest_dir.rglob("*.gguf.json")):
                 manifest = self._load_manifest_file(mf)
-                if manifest is None or manifest.blob is None:
+                if manifest is None:
                     continue
-                blob = self._repo_cache_dir(hf_repo) / "blobs" / manifest.blob
-                if blob.exists():
-                    return blob
+                backing = self._manifest_backing_file(manifest)
+                if backing is not None:
+                    return backing
         for filename in sorted(self._cached_gguf_names(hf_repo)):
             shards = split_shard_filenames(filename)
             if len(shards) > 1:
@@ -407,7 +408,9 @@ class ModelRegistry:
                     size_bytes=blob_path.stat().st_size,
                     task=task,
                     downloaded_at=datetime.now(UTC).isoformat(),
-                    blob=blob_path.name,  # the blob's filename is its sha in the HF cache
+                    # Only a file under blobs/ is named by its sha; a symlink-less
+                    # snapshot file is not, so no digest is recorded for it.
+                    blob=blob_path.name if blob_path.parent.name == "blobs" else None,
                     total_size_bytes=total_size,
                     shard_blobs=shard_blobs,
                 )
@@ -481,16 +484,31 @@ class ModelRegistry:
         repo_dir = manifest_path.parent
         if repo_dir.exists() and not any(repo_dir.iterdir()):
             repo_dir.rmdir()
+        self._unlink_snapshot_entries(manifest)
         # Free the primary blob and every extra shard blob; a split GGUF has more
         # than one, and leaving the others orphans them when a sibling quant keeps
         # the repo cache dir alive. The surviving manifests for this repo are read
         # once here rather than per digest (list_installed walks the whole tree).
+        # A symlink-less recovery records no digest; GC still runs once so an
+        # unused repo cache dir is pruned.
         siblings = [m for m in self.list_installed() if m.hf_repo == manifest.hf_repo]
-        for digest in [manifest.blob, *shard_blobs]:
-            if digest is not None:
-                self._gc_blob(manifest.hf_repo, digest, siblings=siblings)
+        digests: list[str | None] = [d for d in [manifest.blob, *shard_blobs] if d is not None]
+        for digest in digests or [None]:
+            self._gc_blob(manifest.hf_repo, digest, siblings=siblings)
         log.info("Removed model %s", ref)
         return True
+
+    def _unlink_snapshot_entries(self, manifest: ModelManifest) -> None:
+        """Drop the snapshot entries for *manifest*'s shards.
+
+        On a symlink-less cache they hold the bytes and would resurrect the
+        model via cache recovery; on a symlinked cache they would dangle once
+        the blob is gc'd.
+        """
+        for shard in split_shard_filenames(manifest.gguf_filename):
+            snapshot_entry = self._snapshot_gguf_path(manifest.hf_repo, shard)
+            if snapshot_entry is not None:
+                snapshot_entry.unlink(missing_ok=True)
 
     def _recover_legacy_shard_blobs(self, ref: str) -> list[str]:
         """Extra shard blob digests for a pre-accounting split GGUF, best-effort.
@@ -505,10 +523,12 @@ class ModelRegistry:
         return []
 
     def _gc_blob(
-        self, hf_repo: str, digest: str, *, siblings: list[ModelManifest] | None = None
+        self, hf_repo: str, digest: str | None, *, siblings: list[ModelManifest] | None = None
     ) -> None:
         """Drop blob bytes and HuggingFace cache cruft now that *digest*
-        and possibly the whole repo are unused.
+        and possibly the whole repo are unused. A None *digest* (a manifest
+        recovered on a symlink-less cache records no digest) only prunes the
+        repo dir when no installed manifest is left.
 
         When the per-repo ``models--<repo>/`` directory has no installed
         manifests left, the whole directory is wiped so HF's ``refs/``,
@@ -531,6 +551,8 @@ class ModelRegistry:
         if not siblings:
             if cache_path.exists():
                 shutil.rmtree(cache_path)
+            return
+        if digest is None:  # no digest recorded (symlink-less recovery): dir-prune only
             return
         if any(digest == m.blob or digest in m.shard_blobs for m in siblings):
             return
@@ -568,11 +590,25 @@ class ModelRegistry:
         return manifests
 
     def _blob_present(self, manifest: ModelManifest) -> bool:
-        """True iff *manifest* points at a blob whose on-disk size matches."""
-        if manifest.blob is None:
-            return False
-        blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
-        return _blob_size_matches(blob_file, manifest.size_bytes)
+        """True iff *manifest*'s bytes are on disk with a matching size."""
+        return self._manifest_backing_file(manifest) is not None
+
+    def _manifest_backing_file(self, manifest: ModelManifest) -> Path | None:
+        """The on-disk file holding *manifest*'s bytes, or None if absent/truncated.
+
+        Normally the content-hashed blob; on a cache without symlinks (the
+        Windows default) the bytes live at the snapshot path, so that is the
+        fallback. ``resolve`` and ``list_installed`` must both gate on this
+        one predicate, or installed-ness disagrees between ``pull`` and ``ask``.
+        """
+        if manifest.blob is not None:
+            blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
+            if _blob_size_matches(blob_file, manifest.size_bytes):
+                return blob_file
+        recovered = self._find_cached_gguf(manifest.hf_repo, manifest.gguf_filename)
+        if recovered is not None and _blob_size_matches(recovered, manifest.size_bytes):
+            return recovered
+        return None
 
     def get_manifest(self, ref: str) -> ModelManifest | None:
         """Return the manifest for *ref* or None if not installed."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -55,6 +55,29 @@ def _write_source(tmp_path: Path, content: bytes = b"GGUF\x00\x00") -> Path:
 _FAKE_REV = "0123456789abcdef0123456789abcdef01234567"  # 40-hex commit-hash-shaped revision
 
 
+def _seed_hf_cache_symlinkless(
+    models_dir: Path,
+    *,
+    repo: str = _REPO,
+    filename: str = _FILENAME,
+    content: bytes = b"GGUF\x00\x00",
+) -> Path:
+    """Lay down the symlink-less HuggingFace cache layout (the Windows default).
+
+    When symlinks are unavailable, ``huggingface_hub`` moves the downloaded blob
+    to ``snapshots/<rev>/<filename>`` as a real file, leaving ``blobs/`` empty.
+    Returns the snapshot file path.
+    """
+    cache = models_dir / f"models--{repo_to_dir(repo)}"
+    (cache / "blobs").mkdir(parents=True, exist_ok=True)
+    snapshot_file = cache / "snapshots" / _FAKE_REV / filename
+    snapshot_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_file.write_bytes(content)
+    (cache / "refs").mkdir(parents=True, exist_ok=True)
+    (cache / "refs" / "main").write_text(_FAKE_REV, encoding="utf-8")
+    return snapshot_file
+
+
 def _seed_hf_cache(
     models_dir: Path,
     *,
@@ -760,6 +783,60 @@ class TestModelRegistryResolve:
         bad.parent.mkdir(parents=True, exist_ok=True)
         bad.write_text('{"repo": "old-format", "extra": "fields the current schema lacks"}')
         assert registry.resolve(_REF) == blob.resolve()
+
+    def test_symlinkless_recovery_agrees_between_resolve_and_listing(self, tmp_path: Path) -> None:
+        """On a symlink-less cache (the Windows default), a recovered model must
+        count as installed everywhere, not only in ``resolve``.
+
+        ``resolve`` recovers the snapshot file, but the recovered manifest used to
+        record the snapshot's filename as its blob digest, so ``list_installed``
+        (the gate ``ask`` uses) filtered it out while ``is_installed`` (the gate
+        ``pull`` uses) passed: ask refused with 'No chat model is installed' and
+        the suggested re-pull short-circuited with 'already installed'.
+        """
+        registry = ModelRegistry(tmp_path)
+        snapshot_file = _seed_hf_cache_symlinkless(tmp_path)
+        assert registry.resolve(_REF) == snapshot_file
+        assert registry.is_installed(_REF)
+        assert [m.ref for m in registry.list_installed()] == [_REF]
+
+    def test_symlinkless_resolve_does_not_rewrite_manifest_every_call(self, tmp_path: Path) -> None:
+        """After the first recovery writes a manifest, later resolves trust it.
+
+        The old code's blob check could never pass on a symlink-less cache, so
+        every resolve took the recovery path and rewrote the manifest."""
+        registry = ModelRegistry(tmp_path)
+        snapshot_file = _seed_hf_cache_symlinkless(tmp_path)
+        registry.resolve(_REF)  # first call recovers and writes the manifest
+        with mock.patch.object(ModelRegistry, "_write_manifest") as write_manifest:
+            assert registry.resolve(_REF) == snapshot_file
+        write_manifest.assert_not_called()
+
+    def test_symlinkless_recovered_model_removes_cleanly(self, tmp_path: Path) -> None:
+        """A cache-recovered model on a symlink-less cache can be removed."""
+        registry = ModelRegistry(tmp_path)
+        _seed_hf_cache_symlinkless(tmp_path)
+        registry.resolve(_REF)
+        assert registry.remove(_REF)
+        assert not registry.is_installed(_REF)
+        assert registry.list_installed() == []
+        assert not (tmp_path / f"models--{repo_to_dir(_REPO)}").exists()
+
+    def test_symlinkless_remove_keeps_sibling_quant(self, tmp_path: Path) -> None:
+        """Removing one symlink-less quant leaves a sibling quant installed.
+
+        No digest is recorded for either, so GC must prune only the removed
+        model's snapshot file, not the shared repo cache dir."""
+        registry = ModelRegistry(tmp_path)
+        other = "Qwen3-0.6B-Q8_0.gguf"
+        _seed_hf_cache_symlinkless(tmp_path)
+        _seed_hf_cache_symlinkless(tmp_path, filename=other, content=b"GGUF\x08")
+        registry.resolve(_REF)
+        registry.resolve(f"{_REPO}/{other}")
+        assert registry.remove(_REF)
+        assert not registry.is_installed(_REF)
+        assert [m.ref for m in registry.list_installed()] == [f"{_REPO}/{other}"]
+        assert registry.resolve(f"{_REPO}/{other}").exists()
 
     def test_recovery_ignores_snapshot_symlink_escaping_root(self, tmp_path: Path) -> None:
         """A snapshot entry symlinking outside the registry root is not followed."""


### PR DESCRIPTION
## Problem
On a HuggingFace cache without symlinks (the Windows default; also `HF_HUB_DISABLE_SYMLINKS` or filesystems without symlink support), a model recovered from the cache resolves but never lists as installed. `lilbee ask` refuses with "No chat model is installed" while `lilbee model show` reports it installed, and the suggested re-pull is a no-op because `pull` gates on the resolving side. The recovered manifest recorded the snapshot's filename as its blob digest, and the listing filter only looks under `blobs/`, which holds nothing on such a cache. Reproduced on a real Windows 11 box.

## Fix
`resolve` and `list_installed` now gate on one shared backing-file predicate: the content-hashed blob when present, else the snapshot file with a matching size. Recovery records no digest when the recovered path is not under `blobs/`, and resolve no longer rewrites the manifest on every call on these caches.

## Removal
`remove()` now unlinks the model's snapshot entries and always runs GC, so a removed model cannot resurrect through cache recovery and an unused repo cache dir is still pruned.