### PR TITLE
Retry the Ollama warm-up in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,12 +453,36 @@ jobs:
           fi
           du -sh ~/.ollama/models
 
+      # Ollama's model runner segfaults here often enough to kill whole runs
+      # ("llama runner process has terminated: signal: segmentation fault"),
+      # and the pull steps around it already retry. Warming a model is setup,
+      # not a subject under test, so a transient crash must not fail the job
+      # before a single test runs. Three failures still fail it.
       - name: Warm up Ollama models (Linux/macOS)
         if: runner.os != 'Windows'
+        shell: bash
         run: |
-          ollama run qwen3:0.6b "warm up" >/dev/null
-          curl -fsS localhost:11434/api/embed \
-            -d '{"model":"nomic-embed-text","input":"warm up"}' >/dev/null
+          set -euo pipefail
+
+          warm_up() {
+            ollama run qwen3:0.6b "warm up" >/dev/null &&
+              curl -fsS localhost:11434/api/embed \
+                -d '{"model":"nomic-embed-text","input":"warm up"}' >/dev/null
+          }
+
+          delay=5
+          for attempt in 1 2 3; do
+            if warm_up; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "Ollama warm-up failed (attempt ${attempt}/3). Retry in ${delay}s."
+              sleep "${delay}"
+              delay=$((delay * 2))
+            fi
+          done
+          echo "::error::Ollama warm-up failed after 3 attempts."
+          exit 1
 
       - name: Start Ollama (Windows)
         if: runner.os == 'Windows'
@@ -480,13 +504,29 @@ jobs:
             qwen3:0.6b
             nomic-embed-text
 
+      # Same retry as the Linux/macOS warm-up: one runner crash must not end
+      # the job. ollama.exe reports failure through the exit code, not an
+      # exception, so check it rather than relying on try/catch alone.
       - name: Warm up Ollama models (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          & C:\ollama\ollama.exe run qwen3:0.6b "warm up" | Out-Null
-          Invoke-RestMethod -Method Post -Uri "http://localhost:11434/api/embed" `
-            -Body '{"model":"nomic-embed-text","input":"warm up"}' | Out-Null
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            & C:\ollama\ollama.exe run qwen3:0.6b "warm up" | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+              try {
+                Invoke-RestMethod -Method Post -Uri "http://localhost:11434/api/embed" `
+                  -Body '{"model":"nomic-embed-text","input":"warm up"}' | Out-Null
+                exit 0
+              } catch { }
+            }
+            if ($attempt -lt 3) {
+              Write-Host "Ollama warm-up failed (attempt $attempt/3). Retry in 5s."
+              Start-Sleep -Seconds 5
+            }
+          }
+          Write-Host "::error::Ollama warm-up failed after 3 attempts."
+          exit 1
 
       - name: Restore GGUF models from release mirror
         id: ci-models


### PR DESCRIPTION
## Problem

The Ollama pull steps retry; the warm-up step that follows them does not. One crash in Ollama's model runner ends the integration job before a single test runs:

```
Error: 500 Internal Server Error: llama-server process has terminated: signal: segmentation fault (core dumped)
```

Across five runs on one branch today the Ubuntu integration cells failed 3/3, then 0/3, then 1/3, then 0/3 -- always at this step, always before any test. That is a re-run on roughly half of pushes. #747 fixed the registry pulls and is already in main; it does not cover this, because the failure is a runner crash rather than a failed pull.

## Fix

Three attempts with backoff on both the Linux/macOS and Windows warm-up steps, matching the retry discipline the pull steps already use. Three failures still fail the job, so a genuinely broken daemon is not hidden.

Windows reports failure through the exit code rather than an exception, so that branch checks `$LASTEXITCODE` instead of relying on try/catch.

## Not fixed

The segfault is upstream in Ollama's model runner. Nothing in this repo can fix it; this stops it from costing a job.