### PR TITLE
Warn about an overrun while the card can still hold it

### DIFF
--- a/src/lilbee/providers/fleet/readback.py
+++ b/src/lilbee/providers/fleet/readback.py
@@ -171,7 +171,8 @@ def report_divergence(
     if estimated_bytes <= 0 or actual_bytes <= 0:
         return False
     ratio = actual_bytes / estimated_bytes
-    if abs(ratio - 1.0) <= tolerance:
+    limit = min(tolerance, _absorbable_overrun()) if ratio > 1.0 else tolerance
+    if abs(ratio - 1.0) <= limit:
         return False
     log.warning(
         "The %s model %s allocated %.1f GiB of GPU memory but was planned for %.1f GiB "
@@ -311,6 +312,26 @@ def _without_unreported(est_by_device: dict[str, int], unreported: int) -> dict[
 # whole-slot and whole-cache mistakes this exists to surface.
 _TOLERANCE = 0.25
 
+# Share of the card's remaining margin an overrun may eat before it is worth
+# saying. At the default gpu_memory_fraction this works out to exactly
+# _TOLERANCE, so the long-standing 25% is unchanged where it was chosen.
+_MARGIN_WARN_FRACTION = 0.75
+
+
+def _absorbable_overrun() -> float:
+    """How far past its estimate a load may land while the card still holds it.
+
+    Planning charges at most ``cfg.gpu_memory_fraction`` of a card, so a load
+    that fills its budget overflows once it exceeds the estimate by the rest.
+    The warning has to come before that, which makes the threshold a function of
+    the margin rather than a constant: raising the fraction to serve a model that
+    barely fits also shrinks the room an under-estimate can hide in, and a fixed
+    25% would then first speak after the load had already overflowed.
+    """
+    from lilbee.core.config import cfg
+
+    return max(0.0, 1.0 / cfg.gpu_memory_fraction - 1.0) * _MARGIN_WARN_FRACTION
+
 
 def _report_per_device(
     role: WorkerRole,
@@ -334,7 +355,8 @@ def _report_per_device(
         # less is only the symptom of the same skew.
         if (over, gap) > (worst_over, worst_gap):
             worst_label, worst_gap, worst_over = label, gap, over
-    if not worst_label or (estimated.get(worst_label) and worst_gap <= _TOLERANCE):
+    limit = min(_TOLERANCE, _absorbable_overrun()) if worst_over else _TOLERANCE
+    if not worst_label or (estimated.get(worst_label) and worst_gap <= limit):
         return False
     log.warning(
         "The %s model %s did not land where it was planned: %s holds %.1f GiB but was "

--- a/src/lilbee/providers/fleet/readback.py
+++ b/src/lilbee/providers/fleet/readback.py
@@ -37,6 +37,7 @@ import subprocess
 from pathlib import Path
 
 from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.vram import usable_vram_fraction
 from lilbee.providers.roles import WorkerRole
 
 log = logging.getLogger(__name__)
@@ -313,24 +314,25 @@ def _without_unreported(est_by_device: dict[str, int], unreported: int) -> dict[
 _TOLERANCE = 0.25
 
 # Share of the card's remaining margin an overrun may eat before it is worth
-# saying. At the default gpu_memory_fraction this works out to exactly
-# _TOLERANCE, so the long-standing 25% is unchanged where it was chosen.
+# saying, leaving the operator a gap between the warning and the overflow.
 _MARGIN_WARN_FRACTION = 0.75
 
 
 def _absorbable_overrun() -> float:
     """How far past its estimate a load may land while the card still holds it.
 
-    Planning charges at most ``cfg.gpu_memory_fraction`` of a card, so a load
-    that fills its budget overflows once it exceeds the estimate by the rest.
-    The warning has to come before that, which makes the threshold a function of
-    the margin rather than a constant: raising the fraction to serve a model that
-    barely fits also shrinks the room an under-estimate can hide in, and a fixed
-    25% would then first speak after the load had already overflowed.
+    Placement packs a card up to ``cfg.usable_vram_fraction`` and a single-card
+    chat sizes its cache against ``cfg.gpu_memory_fraction``; the binding one is
+    whichever leaves less room, since either can be raised past the other. A load
+    filling that share overflows once it exceeds its estimate by the remainder,
+    so the warning has to come before that, which makes the threshold a function
+    of the margin rather than a constant. At the stock 0.9 usable fraction the
+    room is 11%, well inside the flat 25% this replaces.
     """
     from lilbee.core.config import cfg
 
-    return max(0.0, 1.0 / cfg.gpu_memory_fraction - 1.0) * _MARGIN_WARN_FRACTION
+    committed = max(cfg.gpu_memory_fraction, usable_vram_fraction())
+    return max(0.0, 1.0 / committed - 1.0) * _MARGIN_WARN_FRACTION
 
 
 def _report_per_device(

--- a/tests/test_fleet_readback.py
+++ b/tests/test_fleet_readback.py
@@ -92,14 +92,30 @@ class TestReportDivergence:
         assert warned is True
         assert "-75%" in caplog.text
 
-    def test_the_overrun_threshold_is_unchanged_at_the_default_margin(self, monkeypatch) -> None:
-        # cfg default 0.75 leaves 33% of absorbable overrun, and the warning has
-        # always fired at 25%. Deriving it must not move that.
+    def test_the_binding_fraction_is_the_one_that_leaves_least_room(self, monkeypatch) -> None:
+        # Placement packs a card to usable_vram_fraction while a single-card chat
+        # sizes its cache against gpu_memory_fraction. The card overflows on
+        # whichever is larger, so that is the one the threshold has to follow.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet import readback
 
+        monkeypatch.setattr(cfg, "usable_vram_fraction", 0.9)
         monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
-        assert readback._absorbable_overrun() == pytest.approx(0.25)
+        # 1/0.9 - 1 = 11.1% of room, not the 33% the smaller fraction suggests.
+        assert readback._absorbable_overrun() == pytest.approx((1 / 0.9 - 1) * 0.75)
+
+        # And the other way round once the serve budget is raised past it.
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.95)
+        assert readback._absorbable_overrun() == pytest.approx((1 / 0.95 - 1) * 0.75)
+
+    def test_the_stock_threshold_is_tighter_than_the_flat_constant(self, monkeypatch) -> None:
+        # The flat 25% was already past the overflow point on a packed card.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet import readback
+
+        monkeypatch.setattr(cfg, "usable_vram_fraction", 0.9)
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
+        assert readback._absorbable_overrun() < readback._TOLERANCE
 
     def test_a_raised_memory_fraction_warns_earlier(self, monkeypatch, caplog) -> None:
         # At 0.9 the card only absorbs an 11% overrun, so a fixed 25% threshold
@@ -107,6 +123,7 @@ class TestReportDivergence:
         from lilbee.core.config import cfg
         from lilbee.providers.fleet import readback
 
+        monkeypatch.setattr(cfg, "usable_vram_fraction", 0.9)
         monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.9)
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
             warned = report_divergence(
@@ -136,15 +153,17 @@ class TestReportDivergence:
             )
         assert warned is False
 
-    @pytest.mark.parametrize("fraction", [0.5, 0.75, 0.8, 0.9, 0.95, 1.0])
-    def test_the_warning_always_precedes_the_overflow(self, monkeypatch, fraction) -> None:
+    @pytest.mark.parametrize("usable", [0.5, 0.75, 0.9, 0.95, 1.0])
+    @pytest.mark.parametrize("serve", [0.5, 0.75, 0.9, 1.0])
+    def test_the_warning_always_precedes_the_overflow(self, monkeypatch, usable, serve) -> None:
         # The whole point: the operator hears about the gap while the card can
-        # still hold the load, never after.
+        # still hold the load, never after, at every combination of the two.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet import readback
 
-        monkeypatch.setattr(cfg, "gpu_memory_fraction", fraction)
-        absorbable = 1.0 / fraction - 1.0
+        monkeypatch.setattr(cfg, "usable_vram_fraction", usable)
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", serve)
+        absorbable = 1.0 / max(usable, serve) - 1.0
         assert readback._absorbable_overrun() <= absorbable
 
     def test_stays_quiet_inside_the_tolerance(self, caplog) -> None:

--- a/tests/test_fleet_readback.py
+++ b/tests/test_fleet_readback.py
@@ -92,6 +92,61 @@ class TestReportDivergence:
         assert warned is True
         assert "-75%" in caplog.text
 
+    def test_the_overrun_threshold_is_unchanged_at_the_default_margin(self, monkeypatch) -> None:
+        # cfg default 0.75 leaves 33% of absorbable overrun, and the warning has
+        # always fired at 25%. Deriving it must not move that.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet import readback
+
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
+        assert readback._absorbable_overrun() == pytest.approx(0.25)
+
+    def test_a_raised_memory_fraction_warns_earlier(self, monkeypatch, caplog) -> None:
+        # At 0.9 the card only absorbs an 11% overrun, so a fixed 25% threshold
+        # would first speak after the load had already overflowed.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet import readback
+
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.9)
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
+            warned = report_divergence(
+                WorkerRole.CHAT,
+                "org/m.gguf",
+                4 * 1024**3,
+                int(4.6 * 1024**3),  # +15%: quiet under the old constant
+                tolerance=readback._TOLERANCE,
+            )
+        assert warned is True
+        assert "+15%" in caplog.text
+
+    def test_a_shortfall_keeps_the_wider_tolerance(self, monkeypatch, caplog) -> None:
+        # Only the overrun side tracks the margin. An over-estimate costs capacity,
+        # not the load, so tightening it on a full card would be noise.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet import readback
+
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.95)
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
+            warned = report_divergence(
+                WorkerRole.CHAT,
+                "org/m.gguf",
+                4 * 1024**3,
+                int(3.2 * 1024**3),  # -20%, inside the baseline tolerance
+                tolerance=readback._TOLERANCE,
+            )
+        assert warned is False
+
+    @pytest.mark.parametrize("fraction", [0.5, 0.75, 0.8, 0.9, 0.95, 1.0])
+    def test_the_warning_always_precedes_the_overflow(self, monkeypatch, fraction) -> None:
+        # The whole point: the operator hears about the gap while the card can
+        # still hold the load, never after.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet import readback
+
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", fraction)
+        absorbable = 1.0 / fraction - 1.0
+        assert readback._absorbable_overrun() <= absorbable
+
     def test_stays_quiet_inside_the_tolerance(self, caplog) -> None:
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
             warned = report_divergence(


### PR DESCRIPTION
## Problem

The readback compares the engine's real footprint against the estimate and warns when they diverge. Its threshold was a flat 25%, while the margin that threshold protects is a setting.

Placement packs a card up to `cfg.usable_vram_fraction` and a single-card chat sizes its cache against `cfg.gpu_memory_fraction`. A load filling the binding share overflows once it exceeds its estimate by the remainder:

| usable_vram_fraction | overrun the card absorbs | fixed 25% threshold |
|---|---|---|
| 0.9 (stock) | 11% | overflows first |
| 0.95 | 5% | overflows first |
| 1.0 | 0% | overflows first |

So this is not only a problem once someone raises the setting. At stock values the warning already arrived after the overflow it exists to predict, on any card packed to its planning ceiling. Raising the fraction makes it worse, and that is done by exactly the people with the least room: its own docstring offers it as the way to serve a model that would otherwise be refused.

## Change

The overrun side takes the smaller of the old constant and three quarters of the room the binding fraction leaves. The binding fraction is `max(usable_vram_fraction, gpu_memory_fraction)`, since either can be raised past the other. At stock settings the threshold becomes 8.3%, inside the 11% the card can absorb.

## What keeps the flat tolerance

The shortfall side. An over-estimate costs capacity rather than the load, so narrowing it would add noise without preventing anything.

## Both paths

`report_divergence` and `_report_per_device` both take the bound. The per-device path reports the same overrun for a tensor-split load, and fixing only the first would have left the defect wherever a chat model spans cards.

## Verified on hardware

The threshold tightened from 25% to 8.3%, so the risk worth measuring is whether a correctly sized load now warns. On a RunPod A40 serving Qwen3-0.6B through `lilbee serve`, a real generation (`chat_ctx=16384`, HTTP 200, 4783 MiB resident) produced **zero** divergence warnings. Threshold tracking against the live config on the same machine: 0.9 -> 8.33%, 0.95 -> 3.95%, 1.0 -> 0.00%, and `gpu_memory_fraction=0.95` -> 3.95%, each at or below what the card absorbs. A measured +10% overrun warns where the flat 25% stayed silent.

Not measured: the live divergence ratio itself, only that it sat under 8.3%. This engine serves `GET /memory` rather than writing an engine log, so the log-parsing path was not the one exercised.

## Suite

`readback.py` at 100% coverage, 2063 tests green across the fleet/planning/placement/swap sweep, lint and mypy clean. A parametrized test asserts the threshold stays at or below the absorbable overrun across 20 combinations of the two settings, and restoring the fixed threshold fails the raised-fraction case.