### PR TITLE
Fix the Ollama setup in CI: make the model cache real and retry registry pulls

### DIFF
--- a/.github/actions/ollama-pull/action.yml
+++ b/.github/actions/ollama-pull/action.yml
@@ -1,0 +1,61 @@
+name: Pull Ollama models with retries
+description: "Pull one or more models from the Ollama registry, retrying on transient registry errors. A model already in the local store satisfies the pull."
+
+inputs:
+  models:
+    description: "Model refs to pull, one per line (e.g. qwen3:0.6b)."
+    required: true
+  host:
+    description: "Base URL of the running Ollama daemon."
+    required: false
+    default: "http://127.0.0.1:11434"
+  ollama:
+    description: "Path to the ollama binary. Use forward slashes on Windows."
+    required: false
+    default: "ollama"
+
+runs:
+  using: composite
+  steps:
+    # registry.ollama.ai returns 503 often enough to kill whole CI runs, and a
+    # warm ~/.ollama/models cache does not help: pull always fetches the
+    # manifest first. So retry with backoff, and after each failure ask the
+    # local daemon whether it already has the model.
+    - name: Pull models
+      shell: bash
+      env:
+        OLLAMA_MODELS_TO_PULL: ${{ inputs.models }}
+        OLLAMA_API: ${{ inputs.host }}
+        OLLAMA_BIN: ${{ inputs.ollama }}
+      run: |
+        set -euo pipefail
+
+        have_locally() {
+          curl -sf -o /dev/null "${OLLAMA_API}/api/show" -d "{\"model\":\"$1\"}"
+        }
+
+        pull_model() {
+          local model="$1" delay=10 attempt
+          for attempt in 1 2 3 4 5; do
+            if "${OLLAMA_BIN}" pull "${model}"; then
+              return 0
+            fi
+            if have_locally "${model}"; then
+              echo "::warning::The registry pull of ${model} failed. The local model store has it, so the job continues."
+              return 0
+            fi
+            if [ "${attempt}" -lt 5 ]; then
+              echo "Pull of ${model} failed (attempt ${attempt}/5). Retry in ${delay}s."
+              sleep "${delay}"
+              delay=$((delay * 2))
+            fi
+          done
+          echo "::error::Cannot pull ${model} after 5 attempts and it is not in the local model store."
+          return 1
+        }
+
+        # Read the list on fd 3: ollama pull owns stdin.
+        while IFS= read -r model <&3; do
+          [ -n "${model}" ] || continue
+          pull_model "${model}"
+        done 3<<< "${OLLAMA_MODELS_TO_PULL}"

--- a/.github/actions/ollama-up/action.yml
+++ b/.github/actions/ollama-up/action.yml
@@ -9,10 +9,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install ollama, start daemon, pull model
+    - name: Install ollama and start the daemon
       shell: bash
-      env:
-        OLLAMA_MODEL: ${{ inputs.model }}
       run: |
         set -euo pipefail
         curl -fsSL https://ollama.com/install.sh | sh
@@ -21,7 +19,18 @@ runs:
           if curl -sf http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then break; fi
           sleep 0.5
         done
-        ollama pull "${OLLAMA_MODEL}"
+
+    - name: Pull the model
+      uses: ./.github/actions/ollama-pull
+      with:
+        models: ${{ inputs.model }}
+
+    - name: Export QA env vars
+      shell: bash
+      env:
+        OLLAMA_MODEL: ${{ inputs.model }}
+      run: |
+        set -euo pipefail
         {
           echo "LILBEE_QA_OLLAMA_HOST=127.0.0.1"
           echo "LILBEE_QA_OLLAMA_PORT=11434"

--- a/.github/actions/ollama-up/action.yml
+++ b/.github/actions/ollama-up/action.yml
@@ -14,6 +14,9 @@ runs:
       run: |
         set -euo pipefail
         curl -fsSL https://ollama.com/install.sh | sh
+        # Stop the systemd service install.sh starts: it holds port 11434 as the
+        # 'ollama' user, so the daemon below would lose the bind and die.
+        sudo systemctl disable --now ollama
         OLLAMA_HOST=127.0.0.1:11434 nohup ollama serve >/tmp/ollama.log 2>&1 &
         for _ in $(seq 1 60); do
           if curl -sf http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then break; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,20 +376,32 @@ jobs:
       # nothing ever wrote ~/.cache/huggingface/hub. The cache block that used to
       # sit here only churned a key off pyproject.toml and consumed the cap.
 
-      # Linux only, deliberately. The pull is ~2 min; the entry is ~750 MB per OS,
-      # and the repo cache sits against a hard 10 GB cap where every GB evicts an
-      # engine cache worth ~50 min to a release build. Windows/macOS re-pull.
+      # Linux only, deliberately. The entry is ~750 MB per OS, and the repo cache
+      # sits against a hard 10 GB cap where every GB evicts an engine cache worth
+      # ~50 min to a release build. Windows/macOS re-pull.
+      #
+      # This is the runner's model store, which only works because the step below
+      # stops the daemon that install.sh runs as the 'ollama' user. The v1 entry
+      # was written against that other store and never fed a pull, so start a
+      # fresh key here.
       - name: Cache Ollama models
         if: runner.os == 'Linux'
         uses: actions/cache@v6
         with:
           path: ~/.ollama/models
-          key: ollama-models-${{ runner.os }}-qwen3-nomic-v1
-          restore-keys: ollama-models-${{ runner.os }}-
+          key: ollama-models-${{ runner.os }}-qwen3-nomic-v2
 
+      # install.sh also registers a systemd service that runs the daemon as the
+      # 'ollama' user, whose model store is /usr/share/ollama/.ollama/models.
+      # That daemon takes port 11434 first, so the 'ollama serve' below loses the
+      # bind and dies, every pull writes to a store no cache covers, and
+      # OLLAMA_KEEP_ALIVE never reaches the daemon that serves the tests. Stop it
+      # and serve the models ourselves.
       - name: Install Ollama (Linux)
         if: runner.os == 'Linux'
-        run: curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION="${OLLAMA_PIN}" sh
+        run: |
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION="${OLLAMA_PIN}" sh
+          sudo systemctl disable --now ollama
 
       - name: Install Ollama (macOS)
         if: runner.os == 'macOS'
@@ -428,6 +440,18 @@ jobs:
           models: |
             qwen3:0.6b
             nomic-embed-text
+
+      # Guards the cache against a silent return to a daemon with its own store:
+      # if the pull did not land here, there is nothing to save and the next run
+      # re-downloads ~800 MB.
+      - name: Check the models landed in the cached store (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          if [ ! -d ~/.ollama/models/blobs ]; then
+            echo "::error::The pull did not write to ~/.ollama/models. Another daemon owns port 11434."
+            exit 1
+          fi
+          du -sh ~/.ollama/models
 
       - name: Warm up Ollama models (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
       # generation on a loaded runner overruns the request timeout ("Couldn't
       # reach the provider ... or it timed out"). The warm-up calls pay the
       # load cost here, where nothing is timing the request.
-      - name: Start Ollama and pull models (Linux/macOS)
+      - name: Start Ollama (Linux/macOS)
         if: runner.os != 'Windows'
         run: |
           OLLAMA_KEEP_ALIVE=-1 nohup ollama serve > /dev/null 2>&1 &
@@ -420,13 +420,23 @@ jobs:
             curl -fsS localhost:11434/api/version >/dev/null 2>&1 && break
             sleep 1
           done
-          ollama pull qwen3:0.6b
-          ollama pull nomic-embed-text
+
+      - name: Pull Ollama models (Linux/macOS)
+        if: runner.os != 'Windows'
+        uses: ./.github/actions/ollama-pull
+        with:
+          models: |
+            qwen3:0.6b
+            nomic-embed-text
+
+      - name: Warm up Ollama models (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
           ollama run qwen3:0.6b "warm up" >/dev/null
           curl -fsS localhost:11434/api/embed \
             -d '{"model":"nomic-embed-text","input":"warm up"}' >/dev/null
 
-      - name: Start Ollama and pull models (Windows)
+      - name: Start Ollama (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -436,8 +446,20 @@ jobs:
             try { Invoke-RestMethod "http://localhost:11434/api/version" | Out-Null; break }
             catch { Start-Sleep -Seconds 1 }
           }
-          & C:\ollama\ollama.exe pull qwen3:0.6b
-          & C:\ollama\ollama.exe pull nomic-embed-text
+
+      - name: Pull Ollama models (Windows)
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/ollama-pull
+        with:
+          ollama: C:/ollama/ollama.exe
+          models: |
+            qwen3:0.6b
+            nomic-embed-text
+
+      - name: Warm up Ollama models (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
           & C:\ollama\ollama.exe run qwen3:0.6b "warm up" | Out-Null
           Invoke-RestMethod -Method Post -Uri "http://localhost:11434/api/embed" `
             -Body '{"model":"nomic-embed-text","input":"warm up"}' | Out-Null


### PR DESCRIPTION
## Problem

Integration jobs fail in the Ollama setup step when `registry.ollama.ai` returns 503, before the test suite runs. The last case took out all three lanes in about two minutes.

The Linux model cache does not protect the step, and the reason is not that pulls are expensive to verify: the cache has never fed a pull at all. `install.sh` registers a systemd service that runs the daemon as the `ollama` user, whose model store is `/usr/share/ollama/.ollama/models`. That daemon owns port 11434 before the workflow starts its own `ollama serve`, so the second daemon loses the bind and dies with its output on `/dev/null`.

Run 32084841469 shows the cost. The cache restored 713 MB, and the pull then downloaded 522 MB plus 274 MB from the registry anyway. That download is what the 503 killed. `OLLAMA_KEEP_ALIVE=-1` never reached the serving daemon either, so the unload behaviour the comment describes was never in effect.

## Serve from the store the cache covers

Stop the systemd service after install, on both the integration lane and the `ollama-up` action behind the QA matrix. The workflow daemon then owns the port, models land in `~/.ollama/models`, and keep-alive applies.

The cache key moves to v2, because the v1 entry was written against the other store. The prefix `restore-keys` is gone so the stale entry cannot come back as a partial match.

A new step fails the job if the pull did not land in the cached store, so this cannot regress quietly into re-downloading 800 MB per run.

## Retry the pull

A new `ollama-pull` composite action retries each pull five times with exponential backoff, 10s to 80s.

After every failed attempt it asks the local daemon through `/api/show` whether the model is already in the store, and continues with a warning if it is. With the cache now feeding that store, a registry outage stops being fatal on Linux instead of merely being retried.

The step fails only when the registry stays unreachable and the model is absent locally, so an outage never silently drops Ollama coverage.

## Not covered

Windows and macOS still re-pull every run. Extending the cache to those runners would push the repo against the 10 GB cache cap, which the existing comment in `ci.yml` explains.