### PR TITLE
Default MCP crawls to a single page

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1263,7 +1263,8 @@ lilbee add https://docs.example.com https://wiki.example.com
 ```
 
 Also available via MCP (`crawl`), REST API (`POST /api/crawl`), and TUI
-(`/crawl`).
+(`/crawl`). The MCP tool defaults to a single page (`depth=0`); agents pass a
+depth, or `depth=null` for the whole site.
 
 **Configuration (all optional):**
 

--- a/examples/agent-integration/AGENTS.md
+++ b/examples/agent-integration/AGENTS.md
@@ -74,7 +74,9 @@ the Task / Agent tool). Wait for the worker to report done, then continue answer
   path is instant; you can call it unconditionally instead of probing first. The worker
   runs `lilbee_init` for you if no `.lilbee/` exists.
 - `lilbee_sync` — re-index after the watched paths change.
-- `lilbee_crawl` — fetch a docs site (worker polls `lilbee_crawl_status` to completion).
+- `lilbee_crawl` — crawl a docs site: pass a `depth` (or `depth=null` for the whole
+  site); the default fetches only the given page. The worker polls `lilbee_crawl_status`
+  to completion.
 - `lilbee_model_pull` — download a model from Hugging Face.
 
 ## Writing code against an indexed API reference

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -370,7 +370,7 @@ async def add(
     render_mode: CrawlRenderMode | None = None,
 ) -> dict[str, Any]:
     """Add files, directories, or URLs to the knowledge base, then sync.
-    Paths must be absolute; URLs are crawled as markdown."""
+    Paths must be absolute. URLs are fetched as single pages; use ``crawl`` for sites."""
     from lilbee.app.ingest import register_sources
     from lilbee.data.ingest import sync as run_sync
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -404,7 +404,8 @@ async def add(
             except ValueError as exc:
                 errors.append(f"{url}: {exc}")
                 continue
-            crawled_paths = await crawl_and_save(url, render_mode=render_mode)
+            # add fetches single pages (depth=0); site crawls go through the crawl tool
+            crawled_paths = await crawl_and_save(url, depth=0, render_mode=render_mode)
             crawled_count += len(crawled_paths)
 
     # Registration touches config.toml (a locked read-modify-write); keep the
@@ -435,13 +436,14 @@ async def add(
 @_tool_if(crawler_available)
 async def crawl(
     url: str,
-    depth: int | None = None,
+    depth: int | None = 0,
     max_pages: int | None = None,
     render_mode: CrawlRenderMode | None = None,
     include_subdomains: bool = False,
 ) -> dict[str, Any]:
     """Start a non-blocking crawl; poll via ``crawl_status(task_id)``.
-    ``depth=None`` = whole site, ``0`` = single URL. ``render_mode``: "http"/"browser"."""
+    ``depth=0`` (default) = single URL, ``N`` = follow links N levels,
+    ``null`` = whole site. ``render_mode``: "http"/"browser"."""
     from lilbee.crawler import crawler_available
 
     if not crawler_available():
@@ -449,7 +451,7 @@ async def crawl(
     # Mirror the REST CrawlRequest bounds so a negative value is a clean error,
     # not an unbounded crawl.
     if depth is not None and depth < 0:
-        return _error("depth must be 0 or greater (omit it to crawl the whole site)")
+        return _error("depth must be 0 or greater (pass depth=null to crawl the whole site)")
     if max_pages is not None and max_pages < 0:
         return _error("max_pages must be 0 or greater (0 = unlimited, omit for the safety cap)")
     try:

--- a/src/lilbee/skills/lilbee_mcp/SKILL.md
+++ b/src/lilbee/skills/lilbee_mcp/SKILL.md
@@ -106,7 +106,7 @@ wait ~10s, re-check `lilbee_status`, retry. Don't switch tools.
 |---|---|
 | `lilbee_add(paths, force, enable_ocr, ocr_timeout, render_mode)` | Copy files / dirs / URLs into the library and index them. Seconds to minutes. |
 | `lilbee_sync(force_rebuild, retry_skipped)` | Re-index the documents directory after edits. Minutes on large libraries. |
-| `lilbee_crawl(url, depth, max_pages, render_mode, include_subdomains)` | Start a non-blocking crawl. Returns `task_id`; poll `lilbee_crawl_status`. |
+| `lilbee_crawl(url, depth, max_pages, render_mode, include_subdomains)` | Start a non-blocking crawl. Default `depth=0` fetches one page; pass a depth (or `null` for the whole site) to follow links. Returns `task_id`; poll `lilbee_crawl_status`. |
 | `lilbee_model_pull(model, source, allow_unsupported)` | Download a model. Streams progress as MCP notifications. Large models take minutes. Set `allow_unsupported=true` to override the architecture-compat check; without it, the call returns a structured error with `code: "unsupported_arch"` and the supported-architecture list. |
 | `lilbee_import_dataset(dataset, fmt)` | Import a per-page dataset file, re-embedding every page under the current model. Replaces existing copies of each source. Streams progress as MCP notifications. |
 | `lilbee_reset(confirm)` | Wipe the entire index and data dir. Pass `confirm=true`. Destructive. |
@@ -148,9 +148,9 @@ lilbee-worker:   lilbee_add(["/path/to/dir", "https://docs.example.com/page"])
 lilbee_status                           # confirm new sources appeared
 ```
 
-`lilbee_add` accepts absolute paths, directories (recursive), and URLs (which get crawled
-to markdown). It runs `lilbee_sync` after copying, so the new content is indexed in one
-call. For continuous web monitoring, use `lilbee_crawl` instead.
+`lilbee_add` accepts absolute paths, directories (recursive), and URLs (fetched as single
+pages). It runs `lilbee_sync` after copying, so the new content is indexed in one call.
+For multi-page site crawls or continuous web monitoring, use `lilbee_crawl` instead.
 
 ### 3. User wants to crawl a docs site
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -810,6 +810,17 @@ class TestAddWithUrls:
     @mock.patch("lilbee.crawler.crawler_available", return_value=True)
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     @mock.patch("lilbee.crawler.crawl_and_save", new_callable=AsyncMock)
+    async def test_add_url_fetches_single_page(
+        self, mock_crawl, mock_sync, _mock_avail, isolated_env
+    ):
+        """add() fetches a URL as one page (depth=0), like CLI add without --crawl."""
+        mock_crawl.return_value = []
+        await add(paths=["https://example.com"])
+        assert mock_crawl.call_args.kwargs["depth"] == 0
+
+    @mock.patch("lilbee.crawler.crawler_available", return_value=True)
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    @mock.patch("lilbee.crawler.crawl_and_save", new_callable=AsyncMock)
     async def test_add_mixed_urls_and_paths(self, mock_crawl, mock_sync, _mock_avail, isolated_env):
         """Mixed URLs and paths: URLs crawled, nonexistent paths reported."""
         mock_crawl.return_value = []
@@ -852,11 +863,31 @@ class TestCrawl:
         assert result["url"] == "https://example.com"
         mock_start.assert_called_once_with(
             "https://example.com",
-            depth=None,
+            depth=0,
             max_pages=None,
             render_mode=None,
             include_subdomains=False,
         )
+
+    @mock.patch("lilbee.crawler.crawler_available", return_value=True)
+    @mock.patch("lilbee.crawler.url_filter.socket.getaddrinfo")
+    @mock.patch("lilbee.mcp_server.start_crawl", return_value="abc123")
+    async def test_default_depth_is_single_page(
+        self, mock_start, _mock_dns, _mock_avail, isolated_env
+    ):
+        """Omitted depth crawls one page, not the whole site (bb-dotjq)."""
+        await crawl(url="https://en.wikipedia.org/wiki/Sauna")
+        assert mock_start.call_args.kwargs["depth"] == 0
+
+    @mock.patch("lilbee.crawler.crawler_available", return_value=True)
+    @mock.patch("lilbee.crawler.url_filter.socket.getaddrinfo")
+    @mock.patch("lilbee.mcp_server.start_crawl", return_value="abc123")
+    async def test_explicit_null_depth_crawls_whole_site(
+        self, mock_start, _mock_dns, _mock_avail, isolated_env
+    ):
+        """depth=None stays the explicit whole-site opt-in."""
+        await crawl(url="https://example.com", depth=None)
+        assert mock_start.call_args.kwargs["depth"] is None
 
     @mock.patch("lilbee.crawler.crawler_available", return_value=True)
     @mock.patch("lilbee.crawler.url_filter.socket.getaddrinfo")
@@ -911,7 +942,7 @@ class TestCrawl:
         await crawl(url="https://example.com", render_mode=CrawlRenderMode.BROWSER)
         mock_start.assert_called_once_with(
             "https://example.com",
-            depth=None,
+            depth=0,
             max_pages=None,
             render_mode=CrawlRenderMode.BROWSER,
             include_subdomains=False,


### PR DESCRIPTION
## Problem
The MCP crawl tool treats an omitted depth as a whole-site crawl. An agent that passes just a URL follows every outbound link, bounded only by the 5,000-page safety cap. The MCP add tool has the same unbounded default for URLs.

## Solution
The crawl tool defaults to depth=0 and fetches only the given URL. An explicit depth=null remains the whole-site opt-in, and the max_pages safety cap still applies. The add tool fetches URLs as single pages, matching CLI add without --crawl.

## Unchanged
REST, CLI, and TUI keep their whole-site semantics: their site crawls are explicit user actions.