### PR TITLE
Bound a chat estimate by its weights, not by dense-attention header math

### DIFF
--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -959,7 +959,7 @@ def _estimate_or_fallback(
     """Size *role* for placement, degrading rather than refusing.
 
     A missing model is skipped and recorded; a sizing failure on an installed
-    model falls back to its weight bytes; weights alone exceeding the physical
+    model falls back to the analytic floor; weights alone exceeding the physical
     VRAM refuse with a plain message (ground truth, not an estimate).
     """
     from lilbee.providers.base import ProviderError, ProviderErrorKind
@@ -1055,9 +1055,8 @@ def _analytic_footprint_floor(
 def _estimate_is_implausible(*, estimated: int, floor: int) -> bool:
     """Whether *estimated* describes a load that cannot exist.
 
-    Below the analytic floor, which is the model's own weight bytes plus the
-    cache and buffers it was asked to hold, there is no arrangement of memory
-    that serves it. A floor of zero means nothing could be computed to compare
+    Below the bytes the card must hold there is no arrangement of memory that
+    serves the model. A floor of zero means nothing could be computed to compare
     against, and a guess is not grounds to discard the only measurement there is.
     """
     return floor > 0 and 0 < estimated < floor
@@ -1066,25 +1065,32 @@ def _estimate_is_implausible(*, estimated: int, floor: int) -> bool:
 def _floor_implausible_estimate(
     estimate: ModelPlacementInput, role: WorkerRole, ref: str
 ) -> ModelPlacementInput:
-    """*estimate*, or the analytic floor when the estimator returned less than one.
+    """*estimate*, or the model's weight bytes when it reports less than those.
 
-    The fallback floor otherwise fires only when the estimator cannot answer, so
-    an answer that is well formed and impossible went straight through, and
-    placement committed a card against a number the load then overran.
+    The bound is the weights alone, not the analytic footprint. That figure
+    sizes a KV cache as though every layer ran dense attention over the whole
+    window, which linear-attention, sliding-window and MLA models do not, so it
+    sits far above what they hold. Weights are architecture-independent, which
+    makes an estimate under them the one answer the planner can call impossible
+    without modelling attention.
+
+    Offload lifts the bound: the layers in system memory are weight bytes the
+    card never holds.
     """
-    floor = _fallback_floor_for(role, ref, _role_weights_bytes(role, ref))
-    if not _estimate_is_implausible(estimated=estimate.est_vram_bytes, floor=floor):
+    if _cpu_offload_in_play():
+        return estimate
+    weights = _role_weights_bytes(role, ref)
+    if not _estimate_is_implausible(estimated=estimate.est_vram_bytes, floor=weights):
         return estimate
     log.warning(
-        "The estimator sized the %s model %s at %.1f GiB, below the %.1f GiB its "
-        "weights and cache alone need. Charging the floor instead; the estimate "
-        "cannot be describing this load.",
+        "The estimator sized the %s model %s at %.1f GiB, below the %.1f GiB of "
+        "weights the card has to hold. Charging the weights instead.",
         role.value,
         ref,
         estimate.est_vram_bytes / 1024**3,
-        floor / 1024**3,
+        weights / 1024**3,
     )
-    return replace(estimate, est_vram_bytes=floor)
+    return replace(estimate, est_vram_bytes=weights)
 
 
 def _sizing_failure_fallback(

--- a/tests/test_estimator_plausibility.py
+++ b/tests/test_estimator_plausibility.py
@@ -1,9 +1,10 @@
 """An estimate the parser returns confidently can still be impossible.
 
 The fallback floor fires only when the estimator cannot answer. An answer below
-the model's own weights plus the cache it was asked to hold is not a small error,
-it is a number that cannot describe any load, and placement acting on it commits
-a card it will then overrun.
+the weight bytes the card must hold is not a small error, it is a number that
+cannot describe any load, and placement acting on it commits a card it will then
+overrun. Everything above that bound is the estimator's to report: how much cache
+a layer holds depends on the attention it runs, and the planner does not model that.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from lilbee.providers.roles import WorkerRole
 _GB = 1024**3
 
 
-def test_an_estimate_below_the_analytic_floor_is_rejected() -> None:
+def test_an_estimate_below_the_floor_is_rejected() -> None:
     assert planning._estimate_is_implausible(estimated=1 * _GB, floor=8 * _GB)
 
 
@@ -32,10 +33,43 @@ def test_an_unknown_floor_never_rejects() -> None:
 def test_the_floor_replaces_an_impossible_estimate(monkeypatch, caplog) -> None:
     from lilbee.providers.fleet.placement import ModelPlacementInput
 
+    monkeypatch.setattr(planning, "_cpu_offload_in_play", lambda: False)
     monkeypatch.setattr(planning, "_role_weights_bytes", lambda *_a: 8 * _GB)
-    monkeypatch.setattr(planning, "_fallback_floor_for", lambda *_a: 9 * _GB)
     tiny = ModelPlacementInput(WorkerRole.CHAT, 1 * _GB)
     with caplog.at_level("WARNING"):
         corrected = planning._floor_implausible_estimate(tiny, WorkerRole.CHAT, "org/m")
-    assert corrected.est_vram_bytes == 9 * _GB
+    assert corrected.est_vram_bytes == 8 * _GB
     assert "org/m" in caplog.text
+
+
+def test_a_cache_smaller_than_dense_attention_would_hold_is_kept(monkeypatch, caplog) -> None:
+    # Qwen3.6-27B on an A40: the parser said 25.7 GiB and the load took 26.4,
+    # while header math over a window this size predicts far more, because most
+    # of the model's layers run linear attention and hold no per-token cache.
+    from lilbee.providers.fleet.placement import ModelPlacementInput
+
+    def _refuse(*_a: object) -> int:
+        raise AssertionError("the analytic floor must not weigh in on a well-formed estimate")
+
+    monkeypatch.setattr(planning, "_cpu_offload_in_play", lambda: False)
+    monkeypatch.setattr(planning, "_role_weights_bytes", lambda *_a: 17 * _GB)
+    monkeypatch.setattr(planning, "_fallback_floor_for", _refuse)
+    measured = ModelPlacementInput(WorkerRole.CHAT, 26 * _GB)
+    with caplog.at_level("WARNING"):
+        kept = planning._floor_implausible_estimate(measured, WorkerRole.CHAT, "org/qwen")
+    assert kept.est_vram_bytes == 26 * _GB
+    assert not caplog.text
+
+
+def test_an_offloaded_model_may_hold_less_than_its_weights(monkeypatch, caplog) -> None:
+    # Part of the model lives in system memory, so the card holds less than the
+    # file: the weight bytes stop being a bound on what the GPU takes.
+    from lilbee.providers.fleet.placement import ModelPlacementInput
+
+    monkeypatch.setattr(planning, "_cpu_offload_in_play", lambda: True)
+    monkeypatch.setattr(planning, "_role_weights_bytes", lambda *_a: 60 * _GB)
+    split = ModelPlacementInput(WorkerRole.CHAT, 12 * _GB)
+    with caplog.at_level("WARNING"):
+        kept = planning._floor_implausible_estimate(split, WorkerRole.CHAT, "org/moe")
+    assert kept.est_vram_bytes == 12 * _GB
+    assert not caplog.text

--- a/tests/test_placement_properties.py
+++ b/tests/test_placement_properties.py
@@ -230,3 +230,21 @@ class TestTheEstimatePlausibilityBand:
     def test_an_unknown_floor_rejects_nothing(self, estimated: int) -> None:
         assume(estimated > 0)
         assert not planning._estimate_is_implausible(estimated=estimated, floor=0)
+
+    @given(
+        weights=st.integers(min_value=1, max_value=200 * _GB),
+        headroom=st.integers(min_value=0, max_value=300 * _GB),
+    )
+    def test_an_estimate_covering_the_weights_is_never_raised(
+        self, weights: int, headroom: int
+    ) -> None:
+        # Above the weights, how much more a load takes is the estimator's to
+        # report: the planner does not know how much cache the architecture holds.
+        from lilbee.providers.fleet.placement import ModelPlacementInput
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(planning, "_cpu_offload_in_play", lambda: False)
+            mp.setattr(planning, "_role_weights_bytes", lambda *_a: weights)
+            estimate = ModelPlacementInput(WorkerRole.CHAT, weights + headroom)
+            kept = planning._floor_implausible_estimate(estimate, WorkerRole.CHAT, "org/m")
+        assert kept.est_vram_bytes == weights + headroom


### PR DESCRIPTION
## Problem

Placement discarded any gguf-parser estimate that fell below the analytic footprint floor and charged the floor in its place. That floor sizes a KV cache as though every layer ran dense attention over the whole window. Linear-attention, sliding-window and MLA models hold far less, so their correct estimates read as impossible and were replaced by a number well above what the load takes. On a 48 GB card that over-charge can force a tensor split, or a refusal, for a model that fits comfortably.

## Change

The bound is the model's weight bytes. Weights are architecture-independent, which makes an estimate under them the one answer the planner can call impossible without modelling attention. Above them, how much more a load takes is the estimator's to report.

## Offload

Skips the check. Layers in system memory are weight bytes the card never holds, so the weights stop bounding what the GPU takes.

## Unchanged

The analytic floor keeps its other caller, the path where the estimator cannot answer at all and a conservative guess beats nothing.

## Verified

RunPod A40 48 GB, Qwen3.6-27B Q4_K_M at `kv_cache_type=q4_0`, flash attention on, `chat_n_ctx_target` 262144. On `main` the warning fires and placement charges 35.23 GiB against the estimator's 25.73 GiB; observed usage for this load is 26.4 GiB. On this branch no warning fires and placement charges 25.73 GiB. Lint, format, mypy and the fleet/placement/estimator suites are green locally.