### PR TITLE
Choose the GGUF to download by its header, not by its name

### DIFF
--- a/src/lilbee/catalog/compat.py
+++ b/src/lilbee/catalog/compat.py
@@ -8,9 +8,11 @@ from huggingface_hub import hf_hub_url
 from huggingface_hub.utils import HFValidationError
 
 from lilbee._generated.engine_archs import SUPPORTED_ARCHS
-from lilbee.catalog.header_probe import probe_architecture
+from lilbee.catalog.header_probe import GgufHeader, probe_header
 from lilbee.catalog.refs import (
+    GGUF_SUFFIX,
     NATIVE_GGUF_REF_MIN_SLASHES,
+    WILDCARD,
     gguf_filename_from_ref,
     hf_repo_from_ref,
 )
@@ -30,7 +32,7 @@ def classify(architecture: str) -> ModelCompat:
 def resolve_arch_for_pull(ref: str, hf_client: HfClient) -> str:
     """Resolve general.architecture for *ref*: cache hit > Range-GET probe > empty (UNKNOWN).
 
-    ``probe_architecture`` returns ``""`` on any failure (network, non-200, parse),
+    ``probe_header`` returns empty fields on any failure (network, non-200, parse),
     so an empty result means "undetermined", never a real verdict. Only a non-empty
     arch is cached; otherwise a transient probe failure would be cached permanently
     and disable the unsupported-arch guard for this ref on every later pull.
@@ -41,10 +43,24 @@ def resolve_arch_for_pull(ref: str, hf_client: HfClient) -> str:
     url = _resolve_blob_url(ref)
     if not url:
         return ""
-    arch = probe_architecture(url)
+    arch = probe_header(url).architecture
     if arch:
         hf_client.cache_arch(ref, arch)
     return arch
+
+
+def file_header(hf_repo: str, filename: str) -> GgufHeader:
+    """The GGUF header of one repo file, empty when it cannot be read.
+
+    An unreadable header is not a verdict: every field stays empty, which reads
+    as "a model of undetermined architecture" so an offline or gated repo
+    resolves the way it did before the probe existed.
+    """
+    try:
+        url = hf_hub_url(hf_repo, filename)
+    except (HFValidationError, ValueError):
+        return GgufHeader()
+    return probe_header(url)
 
 
 def _resolve_blob_url(ref: str) -> str:
@@ -54,13 +70,13 @@ def _resolve_blob_url(ref: str) -> str:
     (the filename may add subdirs for a quant), so the repo and filename are split
     on that shape; an ollama-style ``repo:tag`` ref is split on the colon.
     """
-    if ref.endswith(".gguf") and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
+    if ref.endswith(GGUF_SUFFIX) and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
         repo, filename = hf_repo_from_ref(ref), gguf_filename_from_ref(ref)
     elif ":" in ref:
         repo, filename = ref.split(":", 1)
     else:
         repo, filename = ref, ""
-    if not filename or "*" in filename:
+    if not filename or WILDCARD in filename:
         return ""
     try:
         return hf_hub_url(repo, filename)

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -3,7 +3,6 @@
 import fnmatch
 import logging
 import os
-import re
 import shutil
 import sys
 import threading
@@ -16,6 +15,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel
 
+from lilbee.catalog.compat import classify, file_header
 from lilbee.catalog.download_progress import ProgressCallback, _ProgressTracker
 from lilbee.catalog.hf_client import (
     DEFAULT_TIMEOUT,
@@ -25,8 +25,15 @@ from lilbee.catalog.hf_client import (
     repo_has_mmproj,
 )
 from lilbee.catalog.models import CatalogModel
-from lilbee.catalog.refs import DEFAULT_MMPROJ_PATTERN, pick_best_gguf
-from lilbee.catalog.types import ModelTask
+from lilbee.catalog.refs import (
+    DEFAULT_MMPROJ_PATTERN,
+    FLOAT_QUANTS,
+    WILDCARD,
+    quant_label,
+    rank_gguf_candidates,
+    split_shard_filenames,
+)
+from lilbee.catalog.types import ModelCompat, ModelTask
 from lilbee.runtime.cancellation import CancelSignal, TaskCancelledError
 
 CompleteCallback = Callable[[CatalogModel, Path], None]
@@ -372,25 +379,6 @@ def _hf_download_or_translate(entry: CatalogModel, config: DownloadConfig) -> Pa
         ) from None
 
 
-_SPLIT_SHARD_RE = re.compile(r"^(?P<base>.+)-(?P<idx>\d{5})-of-(?P<total>\d{5})\.gguf$")
-
-
-def split_shard_filenames(filename: str) -> list[str]:
-    """Return every shard of a split GGUF in order, or ``[filename]`` if it isn't split.
-
-    A split GGUF names its parts ``<base>-00001-of-0000N.gguf`` through
-    ``<base>-0000N-of-0000N.gguf``. llama.cpp loads the whole set from the first
-    shard but needs every part on disk, so the catalog must fetch all of them and
-    only consider the model installed once the full set is present.
-    """
-    match = _SPLIT_SHARD_RE.match(filename)
-    if match is None:
-        return [filename]
-    base = match.group("base")
-    total = int(match.group("total"))
-    return [f"{base}-{index:05d}-of-{total:05d}.gguf" for index in range(1, total + 1)]
-
-
 def download_model(
     entry: CatalogModel,
     *,
@@ -564,54 +552,22 @@ def _fetch_mmproj(
     return path
 
 
-def _resolve_mmproj_filename(hf_repo: str, pattern: str) -> str | None:
-    """Resolve an mmproj filename pattern to a concrete filename via the HF API."""
-    if "*" not in pattern:
-        return pattern
+def _repo_sibling_files(hf_repo: str) -> list[str]:
+    """Every filename the HuggingFace API lists for *hf_repo*.
 
+    Raises:
+        PermissionError: the repo is gated and needs authentication.
+        RuntimeError: the listing could not be fetched.
+    """
     try:
         resp = httpx.get(
             f"{HF_API_URL}/{hf_repo}",
             timeout=DEFAULT_TIMEOUT,
             headers=hf_headers(),
         )
-        resp.raise_for_status()
-        siblings = resp.json().get("siblings", [])
-    except Exception as exc:
-        log.warning("Cannot query mmproj files for %s: %s", hf_repo, exc)
-        return None
-
-    mmproj_files: list[str] = [
-        s.get("rfilename", "") for s in siblings if fnmatch.fnmatch(s.get("rfilename", ""), pattern)
-    ]
-    if not mmproj_files:
-        return None
-
-    # Prefer an F16 mmproj when one is offered; otherwise take the first match.
-    for preference in ("f16", "F16"):
-        for f in mmproj_files:
-            if preference in f:
-                return f
-    return mmproj_files[0]
-
-
-def resolve_filename(entry: CatalogModel) -> str:
-    """Resolve a GGUF filename pattern to the best concrete filename.
-    For exact filenames, return as-is. For wildcards, query the HF API
-    and pick the best quantization (prefer Q4_K_M for balance of size/quality).
-    """
-    if "*" not in entry.gguf_filename:
-        return entry.gguf_filename
-
-    try:
-        resp = httpx.get(
-            f"{HF_API_URL}/{entry.hf_repo}",
-            timeout=DEFAULT_TIMEOUT,
-            headers=hf_headers(),
-        )
         if resp.status_code == HTTPStatus.UNAUTHORIZED:
             raise PermissionError(
-                f"{entry.hf_repo} requires HuggingFace authentication. "
+                f"{hf_repo} requires HuggingFace authentication. "
                 "Set HF_TOKEN env var or visit the repo page to request access."
             )
         resp.raise_for_status()
@@ -619,15 +575,59 @@ def resolve_filename(entry: CatalogModel) -> str:
     except PermissionError:
         raise
     except Exception as exc:
-        raise RuntimeError(f"Cannot query files for {entry.hf_repo}: {exc}") from exc
+        raise RuntimeError(f"Cannot query files for {hf_repo}: {exc}") from exc
+    return [s.get("rfilename", "") for s in siblings]
 
-    gguf_files = [
-        s.get("rfilename", "") for s in siblings if s.get("rfilename", "").endswith(".gguf")
-    ]
-    if not gguf_files:
-        raise RuntimeError(f"No GGUF files found in {entry.hf_repo}")
 
-    return pick_best_gguf(gguf_files)
+def _mmproj_rank(filename: str) -> tuple[bool, str]:
+    """Sort key preferring an unquantized projector, ties broken by name."""
+    return (quant_label(filename) not in FLOAT_QUANTS, filename)
+
+
+def _resolve_mmproj_filename(hf_repo: str, pattern: str) -> str | None:
+    """Resolve an mmproj filename pattern to a concrete filename via the HF API."""
+    if WILDCARD not in pattern:
+        return pattern
+    try:
+        names = _repo_sibling_files(hf_repo)
+    except (PermissionError, RuntimeError) as exc:
+        log.warning("Cannot query mmproj files for %s: %s", hf_repo, exc)
+        return None
+    matches = [name for name in names if fnmatch.fnmatch(name, pattern)]
+    return min(matches, key=_mmproj_rank) if matches else None
+
+
+def resolve_filename(entry: CatalogModel) -> str:
+    """The repo file a pull of *entry* fetches, gated on each candidate's GGUF header.
+
+    Quant labels only order the candidates. A file whose header calls it a
+    projector or an adapter is never the model, so a repo that labels its
+    projector ``Q8_0`` cannot install it as one.
+
+    A supported architecture wins outright. Where a repo mixes architectures, a
+    speculative-decoding drafter loses to the weights it drafts for. Where none
+    is supported, the best-ranked weights still come back: refusing here would
+    report a generic error and disable ``--allow-unsupported``, so that verdict
+    belongs to the architecture guard.
+
+    Raises:
+        PermissionError: the repo is gated and needs authentication.
+        RuntimeError: the repo listing failed, or it holds no model weights.
+    """
+    named = entry.gguf_filename
+    if WILDCARD not in named and file_header(entry.hf_repo, named).is_model:
+        return named
+    unsupported: str | None = None
+    for candidate in rank_gguf_candidates(_repo_sibling_files(entry.hf_repo)):
+        header = file_header(entry.hf_repo, candidate)
+        if not header.is_model:
+            continue
+        if classify(header.architecture) is not ModelCompat.UNSUPPORTED:
+            return candidate
+        unsupported = unsupported or candidate
+    if unsupported is not None:
+        return unsupported
+    raise RuntimeError(f"No GGUF model weights found in {entry.hf_repo}")
 
 
 _SIZE_UNKNOWN = 0

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -1,7 +1,7 @@
-"""Range-GET a GGUF blob's header and extract general.architecture.
+"""Range-GET a GGUF blob's header and read the fields that identify the file.
 
-The architecture is read by walking the metadata KV table directly (see
-``_parse_arch``) rather than via gguf-py's ``GGUFReader``, which needs the whole
+The fields are read by walking the metadata KV table directly (see
+``_parse_header``) rather than via gguf-py's ``GGUFReader``, which needs the whole
 KV table -- including a model's multi-megabyte tokenizer arrays -- present, and
 so chokes on a Range-GET-truncated header.
 """
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import struct
+from dataclasses import dataclass
 from http import HTTPStatus
 
 import httpx
@@ -20,11 +21,31 @@ log = logging.getLogger(__name__)
 GGUF_HEADER_PROBE_BYTES = 65536
 GGUF_MAGIC = b"GGUF"
 GGUF_ARCH_KEY = "general.architecture"
+GGUF_TYPE_KEY = "general.type"
+
+# ``general.type`` values that name something other than loadable model weights.
+# A file that omits the key predates it and counts as a model, so the check only
+# rejects a file whose header says outright that it is not one.
+NON_MODEL_GGUF_TYPES = frozenset({"mmproj", "adapter"})
+
 _PROBE_TIMEOUT_S = 10.0
 
 
-def probe_architecture(blob_url: str) -> str:
-    """Return general.architecture from the GGUF header, or empty string on any failure."""
+@dataclass(frozen=True)
+class GgufHeader:
+    """What a GGUF file says it is. Empty fields mean the header was unreadable."""
+
+    architecture: str = ""
+    file_type: str = ""
+
+    @property
+    def is_model(self) -> bool:
+        """True unless the header identifies the file as a projector or adapter."""
+        return self.file_type not in NON_MODEL_GGUF_TYPES
+
+
+def probe_header(blob_url: str) -> GgufHeader:
+    """Read a GGUF blob's identifying header fields, empty on any failure."""
     try:
         headers = {"Range": f"bytes=0-{GGUF_HEADER_PROBE_BYTES - 1}"}
         # follow_redirects: a HuggingFace ``/resolve/`` URL for an LFS-backed GGUF
@@ -33,11 +54,11 @@ def probe_architecture(blob_url: str) -> str:
         # silently UNKNOWN (so the unsupported-arch guard never fires).
         resp = httpx.get(blob_url, headers=headers, timeout=_PROBE_TIMEOUT_S, follow_redirects=True)
         if resp.status_code >= HTTPStatus.BAD_REQUEST:
-            return ""
-        return _parse_arch(resp.content)
+            return GgufHeader()
+        return _parse_header(resp.content)
     except httpx.HTTPError as exc:
         log.debug("GGUF header probe failed for %s: %s", blob_url, exc)
-        return ""
+        return GgufHeader()
 
 
 # GGUF metadata value-type tags (gguf spec) and the fixed byte sizes of the
@@ -102,36 +123,56 @@ def _skip_value(cur: _HeaderCursor, value_type: int) -> None:
     raise _TruncatedHeaderError  # unknown value type: stop parsing
 
 
-def _parse_arch(blob: bytes) -> str:
-    """Extract general.architecture from a (possibly truncated) GGUF header.
+_WANTED_STRING_KEYS: dict[bytes, str] = {
+    GGUF_ARCH_KEY.encode("utf-8"): "architecture",
+    GGUF_TYPE_KEY.encode("utf-8"): "file_type",
+}
+_GGUF_MAGIC_LEN = 4
 
-    Walks the metadata KV table directly and returns as soon as it reaches
-    ``general.architecture``, which GGUF writers emit among the first entries.
-    This deliberately avoids gguf-py's ``GGUFReader``, which parses the entire KV
-    table up front: a real model's multi-megabyte tokenizer arrays run past the
-    Range-GET probe window, so ``GGUFReader`` raises on the truncation before any
-    field can be read. Returns empty string on a malformed or too-short header.
+
+def _collect_string_fields(cur: _HeaderCursor, kv_count: int) -> dict[str, str]:
+    """Walk the KV table and return the ``_WANTED_STRING_KEYS`` values it carries.
+
+    Keeps what it read when the probe window ends mid-table, so a header whose
+    wanted keys precede a huge tokenizer array still resolves.
     """
-    if len(blob) < _GGUF_HEADER_FIXED or blob[:4] != GGUF_MAGIC:
-        return ""
-    cur = _HeaderCursor(blob)
-    arch_key = GGUF_ARCH_KEY.encode("utf-8")
+    found: dict[str, str] = {}
     try:
-        cur.take(4)  # magic
-        cur.u32()  # version
-        cur.u64()  # tensor_count (the tensor-info table is never read)
-        kv_count = cur.u64()
         for _ in range(kv_count):
             key = cur.gguf_string()
             value_type = cur.u32()
-            if key == arch_key:
-                if value_type != _GGUF_TYPE_STRING:
-                    return ""
-                return cur.gguf_string().decode("utf-8", errors="replace")
-            _skip_value(cur, value_type)
+            field = _WANTED_STRING_KEYS.get(key)
+            if field is not None and value_type == _GGUF_TYPE_STRING:
+                found[field] = cur.gguf_string().decode("utf-8", errors="replace")
+                if len(found) == len(_WANTED_STRING_KEYS):
+                    break
+            else:
+                _skip_value(cur, value_type)
     except _TruncatedHeaderError:
-        return ""
-    return ""
+        pass
+    return found
+
+
+def _parse_header(blob: bytes) -> GgufHeader:
+    """Extract the identifying fields from a (possibly truncated) GGUF header.
+
+    Walks the metadata KV table directly and stops once every wanted key is read;
+    GGUF writers emit ``general.architecture`` and ``general.type`` among the
+    first entries. This deliberately avoids gguf-py's ``GGUFReader``, which parses
+    the entire KV table up front: a real model's multi-megabyte tokenizer arrays
+    run past the Range-GET probe window, so ``GGUFReader`` raises on the
+    truncation before any field can be read. A malformed or too-short header
+    yields whatever was read before the truncation.
+    """
+    if len(blob) < _GGUF_HEADER_FIXED or blob[:_GGUF_MAGIC_LEN] != GGUF_MAGIC:
+        return GgufHeader()
+    # The length guard above covers exactly these reads, so none of them can
+    # run off the end; only the KV walk that follows can truncate.
+    cur = _HeaderCursor(blob)
+    cur.take(_GGUF_MAGIC_LEN)
+    cur.u32()  # version
+    cur.u64()  # tensor_count (the tensor-info table is never read)
+    return GgufHeader(**_collect_string_fields(cur, cur.u64()))
 
 
 def gguf_scalar_str(field: ReaderField | None) -> str | None:

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -22,7 +22,7 @@ from lilbee.catalog.models import (
     estimate_min_ram_gb,
     estimate_size_gb,
 )
-from lilbee.catalog.refs import GGUF_GLOB, pick_best_gguf
+from lilbee.catalog.refs import GGUF_GLOB, rank_gguf_candidates
 
 log = logging.getLogger(__name__)
 
@@ -144,15 +144,15 @@ def repo_has_mmproj(hf_repo: str) -> bool:
 
 
 def _resolve_sibling_gguf(siblings: list[RepoSibling]) -> str:
-    """Concrete GGUF filename for a repo's sibling list, or ``GGUF_GLOB``.
+    """Best-guess GGUF filename for a repo's sibling list, or ``GGUF_GLOB``.
 
-    Uses the same quant picker as the pull path so the filename a catalog
-    row carries always names the file a pull of that row produces.
+    Ranks by quant label alone: a listing covers up to a full page of repos and
+    cannot afford a header probe per row. A pull re-checks the choice against the
+    file's header, so a row may name a file the pull then rejects in favour of a
+    better one.
     """
-    gguf_files = [s.rfilename for s in siblings if s.rfilename.endswith(".gguf")]
-    if not gguf_files:
-        return GGUF_GLOB
-    return pick_best_gguf(gguf_files)
+    ranked = rank_gguf_candidates(s.rfilename for s in siblings)
+    return next(iter(ranked), GGUF_GLOB)
 
 
 class HfClient:

--- a/src/lilbee/catalog/models.py
+++ b/src/lilbee/catalog/models.py
@@ -1,10 +1,10 @@
-"""Catalog dataclasses and pydantic types: leaf module, no sibling imports."""
+"""Catalog dataclasses and pydantic types. Imports only the catalog's leaf modules."""
 
-import re
 from dataclasses import dataclass
 
 from pydantic import BaseModel
 
+from lilbee.catalog.refs import quant_label
 from lilbee.catalog.types import ModelCompat, ModelTask
 
 # Minimum recommended floor so a tiny model still reports a sane RAM ask.
@@ -45,15 +45,9 @@ _BYTES_PER_PARAM: dict[str, float] = {
     "F32": 4.0,
 }
 
-# Q4_K_M is what ``pick_best_gguf`` prefers, so an unrecognized quant label
+# Q4_K_M heads the pull path's quant preference, so an unrecognized label
 # estimates as if it were the quant a pull would most likely land on.
 _DEFAULT_BYTES_PER_PARAM = _BYTES_PER_PARAM["Q4_K_M"]
-
-# Quant label as written in a GGUF filename. Matches the K/legacy quants
-# (``Q4_K_M``), the IQ family (``IQ4_XS``) and the unquantized float types,
-# which ``formatting.extract_quant`` does not: it exists to label a row for
-# display and only recognizes ``Q``-prefixed names.
-_QUANT_IN_FILENAME = re.compile(r"\b(I?Q\d[A-Z0-9_]*|BF16|F16|F32)\b", re.IGNORECASE)
 
 
 def _ggml_floor(quant: str) -> float | None:
@@ -72,8 +66,7 @@ def _ggml_floor(quant: str) -> float | None:
 
 def _quant_bytes_per_param(gguf_filename: str) -> float:
     """Bytes per weight for the quant *gguf_filename* names, never below its floor."""
-    match = _QUANT_IN_FILENAME.search(gguf_filename)
-    quant = match.group(1).upper() if match else ""
+    quant = quant_label(gguf_filename)
     measured = _BYTES_PER_PARAM.get(quant, _DEFAULT_BYTES_PER_PARAM)
     floor = _ggml_floor(quant)
     return max(measured, floor) if floor is not None else measured
@@ -156,7 +149,7 @@ class CatalogModel:
     @property
     def display_name(self) -> str:
         """Human-readable label derived from the HuggingFace repo id."""
-        # Local import keeps models.py a leaf (no sibling imports at module top).
+        # circular: models -> formatting via clean_display_name
         from lilbee.catalog.formatting import clean_display_name
 
         return clean_display_name(self.hf_repo)

--- a/src/lilbee/catalog/refs.py
+++ b/src/lilbee/catalog/refs.py
@@ -2,32 +2,140 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable
+from enum import IntEnum
+
 # A native GGUF ref ``<org>/<repo>/<file>.gguf`` has at least two ``/`` separators;
 # the filename may add more when a quant lives in a repo subdir (``Q4_K_M/...``).
 NATIVE_GGUF_REF_MIN_SLASHES = 2
 
-GGUF_GLOB = "*.gguf"
+WILDCARD = "*"
+GGUF_SUFFIX = ".gguf"
+GGUF_GLOB = f"{WILDCARD}{GGUF_SUFFIX}"
 
 # Vision models need both the main GGUF and an mmproj (CLIP projection) file.
 # Resolved by glob rather than a per-repo table: every mainstream VL repo names
 # its projector this way, and a table would be one more thing to maintain.
-DEFAULT_MMPROJ_PATTERN = "*mmproj*.gguf"
+DEFAULT_MMPROJ_PATTERN = f"{WILDCARD}mmproj{WILDCARD}{GGUF_SUFFIX}"
 
-_QUANT_PREFERENCE = ("Q4_K_M", "Q4_K_S", "Q5_K_M", "Q5_K_S", "Q8_0", "Q6_K", "Q3_K_M")
+# Quantization labels in descending order of preference, best size/quality
+# balance first. This orders the candidates a pull tries; which one is really
+# the model is settled by the GGUF header, not by the name.
+_QUANT_PREFERENCE = (
+    "Q4_K_M",
+    "Q4_K_S",
+    "Q5_K_M",
+    "Q5_K_S",
+    "Q8_0",
+    "Q6_K",
+    "Q3_K_M",
+    "IQ4_XS",
+    "Q4_0",
+    "Q5_0",
+    "Q3_K_L",
+    "Q3_K_S",
+    "Q2_K",
+)
+
+# Unquantized types. A repo that publishes one beside quantized packs offers it
+# as the reference copy, so it ranks below every quant including unrecognized
+# ones: picking it turns a 7 GB pull into a 54 GB one.
+FLOAT_QUANTS = frozenset({"F16", "BF16", "F32"})
+
+# A quant label occupies a whole ``-``/``_``/``.``/``/``-delimited segment of the
+# filename. Matching it as a bare substring makes ``Q8_0`` match inside
+# ``mmproj-Q8_0`` and ``F16`` inside ``BF16``.
+_QUANT_TOKEN_RE = re.compile(
+    r"(?:^|[-_./])(I?Q\d[A-Za-z0-9_]*|BF16|F16|F32)(?=$|[-_./])", re.IGNORECASE
+)
+
+_SPLIT_SHARD_RE = re.compile(r"^(?P<base>.+)-(?P<idx>\d{5})-of-(?P<total>\d{5})\.gguf$")
+_SHARD_NUMBER_WIDTH = 5
+_FIRST_SHARD_INDEX = 1
+
+_PREFERENCE_INDEX: dict[str, int] = {quant: i for i, quant in enumerate(_QUANT_PREFERENCE)}
 
 
-def pick_best_gguf(filenames: list[str]) -> str:
-    """Pick the best GGUF file by quantization preference."""
-    for quant in _QUANT_PREFERENCE:
-        for f in filenames:
-            if quant in f:
-                return f
-    return filenames[0]
+class _QuantTier(IntEnum):
+    """Ordering tier of a GGUF candidate, best first."""
+
+    PREFERRED = 0
+    UNRANKED = 1
+    FLOAT = 2
+
+
+def quant_label(filename: str) -> str:
+    """The GGUF quantization label *filename* names, uppercased, or empty string.
+
+    Reads the last labelled segment: a quant stored in a repo subdir repeats the
+    label in both the directory and the file, and a mismatched pair names the
+    real type on the file.
+    """
+    matches = _QUANT_TOKEN_RE.findall(filename)
+    return matches[-1].upper() if matches else ""
+
+
+def _shard_name(base: str, index: int, total: int) -> str:
+    """Render one part of a split GGUF's ``<base>-<i>-of-<n>.gguf`` naming."""
+    return f"{base}-{index:0{_SHARD_NUMBER_WIDTH}d}-of-{total:0{_SHARD_NUMBER_WIDTH}d}{GGUF_SUFFIX}"
+
+
+def split_shard_filenames(filename: str) -> list[str]:
+    """Return every shard of a split GGUF in order, or ``[filename]`` if it isn't split.
+
+    A split GGUF names its parts ``<base>-00001-of-0000N.gguf`` through
+    ``<base>-0000N-of-0000N.gguf``. llama.cpp loads the whole set from the first
+    shard but needs every part on disk, so the catalog must fetch all of them and
+    only consider the model installed once the full set is present.
+    """
+    match = _SPLIT_SHARD_RE.match(filename)
+    if match is None:
+        return [filename]
+    base = match.group("base")
+    total = int(match.group("total"))
+    return [_shard_name(base, index, total) for index in range(_FIRST_SHARD_INDEX, total + 1)]
+
+
+def _first_shard(filename: str) -> str:
+    """The shard llama.cpp loads a split GGUF from, or *filename* when it isn't split.
+
+    Only the first shard carries the full metadata header, so it is the one a
+    header probe can read and the only part worth ranking as a candidate.
+    """
+    match = _SPLIT_SHARD_RE.match(filename)
+    if match is None:
+        return filename
+    return _shard_name(match.group("base"), _FIRST_SHARD_INDEX, int(match.group("total")))
+
+
+def _rank_key(filename: str) -> tuple[int, int, str]:
+    """Sort key placing the best-quantized candidate first, ties broken by name."""
+    quant = quant_label(filename)
+    preference = _PREFERENCE_INDEX.get(quant)
+    if preference is not None:
+        return (_QuantTier.PREFERRED, preference, filename)
+    tier = _QuantTier.FLOAT if quant in FLOAT_QUANTS else _QuantTier.UNRANKED
+    return (tier, 0, filename)
+
+
+def rank_gguf_candidates(filenames: Iterable[str]) -> list[str]:
+    """A repo's GGUF files in the order a pull should try them, best quant first.
+
+    Split shards collapse to their first part. An unrecognized quant outranks an
+    unquantized copy, so a repo that publishes only exotic packs beside an F16
+    still resolves to a pack rather than the full-precision weights.
+
+    Hand-rolled because neither huggingface_hub nor gguf-py exposes a
+    "choose a file from this repo" API; both stop at listing and reading.
+    """
+    candidates = {_first_shard(name) for name in filenames if name.endswith(GGUF_SUFFIX)}
+    return sorted(candidates, key=_rank_key)
 
 
 def is_bare_hf_repo(ref: str) -> bool:
     """True if *ref* has the bare ``<org>/<repo>`` shape (no filename segment)."""
-    return ref.count("/") == 1 and not ref.endswith(".gguf")
+    return ref.count("/") == 1 and not ref.endswith(GGUF_SUFFIX)
 
 
 def hf_repo_from_ref(ref: str) -> str:
@@ -39,7 +147,7 @@ def hf_repo_from_ref(ref: str) -> str:
     Provider-prefixed refs (``openai/gpt-4``, ``ollama/llama3:8b``) and bare
     repos lack the ``.gguf`` suffix and are returned unchanged.
     """
-    if ref.endswith(".gguf") and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
+    if ref.endswith(GGUF_SUFFIX) and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
         return "/".join(ref.split("/")[:NATIVE_GGUF_REF_MIN_SLASHES])
     return ref
 
@@ -48,10 +156,10 @@ def gguf_filename_from_ref(ref: str) -> str:
     """Return the filename portion of a native GGUF ref (after ``<org>/<repo>/``).
 
     The filename may include repo subdirectories (a quant stored under e.g.
-    ``Q4_K_M/...gguf``), so everything past the first two segments is kept.
+    ``Q4_K_M/``), so everything past the first two segments is kept.
     Returns empty string for non-native refs (bare repos, provider-prefixed).
     """
-    if ref.endswith(".gguf") and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
+    if ref.endswith(GGUF_SUFFIX) and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
         return "/".join(ref.split("/")[NATIVE_GGUF_REF_MIN_SLASHES:])
     return ""
 

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -21,12 +21,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from lilbee.catalog.download import split_shard_filenames
 from lilbee.catalog.query import reclassify_by_name
 from lilbee.catalog.refs import (
     NATIVE_GGUF_REF_MIN_SLASHES,
     format_native_gguf_ref,
     is_bare_hf_repo,
+    split_shard_filenames,
 )
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config.model import cfg

--- a/tests/_gguf_fixture.py
+++ b/tests/_gguf_fixture.py
@@ -9,16 +9,22 @@ GGUF_VERSION = 3
 GGUF_TYPE_STRING = 8
 
 
-def make_minimal_gguf(architecture: str) -> bytes:
-    """Return a minimal valid GGUF header containing only general.architecture=<arch>."""
-    buf = bytearray()
-    buf += GGUF_MAGIC
-    buf += struct.pack("<I", GGUF_VERSION)
-    buf += struct.pack("<Q", 0)
-    buf += struct.pack("<Q", 1)
-    key = b"general.architecture"
-    buf += struct.pack("<Q", len(key)) + key
-    buf += struct.pack("<I", GGUF_TYPE_STRING)
-    val = architecture.encode("utf-8")
-    buf += struct.pack("<Q", len(val)) + val
-    return bytes(buf)
+def _string_kv(key: bytes, value: str) -> bytes:
+    """One GGUF metadata entry holding a string value."""
+    encoded = value.encode("utf-8")
+    return (
+        struct.pack("<Q", len(key))
+        + key
+        + struct.pack("<I", GGUF_TYPE_STRING)
+        + struct.pack("<Q", len(encoded))
+        + encoded
+    )
+
+
+def make_minimal_gguf(architecture: str, file_type: str | None = None) -> bytes:
+    """A minimal valid GGUF header carrying general.architecture and optionally general.type."""
+    entries = [_string_kv(b"general.architecture", architecture)]
+    if file_type is not None:
+        entries.append(_string_kv(b"general.type", file_type))
+    head = GGUF_MAGIC + struct.pack("<I", GGUF_VERSION) + struct.pack("<Q", 0)
+    return head + struct.pack("<Q", len(entries)) + b"".join(entries)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,6 +226,22 @@ def _sealed_engine_resolution(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _sealed_gguf_header_probe(monkeypatch):
+    """Seal the GGUF header probe so no unit test reaches HuggingFace.
+
+    Resolving a pull reads each candidate's header over the network. An empty
+    header is the documented offline verdict: the file stays eligible and
+    selection falls back to the quant ranking. Tests that exercise the gate
+    patch ``compat.probe_header`` or ``download.file_header`` themselves, which
+    wins over this default; ``header_probe``'s own tests stub ``httpx`` below it.
+    """
+    from lilbee.catalog import compat
+    from lilbee.catalog.header_probe import GgufHeader
+
+    monkeypatch.setattr(compat, "probe_header", lambda _url: GgufHeader())
+
+
+@pytest.fixture(autouse=True)
 def _reset_services_after_test():
     """Drop any Services container ``set_services()`` left around.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,9 +16,10 @@ from lilbee.core.system import canonical_models_dir
 _DEFAULT_CHAT_REPO = "Qwen/Qwen3-0.6B-GGUF"
 _DEFAULT_CHAT_FILE = "Qwen3-0.6B-Q8_0.gguf"
 _CI_CHAT_REPO = os.environ.get("LILBEE_TEST_CHAT_MODEL", _DEFAULT_CHAT_REPO)
-# Exact filename, not a wildcard: resolve_filename only calls the HF API to
-# expand a pattern, and one call per entry rate-limits the matrix cells that run
-# last. An overridden repo has no known filename, so it keeps the pattern.
+# Exact filename, not a wildcard: a named file costs one header probe, while a
+# pattern also lists the repo, and the extra call per entry rate-limits the
+# matrix cells that run last. An overridden repo has no known filename, so it
+# keeps the pattern.
 _CI_CHAT_FILE = _DEFAULT_CHAT_FILE if _CI_CHAT_REPO == _DEFAULT_CHAT_REPO else "*Q8_0.gguf"
 _EMBED_REPO = "nomic-ai/nomic-embed-text-v1.5-GGUF"
 _EMBED_FILE = "nomic-embed-text-v1.5.Q4_K_M.gguf"

--- a/tests/integration/test_xet_download_e2e.py
+++ b/tests/integration/test_xet_download_e2e.py
@@ -149,7 +149,7 @@ def _gguf_names(models_dir: Path) -> set[str]:
 def _repo_gguf_count(models_dir: Path, hf_repo: str) -> int:
     """GGUFs landed for *hf_repo*, identified by repo rather than filename.
 
-    The requested quant is not the one that necessarily arrives: pick_best_gguf
+    The requested quant is not the one that necessarily arrives: resolution
     resolves to the best available, so asserting on the filename asserts a
     choice the catalog is free to make.
     """

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -45,9 +47,15 @@ from lilbee.catalog import (
 from lilbee.catalog import (
     query as _query,
 )
+from lilbee.catalog.header_probe import GgufHeader
 from lilbee.catalog.hf_client import hf_token
 from lilbee.catalog.models import HfPage
-from lilbee.catalog.refs import GGUF_GLOB, is_bare_hf_repo, pick_best_gguf
+from lilbee.catalog.refs import (
+    GGUF_GLOB,
+    is_bare_hf_repo,
+    quant_label,
+    rank_gguf_candidates,
+)
 from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 from lilbee.core.config import cfg
 
@@ -969,10 +977,10 @@ class TestResolvePullTarget:
 
 class TestSplitShardFilenames:
     def test_single_file_returns_itself(self) -> None:
-        assert catalog.download.split_shard_filenames("model-Q4_K_M.gguf") == ["model-Q4_K_M.gguf"]
+        assert catalog.refs.split_shard_filenames("model-Q4_K_M.gguf") == ["model-Q4_K_M.gguf"]
 
     def test_split_returns_every_part_in_order(self) -> None:
-        parts = catalog.download.split_shard_filenames("Q4_K_M/M-Q4_K_M-00001-of-00003.gguf")
+        parts = catalog.refs.split_shard_filenames("Q4_K_M/M-Q4_K_M-00001-of-00003.gguf")
         assert parts == [
             "Q4_K_M/M-Q4_K_M-00001-of-00003.gguf",
             "Q4_K_M/M-Q4_K_M-00002-of-00003.gguf",
@@ -1217,65 +1225,165 @@ class TestDownloadModel:
             download_model(entry)
 
 
+def _bonsai_header(name: str) -> GgufHeader:
+    """Headers for the mixed-architecture repo shape: weights, projector, drafter."""
+    if "mmproj" in name:
+        return GgufHeader(architecture="clip", file_type="mmproj")
+    if "dspark" in name:
+        return GgufHeader(architecture="dspark", file_type="model")
+    if "inkling" in name:
+        return GgufHeader(architecture="inkling", file_type="model")
+    return GgufHeader(architecture="qwen35", file_type="model")
+
+
 class TestResolveFilename:
+    """The pull path resolves a repo to the file whose header says it is the model."""
+
+    @staticmethod
+    def _siblings(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+        data = {"siblings": [{"rfilename": name} for name in names]}
+        mock_resp = httpx.Response(200, json=data, request=httpx.Request("GET", "https://x"))
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+
+    @staticmethod
+    def _headers(
+        monkeypatch: pytest.MonkeyPatch,
+        lookup: Callable[[str], GgufHeader] | None = None,
+    ) -> None:
+        """Stub the per-file header probe; *lookup* maps a filename to its header."""
+
+        def _header(_repo: str, name: str) -> GgufHeader:
+            if lookup is None:
+                return GgufHeader(architecture="llama", file_type="model")
+            return lookup(name)
+
+        monkeypatch.setattr(catalog.download, "file_header", _header)
+
     def test_exact_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._headers(monkeypatch)
         entry = PICKS_EMBEDDING[0]
-        result = catalog.resolve_filename(entry)
-        assert result == entry.gguf_filename
+        assert catalog.resolve_filename(entry) == entry.gguf_filename
 
     def test_wildcard_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        entry = PICKS_CHAT[0]
-        data = {
-            "siblings": [
-                {"rfilename": "Qwen3-0.6B-Q4_K_M.gguf"},
-                {"rfilename": "Qwen3-0.6B-Q8_0.gguf"},
-            ]
-        }
-        mock_resp = httpx.Response(200, json=data, request=httpx.Request("GET", "https://x"))
-        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        result = catalog.resolve_filename(entry)
-        assert result == "Qwen3-0.6B-Q4_K_M.gguf"
+        self._headers(monkeypatch)
+        self._siblings(monkeypatch, "Qwen3-0.6B-Q4_K_M.gguf", "Qwen3-0.6B-Q8_0.gguf")
+        assert catalog.resolve_filename(PICKS_CHAT[0]) == "Qwen3-0.6B-Q4_K_M.gguf"
+
+    def test_projector_labelled_q8_does_not_win(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A repo whose only preferred-quant file is its projector resolves to the weights."""
+        self._headers(monkeypatch, _bonsai_header)
+        self._siblings(
+            monkeypatch,
+            "Bonsai-27B-mmproj-Q8_0.gguf",
+            "Bonsai-27B-Q2_0.gguf",
+            "Bonsai-27B-F16.gguf",
+        )
+        assert catalog.resolve_filename(PICKS_CHAT[0]) == "Bonsai-27B-Q2_0.gguf"
+
+    def test_named_file_rejected_by_header_reresolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A catalog row naming the projector re-resolves instead of pulling it."""
+        entry = replace(PICKS_CHAT[0], gguf_filename="Bonsai-27B-mmproj-Q8_0.gguf")
+        self._headers(monkeypatch, _bonsai_header)
+        self._siblings(monkeypatch, "Bonsai-27B-mmproj-Q8_0.gguf", "Bonsai-27B-Q2_0.gguf")
+        assert catalog.resolve_filename(entry) == "Bonsai-27B-Q2_0.gguf"
+
+    def test_unsupported_architecture_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A speculative-decoding drafter on an unsupported arch never wins."""
+        self._headers(monkeypatch, _bonsai_header)
+        self._siblings(monkeypatch, "Bonsai-27B-dspark-Q4_1.gguf", "Bonsai-27B-Q2_g64.gguf")
+        assert catalog.resolve_filename(PICKS_CHAT[0]) == "Bonsai-27B-Q2_g64.gguf"
+
+    def test_projector_only_repo_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A repo holding nothing but a projector has no weights to install."""
+        self._headers(monkeypatch, _bonsai_header)
+        self._siblings(monkeypatch, "Bonsai-27B-mmproj-Q8_0.gguf")
+        with pytest.raises(RuntimeError, match="No GGUF model weights found"):
+            catalog.resolve_filename(PICKS_CHAT[0])
+
+    def test_unsupported_arch_still_resolves_for_the_arch_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Refusing here would report a generic error and break --allow-unsupported."""
+        self._headers(monkeypatch, _bonsai_header)
+        self._siblings(monkeypatch, "inkling-Q4_K_M.gguf", "mmproj-BF16.gguf")
+        assert catalog.resolve_filename(PICKS_CHAT[0]) == "inkling-Q4_K_M.gguf"
 
     def test_wildcard_no_match_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        entry = PICKS_CHAT[0]
-        data = {"siblings": [{"rfilename": "something-else.bin"}]}
-        mock_resp = httpx.Response(200, json=data, request=httpx.Request("GET", "https://x"))
-        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        with pytest.raises(RuntimeError, match="No GGUF files found"):
-            catalog.resolve_filename(entry)
+        self._headers(monkeypatch)
+        self._siblings(monkeypatch, "something-else.bin")
+        with pytest.raises(RuntimeError, match="No GGUF model weights found"):
+            catalog.resolve_filename(PICKS_CHAT[0])
 
     def test_wildcard_api_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        entry = PICKS_CHAT[0]
-
         def raise_connect(*a: object, **kw: object) -> httpx.Response:
             raise httpx.ConnectError("x")
 
         monkeypatch.setattr(httpx, "get", raise_connect)
         with pytest.raises(RuntimeError, match="Cannot query files"):
-            catalog.resolve_filename(entry)
+            catalog.resolve_filename(PICKS_CHAT[0])
 
     def test_wildcard_http_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        entry = PICKS_CHAT[0]
-        mock_resp = httpx.Response(500)
-        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(500))
         with pytest.raises(RuntimeError):
-            catalog.resolve_filename(entry)
+            catalog.resolve_filename(PICKS_CHAT[0])
 
     def test_wildcard_401_raises_permission_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """HTTP 401 response raises PermissionError with auth message."""
-        entry = PICKS_CHAT[0]
-        mock_resp = httpx.Response(401)
-        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(401))
         with pytest.raises(PermissionError, match="requires HuggingFace authentication"):
-            catalog.resolve_filename(entry)
+            catalog.resolve_filename(PICKS_CHAT[0])
 
-    def test_pick_best_gguf_prefers_q4_k_m(self) -> None:
+
+class TestQuantLabel:
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("model-Q4_K_M.gguf", "Q4_K_M"),
+            ("Q4_K_M/model-Q4_K_M-00001-of-00002.gguf", "Q4_K_M"),
+            ("model-IQ4_XS.gguf", "IQ4_XS"),
+            ("mmproj-model-f16.gguf", "F16"),
+            ("model-bf16.gguf", "BF16"),
+            ("Ternary-Bonsai-27B-Q2_g64.gguf", "Q2_G64"),
+            ("Qwen3-30B-A3B.gguf", ""),
+        ],
+    )
+    def test_reads_the_labelled_segment(self, filename: str, expected: str) -> None:
+        assert quant_label(filename) == expected
+
+    def test_label_must_be_a_whole_segment(self) -> None:
+        """``F16`` inside ``BF16`` and ``Q8_0`` inside a longer word are not labels."""
+        assert quant_label("model-BF16.gguf") == "BF16"
+        assert quant_label("modelQ8_0x.gguf") == ""
+
+
+class TestRankGgufCandidates:
+    def test_prefers_q4_k_m(self) -> None:
         files = ["model-Q8_0.gguf", "model-Q4_K_M.gguf", "model-Q5_K_M.gguf"]
-        assert pick_best_gguf(files) == "model-Q4_K_M.gguf"
+        assert rank_gguf_candidates(files) == [
+            "model-Q4_K_M.gguf",
+            "model-Q5_K_M.gguf",
+            "model-Q8_0.gguf",
+        ]
 
-    def test_pick_best_gguf_fallback_first(self) -> None:
-        files = ["model-weird.gguf"]
-        assert pick_best_gguf(files) == "model-weird.gguf"
+    def test_unrecognized_quant_outranks_unquantized(self) -> None:
+        """An exotic pack beats the F16 reference copy, which is many times its size."""
+        files = ["Ternary-Bonsai-8B-F16.gguf", "Ternary-Bonsai-8B-Q2_0.gguf"]
+        assert rank_gguf_candidates(files) == [
+            "Ternary-Bonsai-8B-Q2_0.gguf",
+            "Ternary-Bonsai-8B-F16.gguf",
+        ]
+
+    def test_collapses_split_shards_to_the_first_part(self) -> None:
+        files = [
+            "Q4_K_M/M-Q4_K_M-00001-of-00002.gguf",
+            "Q4_K_M/M-Q4_K_M-00002-of-00002.gguf",
+        ]
+        assert rank_gguf_candidates(files) == ["Q4_K_M/M-Q4_K_M-00001-of-00002.gguf"]
+
+    def test_drops_non_gguf_files(self) -> None:
+        assert rank_gguf_candidates(["README.md", "config.json"]) == []
 
 
 class TestIsBareHfRepo:

--- a/tests/test_catalog_compat_coverage.py
+++ b/tests/test_catalog_compat_coverage.py
@@ -28,7 +28,7 @@ def test_probe_returns_empty_when_blob_lacks_gguf_magic(
     """A response that doesn't start with the GGUF magic bytes returns empty."""
     blob = b"NOTGGUF" + b"\x00" * 32
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
-    assert header_probe.probe_architecture("https://example.test/x.gguf") == ""
+    assert header_probe.probe_header("https://example.test/x.gguf").architecture == ""
 
 
 def test_download_target_translates_unsupported_arch_to_runtime_error() -> None:
@@ -61,3 +61,38 @@ def test_download_target_translates_unsupported_arch_to_runtime_error() -> None:
         pytest.raises(RuntimeError, match="kimi_k2"),
     ):
         _download_target(_Reporter(), model)
+
+
+class TestFileHeader:
+    """The per-candidate header read the pull path gates on."""
+
+    @staticmethod
+    def _header(monkeypatch: pytest.MonkeyPatch, header: header_probe.GgufHeader) -> None:
+        monkeypatch.setattr(compat, "probe_header", lambda _url: header)
+
+    def test_reads_model_weights(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._header(monkeypatch, header_probe.GgufHeader("llama", "model"))
+        header = compat.file_header("acme/foo-GGUF", "foo-Q4_K_M.gguf")
+        assert (header.architecture, header.is_model) == ("llama", True)
+
+    def test_reads_projector(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """clip is a supported architecture, so only general.type rules the projector out."""
+        self._header(monkeypatch, header_probe.GgufHeader("clip", "mmproj"))
+        assert compat.file_header("acme/foo-GGUF", "foo-mmproj-Q8_0.gguf").is_model is False
+
+    def test_unreadable_header_reads_as_an_eligible_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Offline, the probe yields nothing; that must not block the pull."""
+        self._header(monkeypatch, header_probe.GgufHeader())
+        header = compat.file_header("acme/foo-GGUF", "foo-Q4_K_M.gguf")
+        assert (header.architecture, header.is_model) == ("", True)
+
+    def test_unresolvable_repo_id_yields_an_empty_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*args: object, **kwargs: object) -> str:
+            raise ValueError("bad repo")
+
+        monkeypatch.setattr(compat, "hf_hub_url", _raise)
+        assert compat.file_header("not a repo", "foo.gguf") == header_probe.GgufHeader()

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -1,4 +1,4 @@
-"""Unit tests for catalog.header_probe.probe_architecture."""
+"""Unit tests for catalog.header_probe: the GGUF header fields a pull reads."""
 
 from __future__ import annotations
 
@@ -8,14 +8,14 @@ import httpx
 import pytest
 
 from lilbee.catalog import header_probe
-from lilbee.catalog.header_probe import GGUF_HEADER_PROBE_BYTES, probe_architecture
+from lilbee.catalog.header_probe import GGUF_HEADER_PROBE_BYTES, probe_header
 from tests._gguf_fixture import make_minimal_gguf
 
 
 def test_probe_reads_architecture(monkeypatch: pytest.MonkeyPatch) -> None:
     blob = make_minimal_gguf("llama")
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
-    assert probe_architecture("https://example.test/model.gguf") == "llama"
+    assert probe_header("https://example.test/model.gguf").architecture == "llama"
 
 
 def _gguf_arch_then_truncated_tokenizer(arch: str) -> bytes:
@@ -53,7 +53,7 @@ def _hdr(entries: list[bytes], kv_count: int | None = None) -> bytes:
 
 
 class TestParseArchWalker:
-    """The KV walker behind probe_architecture, exercised at the byte level."""
+    """The KV walker behind probe_header, exercised at the byte level."""
 
     def test_skips_scalar_string_and_array_values_before_arch(self) -> None:
         blob = _hdr(
@@ -68,7 +68,7 @@ class TestParseArchWalker:
                 _kv(b"general.architecture", 8, _gstr(b"qwen3")),
             ]
         )
-        assert header_probe._parse_arch(blob) == "qwen3"
+        assert header_probe._parse_header(blob).architecture == "qwen3"
 
     def test_skips_string_array_before_arch(self) -> None:
         arr = struct.pack("<I", 8) + struct.pack("<Q", 2) + _gstr(b"a") + _gstr(b"bb")
@@ -78,24 +78,24 @@ class TestParseArchWalker:
                 _kv(b"general.architecture", 8, _gstr(b"llama")),
             ]
         )
-        assert header_probe._parse_arch(blob) == "llama"
+        assert header_probe._parse_header(blob).architecture == "llama"
 
     def test_truncated_mid_kv_returns_empty(self) -> None:
         blob = _hdr([_kv(b"general.name", 8, _gstr(b"m"))], kv_count=5)  # claims 5, only 1 present
-        assert header_probe._parse_arch(blob) == ""
+        assert header_probe._parse_header(blob).architecture == ""
 
     def test_unknown_value_type_returns_empty(self) -> None:
         blob = _hdr([_kv(b"weird", 99, b"")], kv_count=1)  # arch never reached
-        assert header_probe._parse_arch(blob) == ""
+        assert header_probe._parse_header(blob).architecture == ""
 
     def test_unknown_array_element_type_returns_empty(self) -> None:
         bad_arr = struct.pack("<I", 99) + struct.pack("<Q", 1)
         blob = _hdr([_kv(b"weird", 9, bad_arr)], kv_count=1)
-        assert header_probe._parse_arch(blob) == ""
+        assert header_probe._parse_header(blob).architecture == ""
 
     def test_non_string_arch_returns_empty(self) -> None:
         blob = _hdr([_kv(b"general.architecture", 4, struct.pack("<I", 1))])
-        assert header_probe._parse_arch(blob) == ""
+        assert header_probe._parse_header(blob).architecture == ""
 
 
 def test_probe_reads_arch_before_truncated_tokenizer_array(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -105,17 +105,17 @@ def test_probe_reads_arch_before_truncated_tokenizer_array(monkeypatch: pytest.M
     the arch-compat guard never fired (bb-ziks.43 end-to-end)."""
     blob = _gguf_arch_then_truncated_tokenizer("qwen3")
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
-    assert probe_architecture("https://example.test/model.gguf") == "qwen3"
+    assert probe_header("https://example.test/model.gguf").architecture == "qwen3"
 
 
 def test_probe_handles_truncated_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=b"GGUF\x03"))
-    assert probe_architecture("https://example.test/model.gguf") == ""
+    assert probe_header("https://example.test/model.gguf").architecture == ""
 
 
 def test_probe_handles_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(404, content=b""))
-    assert probe_architecture("https://example.test/model.gguf") == ""
+    assert probe_header("https://example.test/model.gguf").architecture == ""
 
 
 def test_probe_handles_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -123,7 +123,7 @@ def test_probe_handles_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
         raise httpx.ConnectError("offline")
 
     monkeypatch.setattr(httpx, "get", _raise)
-    assert probe_architecture("https://example.test/model.gguf") == ""
+    assert probe_header("https://example.test/model.gguf").architecture == ""
 
 
 def test_probe_sends_range_header(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -138,7 +138,7 @@ def test_probe_sends_range_header(monkeypatch: pytest.MonkeyPatch) -> None:
         return httpx.Response(200, content=blob)
 
     monkeypatch.setattr(header_probe.httpx, "get", _capture)
-    probe_architecture("https://example.test/model.gguf")
+    probe_header("https://example.test/model.gguf")
     assert captured["headers"]["Range"] == f"bytes=0-{GGUF_HEADER_PROBE_BYTES - 1}"
     # HF /resolve/ URLs 302 to the CDN; the probe must follow the redirect or it
     # reads the redirect notice instead of the GGUF header (bb-ziks.43).
@@ -148,7 +148,7 @@ def test_probe_sends_range_header(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_probe_returns_empty_on_missing_arch_key(monkeypatch: pytest.MonkeyPatch) -> None:
     blob = b"GGUF" + struct.pack("<I", 3) + struct.pack("<Q", 0) + struct.pack("<Q", 0)
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
-    assert probe_architecture("https://example.test/model.gguf") == ""
+    assert probe_header("https://example.test/model.gguf").architecture == ""
 
 
 def test_probe_returns_empty_on_non_string_arch_value(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -163,7 +163,7 @@ def test_probe_returns_empty_on_non_string_arch_value(monkeypatch: pytest.Monkey
     buf += struct.pack("<I", 4)
     buf += struct.pack("<I", 99)
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=bytes(buf)))
-    assert probe_architecture("https://example.test/model.gguf") == ""
+    assert probe_header("https://example.test/model.gguf").architecture == ""
 
 
 def test_probe_skips_unrelated_kv_entries(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -183,7 +183,7 @@ def test_probe_skips_unrelated_kv_entries(monkeypatch: pytest.MonkeyPatch) -> No
     val = b"qwen3"
     buf += struct.pack("<Q", len(val)) + val
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=bytes(buf)))
-    assert probe_architecture("https://example.test/model.gguf") == "qwen3"
+    assert probe_header("https://example.test/model.gguf").architecture == "qwen3"
 
 
 def test_probe_handles_array_value_in_skip(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -206,7 +206,7 @@ def test_probe_handles_array_value_in_skip(monkeypatch: pytest.MonkeyPatch) -> N
     val = b"gemma3"
     buf += struct.pack("<Q", len(val)) + val
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=bytes(buf)))
-    assert probe_architecture("https://example.test/model.gguf") == "gemma3"
+    assert probe_header("https://example.test/model.gguf").architecture == "gemma3"
 
 
 def test_probe_returns_empty_on_unknown_value_type_in_skip(
@@ -227,4 +227,51 @@ def test_probe_returns_empty_on_unknown_value_type_in_skip(
     val = b"llama"
     buf += struct.pack("<Q", len(val)) + val
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=bytes(buf)))
-    assert probe_architecture("https://example.test/model.gguf") == ""
+    assert probe_header("https://example.test/model.gguf").architecture == ""
+
+
+class TestFileTypeGate:
+    """``general.type`` is what separates model weights from a projector."""
+
+    def test_reads_file_type_alongside_architecture(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        blob = make_minimal_gguf("clip", file_type="mmproj")
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
+        header = probe_header("https://example.test/mmproj.gguf")
+        assert (header.architecture, header.file_type) == ("clip", "mmproj")
+
+    def test_projector_is_not_a_model(self) -> None:
+        assert header_probe.GgufHeader(architecture="clip", file_type="mmproj").is_model is False
+
+    def test_adapter_is_not_a_model(self) -> None:
+        assert header_probe.GgufHeader(architecture="llama", file_type="adapter").is_model is False
+
+    def test_declared_model_is_a_model(self) -> None:
+        assert header_probe.GgufHeader(architecture="qwen35", file_type="model").is_model is True
+
+    def test_header_without_the_key_stays_a_model(self) -> None:
+        """GGUFs written before general.architecture gained a sibling type key omit it."""
+        assert header_probe.GgufHeader(architecture="llama").is_model is True
+
+    def test_unreadable_header_stays_a_model(self) -> None:
+        """An empty header is not a verdict, so the candidate stays eligible."""
+        assert header_probe.GgufHeader().is_model is True
+
+    def test_stops_once_both_keys_are_read(self) -> None:
+        """The walk ends at the second wanted key. A later re-declaration is never read."""
+        entries = [
+            _kv(b"general.architecture", 8, _gstr(b"qwen35")),
+            _kv(b"general.type", 8, _gstr(b"model")),
+            _kv(b"general.type", 8, _gstr(b"mmproj")),
+        ]
+        header = header_probe._parse_header(_hdr(entries))
+        assert (header.architecture, header.file_type) == ("qwen35", "model")
+
+    def test_keeps_fields_read_before_a_truncated_array(self) -> None:
+        """A tokenizer array running past the probe window does not lose the fields."""
+        entries = [
+            _kv(b"general.architecture", 8, _gstr(b"qwen35")),
+            _kv(b"tokenizer.ggml.tokens", 9, struct.pack("<I", 8) + struct.pack("<Q", 151936)),
+            _kv(b"general.type", 8, _gstr(b"model")),
+        ]
+        header = header_probe._parse_header(_hdr(entries))
+        assert (header.architecture, header.file_type) == ("qwen35", "")

--- a/tests/test_catalog_resolve_arch.py
+++ b/tests/test_catalog_resolve_arch.py
@@ -6,6 +6,7 @@ import pytest
 
 from lilbee.catalog import compat
 from lilbee.catalog.compat import resolve_arch_for_pull
+from lilbee.catalog.header_probe import GgufHeader
 from lilbee.catalog.hf_client import HfClient
 
 
@@ -28,13 +29,13 @@ def test_resolve_miss_returns_empty_when_no_probe_target(
 
 def test_resolve_miss_invokes_probe(client: HfClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(compat, "_resolve_blob_url", lambda ref: f"https://example.test/{ref}.gguf")
-    monkeypatch.setattr(compat, "probe_architecture", lambda _url: "qwen3")
+    monkeypatch.setattr(compat, "probe_header", lambda _url: GgufHeader(architecture="qwen3"))
     assert resolve_arch_for_pull("acme/foo-GGUF", client) == "qwen3"
 
 
 def test_resolve_writes_back_to_cache(client: HfClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(compat, "_resolve_blob_url", lambda _ref: "https://example.test/x.gguf")
-    monkeypatch.setattr(compat, "probe_architecture", lambda _url: "gemma3")
+    monkeypatch.setattr(compat, "probe_header", lambda _url: GgufHeader(architecture="gemma3"))
     resolve_arch_for_pull("acme/bar-GGUF", client)
     assert client.get_cached_arch("acme/bar-GGUF") == "gemma3"
 
@@ -46,11 +47,11 @@ def test_resolve_does_not_cache_empty_arch_on_probe_failure(
     guard would be permanently disabled for this ref. A later successful probe
     must still be able to resolve and cache the real arch."""
     monkeypatch.setattr(compat, "_resolve_blob_url", lambda _ref: "https://example.test/x.gguf")
-    monkeypatch.setattr(compat, "probe_architecture", lambda _url: "")
+    monkeypatch.setattr(compat, "probe_header", lambda _url: GgufHeader(architecture=""))
     assert resolve_arch_for_pull("acme/flaky-GGUF", client) == ""
     assert client.get_cached_arch("acme/flaky-GGUF") is None
 
-    monkeypatch.setattr(compat, "probe_architecture", lambda _url: "llama")
+    monkeypatch.setattr(compat, "probe_header", lambda _url: GgufHeader(architecture="llama"))
     assert resolve_arch_for_pull("acme/flaky-GGUF", client) == "llama"
     assert client.get_cached_arch("acme/flaky-GGUF") == "llama"
 


### PR DESCRIPTION
## Problem

lilbee chose which GGUF to download by scanning filenames for a quant label as a bare substring, first match wins, over every file in the repo. Projectors were candidates like any other file, so `prism-ml/Ternary-Bonsai-27B-gguf` resolved to its 600 MB projector, as did Google's `gemma-4-26B-A4B-it-qat-q4_0-gguf` and `gemma-4-31B-it-qat-q4_0-gguf`.

Matching was also case-sensitive. A repo naming its quants in lower case matched nothing and fell through to a silent first-item fallback, so Qwen's own `Qwen2.5-1.5B-Instruct-GGUF` pulled a 3.32 GB fp16 instead of the 1.04 GB q4_k_m.

## Solution

Quant labels now only order the candidates. The GGUF header settles it: `probe_header` reads `general.type` beside `general.architecture` in one Range-GET, and a file whose header calls it a projector or an adapter is never the model.

## Unsupported architectures

Where a repo mixes architectures a supported one wins, so a speculative-decoding drafter loses to the weights it drafts for. Where none is supported the best-ranked weights still come back. Refusing inside resolution would report a generic error and disable `--allow-unsupported`, so that verdict stays with the architecture guard.

## Ranking

An unrecognized quant outranks an unquantized copy, so a repo publishing only exotic packs beside an F16 resolves to a pack. Appending to the preference list rather than reordering it leaves selection unchanged for every repo carrying one of the original seven quants.

## Validation

Resolved the 240 most-downloaded GGUF repos across all four roles against the live HuggingFace API, confirming each pick by its header and a HEAD request. All 240 resolve to a downloadable file and none resolves to a projector. 37 differ from `main`: 5 were projectors, 9 took the unquantized copy.

## Not covered

Compatibility is still judged by architecture alone, so a fork-specific tensor type downloads and fails at load. The guard also never fires for a bare repo ref. Both are filed separately, along with the size estimate for unrecognized quants.
