### PR TITLE
Grant chat context against the real quantized KV cache cost

### DIFF
--- a/src/lilbee/core/config/enums.py
+++ b/src/lilbee/core/config/enums.py
@@ -97,11 +97,14 @@ class KvCacheType(StrEnum):
     Q4_0 = "q4_0"
 
 
-# Bytes per KV element for memory budgeting. The quantized variants are
-# ~1 byte of data plus shared scales, close enough for context-fit math.
-KV_CACHE_TYPE_BYTES: dict[KvCacheType, int] = {
-    KvCacheType.F16: 2,
-    KvCacheType.F32: 4,
-    KvCacheType.Q8_0: 1,
-    KvCacheType.Q4_0: 1,
+# Bytes per KV element for memory budgeting, from llama.cpp's block layouts:
+# q8_0 stores 32 elements in 34 bytes (2-byte scale + 32 data bytes) and q4_0
+# stores 32 elements in 18 bytes (2-byte scale + 16 bytes of packed nibbles).
+# Rounding q4_0 up to a whole byte charged its cache at almost twice the real
+# size and nearly halved the context window the dynamic picker granted.
+KV_CACHE_TYPE_BYTES: dict[KvCacheType, float] = {
+    KvCacheType.F16: 2.0,
+    KvCacheType.F32: 4.0,
+    KvCacheType.Q8_0: 34 / 32,
+    KvCacheType.Q4_0: 18 / 32,
 }

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from lilbee.modelhub.registry import ModelRegistry
 from lilbee.core.config import DEFAULT_NUM_CTX, cfg
-from lilbee.core.config.enums import KV_CACHE_TYPE_BYTES
+from lilbee.core.config.enums import KV_CACHE_TYPE_BYTES, KvCacheType
 from lilbee.providers.base import (
     CONTEXT_WINDOW_MARGIN_TOKENS,
     GENERATION_RESERVE_TOKENS,
@@ -142,9 +142,24 @@ def resolve_model_path(model: str, registry: ModelRegistry | None = None) -> Pat
     )
 
 
-def _kv_elem_bytes_for_cfg() -> int:
-    """Bytes per KV element implied by the configured cache type."""
-    return KV_CACHE_TYPE_BYTES[cfg.kv_cache_type]
+def chat_kv_elem_bytes() -> tuple[float, float]:
+    """Per-element (K, V) byte costs of the KV cache a chat launch allocates.
+
+    Reads the same flags the launch passes
+    (:func:`lilbee.providers.fleet.planning.chat_cache_type_flags`): K carries
+    ``cfg.kv_cache_type``, while V carries it only when flash attention is
+    certain to be on, because llama.cpp refuses a quantized V cache without it
+    and the launch then leaves V at f16. Budgeting from the launch flags keeps
+    the granted window in step with the cache the engine actually allocates.
+    """
+    # call-time import: planning imports this module at load
+    from lilbee.providers.fleet.planning import chat_cache_type_flags
+
+    def elem_bytes(flag: str | None) -> float:
+        return KV_CACHE_TYPE_BYTES[KvCacheType(flag) if flag else KvCacheType.F16]
+
+    k_flag, v_flag = chat_cache_type_flags()
+    return elem_bytes(k_flag), elem_bytes(v_flag)
 
 
 def chat_ctx_ceiling(meta: dict[str, str] | None, model_path: Path) -> int:
@@ -176,7 +191,7 @@ def resolve_chat_ctx(
 
     try:
         model_bytes = model_path.stat().st_size
-        kv_per_tok = kv_bytes_per_token(meta, _kv_elem_bytes_for_cfg())
+        kv_per_tok = kv_bytes_per_token(meta, *chat_kv_elem_bytes())
         if available_bytes is None:
             available_bytes = get_available_memory(cfg.gpu_memory_fraction)
         return compute_dynamic_ctx(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from lilbee.core.config.enums import KvCacheType
+from lilbee.core.config.enums import KV_CACHE_TYPE_BYTES, KvCacheType
 from lilbee.core.system import is_network_path
 from lilbee.providers import engine_params, model_cache
 from lilbee.providers.base import ProviderError
@@ -1022,7 +1022,7 @@ def _admit_estimate(
 
 
 def _analytic_footprint_floor(
-    weights: int, *, meta: dict[str, str] | None, ctx: int, slots: int
+    weights: int, *, role: WorkerRole, meta: dict[str, str] | None, ctx: int, slots: int
 ) -> int:
     """The least this instance can occupy: weights, its KV cache, and overhead.
 
@@ -1040,7 +1040,11 @@ def _analytic_footprint_floor(
     """
 
     kv_bytes = (
-        model_cache.kv_bytes_per_token(meta, engine_params._kv_elem_bytes_for_cfg())
+        model_cache.kv_bytes_per_token(
+            meta,
+            KV_CACHE_TYPE_BYTES[_role_kv_cache_type(role)],
+            KV_CACHE_TYPE_BYTES[_role_kv_cache_type_v(role)],
+        )
         * ctx
         * max(slots, 1)
     )
@@ -1135,7 +1139,7 @@ def _fallback_floor_for(role: WorkerRole, ref: str, weights: int) -> int:
         path = None
     ctx = _placement_estimate_ctx(role, path, meta) if path is not None else _MIN_USABLE_CHAT_CTX
     return _analytic_footprint_floor(
-        weights, meta=meta, ctx=ctx, slots=_placement_estimate_slots(role, meta)
+        weights, role=role, meta=meta, ctx=ctx, slots=_placement_estimate_slots(role, meta)
     )
 
 

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -41,27 +41,37 @@ _DYNAMIC_CTX_QUANTUM = 256
 _KV_ELEM_BYTES_F16 = 2
 
 
-def kv_bytes_per_token(meta: dict[str, str] | None, kv_elem_bytes: int = _KV_ELEM_BYTES_F16) -> int:
+def kv_bytes_per_token(
+    meta: dict[str, str] | None,
+    k_elem_bytes: float = _KV_ELEM_BYTES_F16,
+    v_elem_bytes: float | None = None,
+) -> int:
     """Estimate per-token KV cache size in bytes from GGUF metadata.
 
-    Formula: 2 (K + V) * n_layers * n_kv_heads * head_dim * elem_bytes.
-    Falls back to ``_KV_BYTES_PER_CTX_TOKEN`` when metadata is missing.
+    Formula: n_layers * n_kv_heads * (k_dim * k_elem_bytes + v_dim * v_elem_bytes).
+    K and V are charged separately because a launch can quantize one and not the
+    other: a quantized V cache needs flash attention, so the engine keeps V at
+    f16 when flash attention is not certain. ``v_elem_bytes`` defaults to the K
+    cost for callers whose caches match. Falls back to
+    ``_KV_BYTES_PER_CTX_TOKEN`` when metadata is missing.
     """
+    if v_elem_bytes is None:
+        v_elem_bytes = k_elem_bytes
     if not meta:
         return _KV_BYTES_PER_CTX_TOKEN
     try:
         n_layers = int(meta["block_count"])
         head_count_kv = int(meta.get("head_count_kv") or meta["head_count"])
         if "key_length" in meta and "value_length" in meta:
-            kv_dim = int(meta["key_length"]) + int(meta["value_length"])
+            k_dim = int(meta["key_length"])
+            v_dim = int(meta["value_length"])
         else:
             embed = int(meta["embedding_length"])
             head_count = int(meta.get("head_count") or head_count_kv)
-            head_dim = embed // head_count
-            kv_dim = 2 * head_dim
+            k_dim = v_dim = embed // head_count
     except (KeyError, ValueError, ZeroDivisionError):
         return _KV_BYTES_PER_CTX_TOKEN
-    return n_layers * head_count_kv * kv_dim * kv_elem_bytes
+    return int(n_layers * head_count_kv * (k_dim * k_elem_bytes + v_dim * v_elem_bytes))
 
 
 def estimate_model_memory(

--- a/tests/test_engine_params.py
+++ b/tests/test_engine_params.py
@@ -86,7 +86,7 @@ class TestResolveChatCtx:
         model.write_bytes(b"x" * 100)
         monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 8192)
         monkeypatch.setattr(ep, "get_available_memory", lambda _frac: 10**10)
-        monkeypatch.setattr(ep, "kv_bytes_per_token", lambda _meta, _b: 1000)
+        monkeypatch.setattr(ep, "kv_bytes_per_token", lambda _meta, *_b: 1000)
         monkeypatch.setattr(ep, "compute_dynamic_ctx", lambda **_k: 6000)
         monkeypatch.setattr(cfg, "num_ctx_max", None)
         monkeypatch.setattr(cfg, "chat_n_ctx_target", 8192)
@@ -98,7 +98,7 @@ class TestResolveChatCtx:
         seen: dict = {}
         monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 99999)
         monkeypatch.setattr(ep, "get_available_memory", lambda _frac: 10**10)
-        monkeypatch.setattr(ep, "kv_bytes_per_token", lambda _meta, _b: 1000)
+        monkeypatch.setattr(ep, "kv_bytes_per_token", lambda _meta, *_b: 1000)
 
         def _capture(**kwargs):
             seen.update(kwargs)
@@ -110,12 +110,65 @@ class TestResolveChatCtx:
         ep.resolve_chat_ctx(model, None)
         assert seen["ceiling"] == 4096  # explicit num_ctx_max caps below training_ctx
 
+    def test_quantized_kv_widens_the_grant(self, monkeypatch, tmp_path) -> None:
+        """The field case: a quantized-KV config must grant the wider window its
+        smaller cache affords, not one budgeted at a rounded-up byte cost.
+
+        Meta shaped like a dense GQA model (48 layers, 8 KV heads, 128-dim
+        K and V). With q4_0 K+V the per-token cache is 55296 bytes; the old
+        1-byte-per-element charge said 98304 and granted 9984 tokens where
+        17920 fit."""
+        from lilbee.core.config.enums import KvCacheType
+
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"x" * 10**6)
+        meta = {
+            "block_count": "48",
+            "head_count": "32",
+            "head_count_kv": "8",
+            "key_length": "128",
+            "value_length": "128",
+        }
+        monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 262144)
+        monkeypatch.setattr(cfg, "kv_cache_type", KvCacheType.Q4_0)
+        monkeypatch.setattr(cfg, "flash_attention", True)
+        monkeypatch.setattr(cfg, "num_ctx_max", None)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 200000)
+        assert ep.resolve_chat_ctx(model, meta, available_bytes=10**9) == 17920
+
     def test_falls_back_to_static_cap_on_stat_error(self, monkeypatch) -> None:
         monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 8192)
         monkeypatch.setattr(cfg, "num_ctx_max", None)
         monkeypatch.setattr(cfg, "chat_n_ctx_target", 4096)
         # A nonexistent path makes .stat() raise OSError -> static min(training, target).
         assert ep.resolve_chat_ctx(Path("/nonexistent/x.gguf"), None) == 4096
+
+
+class TestChatKvElemBytes:
+    def test_quantized_kv_costs_its_block_bytes(self, monkeypatch) -> None:
+        from lilbee.core.config.enums import KvCacheType
+
+        monkeypatch.setattr(cfg, "kv_cache_type", KvCacheType.Q4_0)
+        monkeypatch.setattr(cfg, "flash_attention", True)
+        assert ep.chat_kv_elem_bytes() == (18 / 32, 18 / 32)
+
+    def test_q8_0_costs_more_than_a_byte(self, monkeypatch) -> None:
+        # 34-byte block per 32 elements: rounding down to 1 over-grants.
+        from lilbee.core.config.enums import KvCacheType
+
+        monkeypatch.setattr(cfg, "kv_cache_type", KvCacheType.Q8_0)
+        monkeypatch.setattr(cfg, "flash_attention", True)
+        assert ep.chat_kv_elem_bytes() == (34 / 32, 34 / 32)
+
+    def test_v_cache_charged_f16_when_flash_attention_is_off(self, monkeypatch) -> None:
+        """The launch leaves V at f16 without flash attention (llama.cpp refuses
+        a quantized V cache there); budgeting V at the quantized cost would
+        grant a window the card cannot hold."""
+        from lilbee.core.config.enums import KvCacheType
+
+        monkeypatch.setattr(cfg, "kv_cache_type", KvCacheType.Q4_0)
+        monkeypatch.setattr(cfg, "flash_attention", False)
+        assert ep.chat_kv_elem_bytes() == (18 / 32, 2.0)
 
 
 class TestChatCtxCeiling:

--- a/tests/test_estimator_fallback.py
+++ b/tests/test_estimator_fallback.py
@@ -21,6 +21,7 @@ class TestTheFallbackIncludesTheCacheItWillAllocate:
         weights = 4 * _GB
         floor = _analytic_footprint_floor(
             weights,
+            role=WorkerRole.CHAT,
             meta={
                 "block_count": "32",
                 "head_count_kv": "8",
@@ -41,8 +42,10 @@ class TestTheFallbackIncludesTheCacheItWillAllocate:
             "key_length": "128",
             "value_length": "128",
         }
-        one = _analytic_footprint_floor(4 * _GB, meta=meta, ctx=8192, slots=1)
-        four = _analytic_footprint_floor(4 * _GB, meta=meta, ctx=8192, slots=4)
+        one = _analytic_footprint_floor(4 * _GB, role=WorkerRole.CHAT, meta=meta, ctx=8192, slots=1)
+        four = _analytic_footprint_floor(
+            4 * _GB, role=WorkerRole.CHAT, meta=meta, ctx=8192, slots=4
+        )
         assert four > one
 
     def test_unknown_metadata_still_charges_more_than_weights(self) -> None:
@@ -50,7 +53,10 @@ class TestTheFallbackIncludesTheCacheItWillAllocate:
         # because zero KV is the one answer that is certainly wrong.
         from lilbee.providers.fleet.planning import _analytic_footprint_floor
 
-        assert _analytic_footprint_floor(4 * _GB, meta=None, ctx=8192, slots=1) > 4 * _GB
+        assert (
+            _analytic_footprint_floor(4 * _GB, role=WorkerRole.CHAT, meta=None, ctx=8192, slots=1)
+            > 4 * _GB
+        )
 
 
 class TestTheFallbackIsUsedAndSaidOutLoud:

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -57,6 +57,34 @@ class TestKvBytesPerToken:
     def test_returns_default_on_missing_keys(self) -> None:
         assert kv_bytes_per_token({"block_count": "abc"}) == _KV_BYTES_PER_CTX_TOKEN
 
+    def test_quantized_kv_charges_the_real_block_bytes(self) -> None:
+        """q4_0 stores 32 elements in an 18-byte block (0.5625 bytes/element).
+
+        Charging it a whole byte per element nearly halved the context window
+        the dynamic picker granted on a quantized-KV config."""
+        meta = {
+            "block_count": "32",
+            "head_count": "32",
+            "head_count_kv": "8",
+            "key_length": "128",
+            "value_length": "128",
+        }
+        # 32 layers * 8 heads * (128 + 128) elements * 18/32 bytes
+        assert kv_bytes_per_token(meta, 18 / 32, 18 / 32) == 36864
+
+    def test_k_and_v_costs_are_charged_separately(self) -> None:
+        """A quantized V cache needs flash attention, so a launch can quantize
+        K while V stays f16; the estimate must charge each at its own cost."""
+        meta = {
+            "block_count": "32",
+            "head_count": "32",
+            "head_count_kv": "8",
+            "key_length": "128",
+            "value_length": "128",
+        }
+        # 32 layers * 8 heads * (128 * 18/32 + 128 * 2)
+        assert kv_bytes_per_token(meta, 18 / 32, 2.0) == 83968
+
 
 class TestEstimateModelMemory:
     def test_zero_bytes_when_path_missing(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem
On a quantized-KV config the dynamic context picker under-grants the chat window. It charges q4_0 KV a whole byte per element, while llama.cpp's q4_0 block stores 32 elements in 18 bytes (`block_q4_0` in ggml-common.h), so the KV term costs ~1.8x its real size and the picker grants barely half the window the card holds.

## Fix
`KV_CACHE_TYPE_BYTES` now carries the block-derived per-element costs: q4_0 = 18/32, q8_0 = 34/32 (the old table also rounded q8_0 down to 1, a slight over-grant).

## K and V charged separately
The launch quantizes the V cache only when flash attention is definitely on, so the grant now reads the same launch flags and charges each cache at its own cost. A flash-off config no longer budgets V at a quantized size the engine will not use.

## Placement floor
The analytic footprint floor charges each role's own KV types (embed/rerank/vision run f16) instead of the chat config for every role.

## Validation (RunPod A40 48GB, Qwen3.6-27B Q4_K_M, kv_cache_type=q4_0, flash on)
Released build grants 131,584 tokens (q4_0 charged at 1 byte/element, 131,072 KV bytes/token). This branch grants 234,240 tokens (73,728 KV bytes/token). The engine loads at the granted window (`--ctx-size 468480 --parallel 2 --cache-type-k q4_0 --cache-type-v q4_0`, 26.4 GiB used of 46), `/api/health` reports `chat_ctx: 234240`, and `/v1/messages` serves both a short completion and a 20,024-token prompt (22 s prefill).