### PR TITLE
Read GGUF files with one parser instead of two

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
     "diskcache>=5.6.1",
     "jinja2>=2.11.3",
     "typing-extensions>=4.5.0",
-    "gguf>=0.18",
     "huggingface_hub>=1.27.0",
     "psutil>=5.9",
     "pydantic-settings>=2.14.2",
@@ -150,6 +149,11 @@ dev = [
     # without this, chardet only arrives via the crawler extra, and the bare
     # `uv sync --locked` CI test env cannot run those tests.
     "chardet>=7",
+    # llama.cpp's Python package, for tests only. It is not a second GGUF reader
+    # in the product: gguf-parser is, built from the pin that builds
+    # llama-server. This supplies GGML_QUANT_SIZES so the measured
+    # bytes-per-weight table is checked against the authoritative block sizes.
+    "gguf>=0.18",
     "hypothesis>=6.100",
     "mypy>=1.19.1",
     "packaging>=24",

--- a/src/lilbee/catalog/formatting.py
+++ b/src/lilbee/catalog/formatting.py
@@ -4,7 +4,11 @@ import re
 from dataclasses import dataclass
 
 from lilbee.catalog.models import CatalogModel, CatalogResult
-from lilbee.catalog.refs import hf_repo_from_ref
+from lilbee.catalog.refs import (
+    GGUF_SUFFIX,
+    NATIVE_GGUF_REF_MIN_SLASHES,
+    hf_repo_from_ref,
+)
 from lilbee.catalog.types import ModelCompat, ModelSource, ModelTask
 
 PARAM_COUNT_RE = re.compile(r"(\d+\.?\d*B)", re.IGNORECASE)
@@ -21,10 +25,6 @@ _DISPLAY_NAME_NOISE = re.compile(
 _DISPLAY_NAME_META_PREFIX = re.compile(r"^Meta-", re.IGNORECASE)
 # A bare parameter-count word (``300m``, ``0.6b``); rendered uppercase.
 _PARAM_COUNT_WORD = re.compile(r"\d+(?:\.\d+)?[bm]", re.IGNORECASE)
-
-# A native GGUF ref of the form ``<owner>/<repo>/<file>.gguf`` has at least
-# two ``/`` separators; one-slash refs are bare repo IDs.
-_NATIVE_GGUF_REF_MIN_SLASHES = 2
 
 
 def _prettify_word(word: str) -> str:
@@ -70,7 +70,7 @@ def download_task_name(ref: str) -> str:
         return ""
     # A ``.gguf`` ref needs ``<owner>/<repo>/<file>`` (two slashes) to be a valid
     # native ref; a one-slash ``<file>.gguf`` is malformed and has no repo label.
-    if ref.endswith(".gguf") and ref.count("/") < _NATIVE_GGUF_REF_MIN_SLASHES:
+    if ref.endswith(GGUF_SUFFIX) and ref.count("/") < NATIVE_GGUF_REF_MIN_SLASHES:
         return ""
     # Every remaining ref has a ``<owner>/<repo>`` portion: a native ref keeps its
     # first two segments, a provider-prefixed/bare ref is returned unchanged.
@@ -86,7 +86,7 @@ def display_label_for_ref(ref: str) -> str:
     """
     if not ref:
         return ""
-    if ref.endswith(".gguf") and ref.count("/") >= _NATIVE_GGUF_REF_MIN_SLASHES:
+    if ref.endswith(GGUF_SUFFIX) and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
         # hf_repo_from_ref keeps the first two segments, so a subdir-quant ref
         # (``unsloth/MiniMax-M2-GGUF/Q4_K_M/...gguf``) still yields the real repo.
         return clean_display_name(hf_repo_from_ref(ref))

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass
 from http import HTTPStatus
 
 import httpx
-from gguf import GGUFValueType, ReaderField
 
 log = logging.getLogger(__name__)
 
@@ -181,26 +180,3 @@ def _parse_header(blob: bytes) -> GgufHeader:
     cur.u32()  # version
     cur.u64()  # tensor_count (the tensor-info table is never read)
     return GgufHeader(**_collect_string_fields(cur, cur.u64()))
-
-
-def gguf_scalar_str(field: ReaderField | None) -> str | None:
-    """Render a scalar GGUF metadata field as a string, or ``None``.
-
-    Mirrors what ``Llama(vocab_only=True).metadata`` produced: STRING fields
-    decode their bytes; numeric scalars (UINT*/INT*/FLOAT*/BOOL) stringify
-    their single value. ARRAY fields and empty fields return ``None`` (callers
-    here only read scalars). This is the one place the gguf-py ReaderField shape
-    is decoded, so a gguf-py layout change breaks here, not at every call site.
-    """
-    if field is None or not field.types or not field.data:
-        return None
-    value_type = field.types[-1]
-    part = field.parts[field.data[0]]
-    if value_type == GGUFValueType.STRING:
-        return bytes(part).decode("utf-8", errors="replace")
-    if value_type == GGUFValueType.ARRAY:
-        return None
-    scalar = part.tolist() if hasattr(part, "tolist") else part
-    if isinstance(scalar, (list, tuple)):
-        scalar = scalar[0] if scalar else None
-    return None if scalar is None else str(scalar)

--- a/src/lilbee/catalog/models.py
+++ b/src/lilbee/catalog/models.py
@@ -24,15 +24,15 @@ _BYTES_PER_GB = 1024**3
 # nominal type. These are measured file sizes; Qwen3-8B-GGUF publishes 0.614
 # (Q4_K_M), 0.699 (Q5_0), 0.714 (Q5_K_M), 0.821 (Q6_K) and 1.063 (Q8_0).
 #
-# GGML_QUANT_SIZES is still used, as the physical floor: no file can be smaller
-# than its base type, so _quant_bytes_per_param clamps to it and a typo below the
-# floor cannot survive.
+# No entry may sit below its base type's bytes per weight, which is physically
+# impossible; ``test_measured_quants_are_above_their_ggml_floor`` checks each one
+# against ``gguf.constants.GGML_QUANT_SIZES`` so a typo cannot survive review.
 _BYTES_PER_PARAM: dict[str, float] = {
     "Q2_K": 0.33,
     "Q3_K_S": 0.45,
     "Q3_K_M": 0.488,
     "Q3_K_L": 0.53,
-    "IQ4_XS": 0.53,
+    "IQ4_XS": 0.532,
     "Q4_0": 0.569,
     "Q4_K_S": 0.575,
     "Q4_K_M": 0.614,
@@ -59,20 +59,6 @@ _SCALE_OVERHEAD = 1.125
 _BITS_PER_BYTE = 8
 
 
-def _ggml_floor(quant: str) -> float | None:
-    """Bytes per weight of *quant*'s base ggml type, or None if it names none."""
-    from gguf.constants import GGML_QUANT_SIZES, GGMLQuantizationType
-
-    base = quant.split("_")[0] if quant.startswith(("F", "BF")) else quant
-    for name in (quant, base, "_".join(quant.split("_")[:2])):
-        try:
-            block, type_size = GGML_QUANT_SIZES[GGMLQuantizationType[name]]
-        except KeyError:
-            continue
-        return type_size / block
-    return None
-
-
 def _packed_bits(quant: str) -> int | None:
     """The bit width *quant* packs each weight into, or None if it names none."""
     match = re.match(r"I?Q(\d)", quant)
@@ -80,18 +66,15 @@ def _packed_bits(quant: str) -> int | None:
 
 
 def _quant_bytes_per_param(gguf_filename: str) -> float:
-    """Bytes per weight for the quant *gguf_filename* names, never below its floor."""
+    """Bytes per weight for the quant *gguf_filename* names."""
     quant = quant_label(gguf_filename)
     measured = _BYTES_PER_PARAM.get(quant)
-    if measured is None:
-        bits = _packed_bits(quant)
-        measured = (
-            bits / _BITS_PER_BYTE * _SCALE_OVERHEAD
-            if bits is not None
-            else _DEFAULT_BYTES_PER_PARAM
-        )
-    floor = _ggml_floor(quant)
-    return max(measured, floor) if floor is not None else measured
+    if measured is not None:
+        return measured
+    bits = _packed_bits(quant)
+    if bits is None:
+        return _DEFAULT_BYTES_PER_PARAM
+    return bits / _BITS_PER_BYTE * _SCALE_OVERHEAD
 
 
 def estimate_min_ram_gb(size_gb: float) -> float:

--- a/src/lilbee/catalog/models.py
+++ b/src/lilbee/catalog/models.py
@@ -1,5 +1,6 @@
 """Catalog dataclasses and pydantic types. Imports only the catalog's leaf modules."""
 
+import re
 from dataclasses import dataclass
 
 from pydantic import BaseModel
@@ -45,9 +46,17 @@ _BYTES_PER_PARAM: dict[str, float] = {
     "F32": 4.0,
 }
 
-# Q4_K_M heads the pull path's quant preference, so an unrecognized label
-# estimates as if it were the quant a pull would most likely land on.
+# Q4_K_M heads the pull path's quant preference, so a label naming no bit width
+# at all estimates as if it were the quant a pull would most likely land on.
 _DEFAULT_BYTES_PER_PARAM = _BYTES_PER_PARAM["Q4_K_M"]
+
+# A quant the table does not name still says how many bits it packs. One fp16
+# scale per group costs an eighth on top, whatever the width, because a group is
+# sized to the width: 1-bit in groups of 128, 2-bit in 64, 4-bit in 32 all carry
+# two bytes per group. Reading the width beats falling back to Q4_K_M, which
+# reports a 2-bit file at more than twice its size.
+_SCALE_OVERHEAD = 1.125
+_BITS_PER_BYTE = 8
 
 
 def _ggml_floor(quant: str) -> float | None:
@@ -64,10 +73,23 @@ def _ggml_floor(quant: str) -> float | None:
     return None
 
 
+def _packed_bits(quant: str) -> int | None:
+    """The bit width *quant* packs each weight into, or None if it names none."""
+    match = re.match(r"I?Q(\d)", quant)
+    return int(match.group(1)) if match else None
+
+
 def _quant_bytes_per_param(gguf_filename: str) -> float:
     """Bytes per weight for the quant *gguf_filename* names, never below its floor."""
     quant = quant_label(gguf_filename)
-    measured = _BYTES_PER_PARAM.get(quant, _DEFAULT_BYTES_PER_PARAM)
+    measured = _BYTES_PER_PARAM.get(quant)
+    if measured is None:
+        bits = _packed_bits(quant)
+        measured = (
+            bits / _BITS_PER_BYTE * _SCALE_OVERHEAD
+            if bits is not None
+            else _DEFAULT_BYTES_PER_PARAM
+        )
     floor = _ggml_floor(quant)
     return max(measured, floor) if floor is not None else measured
 

--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -8,7 +8,12 @@ from huggingface_hub.utils import HFValidationError, validate_repo_id
 from lilbee.app.services import get_services
 from lilbee.catalog.models import CatalogModel, CatalogResult
 from lilbee.catalog.picks import get_picks
-from lilbee.catalog.refs import GGUF_GLOB, hf_repo_from_ref
+from lilbee.catalog.refs import (
+    GGUF_GLOB,
+    GGUF_SUFFIX,
+    NATIVE_GGUF_REF_MIN_SLASHES,
+    hf_repo_from_ref,
+)
 from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 
 log = logging.getLogger(__name__)
@@ -45,11 +50,6 @@ def size_bucket(params: int) -> CatalogSize | None:
         if billions < ceiling:
             return bucket
     return CatalogSize.HUGE
-
-
-# A native GGUF ref of the form ``<owner>/<repo>/<file>.gguf`` has at least
-# two ``/`` separators; one-slash refs are bare repo IDs.
-_NATIVE_GGUF_REF_MIN_SLASHES = 2
 
 
 def get_catalog(
@@ -235,7 +235,7 @@ def resolve_pull_target(model: str) -> CatalogModel | None:
     # circular: modelhub.registry imports catalog.query at top
     from lilbee.modelhub.registry import parse_hf_ref
 
-    if model.endswith(".gguf") and model.count("/") >= _NATIVE_GGUF_REF_MIN_SLASHES:
+    if model.endswith(GGUF_SUFFIX) and model.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
         try:
             hf_repo, gguf_filename = parse_hf_ref(model)
         except ValueError:

--- a/src/lilbee/catalog/refs.py
+++ b/src/lilbee/catalog/refs.py
@@ -47,7 +47,7 @@ FLOAT_QUANTS = frozenset({"F16", "BF16", "F32"})
 # filename. Matching it as a bare substring makes ``Q8_0`` match inside
 # ``mmproj-Q8_0`` and ``F16`` inside ``BF16``.
 _QUANT_TOKEN_RE = re.compile(
-    r"(?:^|[-_./])(I?Q\d[A-Za-z0-9_]*|BF16|F16|F32)(?=$|[-_./])", re.IGNORECASE
+    r"(?:^|[-_./])P?(I?Q\d[A-Za-z0-9_]*|BF16|F16|F32)(?=$|[-_./])", re.IGNORECASE
 )
 
 _SPLIT_SHARD_RE = re.compile(r"^(?P<base>.+)-(?P<idx>\d{5})-of-(?P<total>\d{5})\.gguf$")

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from lilbee.catalog.query import reclassify_by_name
 from lilbee.catalog.refs import (
+    GGUF_SUFFIX,
     NATIVE_GGUF_REF_MIN_SLASHES,
     format_native_gguf_ref,
     is_bare_hf_repo,
@@ -76,7 +77,7 @@ def parse_hf_ref(ref: str) -> tuple[str, str]:
     after is the filename, which may include repo subdirectories (unsloth stores
     quants under e.g. ``Q4_K_M/Model-...-00001-of-00003.gguf``).
     """
-    if not ref.endswith(".gguf") or ref.count("/") < NATIVE_GGUF_REF_MIN_SLASHES:
+    if not ref.endswith(GGUF_SUFFIX) or ref.count("/") < NATIVE_GGUF_REF_MIN_SLASHES:
         raise ValueError(f"Model ref {ref!r} is not a HuggingFace ref. {_REF_SHAPE_HINT}")
     parts = ref.split("/")
     hf_repo = "/".join(parts[:NATIVE_GGUF_REF_MIN_SLASHES])
@@ -312,7 +313,7 @@ class ModelRegistry:
             if repo.repo_id == hf_repo
             for rev in repo.revisions
             for f in rev.files
-            if f.file_name.endswith(".gguf")
+            if f.file_name.endswith(GGUF_SUFFIX)
         }
 
     def _snapshot_gguf_path(self, hf_repo: str, gguf_filename: str) -> Path | None:

--- a/src/lilbee/providers/gguf_meta.py
+++ b/src/lilbee/providers/gguf_meta.py
@@ -11,14 +11,12 @@ import hashlib
 import json
 import logging
 import os
-import struct
+import subprocess
 import threading
 from pathlib import Path
-from typing import cast
+from typing import NamedTuple, cast
 
-from gguf import GGUFReader, GGUFValueType
-
-from lilbee.catalog.header_probe import GGUF_ARCH_KEY, gguf_scalar_str
+from lilbee.catalog.header_probe import GGUF_ARCH_KEY
 from lilbee.providers.base import ProviderError
 
 log = logging.getLogger(__name__)
@@ -90,9 +88,12 @@ def train_ctx_from_meta(
 _METADATA_CACHE: dict[tuple[str, int, int], dict[str, str] | None] = {}
 _METADATA_CACHE_LOCK = threading.Lock()
 
-# Bump when the extracted field set changes, so old entries are ignored rather
-# than served stale.
-_DISK_CACHE_VERSION = 1
+# Bump when the extracted field set changes, or when the reader does, so old
+# entries are ignored rather than served stale. Version 2 reads through
+# gguf-parser: entries written by version 1 recorded "no metadata" for files
+# whose tensor type gguf-py did not know, and the key is (path, mtime, size),
+# so an unchanged file would keep serving that answer after the upgrade.
+_DISK_CACHE_VERSION = 2
 _DISK_CACHE_DIRNAME = "gguf-meta"
 # Distinguishes "no entry on disk" from a cached "this file has no metadata".
 _DISK_MISS = object()
@@ -184,35 +185,107 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     return dict(result) if result is not None else None
 
 
-def _read_gguf_metadata_uncached(model_path: Path) -> dict[str, str] | None:
+# Array values report as ``{type, len, startOffset}`` rather than their contents,
+# so a 151k-token vocabulary costs nothing to skip. Only scalars are read here.
+_PARSER_ARRAY_VALUE_TYPE = 9
+# GGUF string value type, in both readers' numbering.
+_GGUF_STRING_VALUE_TYPE = 8
+_PARSER_TIMEOUT_SECONDS = 60.0
+_PARSER_KILL_WAIT_SECONDS = 5.0
+_PARSER_LABEL = "gguf-parser"
+
+
+class _Scalar(NamedTuple):
+    """One scalar metadata value, and whether the file typed it as a string.
+
+    A caller that wants text out of a field the file wrote as an integer is
+    reading a malformed file, so the type travels with the value rather than
+    being inferred from how the digits look.
+    """
+
+    text: str
+    is_string: bool
+
+
+def _kv_via_parser(model_path: Path) -> dict[str, _Scalar] | None:
+    """Every scalar metadata key in *model_path*, read by the engine's own parser.
+
+    Returns ``None`` when there is no parser to ask.
+
+    gguf-parser is built from the pin that builds llama-server, so the tensor
+    types it accepts are the ones the engine can decode. gguf-py carries its own
+    table and trails llama.cpp: a Q2_0 file (tensor type 42) that the engine
+    loads makes ``GGUFReader`` raise while it builds tensor descriptors nothing
+    here reads, and every field in the file becomes unreadable with it.
+    """
+    from lilbee.providers.fleet.binary import resolve_gguf_parser
+    from lilbee.providers.fleet.proc import run_bounded
+
     try:
-        reader = GGUFReader(str(model_path))
-        fields = reader.fields
-    except (ValueError, KeyError, IndexError, struct.error, OSError, UnicodeDecodeError) as exc:
-        # A truncated or corrupt GGUF header surfaces as a parser error. Report
-        # "no readable metadata" (None, an outcome callers already handle) rather
-        # than letting a raw parse error abort the whole fleet build.
-        log.warning("Could not parse GGUF metadata from %s: %s", model_path, exc)
+        parser = resolve_gguf_parser()
+    except Exception as exc:
+        log.debug("No gguf-parser to read %s with: %s", model_path, exc)
         return None
+    try:
+        # merge_stderr stays off: the caller parses stdout as JSON.
+        out, code = run_bounded(
+            [str(parser), "--path", str(model_path), "--raw"],
+            timeout_s=_PARSER_TIMEOUT_SECONDS,
+            kill_wait_s=_PARSER_KILL_WAIT_SECONDS,
+            label=_PARSER_LABEL,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.debug("gguf-parser did not run against %s: %s", model_path, exc)
+        return None
+    if code != 0:
+        # The engine's own reader rejected the file. Report "no readable
+        # metadata" rather than asking gguf-py for a second opinion the engine
+        # would not honour anyway.
+        log.warning("Could not parse GGUF metadata from %s: gguf-parser exit %d", model_path, code)
+        return {}
+    try:
+        entries = json.loads(out)["header"]["metadataKV"]
+    except (ValueError, KeyError, TypeError) as exc:
+        log.warning("gguf-parser returned unreadable output for %s: %s", model_path, exc)
+        return {}
+    return {
+        e["key"]: _Scalar(str(e["value"]), e.get("valueType") == _GGUF_STRING_VALUE_TYPE)
+        for e in entries
+        if e.get("valueType") != _PARSER_ARRAY_VALUE_TYPE and e.get("value") is not None
+    }
+
+
+def _scalars(model_path: Path) -> dict[str, _Scalar]:
+    """Scalar metadata for *model_path*, or empty when there is no parser to ask.
+
+    An install without the engine extra has no gguf-parser, and also no
+    llama-server to load a model with, so the fields here have nothing left to
+    size. Callers already treat absent metadata as a fallback case.
+    """
+    return _kv_via_parser(model_path) or {}
+
+
+def _read_gguf_metadata_uncached(model_path: Path) -> dict[str, str] | None:
+    kv = _scalars(model_path)
     result: dict[str, str] = {}
 
-    arch = gguf_scalar_str(fields.get(GGUF_ARCH_KEY))
-    if arch is not None:
-        result["architecture"] = arch
-    arch = arch or _DEFAULT_ARCH
+    arch_field = kv.get(GGUF_ARCH_KEY)
+    if arch_field is not None:
+        result["architecture"] = arch_field.text
+    arch = arch_field.text if arch_field is not None else _DEFAULT_ARCH
 
     for suffix, out_key in _ARCH_FIELD_SUFFIXES.items():
-        value = gguf_scalar_str(fields.get(f"{arch}.{suffix}"))
+        value = kv.get(f"{arch}.{suffix}")
         if value is not None:
-            result[out_key] = value
+            result[out_key] = value.text
     for raw_key, out_key in (
         (_CHAT_TEMPLATE_KEY, "chat_template"),
         (_FILE_TYPE_KEY, "file_type"),
         (_NAME_KEY, "name"),
     ):
-        value = gguf_scalar_str(fields.get(raw_key))
+        value = kv.get(raw_key)
         if value is not None:
-            result[out_key] = value
+            result[out_key] = value.text
     return result or None
 
 
@@ -260,12 +333,5 @@ def find_mmproj_for_model(model_path: Path) -> Path:
 
 def read_mmproj_projector_type(mmproj_path: Path) -> str | None:
     """Read ``clip.projector_type`` from a GGUF mmproj without loading the model."""
-    try:
-        reader = GGUFReader(str(mmproj_path))
-        field = reader.get_field(_CLIP_PROJECTOR_TYPE_KEY)
-    except Exception:
-        log.debug("Failed to read mmproj metadata from %s", mmproj_path, exc_info=True)
-        return None
-    if field is None or not field.types or field.types[-1] != GGUFValueType.STRING:
-        return None
-    return bytes(field.parts[field.data[0]]).decode("utf-8", errors="replace")
+    value = _scalars(mmproj_path).get(_CLIP_PROJECTOR_TYPE_KEY)
+    return value.text if value is not None and value.is_string else None

--- a/src/lilbee/providers/gguf_meta.py
+++ b/src/lilbee/providers/gguf_meta.py
@@ -149,15 +149,12 @@ def _disk_cache_store(key: tuple[str, int, int], result: dict[str, str] | None) 
 
 
 def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
-    """Read header metadata from a GGUF file with the ``gguf`` parser.
+    """Read header metadata from a GGUF file with the engine's own parser.
 
-    Cached by ``(path, mtime, size)`` in memory and on disk. ``GGUFReader`` parses
-    the whole header -- every tensor descriptor and the large tokenizer arrays --
-    to hand back a dozen scalar fields, which measured at ~60s for a 2.6GB model
-    on a spinning-rust-era CPU. Planning reads the same model several times per
-    fleet build, so the in-memory cache collapses those to one parse; the on-disk
-    cache carries it across processes, which is what stops a relaunch paying that
-    minute again while an already-warm engine sits idle waiting to be adopted.
+    Cached by ``(path, mtime, size)`` in memory and on disk. The read itself is
+    cheap now that it goes through gguf-parser, which reports an array as a type
+    and a length rather than its contents; what the cache saves is the process
+    spawn, and planning reads the same model several times per fleet build.
     Keying on mtime and size means an edited or replaced file re-reads. Returns a
     copy so callers can't mutate the shared entry.
     """

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from lilbee.catalog.refs import NATIVE_GGUF_REF_MIN_SLASHES
+from lilbee.catalog.refs import GGUF_SUFFIX, NATIVE_GGUF_REF_MIN_SLASHES
 from lilbee.providers.base import filter_options, normalize_generation_options
 from lilbee.providers.local_servers import (
     LOCAL_SERVER_KEYS,
@@ -44,7 +44,7 @@ def is_native_gguf_ref(raw: str) -> bool:
     (:func:`lilbee.catalog.refs.hf_repo_from_ref`) only recognises the
     lowercase ``.gguf`` suffix, and classification must agree with it.
     """
-    return raw.endswith(".gguf") and raw.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES
+    return raw.endswith(GGUF_SUFFIX) and raw.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES
 
 
 def routes_to_native_gguf(raw: str) -> bool:

--- a/tests/_gguf_fixture.py
+++ b/tests/_gguf_fixture.py
@@ -28,3 +28,20 @@ def make_minimal_gguf(architecture: str, file_type: str | None = None) -> bytes:
         entries.append(_string_kv(b"general.type", file_type))
     head = GGUF_MAGIC + struct.pack("<I", GGUF_VERSION) + struct.pack("<Q", 0)
     return head + struct.pack("<Q", len(entries)) + b"".join(entries)
+
+
+def has_gguf_parser() -> bool:
+    """Whether a gguf-parser binary resolves here.
+
+    The unit lane installs no engine helpers; the integration lane does. Tests
+    that hand real GGUF bytes to the parser are gated on this, and the mapping
+    from a parsed table onto lilbee's fields is covered against a stubbed parser
+    so the unit lane still exercises it.
+    """
+    from lilbee.providers.fleet.binary import resolve_gguf_parser
+
+    try:
+        resolve_gguf_parser()
+    except Exception:
+        return False
+    return True

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2800,3 +2800,43 @@ class TestUnrecognizedQuantEstimate:
 
         assert _quant_bytes_per_param("m-Q4_K_M.gguf") == _BYTES_PER_PARAM["Q4_K_M"]
         assert _quant_bytes_per_param("m-Q8_0.gguf") == _BYTES_PER_PARAM["Q8_0"]
+
+
+class TestMeasuredQuantFloors:
+    """The measured bytes-per-weight table against the ggml block sizes."""
+
+    @staticmethod
+    def _ggml_floor(quant: str) -> float | None:
+        """Bytes per weight of *quant*'s base ggml type, or None if it names none."""
+        from gguf.constants import GGML_QUANT_SIZES, GGMLQuantizationType
+
+        base = quant.split("_")[0] if quant.startswith(("F", "BF")) else quant
+        for name in (quant, base, "_".join(quant.split("_")[:2])):
+            try:
+                block, type_size = GGML_QUANT_SIZES[GGMLQuantizationType[name]]
+            except KeyError:
+                continue
+            return type_size / block
+        return None
+
+    def test_measured_quants_are_above_their_ggml_floor(self) -> None:
+        """No measured figure may sit below its base type, which is impossible.
+
+        llama.cpp promotes some tensors and leaves norms in F32, so a real file
+        always costs more per weight than its nominal type: a table entry under
+        the floor is a typo, not a small model. Checked here rather than clamped
+        at runtime so the table is fixed instead of silently corrected.
+        """
+        from lilbee.catalog.models import _BYTES_PER_PARAM
+
+        below = {
+            quant: (measured, floor)
+            for quant, measured in _BYTES_PER_PARAM.items()
+            if (floor := self._ggml_floor(quant)) is not None and measured < floor
+        }
+        assert not below, f"measured figures below their ggml floor: {below}"
+
+    def test_floor_helper_finds_a_known_type(self) -> None:
+        """The lookup resolves a real quant, so the check above cannot pass vacuously."""
+        assert self._ggml_floor("Q4_K_M") == pytest.approx(0.5625)
+        assert self._ggml_floor("NOT_A_QUANT") is None

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2754,3 +2754,49 @@ class TestRepoHasMmproj:
         monkeypatch.setattr("huggingface_hub.HfApi", _Api)
         hf_client.repo_has_mmproj.cache_clear()
         assert hf_client.repo_has_mmproj("org/unreachable") is False
+
+
+class TestUnrecognizedQuantEstimate:
+    """A quant the table does not name still says how many bits it packs.
+
+    Real bytes-per-parameter, measured from the published files:
+    Ternary-Bonsai-27B-Q2_g64 0.28202, Ternary-Bonsai-1.7B-Q2_0_g64 0.28497,
+    Bonsai-27B-Q1_0 0.14141.
+    """
+
+    @pytest.mark.parametrize(
+        ("filename", "real_bytes_per_param"),
+        [
+            ("Ternary-Bonsai-27B-Q2_0.gguf", 0.28202),
+            ("Ternary-Bonsai-27B-Q2_g64.gguf", 0.28202),
+            ("Ternary-Bonsai-1.7B-Q2_0_g64.gguf", 0.28497),
+            ("Ternary-Bonsai-27B-PQ2_0.gguf", 0.28202),
+            ("Bonsai-27B-Q1_0.gguf", 0.14141),
+        ],
+    )
+    def test_lands_within_five_percent_of_the_real_file(
+        self, filename: str, real_bytes_per_param: float
+    ) -> None:
+        from lilbee.catalog.models import _quant_bytes_per_param
+
+        got = _quant_bytes_per_param(filename)
+        error = abs(got - real_bytes_per_param) / real_bytes_per_param
+        assert error < 0.05, f"{filename}: {got} vs {real_bytes_per_param} is {error:.1%} out"
+
+    def test_a_two_bit_quant_is_not_estimated_as_four(self) -> None:
+        """The old fallback reported a 2-bit file at more than twice its size."""
+        from lilbee.catalog.models import _BYTES_PER_PARAM, _quant_bytes_per_param
+
+        assert _quant_bytes_per_param("m-Q2_g64.gguf") < _BYTES_PER_PARAM["Q4_K_M"] / 2
+
+    def test_a_label_naming_no_width_still_falls_back(self) -> None:
+        from lilbee.catalog.models import _BYTES_PER_PARAM, _quant_bytes_per_param
+
+        assert _quant_bytes_per_param("model.gguf") == _BYTES_PER_PARAM["Q4_K_M"]
+
+    def test_a_named_quant_keeps_its_measured_figure(self) -> None:
+        """The width rule must not displace the table for quants it already holds."""
+        from lilbee.catalog.models import _BYTES_PER_PARAM, _quant_bytes_per_param
+
+        assert _quant_bytes_per_param("m-Q4_K_M.gguf") == _BYTES_PER_PARAM["Q4_K_M"]
+        assert _quant_bytes_per_param("m-Q8_0.gguf") == _BYTES_PER_PARAM["Q8_0"]

--- a/tests/test_gguf_meta.py
+++ b/tests/test_gguf_meta.py
@@ -8,9 +8,20 @@ from pathlib import Path
 import pytest
 
 from lilbee.providers.gguf_meta import read_gguf_metadata
-from tests._gguf_fixture import make_minimal_gguf
+from tests._gguf_fixture import has_gguf_parser, make_minimal_gguf
+
+# These hand real GGUF bytes to the engine's parser. The unit lane installs no
+# engine helpers, where every one of them would pass for the wrong reason: with
+# no parser the read yields no metadata, which is the answer a corrupt header is
+# meant to produce. The mapping and the failure branches are covered against a
+# stubbed parser in test_providers.py.
+_needs_gguf_parser = pytest.mark.skipif(
+    not has_gguf_parser(), reason="no gguf-parser on PATH (installed in the integration lane)"
+)
 
 
+@pytest.mark.real_engine_resolution
+@_needs_gguf_parser
 def test_returns_metadata_for_valid_gguf(tmp_path: Path) -> None:
     f = tmp_path / "ok.gguf"
     f.write_bytes(make_minimal_gguf("llama"))
@@ -41,10 +52,10 @@ def _gguf_with_duplicate_key() -> bytes:
         ("bad_magic", b"XXXX" + b"\x00" * 40),
         # magic only, no count/field table -> IndexError from the gguf reader.
         ("magic_only", b"GGUF"),
-        # duplicate metadata key -> KeyError from GGUFReader._push_field.
-        ("duplicate_key", _gguf_with_duplicate_key()),
     ],
 )
+@pytest.mark.real_engine_resolution
+@_needs_gguf_parser
 def test_returns_none_for_corrupt_header(tmp_path: Path, label: str, data: bytes) -> None:
     """A corrupt-but-parseable GGUF must yield None across the parser's failure
     modes (ValueError, IndexError, and the duplicate-key KeyError are all
@@ -182,3 +193,17 @@ class TestMetadataDiskCache:
         gguf_meta._METADATA_CACHE.clear()
         assert gguf_meta.read_gguf_metadata(model) == {"context_length": "4096"}
         assert len(calls) == 2  # nothing persisted, so the second read re-parses
+
+
+@pytest.mark.real_engine_resolution
+@_needs_gguf_parser
+def test_duplicate_metadata_key_is_read_rather_than_refused(tmp_path: Path) -> None:
+    """A repeated key parses, because the engine's own reader accepts one.
+
+    gguf-py raised KeyError on the second copy and the whole file read as
+    unusable. gguf-parser takes a value and carries on, so a file llama-server
+    would load no longer reads as having no metadata at all.
+    """
+    f = tmp_path / "dup.gguf"
+    f.write_bytes(_gguf_with_duplicate_key())
+    assert read_gguf_metadata(f) == {"name": "x"}

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1254,7 +1254,31 @@ class TestChatCapacityComesFromTheAdoptedLaunch:
         assert FleetProvider().served_chat_slots() is None
 
 
+def _has_gguf_parser() -> bool:
+    """Whether a gguf-parser binary resolves here.
+
+    The unit lane does not install the engine helpers; the integration lane
+    does. Tests that hand real GGUF bytes to the parser are gated on this, and
+    the mapping from parsed KV to lilbee's fields is covered separately against
+    a stubbed parser so the unit lane still exercises it.
+    """
+    from lilbee.providers.fleet.binary import resolve_gguf_parser
+
+    try:
+        resolve_gguf_parser()
+    except Exception:
+        return False
+    return True
+
+
+_needs_gguf_parser = pytest.mark.skipif(
+    not _has_gguf_parser(), reason="no gguf-parser on PATH (installed in the integration lane)"
+)
+
+
 class TestReadMmprojProjectorType:
+    @pytest.mark.real_engine_resolution
+    @_needs_gguf_parser
     def test_reads_projector_type(self, tmp_path: Path) -> None:
         import struct
 
@@ -1283,6 +1307,8 @@ class TestReadMmprojProjectorType:
 
         assert read_mmproj_projector_type(Path("/nonexistent/file.gguf")) is None
 
+    @pytest.mark.real_engine_resolution
+    @_needs_gguf_parser
     def test_non_string_projector_type_returns_none(self, tmp_path: Path) -> None:
         """If clip.projector_type is present but not a string (someone wrote it
         as an int or bool), the reader returns None instead of decoding bytes."""
@@ -1305,6 +1331,8 @@ class TestReadMmprojProjectorType:
         gguf_file.write_bytes(bytes(buf))
         assert read_mmproj_projector_type(gguf_file) is None
 
+    @pytest.mark.real_engine_resolution
+    @_needs_gguf_parser
     def test_reads_projector_type_past_bool_kv(self, tmp_path: Path) -> None:
         """Parser must skip bool KV pairs (1 byte each) to reach projector_type.
         LightOn OCR2's mmproj has ``clip.has_vision_encoder`` (bool) preceding
@@ -2613,24 +2641,55 @@ class TestTrainCtxFromMeta:
         assert train_ctx_from_meta(zero, fallback=4096, model_path=path) == 4096  # vision
 
 
+def _stub_gguf_parser(monkeypatch: pytest.MonkeyPatch, kv: dict[str, tuple[object, int]]) -> None:
+    """Make gguf-parser answer with *kv*, a mapping of key to (value, GGUF value type).
+
+    The engine's parser owns reading the bytes and is exercised against real
+    files in the lane that installs it. What is checked here is the mapping from
+    the parsed table onto lilbee's field names, so the table is supplied
+    directly rather than round-tripped through a file.
+    """
+    import json as _json
+
+    payload = {
+        "header": {
+            "metadataKV": [
+                {"key": key, "valueType": vtype, "value": value}
+                for key, (value, vtype) in kv.items()
+            ]
+        }
+    }
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.binary.resolve_gguf_parser", lambda: Path("/fake/gguf-parser")
+    )
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.proc.run_bounded", lambda *a, **k: (_json.dumps(payload), 0)
+    )
+
+
+_GGUF_STRING = 8
+_GGUF_UINT32 = 4
+
+
 class TestReadGgufMetadata:
-    def test_reads_all_fields(self, tmp_path: Path) -> None:
+    def test_reads_all_fields(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """read_gguf_metadata returns the parsed header fields."""
         from lilbee.providers.gguf_meta import read_gguf_metadata
 
-        path = write_test_gguf(
-            tmp_path / "model.gguf",
-            arch="llama",
-            fields={
-                "llama.context_length": 4096,
-                "llama.embedding_length": 4096,
-                "tokenizer.chat_template": "template",
-                "general.file_type": 7,
-                "general.name": "Test Model",
+        _stub_gguf_parser(
+            monkeypatch,
+            {
+                "general.architecture": ("llama", _GGUF_STRING),
+                "llama.context_length": (4096, _GGUF_UINT32),
+                "llama.embedding_length": (4096, _GGUF_UINT32),
+                "tokenizer.chat_template": ("template", _GGUF_STRING),
+                "general.file_type": (7, _GGUF_UINT32),
+                "general.name": ("Test Model", _GGUF_STRING),
             },
         )
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
 
-        assert read_gguf_metadata(path) == {
+        assert read_gguf_metadata(tmp_path / "model.gguf") == {
             "architecture": "llama",
             "context_length": "4096",
             "embedding_length": "4096",
@@ -2639,40 +2698,74 @@ class TestReadGgufMetadata:
             "name": "Test Model",
         }
 
-    def test_exposes_declared_pooling_type(self, tmp_path: Path) -> None:
+    def test_exposes_declared_pooling_type(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """An embedder's <arch>.pooling_type is surfaced for the embed-pooling choice."""
         from lilbee.providers.gguf_meta import read_gguf_metadata
 
-        path = write_test_gguf(
-            tmp_path / "model.gguf",
-            arch="qwen3",
-            fields={"qwen3.pooling_type": 3},
+        _stub_gguf_parser(
+            monkeypatch,
+            {
+                "general.architecture": ("qwen3", _GGUF_STRING),
+                "qwen3.pooling_type": (3, _GGUF_UINT32),
+            },
         )
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
 
-        assert read_gguf_metadata(path) == {"architecture": "qwen3", "pooling_type": "3"}
+        assert read_gguf_metadata(tmp_path / "model.gguf") == {
+            "architecture": "qwen3",
+            "pooling_type": "3",
+        }
 
-    def test_returns_none_for_empty_metadata(self, tmp_path: Path) -> None:
+    def test_returns_none_for_empty_metadata(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """read_gguf_metadata returns None when the header carries no fields."""
         from lilbee.providers.gguf_meta import read_gguf_metadata
 
-        reader = mock.MagicMock()
-        reader.fields = {}
-        with mock.patch("lilbee.providers.gguf_meta.GGUFReader", return_value=reader):
-            assert read_gguf_metadata(tmp_path / "model.gguf") is None
+        _stub_gguf_parser(monkeypatch, {})
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
+        assert read_gguf_metadata(tmp_path / "model.gguf") is None
 
-    def test_caches_by_path_and_mtime(self, tmp_path: Path) -> None:
+    def test_returns_none_when_no_parser_is_installed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the engine extra there is no reader, and no engine to load with either."""
+        from lilbee.providers.gguf_meta import read_gguf_metadata
+
+        def _no_parser() -> Path:
+            raise RuntimeError("no engine installed")
+
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.binary.resolve_gguf_parser", _no_parser
+        )
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
+        assert read_gguf_metadata(tmp_path / "model.gguf") is None
+
+    def test_caches_by_path_and_mtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A second read of the same file reuses the cache and never re-parses.
 
         Planning reads each model's metadata several times per build; the cache
-        turns those repeats (each a full GGUFReader parse) into one.
+        turns those repeats (each a parser subprocess) into one.
         """
         from lilbee.providers import gguf_meta
 
-        path = write_test_gguf(
-            tmp_path / "model.gguf", arch="llama", fields={"llama.context_length": 4096}
+        _stub_gguf_parser(
+            monkeypatch,
+            {
+                "general.architecture": ("llama", _GGUF_STRING),
+                "llama.context_length": (4096, _GGUF_UINT32),
+            },
         )
+        path = tmp_path / "model.gguf"
+        path.write_bytes(b"GGUF")
         gguf_meta._METADATA_CACHE.clear()
-        with mock.patch.object(gguf_meta, "GGUFReader", wraps=gguf_meta.GGUFReader) as spy:
+        with mock.patch.object(
+            gguf_meta, "_kv_via_parser", wraps=gguf_meta._kv_via_parser
+        ) as spy:
             first = gguf_meta.read_gguf_metadata(path)
             second = gguf_meta.read_gguf_metadata(path)
         assert first == second == {"architecture": "llama", "context_length": "4096"}
@@ -2759,6 +2852,8 @@ class TestFindMmprojForModel:
 
 
 class TestReadMmprojProjectorTypePartial:
+    @pytest.mark.real_engine_resolution
+    @_needs_gguf_parser
     def test_returns_projector_type(self, tmp_path: Path) -> None:
         """read_mmproj_projector_type reads clip.projector_type from GGUF."""
         import struct
@@ -2783,6 +2878,8 @@ class TestReadMmprojProjectorTypePartial:
         result = read_mmproj_projector_type(f)
         assert result == "ldp"
 
+    @pytest.mark.real_engine_resolution
+    @_needs_gguf_parser
     def test_skips_non_matching_keys(self, tmp_path: Path) -> None:
         """read_mmproj_projector_type skips unrelated keys."""
         import struct
@@ -3768,16 +3865,44 @@ class TestRoutingLifecycleForwarding:
         assert RoutingProvider().role_ready(WorkerRole.CHAT) is False
 
 
-def test_gguf_scalar_str_array_field_returns_none() -> None:
-    from types import SimpleNamespace
+def test_parser_kv_skips_array_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An array field is not renderable as a single value, so it is left out.
 
-    from gguf import GGUFValueType
+    gguf-parser reports an array as its type and length rather than its
+    contents, which is what keeps a 151k-token vocabulary off the read; nothing
+    here consumes one.
+    """
+    import json as _json
 
-    from lilbee.catalog.header_probe import gguf_scalar_str
+    from lilbee.providers import gguf_meta
 
-    # An ARRAY-typed scalar field is not renderable as a single value.
-    field = SimpleNamespace(types=[GGUFValueType.ARRAY], data=[0], parts=[b"x"])
-    assert gguf_scalar_str(field) is None
+    payload = {
+        "header": {
+            "metadataKV": [
+                {"key": "general.architecture", "valueType": 8, "value": "qwen3"},
+                {"key": "tokenizer.ggml.tokens", "valueType": 9, "value": {"len": 151669}},
+                {"key": "qwen3.block_count", "valueType": 4, "value": 36},
+            ]
+        }
+    }
+    monkeypatch.setattr(
+        gguf_meta, "_kv_via_parser", gguf_meta._kv_via_parser
+    )  # keep the real function
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.binary.resolve_gguf_parser", lambda: Path("/fake/gguf-parser")
+    )
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.proc.run_bounded",
+        lambda *a, **k: (_json.dumps(payload), 0),
+    )
+    kv = gguf_meta._kv_via_parser(tmp_path / "model.gguf")
+    assert kv is not None
+    assert "tokenizer.ggml.tokens" not in kv
+    assert kv["general.architecture"].text == "qwen3"
+    assert kv["general.architecture"].is_string is True
+    # A non-string scalar is still read, but not as a string.
+    assert kv["qwen3.block_count"].text == "36"
+    assert kv["qwen3.block_count"].is_string is False
 
 
 class TestRoutingRoleReadyRemote:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 
 from lilbee.core.config import cfg
+from tests._gguf_fixture import has_gguf_parser
 from tests._sys_modules import inject_modules
 
 if TYPE_CHECKING:
@@ -1254,25 +1255,8 @@ class TestChatCapacityComesFromTheAdoptedLaunch:
         assert FleetProvider().served_chat_slots() is None
 
 
-def _has_gguf_parser() -> bool:
-    """Whether a gguf-parser binary resolves here.
-
-    The unit lane does not install the engine helpers; the integration lane
-    does. Tests that hand real GGUF bytes to the parser are gated on this, and
-    the mapping from parsed KV to lilbee's fields is covered separately against
-    a stubbed parser so the unit lane still exercises it.
-    """
-    from lilbee.providers.fleet.binary import resolve_gguf_parser
-
-    try:
-        resolve_gguf_parser()
-    except Exception:
-        return False
-    return True
-
-
 _needs_gguf_parser = pytest.mark.skipif(
-    not _has_gguf_parser(), reason="no gguf-parser on PATH (installed in the integration lane)"
+    not has_gguf_parser(), reason="no gguf-parser on PATH (installed in the integration lane)"
 )
 
 
@@ -2737,11 +2721,70 @@ class TestReadGgufMetadata:
         def _no_parser() -> Path:
             raise RuntimeError("no engine installed")
 
+        monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_gguf_parser", _no_parser)
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
+        assert read_gguf_metadata(tmp_path / "model.gguf") is None
+
+    def test_returns_none_when_the_parser_cannot_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A parser that will not spawn is the same case as not having one."""
+        from lilbee.providers.gguf_meta import read_gguf_metadata
+
+        def _boom(*_a: object, **_k: object) -> tuple[str, int]:
+            raise OSError("cannot spawn")
+
         monkeypatch.setattr(
-            "lilbee.providers.fleet.binary.resolve_gguf_parser", _no_parser
+            "lilbee.providers.fleet.binary.resolve_gguf_parser", lambda: Path("/fake/gguf-parser")
+        )
+        monkeypatch.setattr("lilbee.providers.fleet.proc.run_bounded", _boom)
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
+        assert read_gguf_metadata(tmp_path / "model.gguf") is None
+
+    def test_returns_none_when_the_parser_rejects_the_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-zero exit is the engine's own reader refusing the file.
+
+        Reported as no readable metadata rather than retried elsewhere: nothing
+        else here would honour an answer the engine would not.
+        """
+        from lilbee.providers.gguf_meta import read_gguf_metadata
+
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.binary.resolve_gguf_parser", lambda: Path("/fake/gguf-parser")
+        )
+        monkeypatch.setattr("lilbee.providers.fleet.proc.run_bounded", lambda *a, **k: ("", 1))
+        (tmp_path / "model.gguf").write_bytes(b"GGUF")
+        assert read_gguf_metadata(tmp_path / "model.gguf") is None
+
+    def test_returns_none_when_the_parser_output_is_unreadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Output that is not the expected JSON shape yields no metadata."""
+        from lilbee.providers.gguf_meta import read_gguf_metadata
+
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.binary.resolve_gguf_parser", lambda: Path("/fake/gguf-parser")
+        )
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.proc.run_bounded", lambda *a, **k: ("not json", 0)
         )
         (tmp_path / "model.gguf").write_bytes(b"GGUF")
         assert read_gguf_metadata(tmp_path / "model.gguf") is None
+
+    def test_reads_a_path_that_cannot_be_stat_ed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path with no stat is read uncached rather than raising.
+
+        The cache key is (path, mtime, size); a file that vanished between the
+        listing and the read has none, and the read must still answer.
+        """
+        from lilbee.providers.gguf_meta import read_gguf_metadata
+
+        _stub_gguf_parser(monkeypatch, {"general.architecture": ("llama", _GGUF_STRING)})
+        assert read_gguf_metadata(tmp_path / "gone.gguf") == {"architecture": "llama"}
 
     def test_caches_by_path_and_mtime(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2763,9 +2806,7 @@ class TestReadGgufMetadata:
         path = tmp_path / "model.gguf"
         path.write_bytes(b"GGUF")
         gguf_meta._METADATA_CACHE.clear()
-        with mock.patch.object(
-            gguf_meta, "_kv_via_parser", wraps=gguf_meta._kv_via_parser
-        ) as spy:
+        with mock.patch.object(gguf_meta, "_kv_via_parser", wraps=gguf_meta._kv_via_parser) as spy:
             first = gguf_meta.read_gguf_metadata(path)
             second = gguf_meta.read_gguf_metadata(path)
         assert first == second == {"architecture": "llama", "context_length": "4096"}

--- a/uv.lock
+++ b/uv.lock
@@ -1828,7 +1828,6 @@ dependencies = [
     { name = "cachetools" },
     { name = "diskcache" },
     { name = "filelock" },
-    { name = "gguf" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "jinja2" },
@@ -1881,6 +1880,7 @@ release = [
 [package.dev-dependencies]
 dev = [
     { name = "chardet" },
+    { name = "gguf" },
     { name = "httpx" },
     { name = "hypothesis" },
     { name = "lilbee-engine" },
@@ -1906,7 +1906,6 @@ requires-dist = [
     { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.9.0" },
     { name = "diskcache", specifier = ">=5.6.1" },
     { name = "filelock", specifier = "<3.33" },
-    { name = "gguf", specifier = ">=0.18" },
     { name = "graspologic-native", marker = "extra == 'graph'", specifier = ">=1.2" },
     { name = "httpx" },
     { name = "huggingface-hub", specifier = ">=1.27.0" },
@@ -1942,6 +1941,7 @@ provides-extras = ["engine", "litellm", "graph", "crawler", "cuda12", "release"]
 [package.metadata.requires-dev]
 dev = [
     { name = "chardet", specifier = ">=7" },
+    { name = "gguf", specifier = ">=0.18" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "lilbee-engine", directory = "packaging/engine-wheel" },


### PR DESCRIPTION
## Problem

Two GGUF readers disagreed about which tensor types exist. gguf-parser, built from the pin that builds llama-server, accepts what the engine can decode. llama.cpp's Python package carried its own table and trailed it: the newest release on PyPI stops at `Q1_0` (41), so a `Q2_0` file (42) that llama-server loads and serves made `GGUFReader` raise while building tensor descriptors nothing reads. Every field in the file came back missing — context length fell to a default and an unreadable chat template read as no tool support.

Separately, a quant label the size table does not name was sized as if it were Q4_K_M. Ternary Bonsai 27B showed 15.4 GB against the 7.06 GB it really is.

## One reader

gguf-parser is now the only one. Nothing is left to fix in either project: llama.cpp added `Q2_0` to gguf-py on 2026-07-07 and the 0.19.0 release predates it by two months. A reader whose type table ships on someone else's release cadence is the wrong one for deciding what this engine can load.

It is also cheaper. An array reports as a type and a length rather than its contents, so a 151k-token vocabulary is free: the read goes from the ~60s the old docstring records for a 2.6 GB model to 0.03s.

An install without the engine extra now has no reader, and had no llama-server either; absent metadata is a case every caller already handles.

## The size estimate reads the bit width

One fp16 scale per group costs an eighth on top whatever the width, because the group is sized to the width. The packed spelling `PQ2_0` matched no label at all, so the token pattern now allows the prefix.

## gguf-py is a test dependency

It was kept for `GGML_QUANT_SIZES`, a floor under each measured figure. The floor bound on exactly one entry — `IQ4_XS` at 0.530 against a physical 0.53125 — which is a typo, not something to correct at run time. The entry is fixed and a test checks the whole table against those block sizes.

## One home for the ref constants

`query.py` and `formatting.py` each declared a private copy of the native-ref slash count while importing other constants from `refs.py`.

## Validation

| Question | How | Result |
|---|---|---|
| Does the failing model work end to end? | Ternary Bonsai 8B (`Q2_0`, type 42) through lilbee's own provider | selected, loaded, replied `Paris.` |
| Is its metadata readable now? | same file | `arch=qwen3 ctx=65536 template=4063ch`, was `None` |
| Does the engine actually support the type? | shipped b427 `llama-server` | loads in 8s, replies `Paris.` |
| Does any model resolve to a different file? | ranking on both revisions, 487 HF repos | 0 changed |
| Does the estimate get better? | same 487, against published bytes | 11 better, 3 worse, 473 unchanged |
| Does the bad tail shrink? | same 487 | off by >100%: 15 → 11; within 10%: 333 → 336 |
| Do the ref refactors change behaviour? | 7 functions over 2102 refs, both revisions | byte-identical |
| Could that check fail at all? | `GGUF_SUFFIX` set to `.ggml` | goes red |
| Gate | lint, typecheck, 1185 tests in the affected suites | green |

The three worse estimates: `IQ3_M` on one Gemma-4 repo (7.5% → 38.4%), where the old Q4_K_M default happened to sit closer to a file unusually large for its label, and two ROCmFP4 repos that stay within 6%. Three other IQ quants in the same sweep improve by 9 to 133 points.

Tests that hand real GGUF bytes to the parser are marked `real_engine_resolution` and skip where no parser is installed, which is the unit lane; the integration lane installs one. The mapping from parsed table to lilbee's fields is covered against a stubbed parser so the unit lane still exercises it.

## Cache version

The disk cache keys on path, mtime and size, so the "no metadata" it recorded would outlive the upgrade on an unchanged file. Its version moves to 2.
