### PR TITLE
Size the single-GPU chat window with gguf-parser, not header math

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -594,7 +594,12 @@ flowchart LR
   for a chat that fits one card). Its context is then sized (`ctx.fit_split_ctx`, a
   binary search over the gguf-parser estimate) so **each card's own share fits that
   card's own headroom**, never the combined pool, so the per-GPU compute buffer can't
-  overflow device 0 even when the cards are unequal. On a
+  overflow device 0 even when the cards are unequal. A chat on one card searches the
+  same grid against one device (`ctx.fit_single_ctx`, entered through
+  `engine_params.resolve_chat_ctx`), so both paths price the cache the model's
+  architecture holds. Header math (`model_cache.compute_dynamic_ctx`) is the fallback
+  for when gguf-parser cannot answer; it charges every layer as dense attention over
+  the whole window, which under-grants linear-attention, sliding-window and MLA models. On a
   single CPU/Metal box this
   is a fleet-of-one against one shared pool, where the **search-critical roles
   (embed/rerank) are reserved before the elastic chat model**: chat's slot count and

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -175,10 +175,16 @@ def resolve_chat_ctx(
 ) -> int:
     """Pick a single-GPU n_ctx aiming for ``cfg.chat_n_ctx_target``, clamped to model + host.
 
-    When ``cfg.num_ctx_max`` is ``None`` the model's training_ctx is the only
-    ceiling, so a long-context model can grow past the target if the host has
-    the RAM to back it. A multi-GPU tensor-split chat is sized separately by the
-    fleet against its per-device headroom (see :func:`lilbee.providers.fleet.ctx.fit_split_ctx`).
+    A gguf-parser fit answers first
+    (:func:`lilbee.providers.fleet.planning.fit_chat_ctx`), because it prices the
+    cache each layer of this architecture holds. Header math takes over when the
+    estimator cannot answer; it charges every layer as dense attention over the
+    whole window, which under-grants linear-attention, sliding-window and MLA
+    models. Either way the window stops at the smallest of the trained context,
+    ``cfg.num_ctx_max`` and the target.
+
+    A multi-GPU tensor-split chat is sized separately by the fleet against its
+    per-device headroom (see :func:`lilbee.providers.fleet.ctx.fit_split_ctx`).
     ``available_bytes`` overrides the live host-memory read, and every caller
     that is sizing a real launch passes it: the fleet and the surfaces that
     mirror it hand over
@@ -186,14 +192,23 @@ def resolve_chat_ctx(
     memory of the GPU that will run the model and holds a clean-box snapshot so
     a reload sizes ctx like the boot did.
     """
+    # call-time import: planning imports this module at load
+    from lilbee.providers.fleet.planning import fit_chat_ctx
+
     training_ctx = train_ctx_from_meta(meta, fallback=DEFAULT_NUM_CTX, model_path=model_path)
     ceiling = cfg.num_ctx_max if cfg.num_ctx_max is not None else training_ctx
+    if available_bytes is None:
+        available_bytes = get_available_memory(cfg.gpu_memory_fraction)
+    upper = min(training_ctx, ceiling, cfg.chat_n_ctx_target)
+
+    try:
+        return fit_chat_ctx(model_path, meta, available_bytes=available_bytes, ctx_ceiling=upper)
+    except (ProviderError, OSError, ValueError):
+        log.debug("gguf-parser ctx fit failed for %s, using header math", model_path, exc_info=True)
 
     try:
         model_bytes = model_path.stat().st_size
         kv_per_tok = kv_bytes_per_token(meta, *chat_kv_elem_bytes())
-        if available_bytes is None:
-            available_bytes = get_available_memory(cfg.gpu_memory_fraction)
         return compute_dynamic_ctx(
             model_bytes=model_bytes,
             available_bytes=available_bytes,

--- a/src/lilbee/providers/fleet/ctx.py
+++ b/src/lilbee/providers/fleet/ctx.py
@@ -60,6 +60,7 @@ def fit_single_ctx(
     kv_cache_type_v: KvCacheType,
     unified: bool,
     ctx_ceiling: int,
+    expert_offload: tuple[str, ...],
 ) -> int:
     """Largest quantized n_ctx whose gguf-parser estimate fits *available_bytes*.
 
@@ -71,6 +72,8 @@ def fit_single_ctx(
     (``planning.plan_sizing_budget``), so no further fraction applies here.
     *unified* charges the shared-memory figure, which is the whole resident
     footprint on a host whose GPU memory is the system's memory.
+    *expert_offload* names the tensors the launch moves to system memory, so a
+    mixture-of-experts model is not charged VRAM for experts it will not hold.
     """
     if available_bytes <= 0:
         return _DYNAMIC_CTX_FLOOR
@@ -85,6 +88,7 @@ def fit_single_ctx(
             flash_attn=flash_attn,
             kv_cache_type=kv_cache_type,
             kv_cache_type_v=kv_cache_type_v,
+            expert_offload=expert_offload,
         )
         return est.footprint(unified=unified) <= available_bytes
 
@@ -103,6 +107,7 @@ def fit_split_ctx(
     kv_cache_type: KvCacheType,
     kv_cache_type_v: KvCacheType,
     ctx_ceiling: int,
+    expert_offload: tuple[str, ...],
 ) -> int:
     """Largest quantized per-slot n_ctx that fits every card, capped at *ctx_ceiling*.
 
@@ -151,6 +156,7 @@ def fit_split_ctx(
             kv_cache_type=kv_cache_type,
             kv_cache_type_v=kv_cache_type_v,
             tensor_split=ratio,
+            expert_offload=expert_offload,
         )
         shares = est.per_device_vram
         if len(shares) != len(headrooms):

--- a/src/lilbee/providers/fleet/ctx.py
+++ b/src/lilbee/providers/fleet/ctx.py
@@ -1,13 +1,15 @@
-"""Per-device context sizing for a tensor-split chat model in the fleet.
+"""Context sizing for a chat model, from gguf-parser estimates.
 
-Single-GPU chat ctx lives in ``engine_params.resolve_chat_ctx``; this is its
-multi-GPU counterpart, sizing the per-slot context against the busiest card's
-headroom rather than the summed pool. See docs/architecture.md (VRAM estimation).
+:func:`fit_single_ctx` sizes one device against the budget the planner scaled;
+:func:`fit_split_ctx` sizes a tensor split against the busiest card's headroom
+rather than the summed pool. Both bisect the same quantized grid.
+``engine_params.resolve_chat_ctx`` is the entry point for the single-device fit
+and holds the header-math fallback. See docs/architecture.md (VRAM estimation).
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from lilbee.core.config.enums import KvCacheType
@@ -23,6 +25,70 @@ from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTU
 # its estimate, an order of magnitude inside the usable_vram_fraction already held
 # back per card, so the reserve stays 0.
 _MAIN_GPU_SKEW_RESERVE_BYTES = 0
+
+
+def _largest_fitting_ctx(upper: int, fits: Callable[[int], bool]) -> int:
+    """The largest quantized per-slot n_ctx at or below *upper* that *fits*.
+
+    The grid is ``_DYNAMIC_CTX_FLOOR`` plus whole ``_DYNAMIC_CTX_QUANTUM`` steps,
+    so every probe is a context the engine launches with cleanly. Returns the
+    floor when even the floor overflows, which leaves the caller to refuse a
+    window too small to serve.
+    """
+    if not fits(_DYNAMIC_CTX_FLOOR):
+        return _DYNAMIC_CTX_FLOOR
+    steps = max(0, (upper - _DYNAMIC_CTX_FLOOR) // _DYNAMIC_CTX_QUANTUM)
+    lo, hi, best = 0, steps, 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if fits(_DYNAMIC_CTX_FLOOR + mid * _DYNAMIC_CTX_QUANTUM):
+            best, lo = mid, mid + 1
+        else:
+            hi = mid - 1
+    return _DYNAMIC_CTX_FLOOR + best * _DYNAMIC_CTX_QUANTUM
+
+
+def fit_single_ctx(
+    model_path: Path,
+    *,
+    meta: dict[str, str] | None,
+    slots: int,
+    available_bytes: int,
+    gpu_layers: int,
+    flash_attn: bool,
+    kv_cache_type: KvCacheType,
+    kv_cache_type_v: KvCacheType,
+    unified: bool,
+    ctx_ceiling: int,
+) -> int:
+    """Largest quantized n_ctx whose gguf-parser estimate fits *available_bytes*.
+
+    The estimator prices the cache each layer of this architecture actually
+    holds, so a linear-attention, sliding-window or MLA model is granted the
+    window it can serve rather than one budgeted for dense attention everywhere.
+
+    *available_bytes* is the budget the caller already scaled
+    (``planning.plan_sizing_budget``), so no further fraction applies here.
+    *unified* charges the shared-memory figure, which is the whole resident
+    footprint on a host whose GPU memory is the system's memory.
+    """
+    if available_bytes <= 0:
+        return _DYNAMIC_CTX_FLOOR
+    upper = min(chat_ctx_ceiling(meta, model_path), ctx_ceiling)
+
+    def _fits(per_slot: int) -> bool:
+        est = estimate_instance_footprint(
+            model_path,
+            ctx=per_slot,
+            slots=slots,
+            gpu_layers=gpu_layers,
+            flash_attn=flash_attn,
+            kv_cache_type=kv_cache_type,
+            kv_cache_type_v=kv_cache_type_v,
+        )
+        return est.footprint(unified=unified) <= available_bytes
+
+    return _largest_fitting_ctx(upper, _fits)
 
 
 def fit_split_ctx(
@@ -92,14 +158,4 @@ def fit_split_ctx(
             return est.peak_footprint(unified=False) <= min(headrooms)
         return all(share <= room for share, room in zip(shares, headrooms, strict=True))
 
-    if not _peak_fits(_DYNAMIC_CTX_FLOOR):
-        return _DYNAMIC_CTX_FLOOR
-    steps = max(0, (upper - _DYNAMIC_CTX_FLOOR) // _DYNAMIC_CTX_QUANTUM)
-    lo, hi, best = 0, steps, 0
-    while lo <= hi:
-        mid = (lo + hi) // 2
-        if _peak_fits(_DYNAMIC_CTX_FLOOR + mid * _DYNAMIC_CTX_QUANTUM):
-            best, lo = mid, mid + 1
-        else:
-            hi = mid - 1
-    return _DYNAMIC_CTX_FLOOR + best * _DYNAMIC_CTX_QUANTUM
+    return _largest_fitting_ctx(upper, _peak_fits)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -395,6 +395,33 @@ def _fit_slots(
     return 1
 
 
+def fit_chat_ctx(
+    model_path: Path,
+    meta: dict[str, str] | None,
+    *,
+    available_bytes: int,
+    ctx_ceiling: int,
+) -> int:
+    """The chat window gguf-parser says *available_bytes* backs, at the launch flags.
+
+    Sizes one slot, as :func:`_slots_for` then grows the slot count against what
+    the window leaves. Raises when the estimator cannot answer, which sends
+    :func:`engine_params.resolve_chat_ctx` to its header-math fallback.
+    """
+    return fleet_ctx.fit_single_ctx(
+        model_path,
+        meta=meta,
+        slots=1,
+        available_bytes=available_bytes,
+        gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
+        flash_attn=_role_flash(WorkerRole.CHAT),
+        kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
+        kv_cache_type_v=_role_kv_cache_type_v(WorkerRole.CHAT),
+        unified=plan_sizing_is_unified(),
+        ctx_ceiling=ctx_ceiling,
+    )
+
+
 def _role_ctx(
     role: WorkerRole,
     model_path: Path,
@@ -2142,6 +2169,20 @@ def plan_sizing_budget(device: FleetDevice | None = None) -> int:
     if probe is not None:
         return probe.sizing_budget
     return _device_sizing_budget(_live_sizing_devices())
+
+
+def plan_sizing_is_unified() -> bool:
+    """Whether ctx sizing charges the shared-memory footprint rather than VRAM.
+
+    True when no device has memory of its own -- an integrated GPU, an Apple
+    Silicon Mac, or no GPU at all -- because there a model's would-be VRAM and
+    its host bytes are the same memory, and charging only the VRAM half
+    under-reports the load by everything it maps. The same test decides the pool
+    placement charges against (:func:`_unified_memory_budget`).
+    """
+    probe = _plan_probe_store.get()
+    devices = list(probe.devices) if probe is not None else _live_sizing_devices()
+    return all(dev.unified for dev in devices)
 
 
 def _device_sizing_budget(devices: Sequence[FleetDevice]) -> int:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -419,6 +419,7 @@ def fit_chat_ctx(
         kv_cache_type_v=_role_kv_cache_type_v(WorkerRole.CHAT),
         unified=plan_sizing_is_unified(),
         ctx_ceiling=ctx_ceiling,
+        expert_offload=_role_expert_offload(model_path),
     )
 
 
@@ -834,6 +835,7 @@ def _chat_split_ctx_objective(
             kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
             kv_cache_type_v=_role_kv_cache_type_v(WorkerRole.CHAT),
             ctx_ceiling=target,
+            expert_offload=_role_expert_offload(path),
         )
 
     return fit, target
@@ -1522,6 +1524,7 @@ def _launch_for(
                 kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
                 kv_cache_type_v=_role_kv_cache_type_v(WorkerRole.CHAT),
                 ctx_ceiling=_placement_estimate_ctx(WorkerRole.CHAT, model_path, meta),
+                expert_offload=_role_expert_offload(model_path),
             )
 
         split_slots, ctx = _resolve_split_chat_slots(_split_fit)

--- a/tests/cli/test_launch_server_ctx.py
+++ b/tests/cli/test_launch_server_ctx.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lilbee.core.config import cfg
+from lilbee.providers.roles import WorkerRole
 
 
 def _health(monkeypatch, body: dict) -> None:
@@ -118,8 +119,8 @@ def test_hermes_is_quiet_when_the_window_is_unknown(capsys):
 
 @pytest.mark.no_warm_default
 def test_planned_chat_ctx_sizes_a_local_model_the_way_the_fleet_does(monkeypatch, tmp_path):
-    # Exercises the real sizing path: only the model file and its GGUF header are
-    # faked, so resolve_chat_ctx does the arithmetic the fleet's planner does.
+    # Exercises the header-math fallback: the file is not a parsable GGUF, so the
+    # estimator cannot answer and resolve_chat_ctx does the arithmetic itself.
     from lilbee.cli.launchers import server as launch_mod
 
     gguf = tmp_path / "chat.gguf"
@@ -201,3 +202,28 @@ def test_planned_chat_ctx_is_none_when_the_model_file_is_missing(monkeypatch):
     monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", _missing)
 
     assert launch_mod.planned_chat_ctx() is None
+
+
+@pytest.mark.no_warm_default
+def test_both_grant_surfaces_report_the_window_the_estimator_fits(monkeypatch, tmp_path):
+    # The launcher advertises a window the fleet has to serve, so the two must
+    # come from one answer. Both read resolve_chat_ctx; this pins that they agree
+    # on the estimator's number rather than one of them keeping header math.
+    from lilbee.cli.launchers import server as launch_mod
+    from lilbee.providers.fleet import planning as planning_mod
+
+    gguf = tmp_path / "chat.gguf"
+    gguf.write_bytes(b"0" * 1024)
+    meta = {"architecture": "qwen3", "block_count": "36", "context_length": "262144"}
+    fitted = 249856
+
+    monkeypatch.setattr(cfg, "chat_model", "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf")
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "num_ctx_max", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 262144)
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _ref: gguf)
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: meta)
+    monkeypatch.setattr(planning_mod, "fit_chat_ctx", lambda *_a, **_k: fitted)
+
+    assert launch_mod.planned_chat_ctx() == fitted
+    assert planning_mod._role_ctx(WorkerRole.CHAT, gguf, meta) == fitted

--- a/tests/test_engine_params.py
+++ b/tests/test_engine_params.py
@@ -81,6 +81,57 @@ class TestResolveModelPath:
 
 
 class TestResolveChatCtx:
+    """The single-GPU grant: a gguf-parser fit, with header math behind it."""
+
+    @pytest.fixture(autouse=True)
+    def estimator_unavailable(self, monkeypatch):
+        """Default the fit to unanswerable, so each test picks its path on purpose."""
+        from lilbee.providers.fleet import planning
+
+        def _unavailable(*_a: object, **_k: object) -> int:
+            raise ProviderError("gguf-parser is not installed", provider="llama-server")
+
+        monkeypatch.setattr(planning, "fit_chat_ctx", _unavailable)
+
+    def test_the_gguf_parser_fit_decides_the_window(self, tmp_path, monkeypatch) -> None:
+        # The field case: header math prices every layer as dense attention and
+        # under-grants a hybrid model. The fit answers from the real cache.
+        from lilbee.providers.fleet import planning
+
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"x" * 100)
+        seen: dict = {}
+
+        def _fit(_path, _meta, *, available_bytes: int, ctx_ceiling: int) -> int:
+            seen.update(available_bytes=available_bytes, ctx_ceiling=ctx_ceiling)
+            return 249856
+
+        monkeypatch.setattr(planning, "fit_chat_ctx", _fit)
+        monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 262144)
+        monkeypatch.setattr(ep, "compute_dynamic_ctx", lambda **_k: 131072)
+        monkeypatch.setattr(cfg, "num_ctx_max", None)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 262144)
+        assert ep.resolve_chat_ctx(model, {"arch": "x"}, available_bytes=40 * 1024**3) == 249856
+        assert seen == {"available_bytes": 40 * 1024**3, "ctx_ceiling": 262144}
+
+    def test_the_fit_is_capped_by_num_ctx_max_and_the_target(self, tmp_path, monkeypatch) -> None:
+        from lilbee.providers.fleet import planning
+
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"x" * 100)
+        seen: dict = {}
+
+        def _fit(_path, _meta, *, available_bytes: int, ctx_ceiling: int) -> int:
+            seen["ctx_ceiling"] = ctx_ceiling
+            return ctx_ceiling
+
+        monkeypatch.setattr(planning, "fit_chat_ctx", _fit)
+        monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 262144)
+        monkeypatch.setattr(cfg, "num_ctx_max", 65536)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 131072)
+        assert ep.resolve_chat_ctx(model, None, available_bytes=40 * 1024**3) == 65536
+        assert seen["ctx_ceiling"] == 65536
+
     def test_uses_dynamic_sizing(self, tmp_path, monkeypatch) -> None:
         model = tmp_path / "m.gguf"
         model.write_bytes(b"x" * 100)

--- a/tests/test_estimator_real_binary.py
+++ b/tests/test_estimator_real_binary.py
@@ -119,6 +119,7 @@ def test_the_single_device_fit_lands_on_the_last_window_that_fits(parser, tiny_g
         kv_cache_type_v=KvCacheType.F16,
         unified=False,
         ctx_ceiling=4096,
+        expert_offload=(),
     )
     assert (fitted - _DYNAMIC_CTX_FLOOR) % _DYNAMIC_CTX_QUANTUM == 0
     assert _estimate(tiny_gguf, ctx=fitted, slots=1).vram_bytes <= budget

--- a/tests/test_estimator_real_binary.py
+++ b/tests/test_estimator_real_binary.py
@@ -99,3 +99,27 @@ def test_slots_are_folded_into_the_context_not_passed_through(parser, tiny_gguf)
     folded = _estimate(tiny_gguf, ctx=2048, slots=2)
     doubled = _estimate(tiny_gguf, ctx=4096, slots=1)
     assert folded.vram_bytes == doubled.vram_bytes
+
+
+def test_the_single_device_fit_lands_on_the_last_window_that_fits(parser, tiny_gguf) -> None:
+    # The bisection against the real parser, not a stub of it: the window it
+    # returns fits the budget and the next step up does not.
+    from lilbee.providers.fleet.ctx import fit_single_ctx
+    from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTUM
+
+    budget = _estimate(tiny_gguf, ctx=2048, slots=1).vram_bytes
+    fitted = fit_single_ctx(
+        tiny_gguf,
+        meta=None,
+        slots=1,
+        available_bytes=budget,
+        gpu_layers=-1,
+        flash_attn=False,
+        kv_cache_type=KvCacheType.F16,
+        kv_cache_type_v=KvCacheType.F16,
+        unified=False,
+        ctx_ceiling=4096,
+    )
+    assert (fitted - _DYNAMIC_CTX_FLOOR) % _DYNAMIC_CTX_QUANTUM == 0
+    assert _estimate(tiny_gguf, ctx=fitted, slots=1).vram_bytes <= budget
+    assert _estimate(tiny_gguf, ctx=fitted + _DYNAMIC_CTX_QUANTUM, slots=1).vram_bytes > budget

--- a/tests/test_fleet_ctx.py
+++ b/tests/test_fleet_ctx.py
@@ -176,3 +176,81 @@ class TestFitSplitCtx:
         monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", fake)
         _fit(Path("/m.gguf"), slots=1, ratio=(), per_device_free_bytes=[24 * _GB])
         assert seen and all(r == () for r in seen)
+
+
+def _single_estimator(vram_for, unified_for=None):
+    """Fake estimate_instance_footprint for the single-device fit.
+
+    *vram_for* maps total ctx (per-slot x slots) to discrete-GPU bytes;
+    *unified_for* does the same for the unified figure, defaulting to zero so a
+    test that charges VRAM cannot pass by reading the wrong field.
+    """
+
+    def fake(_model_path: Path, **kw: object) -> GgufVramEstimate:
+        total = int(kw["ctx"]) * int(kw["slots"])  # type: ignore[arg-type]
+        return GgufVramEstimate(
+            vram_bytes=vram_for(total),
+            ram_bytes=0,
+            unified_bytes=unified_for(total) if unified_for else 0,
+        )
+
+    return fake
+
+
+def _fit_single(model_path: Path, **overrides: object) -> int:
+    kwargs: dict[str, object] = {
+        "meta": {"arch": "x"},
+        "slots": 1,
+        "available_bytes": 40 * _GB,
+        "gpu_layers": -1,
+        "flash_attn": True,
+        "kv_cache_type": KvCacheType.F16,
+        "kv_cache_type_v": KvCacheType.F16,
+        "unified": False,
+        "ctx_ceiling": 1_000_000,
+    }
+    kwargs.update(overrides)
+    return ctx_mod.fit_single_ctx(model_path, **kwargs)  # type: ignore[arg-type]
+
+
+class TestFitSingleCtx:
+    def test_returns_floor_when_there_is_no_budget(self, monkeypatch) -> None:
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _single_estimator(lambda _c: 1))
+        assert _fit_single(Path("/m.gguf"), available_bytes=0) == _DYNAMIC_CTX_FLOOR
+
+    def test_returns_floor_when_even_the_floor_overflows(self, monkeypatch) -> None:
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 131072)
+        monkeypatch.setattr(
+            ctx_mod, "estimate_instance_footprint", _single_estimator(lambda _c: 999 * _GB)
+        )
+        assert _fit_single(Path("/m.gguf")) == _DYNAMIC_CTX_FLOOR
+
+    def test_returns_the_quantized_ceiling_when_everything_fits(self, monkeypatch) -> None:
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 32768)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _single_estimator(lambda _c: 1))
+        result = _fit_single(Path("/m.gguf"))
+        assert (result - _DYNAMIC_CTX_FLOOR) % _DYNAMIC_CTX_QUANTUM == 0
+        assert 32768 - _DYNAMIC_CTX_QUANTUM < result <= 32768
+
+    def test_bisects_to_the_largest_window_the_budget_backs(self, monkeypatch) -> None:
+        # 1 GiB of weights plus 1 MiB per token: 20 GiB backs just under 19456 tokens.
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 131072)
+        monkeypatch.setattr(
+            ctx_mod,
+            "estimate_instance_footprint",
+            _single_estimator(lambda c: _GB + c * 1024**2),
+        )
+        result = _fit_single(Path("/m.gguf"), available_bytes=20 * _GB)
+        assert result == 19456
+
+    def test_a_unified_host_is_charged_its_unified_footprint(self, monkeypatch) -> None:
+        # VRAM reads as free all the way up; only the unified figure bounds the fit,
+        # so a fit that read the wrong field would return the ceiling.
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 131072)
+        monkeypatch.setattr(
+            ctx_mod,
+            "estimate_instance_footprint",
+            _single_estimator(lambda _c: 0, unified_for=lambda c: _GB + c * 1024**2),
+        )
+        result = _fit_single(Path("/m.gguf"), available_bytes=20 * _GB, unified=True)
+        assert result == 19456

--- a/tests/test_fleet_ctx.py
+++ b/tests/test_fleet_ctx.py
@@ -42,6 +42,7 @@ def _fit(model_path: Path, **overrides: object) -> int:
         # Large by default so the fit-logic tests are gated by the monkeypatched
         # chat_ctx_ceiling; the ceiling-cap test lowers it.
         "ctx_ceiling": 1_000_000,
+        "expert_offload": (),
     }
     kwargs.update(overrides)
     return fit_split_ctx(model_path, **kwargs)  # type: ignore[arg-type]
@@ -178,15 +179,18 @@ class TestFitSplitCtx:
         assert seen and all(r == () for r in seen)
 
 
-def _single_estimator(vram_for, unified_for=None):
+def _single_estimator(vram_for, unified_for=None, seen=None):
+    seen = [] if seen is None else seen
     """Fake estimate_instance_footprint for the single-device fit.
 
     *vram_for* maps total ctx (per-slot x slots) to discrete-GPU bytes;
     *unified_for* does the same for the unified figure, defaulting to zero so a
-    test that charges VRAM cannot pass by reading the wrong field.
+    test that charges VRAM cannot pass by reading the wrong field. Every probe's
+    kwargs land in *seen*.
     """
 
     def fake(_model_path: Path, **kw: object) -> GgufVramEstimate:
+        seen.append(kw)
         total = int(kw["ctx"]) * int(kw["slots"])  # type: ignore[arg-type]
         return GgufVramEstimate(
             vram_bytes=vram_for(total),
@@ -208,6 +212,7 @@ def _fit_single(model_path: Path, **overrides: object) -> int:
         "kv_cache_type_v": KvCacheType.F16,
         "unified": False,
         "ctx_ceiling": 1_000_000,
+        "expert_offload": (),
     }
     kwargs.update(overrides)
     return ctx_mod.fit_single_ctx(model_path, **kwargs)  # type: ignore[arg-type]
@@ -254,3 +259,34 @@ class TestFitSingleCtx:
         )
         result = _fit_single(Path("/m.gguf"), available_bytes=20 * _GB, unified=True)
         assert result == 19456
+
+
+class TestTheFitChargesWhatTheLaunchRuns:
+    """A probe that prices tensors the launch will not hold is not the launch."""
+
+    def test_the_single_fit_passes_the_expert_offload_through(self, monkeypatch) -> None:
+        # cpu_moe moves the experts to system memory. Charging them to VRAM
+        # shrinks the window for exactly the giant MoE models that need it.
+        seen: list[dict] = []
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 4096)
+        monkeypatch.setattr(
+            ctx_mod, "estimate_instance_footprint", _single_estimator(lambda _c: 1, seen=seen)
+        )
+        _fit_single(Path("/m.gguf"), expert_offload=("blk.*ffn.*exps.*=CPU",))
+        assert seen, "the fit never called the estimator"
+        assert all(kw["expert_offload"] == ("blk.*ffn.*exps.*=CPU",) for kw in seen)
+
+    def test_the_split_fit_passes_the_expert_offload_through(self, monkeypatch) -> None:
+        seen: list[dict] = []
+
+        def fake(_model_path: Path, **kw: object) -> GgufVramEstimate:
+            seen.append(kw)
+            return GgufVramEstimate(
+                vram_bytes=1, ram_bytes=0, unified_bytes=0, per_device_vram=(1,)
+            )
+
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 4096)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", fake)
+        _fit(Path("/m.gguf"), expert_offload=("blk.*ffn.*exps.*=CPU",))
+        assert seen, "the fit never called the estimator"
+        assert all(kw["expert_offload"] == ("blk.*ffn.*exps.*=CPU",) for kw in seen)

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -2104,6 +2104,88 @@ class TestPlanProbe:
         assert planning_mod.plan_sizing_budget() == int(32 * _GB * cfg.gpu_memory_fraction)
 
 
+class TestPlanSizingIsUnified:
+    """Which memory model a single-device ctx fit charges its estimate against."""
+
+    def _live(self, monkeypatch, devices) -> None:
+        monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/srv"))
+        monkeypatch.setattr(planning_mod._read_device_cache, "get", lambda _b: devices)
+
+    def test_a_dedicated_card_is_charged_its_vram(self, monkeypatch) -> None:
+        self._live(monkeypatch, [FleetDevice("CUDA", 0, "A", 24 * _GB, 24 * _GB)])
+        assert not planning_mod.plan_sizing_is_unified()
+
+    def test_a_shared_memory_device_is_charged_its_whole_footprint(self, monkeypatch) -> None:
+        self._live(monkeypatch, [FleetDevice("Metal", 0, "M", 24 * _GB, 24 * _GB, unified=True)])
+        assert planning_mod.plan_sizing_is_unified()
+
+    def test_one_dedicated_card_among_shared_ones_decides(self, monkeypatch) -> None:
+        # Mixed hosts plan as dedicated, the same call placement makes, so the two
+        # cannot disagree about which pool a role is charged to.
+        self._live(
+            monkeypatch,
+            [
+                FleetDevice("Vulkan", 0, "igpu", 8 * _GB, 8 * _GB, unified=True),
+                FleetDevice("Vulkan", 1, "card", 16 * _GB, 16 * _GB),
+            ],
+        )
+        assert not planning_mod.plan_sizing_is_unified()
+
+    def test_a_box_with_no_gpu_is_shared_memory(self, monkeypatch) -> None:
+        # The fleet runs on the CPU; its "VRAM" is the system's RAM.
+        self._live(monkeypatch, [])
+        assert planning_mod.plan_sizing_is_unified()
+
+    def test_the_plan_snapshot_wins_over_a_live_probe(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            planning_mod,
+            "_resolve_devices_and_refusal",
+            lambda _b: ([FleetDevice("Metal", 0, "M", 24 * _GB, 24 * _GB, unified=True)], False),
+        )
+        monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/srv"))
+        monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 32 * _GB)
+        planning_mod.capture_plan_probe()
+        try:
+            self._live(monkeypatch, [FleetDevice("CUDA", 0, "A", 24 * _GB, 24 * _GB)])
+            assert planning_mod.plan_sizing_is_unified()
+        finally:
+            planning_mod.clear_plan_probe()
+
+
+class TestFitChatCtx:
+    """The chat role's arguments to the single-device fit."""
+
+    def test_it_sizes_one_slot_at_the_launch_flags(self, monkeypatch, tmp_path) -> None:
+        # Slots stay at one because _slots_for grows the count afterwards, against
+        # what this window leaves; passing more here would charge the cache twice.
+        from lilbee.core.config.enums import KvCacheType
+
+        seen: dict = {}
+
+        def _fit(path, **kwargs):
+            seen.update(model_path=path, **kwargs)
+            return 32768
+
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", _fit)
+        monkeypatch.setattr(planning_mod, "plan_sizing_is_unified", lambda: False)
+        monkeypatch.setattr(cfg, "kv_cache_type", KvCacheType.Q4_0)
+        monkeypatch.setattr(cfg, "flash_attention", True)
+        model = tmp_path / "m.gguf"
+        meta = {"arch": "x"}
+
+        assert (
+            planning_mod.fit_chat_ctx(model, meta, available_bytes=40 * _GB, ctx_ceiling=262144)
+            == 32768
+        )
+        assert seen["model_path"] == model
+        assert seen["meta"] == meta
+        assert seen["slots"] == 1
+        assert seen["available_bytes"] == 40 * _GB
+        assert seen["ctx_ceiling"] == 262144
+        assert seen["unified"] is False
+        assert seen["kv_cache_type"] is KvCacheType.Q4_0
+
+
 class TestPlacementChargesAgainstFreeMemory:
     """VRAM another process is holding is not headroom the fleet can plan into."""
 


### PR DESCRIPTION
## Problem

The single-GPU window came from GGUF header fields, charging every layer as dense attention over the whole window. On an A40 that priced Qwen3.6-27B's cache at 34.5 GiB where the engine allocates about 9.6, so the grant sat well under what the card serves. The error is conservative and never OOMs, but it leaves window on the table for every linear-attention, sliding-window and MLA model.

## Change

`resolve_chat_ctx` bisects gguf-parser estimates against the sizing budget, the way the tensor-split path already fits per-device headroom. Both fits now share one bisection over the same quantized grid, so the window follows the cache the model really holds instead of a per-architecture correction to the formula.

## Fallback

Header math still answers where gguf-parser cannot. Either way the window stops at the smallest of the trained context, `num_ctx_max` and `chat_n_ctx_target`.

## One answer for both surfaces

The fleet's planner and the window a launcher advertises both read `resolve_chat_ctx`, so they cannot drift apart. A test pins that they agree.

## Verified

RunPod A40 48 GB, Qwen3.6-27B Q4_K_M at `kv_cache_type=q4_0`, flash attention on, `chat_n_ctx_target` 262144. The grant goes from 234,240 to 262,144, the full trained window. The engine launches at `--ctx-size 262144`, `/api/health` reports 262144, and it answers a short completion and a 17,805-token prompt while holding 21.8 GiB of 45 GiB. A test against the real parser pins that the bisection returns the last window that fits and that the next step up does not.

## Known cost

The wider window costs a slot on this box: the launch drops from two slots to one, and the card ends up holding less than before. The window and the slot count charge different fractions of the same budget, so neither claims the 24 GiB left free. That predates this change and is filed as its own bug.

## Stacked

Based on #745, which stops the analytic floor overriding the estimate this fit reads.