### PR TITLE
Respect LILBEE_DOCUMENTS_DIR in CLI entry points

### DIFF
--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -72,7 +72,10 @@ def _apply_data_root(root: Path) -> None:
 
     root = canonical_data_root(root)
     cfg.data_root = root
-    cfg.documents_dir = root / "documents"
+    # An explicit LILBEE_DOCUMENTS_DIR wins over the root-derived default,
+    # matching the env precedence a bare ``import lilbee`` applies.
+    documents_env = os.environ.get("LILBEE_DOCUMENTS_DIR", "").strip()
+    cfg.documents_dir = Path(documents_env) if documents_env else root / "documents"
     cfg.data_dir = root / "data"
     cfg.lancedb_dir = root / "data" / "lancedb"
     os.environ["LILBEE_DATA"] = str(root)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -840,6 +840,42 @@ class TestApplyOverrides:
         apply_overrides(use_global=True)
         assert cfg.data_root == default_data_dir()
 
+    def test_lilbee_documents_dir_env_wins_over_derived_default(self, tmp_path, monkeypatch):
+        """LILBEE_DOCUMENTS_DIR wins over the root-derived <root>/documents.
+
+        Regression: ``_apply_data_root`` unconditionally derived documents_dir
+        from the data root, so every CLI entry point (including ``serve``)
+        discarded the env override that a bare ``import lilbee`` honors.
+        """
+        from lilbee.cli import apply_overrides
+
+        env_dir = tmp_path / "env-data"
+        env_dir.mkdir()
+        docs_dir = tmp_path / "my-docs"
+        docs_dir.mkdir()
+        monkeypatch.setenv("LILBEE_DATA", str(env_dir))
+        monkeypatch.setenv("LILBEE_DOCUMENTS_DIR", str(docs_dir))
+        apply_overrides()
+        assert cfg.data_root == env_dir
+        assert cfg.documents_dir == docs_dir
+
+    def test_lilbee_documents_dir_env_wins_over_config_toml(
+        self, tmp_path, monkeypatch, overlay_reads_config_toml
+    ):
+        """LILBEE_DOCUMENTS_DIR also wins over a persisted documents_dir."""
+        from lilbee.cli import apply_overrides
+
+        docs_dir = tmp_path / "my-docs"
+        docs_dir.mkdir()
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / "config.toml").write_text(
+            f'documents_dir = "{tmp_path / "persisted"}"\n', encoding="utf-8"
+        )
+        monkeypatch.setenv("LILBEE_DOCUMENTS_DIR", str(docs_dir))
+        apply_overrides(data_dir=root)
+        assert cfg.documents_dir == docs_dir
+
     def test_generation_option_overrides(self):
         from lilbee.cli import apply_overrides
 


### PR DESCRIPTION
## Problem

Every CLI command calls `apply_overrides()`, and `_apply_data_root()` unconditionally sets `cfg.documents_dir = <root>/documents` whenever a data root resolves (`--data-dir`, `--global`, or `LILBEE_DATA`). The `LILBEE_DOCUMENTS_DIR` env var is silently discarded: a `lilbee serve` started with it set writes crawls to `<root>/documents` and `/api/config` reports the derived default, while a bare `import lilbee` honors the same env var through the pydantic env source.

## Solution

`_apply_data_root()` now derives `<root>/documents` only when `LILBEE_DOCUMENTS_DIR` is unset (stripped, non-empty check). The `overlay_persisted_settings()` call that follows already skips keys whose env var is set, so the override also survives a persisted `documents_dir` in `config.toml`.

## Untouched siblings

The `data_dir` and `lancedb_dir` assignments in the same function stay root-derived. They are internal plain fields, not writable settings like `documents_dir`, so overriding them per-command is not a documented path.