### PR TITLE
Stop charging the chat slot budget for the search roles twice

### DIFF
--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -143,11 +143,6 @@ _FLASH_ROLES = tuple(role for role, info in ROLE_REGISTRY.items() if info.flash_
 # batching slots, leaving room for the weights and any co-located role.
 _VISION_VRAM_FRACTION = 0.5
 
-# Cap chat's footprint at this fraction of usable VRAM when sizing its batching
-# slots, reserving room for the co-located embed/rerank servers and the decode
-# compute buffers (which the flat overhead term only partly covers).
-_CHAT_VRAM_FRACTION = 0.8
-
 # Cap an LLM reranker's footprint at this fraction of usable VRAM when sizing its
 # slots; its per-slot ctx is tiny, so a normal GPU fits the full fan-out and a
 # small one steps down toward 1.
@@ -286,8 +281,16 @@ def _resolve_chat_slots(
     device: FleetDevice | None = None,
 ) -> int:
     """Largest chat slot count (<= ``_CHAT_SLOTS``) whose footprint fits the budget
-    after reserving the search roles; steps to 1 when none fit."""
-    budget = _slot_budget(_CHAT_VRAM_FRACTION, unified_budget, device) - chat_reservation
+    after reserving the search roles; steps to 1 when none fit.
+
+    The budget is the whole serve budget less the search roles' measured
+    footprint. ``cfg.gpu_memory_fraction`` is already the margin held back from
+    the card, and the room for co-located embed/rerank is ``chat_reservation``,
+    which is what those servers were sized at rather than a flat share. A second
+    fraction on top charged that room twice and left a fifth of the card unused
+    on a box with no search roles at all.
+    """
+    budget = _slot_budget(unified_budget, device) - chat_reservation
     return _fit_slots(
         _CHAT_SLOTS,
         WorkerRole.CHAT,
@@ -321,7 +324,7 @@ def _resolve_vision_slots(
         ctx,
         mmproj_path=mmproj_path,
         unified=unified_budget is not None,
-        budget=_slot_budget(_VISION_VRAM_FRACTION, unified_budget, device),
+        budget=_slot_budget(unified_budget, device, vram_fraction=_VISION_VRAM_FRACTION),
     )
 
 
@@ -341,18 +344,25 @@ def _resolve_llm_rerank_slots(
         ctx,
         mmproj_path=None,
         unified=unified_budget is not None,
-        budget=_slot_budget(_LLM_RERANK_VRAM_FRACTION, unified_budget, device),
+        budget=_slot_budget(unified_budget, device, vram_fraction=_LLM_RERANK_VRAM_FRACTION),
         rerank_mode=RerankMode.LLM,
     )
 
 
 def _slot_budget(
-    vram_fraction: float, unified_budget: int | None, device: FleetDevice | None = None
+    unified_budget: int | None,
+    device: FleetDevice | None = None,
+    *,
+    vram_fraction: float = 1.0,
 ) -> int:
-    """Memory budget for slot sizing: *vram_fraction* of the usable memory on *device*
-    (the fleet's smallest when placement has not chosen one yet), capped by
-    ``unified_budget`` (free system RAM) when there is no discrete GPU so the count
-    steps down to fit free memory instead of overcommitting."""
+    """Memory budget for slot sizing: the usable memory on *device* (the fleet's
+    smallest when placement has not chosen one yet), capped by ``unified_budget``
+    (free system RAM) when there is no discrete GPU so the count steps down to fit
+    free memory instead of overcommitting.
+
+    *vram_fraction* takes less than the whole for a role that shares its card by
+    design. Chat takes all of it and subtracts what the search roles were sized
+    at, which is the same room stated as a measurement rather than a share."""
     budget = int(plan_sizing_budget(device) * vram_fraction)
     if unified_budget is not None:
         budget = min(budget, unified_budget)

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -234,7 +234,7 @@ def test_slots_for_llm_rerank_steps_down_when_vram_tight(monkeypatch) -> None:
 def test_slots_for_chat_is_vram_aware(monkeypatch) -> None:
     # Chat is no longer a fixed 4: a giant on a ~24GB Metal budget steps down.
     monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
-    # budget = 24e9 * 0.75 * _CHAT_VRAM_FRACTION(0.8) = 14.4e9; 17e9 base never fits.
+    # budget = 24e9 * 0.75 = 18e9; a 17e9 base leaves no room for a second slot.
     monkeypatch.setattr(
         planning_mod,
         "estimate_instance_footprint",
@@ -257,7 +257,7 @@ def test_resolve_chat_slots_uses_ceiling_when_vram_is_ample(monkeypatch) -> None
 
 
 def test_resolve_chat_slots_drops_to_one_on_constrained_gpu(monkeypatch) -> None:
-    # 17 GB base footprint at >1 slots overruns a ~24GB Metal budget (19.2e9) -> 1.
+    # 17 GB base footprint at >1 slots overruns a ~24GB Metal budget (18e9) -> 1.
     monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
     monkeypatch.setattr(
         planning_mod,
@@ -286,6 +286,40 @@ def test_resolve_chat_slots_steps_down_to_fit_unified_budget(monkeypatch) -> Non
     )
 
 
+def test_resolve_chat_slots_claims_the_whole_serve_budget(monkeypatch) -> None:
+    # The card that fits a second slot must be granted one. gpu_memory_fraction is
+    # already the serve margin; charging a second fraction on top held back a fifth
+    # of the card for co-located roles that the reservation below accounts for
+    # exactly, and that here do not exist.
+    monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
+    monkeypatch.setattr(
+        planning_mod,
+        "estimate_instance_footprint",
+        _slotted_estimator(base=17 * 10**9, per_slot=7 * 10**9),
+    )
+    # 45e9 card -> 33.75e9 serve budget. Two slots cost 31e9 and fit; the old
+    # 0.8 cut the budget to 27e9 and refused them.
+    assert planning_mod._resolve_chat_slots(Path("/m/c.gguf"), 65536, device=_card(45 * 10**9)) == 2
+
+
+def test_resolve_chat_slots_still_yields_to_the_search_reservation(monkeypatch) -> None:
+    # The room for embed/rerank comes from their measured footprint, not from a
+    # flat fraction, so a reservation that leaves no space for the second slot
+    # still takes it away.
+    monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
+    monkeypatch.setattr(
+        planning_mod,
+        "estimate_instance_footprint",
+        _slotted_estimator(base=17 * 10**9, per_slot=7 * 10**9),
+    )
+    assert (
+        planning_mod._resolve_chat_slots(
+            Path("/m/c.gguf"), 65536, chat_reservation=5 * 10**9, device=_card(45 * 10**9)
+        )
+        == 1
+    )
+
+
 def test_resolve_chat_slots_reservation_shrinks_budget(monkeypatch) -> None:
     # The search reservation is subtracted from the chat budget, so a chat that
     # fits 4 slots with no reservation steps down once embed/rerank are held back.
@@ -295,13 +329,13 @@ def test_resolve_chat_slots_reservation_shrinks_budget(monkeypatch) -> None:
         "estimate_instance_footprint",
         _slotted_estimator(base=30 * 10**9, per_slot=2 * 10**9),
     )
-    # Budget = 64e9 * 0.75 * 0.8 = 38.4e9. No reservation: 4 slots (38e9) fits.
+    # Budget = 64e9 * 0.75 = 48e9. No reservation: 4 slots (38e9) fits.
     card = _card(64 * 10**9)
     assert planning_mod._resolve_chat_slots(Path("/m/c.gguf"), 65536, device=card) == 4
-    # Reserve 9e9 for search -> budget 29.4e9; even 2 slots (34e9) overruns -> 1.
+    # Reserve 15e9 for search -> budget 33e9; even 2 slots (34e9) overruns -> 1.
     assert (
         planning_mod._resolve_chat_slots(
-            Path("/m/c.gguf"), 65536, chat_reservation=9 * 10**9, device=card
+            Path("/m/c.gguf"), 65536, chat_reservation=15 * 10**9, device=card
         )
         == 1
     )


### PR DESCRIPTION
## Problem

Chat sized its context against the whole serve budget and its slot count against four fifths of it, less the search reservation. That fifth is documented as room for the co-located embed/rerank servers, which is exactly what the reservation already subtracts, at what those servers were measured to need rather than a flat share. On a box with no search roles configured the fraction still applied, so a fifth of the card was held back for models that did not exist.

The constant dates to the original fleet commit and has never been revisited. The decode compute buffers it also cites are in the estimate gguf-parser now returns.

## Change

Both stages size against one budget: the serve budget less the reservation. `cfg.gpu_memory_fraction` is already the margin held back from the card, so `_CHAT_VRAM_FRACTION` is deleted rather than retuned.

## What is unchanged

The vision and LLM-rerank fractions stay. Those roles share a card by design rather than holding back room a reservation already counts. A search reservation that leaves no space for another slot still takes it away; a test covers that.

## Verified

RunPod A40 48 GB, Qwen3.6-27B Q4_K_M at `kv_cache_type=q4_0`, flash attention on, `chat_n_ctx_target` 262144, same serve budget of 33.32 GiB on both sides.

| | slots | total context |
|---|---|---|
| `main` | 1 | 262,144 |
| this branch | 3 | 786,432 |

The launch is `--ctx-size 786432 --parallel 3`, `/api/health` reports a 262,144 per-slot window, and the card holds 33,369 of 46,068 MiB: 72% used, 12.4 GiB still free. Two concurrent `/v1/messages` requests return in 4.0s each against a 4.3s solo request, so they overlap rather than queue, which is the behaviour the single slot was costing.