### PR TITLE
Raise the huggingface_hub floor to 1.27.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "jinja2>=2.11.3",
     "typing-extensions>=4.5.0",
     "gguf>=0.18",
-    "huggingface_hub>=1.26.0",
+    "huggingface_hub>=1.27.0",
     "psutil>=5.9",
     "pydantic-settings>=2.14.2",
     # 2.5 drops the 3.11 floor and ships 3.12-only stubs mypy rejects at the 3.11 target.

--- a/uv.lock
+++ b/uv.lock
@@ -1409,7 +1409,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.26.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1422,9 +1422,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
 ]
 
 [[package]]
@@ -1908,7 +1908,7 @@ requires-dist = [
     { name = "gguf", specifier = ">=0.18" },
     { name = "graspologic-native", marker = "extra == 'graph'", specifier = ">=1.2" },
     { name = "httpx" },
-    { name = "huggingface-hub", specifier = ">=1.26.0" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
     { name = "jinja2", specifier = ">=2.11.3" },
     { name = "lancedb", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "lancedb", extras = ["pylance"], marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },


### PR DESCRIPTION
## Problem

lilbee pinned huggingface_hub at 1.26.0 while touching two of its private APIs: `abort_xet_session` for download cancellation and the `update_transfer` tqdm protocol for Xet progress. Upstream has said both may change (issues #4632 and #4633), so version bumps need explicit re-verification rather than a routine dependency update.

## Change

Raises the floor to `huggingface_hub>=1.27.0` and re-locks. The lock changes exactly one package. The 1.27.0 delta on our surface is a traceback-retention fix in `file_download.py`. The Xet transfer-bar fix (hub PR #4647) is not in 1.27.0 and lands in the next release; it does not affect lilbee either way, since our tqdm class implements `update_transfer`.

## Verified

The private-API contract tests pass on 1.27.0: the `update_transfer` routing suite drives hub's real `XetDownloadProgressReporter`, and the cancel-abort and stall-guard suites exercise `abort_xet_session`. Full suite: 12694 passed, coverage 100%. Pod acceptance ran the eight real-download tests against HuggingFace on 1.27.0: all passed, with Xet active.
