### PR TITLE
Say what the estimator's --parallel actually does, and pin it

### DIFF
--- a/src/lilbee/providers/fleet/vram.py
+++ b/src/lilbee/providers/fleet/vram.py
@@ -253,9 +253,15 @@ def estimator_argv(
 
     ``ctx`` is the per-slot context, as it is for the launch argv, and
     ``--ctx-size`` carries the total across slots. The parser's ``--parallel``
-    does not divide the context the way llama-server's does: the KV estimate is
-    identical for every value of it, so the multiply has to reach the parser
-    through ``--ctx-size`` or the cache is under-reserved by the slot count.
+    does not divide the context the way llama-server's does, so the multiply has
+    to reach the parser through ``--ctx-size`` or the attention cache is
+    under-reserved by the slot count.
+
+    ``--parallel`` is still passed, and it is not inert. A hybrid or recurrent
+    model holds a per-sequence recurrent state that scales with the sequence
+    count and not with the context, exactly as llama.cpp sizes it, so the parser
+    reads the slot count from this flag. Both flags are load-bearing, for
+    different halves of the memory.
     """
     argv = [
         str(resolve_gguf_parser()),

--- a/tests/test_estimator_real_binary.py
+++ b/tests/test_estimator_real_binary.py
@@ -1,10 +1,12 @@
 """One test that runs the real gguf-parser against a real GGUF.
 
 Every other estimator test monkeypatches the binary, so the suite pins the shape
-of the JSON and nothing about the numbers in it. gguf-parser ignores --parallel
-today, which is why lilbee folds slot count into --ctx-size; a version that
-starts honouring it would return well-formed JSON with doubled KV, shift every
-placement decision, and leave the whole suite green.
+of the JSON and nothing about the numbers in it. The parser does not divide the
+context by --parallel the way llama-server does, which is why lilbee folds the
+slot count into --ctx-size; a version that started dividing it would return
+well-formed JSON with doubled KV, shift every placement decision, and leave the
+whole suite green. --parallel still reaches the recurrent state, which is sized
+per sequence rather than per token, so both flags carry weight.
 """
 
 from __future__ import annotations
@@ -94,8 +96,10 @@ def test_the_kv_cache_scales_with_the_context(parser, tiny_gguf) -> None:
 
 
 def test_slots_are_folded_into_the_context_not_passed_through(parser, tiny_gguf) -> None:
-    # If a future gguf-parser starts honouring --parallel, these stop matching
-    # and every placement decision shifts under a green suite.
+    # Dense attention has no per-sequence term, so folding is exact here. If a
+    # future gguf-parser starts dividing the context by --parallel, these stop
+    # matching and every placement decision shifts under a green suite. The
+    # hybrid case below is deliberately not folded: recurrence is per sequence.
     folded = _estimate(tiny_gguf, ctx=2048, slots=2)
     doubled = _estimate(tiny_gguf, ctx=4096, slots=1)
     assert folded.vram_bytes == doubled.vram_bytes
@@ -124,3 +128,80 @@ def test_the_single_device_fit_lands_on_the_last_window_that_fits(parser, tiny_g
     assert (fitted - _DYNAMIC_CTX_FLOOR) % _DYNAMIC_CTX_QUANTUM == 0
     assert _estimate(tiny_gguf, ctx=fitted, slots=1).vram_bytes <= budget
     assert _estimate(tiny_gguf, ctx=fitted + _DYNAMIC_CTX_QUANTUM, slots=1).vram_bytes > budget
+
+
+@pytest.fixture(scope="module")
+def hybrid_gguf(tmp_path_factory) -> object:
+    """A GGUF shaped like the hybrid Qwen3.x family: interleaved attention and
+    recurrent layers, declared by ``full_attention_interval`` plus the SSM fields
+    the recurrent state is sized from."""
+    gguf = pytest.importorskip("gguf")
+    numpy = pytest.importorskip("numpy")
+    path = tmp_path_factory.mktemp("gguf") / "hybrid.gguf"
+    embd, n_layer, ffn = 256, 8, 512
+    w = gguf.GGUFWriter(str(path), "qwen35moe")
+    w.add_block_count(n_layer)
+    w.add_context_length(4096)
+    w.add_embedding_length(embd)
+    w.add_feed_forward_length(ffn)
+    w.add_head_count(8)
+    w.add_head_count_kv(2)
+    w.add_key_length(32)
+    w.add_value_length(32)
+    w.add_rope_freq_base(10000.0)
+    w.add_layer_norm_rms_eps(1e-5)
+    w.add_uint32("qwen35moe.full_attention_interval", 4)
+    w.add_ssm_conv_kernel(4)
+    w.add_ssm_inner_size(512)
+    w.add_ssm_group_count(1)
+    w.add_ssm_state_size(128)
+    w.add_tokenizer_model("llama")
+    w.add_token_list(["<unk>", "<s>", "</s>"])
+    w.add_token_scores([0.0, 0.0, 0.0])
+    w.add_token_types([2, 3, 3])
+    zeros = lambda *shape: numpy.zeros(shape, dtype=numpy.float32)  # noqa: E731
+    w.add_tensor("token_embd.weight", zeros(3, embd))
+    w.add_tensor("output_norm.weight", zeros(embd))
+    w.add_tensor("output.weight", zeros(3, embd))
+    for i in range(n_layer):
+        for name, shape in (
+            ("attn_norm.weight", (embd,)),
+            ("attn_q.weight", (embd, embd)),
+            ("attn_k.weight", (embd, embd)),
+            ("attn_v.weight", (embd, embd)),
+            ("attn_output.weight", (embd, embd)),
+            ("ffn_norm.weight", (embd,)),
+            ("ffn_gate.weight", (ffn, embd)),
+            ("ffn_up.weight", (ffn, embd)),
+            ("ffn_down.weight", (embd, ffn)),
+        ):
+            w.add_tensor(f"blk.{i}.{name}", zeros(*shape))
+    w.write_header_to_file()
+    w.write_kv_data_to_file()
+    w.write_tensors_to_file()
+    w.close()
+    return path
+
+
+def test_a_hybrid_model_is_charged_per_slot_for_its_recurrent_state(parser, hybrid_gguf) -> None:
+    """Folding slots into the context is exact for attention and not for recurrence.
+
+    llama.cpp sizes the attention half by ``n_ctx / n_seq_max`` and the recurrent
+    half by ``n_seq_max`` alone, so the slot count has to reach the parser through
+    ``--parallel`` as well as the context multiply. Holding the total context
+    fixed, the estimate must therefore rise with the slot count, by the same
+    amount for each added sequence.
+    """
+    one = _estimate(hybrid_gguf, ctx=4096, slots=1).vram_bytes
+    two = _estimate(hybrid_gguf, ctx=2048, slots=2).vram_bytes
+    four = _estimate(hybrid_gguf, ctx=1024, slots=4).vram_bytes
+
+    per_seq = two - one
+    if per_seq == 0:
+        pytest.skip(
+            "this gguf-parser does not model hybrid recurrent state; the engine pin "
+            "(ENGINE_GGUF_PARSER_REF) predates it"
+        )
+    assert per_seq > 0, (one, two)
+    # Linear in the sequence count: three more sequences cost three times one.
+    assert four - one == 3 * per_seq, (one, two, four)


### PR DESCRIPTION
## Problem

Three comments claimed gguf-parser ignores `--parallel` and that its estimate is identical for every value of it. That holds for the attention cache, which the parser sizes from `--ctx-size`, and not for the recurrent state, which it sizes per sequence exactly as llama.cpp does. The code has always passed both flags; only the comments were wrong.

Read as written, the claim says a hybrid model's per-slot state never reaches the estimate. That is a memory under-reservation serious enough to chase, and it was chased before the measurement showed there was nothing wrong.

## Measurement

llama.cpp sizes the attention half by `n_ctx / n_seq_max` and the recurrent half by `n_seq_max` alone. Against the pinned parser and a GGUF shaped like the hybrid Qwen3.x family, holding the total context at 4096, the estimate is 364,990,468 B at one slot, 366,620,680 B at two and 369,881,104 B at four: linear, 1,630,212 B per added sequence. llama.cpp's own formula gives 6 recurrent layers x (2304 + 65536) x 4 B = 1,628,160 B per sequence, so the term that scales is the recurrent state, matching to within tensor padding.

## Change

The comments now say which flag carries which half. A test holds the parser to the behaviour: at a fixed total context the estimate must rise with the slot count, by the same amount for each added sequence. On a parser predating hybrid recurrent state it skips and names the engine pin rather than passing quietly.

## Not duplicated

The launch-to-estimator parity test already fails if `--parallel` stops reaching the parser, so this adds no second copy of that check.