### PR TITLE
Trade GPU layers for the context a chat model needs to answer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -597,7 +597,13 @@ flowchart LR
   overflow device 0 even when the cards are unequal. A chat on one card searches the
   same grid against one device (`ctx.fit_single_ctx`, entered through
   `engine_params.resolve_chat_ctx`), so both paths price the cache the model's
-  architecture holds. Header math (`model_cache.compute_dynamic_ctx`) is the fallback
+  architecture holds. On one card the search covers the **offload as well as the window**
+(`planning.fit_chat_ctx`): when full offload leaves KV room for less than a grounded
+prompt, layers move to system memory until the window is usable and the launch runs at
+that reduced `--n-gpu-layers`, so a small model on a small card is served instead of
+refused. The trade needs the weights alone to fit the budget; past that the model would
+answer out of host RAM, which is the unusable load `plan_launches` refuses on purpose.
+Header math (`model_cache.compute_dynamic_ctx`) is the fallback
   for when gguf-parser cannot answer; it charges every layer as dense attention over
   the whole window, which under-grants linear-attention, sliding-window and MLA models. On a
   single CPU/Metal box this

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -9,6 +9,7 @@ provider compute them identically. No native binding.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -73,7 +74,7 @@ _VISION_PAGE_CTX_CAP = 32768
 """Per-page ceiling on a vision OCR server's context: covers a single high-res page's
 image tokens plus prompt, while keeping a long-context VLM placeable beside a chat giant."""
 
-_N_GPU_LAYERS_AUTO = -1
+N_GPU_LAYERS_AUTO = -1
 """llama.cpp's "fit as many layers as the device holds" value for n_gpu_layers.
 
 The engine measures free VRAM at load and picks the count itself, spilling the
@@ -170,18 +171,33 @@ def chat_ctx_ceiling(meta: dict[str, str] | None, model_path: Path) -> int:
     return training_ctx
 
 
-def resolve_chat_ctx(
+@dataclass(frozen=True)
+class ChatFit:
+    """The GPU offload and per-slot window one chat launch runs with.
+
+    The pair is inseparable: the window was sized against the memory this
+    offload leaves free, so serving it at any other offload overruns the card.
+    """
+
+    gpu_layers: int
+    ctx: int
+
+
+def resolve_chat_fit(
     model_path: Path, meta: dict[str, str] | None, *, available_bytes: int | None = None
-) -> int:
-    """Pick a single-GPU n_ctx aiming for ``cfg.chat_n_ctx_target``, clamped to model + host.
+) -> ChatFit:
+    """Pick a single-GPU offload and n_ctx aiming for ``cfg.chat_n_ctx_target``,
+    clamped to model + host.
 
     A gguf-parser fit answers first
     (:func:`lilbee.providers.fleet.planning.fit_chat_ctx`), because it prices the
-    cache each layer of this architecture holds. Header math takes over when the
-    estimator cannot answer; it charges every layer as dense attention over the
-    whole window, which under-grants linear-attention, sliding-window and MLA
-    models. Either way the window stops at the smallest of the trained context,
-    ``cfg.num_ctx_max`` and the target.
+    cache each layer of this architecture holds, and it may leave layers in
+    system memory to free the KV room a usable window needs. Header math takes
+    over when the estimator cannot answer; it charges every layer as dense
+    attention over the whole window at the configured offload, which
+    under-grants linear-attention, sliding-window and MLA models. Either way the
+    window stops at the smallest of the trained context, ``cfg.num_ctx_max`` and
+    the target.
 
     A multi-GPU tensor-split chat is sized separately by the fleet against its
     per-device headroom (see :func:`lilbee.providers.fleet.ctx.fit_split_ctx`).
@@ -205,7 +221,27 @@ def resolve_chat_ctx(
         return fit_chat_ctx(model_path, meta, available_bytes=available_bytes, ctx_ceiling=upper)
     except (ProviderError, OSError, ValueError):
         log.debug("gguf-parser ctx fit failed for %s, using header math", model_path, exc_info=True)
+    return ChatFit(
+        resolve_n_gpu_layers(embedding=False),
+        _header_math_chat_ctx(
+            model_path,
+            meta,
+            available_bytes=available_bytes,
+            training_ctx=training_ctx,
+            ceiling=ceiling,
+        ),
+    )
 
+
+def _header_math_chat_ctx(
+    model_path: Path,
+    meta: dict[str, str] | None,
+    *,
+    available_bytes: int,
+    training_ctx: int,
+    ceiling: int,
+) -> int:
+    """Window from GGUF header arithmetic: weights plus a dense-attention cache."""
     try:
         model_bytes = model_path.stat().st_size
         kv_per_tok = kv_bytes_per_token(meta, *chat_kv_elem_bytes())
@@ -220,6 +256,14 @@ def resolve_chat_ctx(
     except (OSError, ValueError):
         log.debug("dynamic ctx sizing failed for %s, using static cap", model_path, exc_info=True)
         return min(training_ctx, cfg.chat_n_ctx_target)
+
+
+def resolve_chat_ctx(
+    model_path: Path, meta: dict[str, str] | None, *, available_bytes: int | None = None
+) -> int:
+    """The window half of :func:`resolve_chat_fit`, for callers that only serve
+    or advertise the context."""
+    return resolve_chat_fit(model_path, meta, available_bytes=available_bytes).ctx
 
 
 # Tokens the minimum grounded prompt allows for the question plus the context
@@ -253,7 +297,7 @@ def resolve_n_gpu_layers(*, embedding: bool) -> int:
     if cfg.n_gpu_layers == _N_GPU_LAYERS_NONE:
         return _N_GPU_LAYERS_NONE
     if embedding or cfg.n_gpu_layers is None:
-        return _N_GPU_LAYERS_AUTO
+        return N_GPU_LAYERS_AUTO
     return cfg.n_gpu_layers
 
 

--- a/src/lilbee/providers/fleet/ctx.py
+++ b/src/lilbee/providers/fleet/ctx.py
@@ -3,8 +3,9 @@
 :func:`fit_single_ctx` sizes one device against the budget the planner scaled;
 :func:`fit_split_ctx` sizes a tensor split against the busiest card's headroom
 rather than the summed pool. Both bisect the same quantized grid.
-``engine_params.resolve_chat_ctx`` is the entry point for the single-device fit
-and holds the header-math fallback. See docs/architecture.md (VRAM estimation).
+``engine_params.resolve_chat_fit`` is the entry point for the single-device fit
+and holds the header-math fallback; ``planning.fit_chat_ctx`` searches the offload
+around this window search. See docs/architecture.md (VRAM estimation).
 """
 
 from __future__ import annotations

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -105,6 +105,9 @@ _SPLIT_CHAT_SLOTS = 1
 # its floor after the forced split is refused by plan_launches
 # (_unusable_chat_ctx_reason).
 _MIN_USABLE_CHAT_CTX = 8192
+# Offload-search upper bound meaning "no reduced offload is worth probing": the
+# search runs 0..upper, so a negative bound skips it.
+_NO_OFFLOAD_PROBE = -1
 # Embed and cross-encoder rerank serve one request at a time. Raising it was
 # tried and measured worse: on 8xA40 with an 8B Q8 embedder and one ~100-token
 # passage per request, --parallel 1 gave 133 docs/sec at 81% SM while
@@ -411,26 +414,93 @@ def fit_chat_ctx(
     *,
     available_bytes: int,
     ctx_ceiling: int,
-) -> int:
-    """The chat window gguf-parser says *available_bytes* backs, at the launch flags.
+) -> engine_params.ChatFit:
+    """The offload and chat window gguf-parser says *available_bytes* backs.
 
-    Sizes one slot, as :func:`_slots_for` then grows the slot count against what
-    the window leaves. Raises when the estimator cannot answer, which sends
-    :func:`engine_params.resolve_chat_ctx` to its header-math fallback.
+    Sizes one slot at the configured offload, as :func:`_slots_for` then grows
+    the slot count against what the window leaves. A window that cannot hold a
+    grounded prompt buys KV room by leaving layers in system memory, and the
+    largest offload whose window reaches ``min_usable_chat_ctx`` wins; the
+    alternative for those models is no service at all
+    (:func:`_unusable_chat_ctx_reason`). Raises when the estimator cannot
+    answer, which sends :func:`engine_params.resolve_chat_fit` to its
+    header-math fallback.
     """
-    return fleet_ctx.fit_single_ctx(
-        model_path,
-        meta=meta,
-        slots=1,
-        available_bytes=available_bytes,
-        gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
-        flash_attn=_role_flash(WorkerRole.CHAT),
-        kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
-        kv_cache_type_v=_role_kv_cache_type_v(WorkerRole.CHAT),
-        unified=plan_sizing_is_unified(),
-        ctx_ceiling=ctx_ceiling,
-        expert_offload=_role_expert_offload(model_path),
+
+    def fit_at(gpu_layers: int) -> int:
+        return fleet_ctx.fit_single_ctx(
+            model_path,
+            meta=meta,
+            slots=1,
+            available_bytes=available_bytes,
+            gpu_layers=gpu_layers,
+            flash_attn=_role_flash(WorkerRole.CHAT),
+            kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
+            kv_cache_type_v=_role_kv_cache_type_v(WorkerRole.CHAT),
+            unified=plan_sizing_is_unified(),
+            ctx_ceiling=ctx_ceiling,
+            expert_offload=_role_expert_offload(model_path),
+        )
+
+    configured = _role_gpu_layers(WorkerRole.CHAT)
+    fit = engine_params.ChatFit(configured, fit_at(configured))
+    needed = engine_params.min_usable_chat_ctx()
+    if fit.ctx >= needed or not _chat_offload_is_tradable(
+        model_path, available_bytes=available_bytes, ctx_ceiling=ctx_ceiling, needed=needed
+    ):
+        return fit
+    traded = _traded_chat_fit(
+        fit_at, upper=_chat_offload_probe_ceiling(meta, configured), needed=needed
     )
+    return traded or fit
+
+
+def _chat_offload_is_tradable(
+    model_path: Path, *, available_bytes: int, ctx_ceiling: int, needed: int
+) -> bool:
+    """Whether a too-small chat window may buy KV room by moving layers off the card.
+
+    Only while the weights alone fit *available_bytes*. Past that the layers the
+    trade leaves behind are served from system memory, and a model that answers
+    from host RAM is the unusable load :func:`_unusable_chat_ctx_reason` refuses
+    on purpose. A window the user capped below *needed* is their choice, and the
+    refusal already honours it, so nothing is bought by trading for it either.
+    """
+    return ctx_ceiling >= needed and _weights_bytes(model_path) <= available_bytes
+
+
+def _chat_offload_probe_ceiling(meta: dict[str, str] | None, configured: int) -> int:
+    """Highest layer count the offload search probes, below *configured*.
+
+    ``_NO_OFFLOAD_PROBE`` when the architecture does not report a layer count,
+    which leaves no grid to search.
+    """
+    try:
+        layers = int((meta or {})["block_count"])
+    except (KeyError, ValueError):
+        return _NO_OFFLOAD_PROBE
+    if configured == engine_params.N_GPU_LAYERS_AUTO:
+        return layers
+    return min(configured - 1, layers)
+
+
+def _traded_chat_fit(
+    fit_at: Callable[[int], int], *, upper: int, needed: int
+) -> engine_params.ChatFit | None:
+    """Largest offload at or below *upper* whose window reaches *needed*, or ``None``.
+
+    Binary search: the estimate charges less VRAM the fewer layers the card
+    holds, so the fitted window is monotone in the offload.
+    """
+    lo, hi, best = 0, upper, None
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        ctx = fit_at(mid)
+        if ctx >= needed:
+            best, lo = engine_params.ChatFit(mid, ctx), mid + 1
+        else:
+            hi = mid - 1
+    return best
 
 
 def _role_ctx(
@@ -1516,6 +1586,10 @@ def _launch_for(
             list(plan.devices),
         )
     split_slots = _SPLIT_CHAT_SLOTS
+    # A single-card chat is the one launch whose offload its own window fit can
+    # lower; the split and pinned paths never run that fit.
+    fit_offload = is_chat and not multi_card_chat and cfg.num_ctx is None
+    n_gpu_layers = _role_gpu_layers(plan.role)
     if split_chat:
         reserved = reserved_by_device or {}
         # Headroom left after the embed/rerank servers on each shared card, not the
@@ -1538,6 +1612,15 @@ def _launch_for(
             )
 
         split_slots, ctx = _resolve_split_chat_slots(_split_fit)
+    elif fit_offload:
+        # One call answers both halves. The window was sized against the memory
+        # this offload leaves free, so a second call for the offload could pair a
+        # window with an offload that never fitted it.
+        chat_fit = engine_params.resolve_chat_fit(
+            model_path, meta, available_bytes=plan_sizing_budget(placed_device)
+        )
+        n_gpu_layers = chat_fit.gpu_layers
+        ctx = apply_ctx_downshift(plan.role, chat_fit.ctx)
     else:
         # Downshifted here and not only in the estimate: the role resolvers are
         # pure functions of model and config, so without this the retry after a
@@ -1573,7 +1656,7 @@ def _launch_for(
         spec=spec,
         model_path=model_path,
         devices=plan.devices,
-        n_gpu_layers=_role_gpu_layers(plan.role),
+        n_gpu_layers=n_gpu_layers,
         slots=slots,
         ctx_per_slot=ctx,
         tensor_split=plan.tensor_split,

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -446,7 +446,11 @@ def fit_chat_ctx(
     fit = engine_params.ChatFit(configured, fit_at(configured))
     needed = engine_params.min_usable_chat_ctx()
     if fit.ctx >= needed or not _chat_offload_is_tradable(
-        model_path, available_bytes=available_bytes, ctx_ceiling=ctx_ceiling, needed=needed
+        model_path,
+        meta=meta,
+        available_bytes=available_bytes,
+        ctx_ceiling=ctx_ceiling,
+        needed=needed,
     ):
         return fit
     traded = _traded_chat_fit(
@@ -455,8 +459,22 @@ def fit_chat_ctx(
     return traded or fit
 
 
+# Architectures whose head scores every position it proposes. Their compute
+# buffer grows with the window, and the estimator prices it by the physical
+# batch instead, so the estimate falls further behind the longer the window
+# gets. The trade maximises exactly that window, which turns a fixed
+# under-estimate into an unbounded one: measured on a 1 GiB card, the trade
+# granted gemma-4-26B-A4B-eagle3 59648 tokens against a real 1413 MiB.
+_NON_TRADABLE_ARCHITECTURES = frozenset({"eagle3"})
+
+
 def _chat_offload_is_tradable(
-    model_path: Path, *, available_bytes: int, ctx_ceiling: int, needed: int
+    model_path: Path,
+    *,
+    meta: dict[str, str] | None,
+    available_bytes: int,
+    ctx_ceiling: int,
+    needed: int,
 ) -> bool:
     """Whether a too-small chat window may buy KV room by moving layers off the card.
 
@@ -465,7 +483,12 @@ def _chat_offload_is_tradable(
     from host RAM is the unusable load :func:`_unusable_chat_ctx_reason` refuses
     on purpose. A window the user capped below *needed* is their choice, and the
     refusal already honours it, so nothing is bought by trading for it either.
+
+    Never for a speculator head. The estimate the search reads is not sound over
+    the window for those, so the search optimises a number that grows wrong.
     """
+    if (meta or {}).get("architecture") in _NON_TRADABLE_ARCHITECTURES:
+        return False
     return ctx_ceiling >= needed and _weights_bytes(model_path) <= available_bytes
 
 

--- a/tests/cli/test_launch_server_ctx.py
+++ b/tests/cli/test_launch_server_ctx.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lilbee.core.config import cfg
+from lilbee.providers.engine_params import ChatFit
 from lilbee.providers.roles import WorkerRole
 
 
@@ -223,7 +224,9 @@ def test_both_grant_surfaces_report_the_window_the_estimator_fits(monkeypatch, t
     monkeypatch.setattr(cfg, "chat_n_ctx_target", 262144)
     monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _ref: gguf)
     monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: meta)
-    monkeypatch.setattr(planning_mod, "fit_chat_ctx", lambda *_a, **_k: fitted)
+    monkeypatch.setattr(
+        planning_mod, "fit_chat_ctx", lambda *_a, **_k: ChatFit(gpu_layers=-1, ctx=fitted)
+    )
 
     assert launch_mod.planned_chat_ctx() == fitted
     assert planning_mod._role_ctx(WorkerRole.CHAT, gguf, meta) == fitted

--- a/tests/test_engine_params.py
+++ b/tests/test_engine_params.py
@@ -102,9 +102,9 @@ class TestResolveChatCtx:
         model.write_bytes(b"x" * 100)
         seen: dict = {}
 
-        def _fit(_path, _meta, *, available_bytes: int, ctx_ceiling: int) -> int:
+        def _fit(_path, _meta, *, available_bytes: int, ctx_ceiling: int) -> ep.ChatFit:
             seen.update(available_bytes=available_bytes, ctx_ceiling=ctx_ceiling)
-            return 249856
+            return ep.ChatFit(gpu_layers=-1, ctx=249856)
 
         monkeypatch.setattr(planning, "fit_chat_ctx", _fit)
         monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 262144)
@@ -121,9 +121,9 @@ class TestResolveChatCtx:
         model.write_bytes(b"x" * 100)
         seen: dict = {}
 
-        def _fit(_path, _meta, *, available_bytes: int, ctx_ceiling: int) -> int:
+        def _fit(_path, _meta, *, available_bytes: int, ctx_ceiling: int) -> ep.ChatFit:
             seen["ctx_ceiling"] = ctx_ceiling
-            return ctx_ceiling
+            return ep.ChatFit(gpu_layers=-1, ctx=ctx_ceiling)
 
         monkeypatch.setattr(planning, "fit_chat_ctx", _fit)
         monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 262144)
@@ -142,6 +142,20 @@ class TestResolveChatCtx:
         monkeypatch.setattr(cfg, "num_ctx_max", None)
         monkeypatch.setattr(cfg, "chat_n_ctx_target", 8192)
         assert ep.resolve_chat_ctx(model, {"arch": "x"}) == 6000
+
+    def test_header_math_keeps_the_configured_offload(self, tmp_path, monkeypatch) -> None:
+        # Header math sizes the window against full offload, so the launch has to
+        # run there; a traded offload only ever comes from the estimator's fit.
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"x" * 100)
+        monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 8192)
+        monkeypatch.setattr(ep, "get_available_memory", lambda _frac: 10**10)
+        monkeypatch.setattr(ep, "kv_bytes_per_token", lambda _meta, *_b: 1000)
+        monkeypatch.setattr(ep, "compute_dynamic_ctx", lambda **_k: 6000)
+        monkeypatch.setattr(cfg, "num_ctx_max", None)
+        monkeypatch.setattr(cfg, "n_gpu_layers", None)
+        monkeypatch.setattr(cfg, "chat_n_ctx_target", 8192)
+        assert ep.resolve_chat_fit(model, {"arch": "x"}) == ep.ChatFit(gpu_layers=-1, ctx=6000)
 
     def test_honors_num_ctx_max_ceiling(self, tmp_path, monkeypatch) -> None:
         model = tmp_path / "m.gguf"

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -10,6 +10,7 @@ import pytest
 
 from lilbee.core.config import cfg
 from lilbee.core.config.enums import KvCacheType, RerankerType
+from lilbee.providers.engine_params import ChatFit
 from lilbee.providers.fleet import planning as planning_mod
 from lilbee.providers.fleet.devices import (
     VULKAN_BACKEND,
@@ -981,6 +982,47 @@ class TestBuildFleetWiring:
         assert "--model" in launch.argv
         assert "--port" not in launch.argv  # claimed at spawn, not here
         assert launch.weights_bytes == 2048  # model file size scales the ready timeout
+
+    @staticmethod
+    def _chat_launch(tmp_path, monkeypatch, *, num_ctx: int | None) -> tuple[InstanceLaunch, list]:
+        """A single-card chat launch whose window fit traded offload down to 24."""
+        model = tmp_path / "chat.gguf"
+        model.write_bytes(b"x" * 2048)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+        monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+        calls: list = []
+
+        def _fit(*_a, **kwargs):
+            calls.append(kwargs.get("available_bytes"))
+            return ChatFit(gpu_layers=24, ctx=12288)
+
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_chat_fit", _fit)
+        monkeypatch.setattr(cfg, "num_ctx", num_ctx)
+        monkeypatch.setattr(cfg, "n_gpu_layers", None)
+        plan = InstancePlan(role=WorkerRole.CHAT, devices=(0,))
+        device = FleetDevice("CUDA", 0, "gpu", 2 * _GB, 2 * _GB)
+        launch = planning_mod._launch_for(plan, "ref", Path("/bin/llama-server"), {0: device})
+        return launch, calls
+
+    def test_launch_for_chat_offloads_the_layers_its_window_fit_chose(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # The fit's answer is a (layers, window) pair: launching the window at full
+        # offload would allocate the KV the fit only found room for by leaving
+        # layers in system memory, and the load would run out of VRAM. One call
+        # yields both, so the pair cannot come from two different budgets.
+        launch, calls = self._chat_launch(tmp_path, monkeypatch, num_ctx=None)
+        assert launch.argv[launch.argv.index("--n-gpu-layers") + 1] == "24"
+        assert launch.ctx == 12288
+        assert calls == [int(2 * _GB * cfg.gpu_memory_fraction)]
+
+    def test_launch_for_chat_keeps_full_offload_under_a_num_ctx_pin(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A pin skips the fit entirely, so there is no traded offload to honour.
+        launch, calls = self._chat_launch(tmp_path, monkeypatch, num_ctx=4096)
+        assert launch.argv[launch.argv.index("--n-gpu-layers") + 1] == "-1"
+        assert calls == []
 
     def test_launch_for_split_chat_sizes_ctx_against_per_device_headroom(
         self, tmp_path, monkeypatch
@@ -2207,10 +2249,9 @@ class TestFitChatCtx:
         model = tmp_path / "m.gguf"
         meta = {"arch": "x"}
 
-        assert (
-            planning_mod.fit_chat_ctx(model, meta, available_bytes=40 * _GB, ctx_ceiling=262144)
-            == 32768
-        )
+        assert planning_mod.fit_chat_ctx(
+            model, meta, available_bytes=40 * _GB, ctx_ceiling=262144
+        ) == ChatFit(gpu_layers=-1, ctx=32768)
         assert seen["model_path"] == model
         assert seen["meta"] == meta
         assert seen["slots"] == 1
@@ -2218,6 +2259,100 @@ class TestFitChatCtx:
         assert seen["ctx_ceiling"] == 262144
         assert seen["unified"] is False
         assert seen["kv_cache_type"] is KvCacheType.Q4_0
+
+
+class TestChatOffloadTradedForWindow:
+    """A window too small to answer with buys KV room by leaving layers off the card."""
+
+    @staticmethod
+    def _staircase(usable_at_or_below: int, *, small: int = 512, large: int = 12288):
+        """A fit that only reaches *large* once the offload drops to *usable_at_or_below*."""
+        probed: list[int] = []
+
+        def _fit(_path, *, gpu_layers: int, **_kwargs) -> int:
+            probed.append(gpu_layers)
+            return large if 0 <= gpu_layers <= usable_at_or_below else small
+
+        return _fit, probed
+
+    @pytest.fixture(autouse=True)
+    def _flags(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(planning_mod, "plan_sizing_is_unified", lambda: False)
+        monkeypatch.setattr(cfg, "n_gpu_layers", None)
+        self.model = tmp_path / "chat.gguf"
+        self.model.write_bytes(b"x" * 1024)
+        self.meta = {"block_count": "28"}
+
+    def test_it_keeps_the_largest_offload_that_serves_a_grounded_prompt(self, monkeypatch) -> None:
+        # Full offload leaves KV room for 512 tokens, which cannot hold a prompt.
+        # Dropping four layers to system memory buys a usable window, so the launch
+        # runs there rather than being refused.
+        fit, probed = self._staircase(24)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model, self.meta, available_bytes=2 * _GB, ctx_ceiling=16384
+        ) == ChatFit(gpu_layers=24, ctx=12288)
+        assert max(probed) <= 28  # never probes past the model's own layer count
+
+    def test_it_does_not_trade_when_the_weights_alone_overflow_the_budget(
+        self, monkeypatch
+    ) -> None:
+        # The bb-mud43 case: a model whose weights already exceed the budget only
+        # gets a usable window by running out of system memory, which is the load
+        # plan_launches refuses on purpose. Offload stays put and the refusal stands.
+        fit, probed = self._staircase(24)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model, self.meta, available_bytes=512, ctx_ceiling=16384
+        ) == ChatFit(gpu_layers=-1, ctx=512)
+        assert probed == [-1]
+
+    def test_it_does_not_trade_for_a_window_the_user_capped_below_the_minimum(
+        self, monkeypatch
+    ) -> None:
+        # A sub-minimum num_ctx_max / chat_n_ctx_target is an explicit choice, and
+        # _unusable_chat_ctx_reason honours it; nothing is bought by trading.
+        fit, probed = self._staircase(24)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model, self.meta, available_bytes=2 * _GB, ctx_ceiling=1024
+        ) == ChatFit(gpu_layers=-1, ctx=512)
+        assert probed == [-1]
+
+    def test_it_does_not_trade_without_a_layer_count(self, monkeypatch) -> None:
+        # No block_count means no grid to search, so the configured offload stands.
+        fit, probed = self._staircase(24)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model, {}, available_bytes=2 * _GB, ctx_ceiling=16384
+        ) == ChatFit(gpu_layers=-1, ctx=512)
+        assert probed == [-1]
+
+    def test_it_stays_under_a_user_set_offload(self, monkeypatch) -> None:
+        # cfg.n_gpu_layers is the ceiling the user asked for; the trade only ever
+        # moves layers off the card, never onto it.
+        monkeypatch.setattr(cfg, "n_gpu_layers", 20)
+        fit, probed = self._staircase(10)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model, self.meta, available_bytes=2 * _GB, ctx_ceiling=16384
+        ) == ChatFit(gpu_layers=10, ctx=12288)
+        assert max(probed) == 20
+
+    def test_it_keeps_the_configured_offload_when_no_reduction_serves(self, monkeypatch) -> None:
+        # A model that cannot reach the minimum at any offload is still refused,
+        # and is refused with the window full offload would have served.
+        fit, _probed = self._staircase(-1)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model, self.meta, available_bytes=2 * _GB, ctx_ceiling=16384
+        ) == ChatFit(gpu_layers=-1, ctx=512)
 
 
 class TestPlacementChargesAgainstFreeMemory:
@@ -2461,11 +2596,11 @@ class TestSizingBudgetComesFromTheDevice:
         monkeypatch.setattr(cfg, "num_ctx", None)
         seen: list[int] = []
 
-        def _record_ctx(_path, _meta, *, available_bytes=None):
+        def _record_fit(_path, _meta, *, available_bytes=None):
             seen.append(available_bytes)
-            return 4096
+            return ChatFit(gpu_layers=-1, ctx=4096)
 
-        monkeypatch.setattr("lilbee.providers.engine_params.resolve_chat_ctx", _record_ctx)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_chat_fit", _record_fit)
         plan = InstancePlan(role=WorkerRole.CHAT, devices=(1,))
         planning_mod._launch_for(plan, "ref", Path("/bin/llama-server"), {0: small, 1: large})
         assert seen == [int(48 * _GB * cfg.gpu_memory_fraction)]

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -2322,6 +2322,24 @@ class TestChatOffloadTradedForWindow:
         ) == ChatFit(gpu_layers=-1, ctx=512)
         assert probed == [-1]
 
+    def test_it_does_not_trade_for_a_speculator_head(self, monkeypatch) -> None:
+        # A speculator scores every position it proposes, so its compute buffer
+        # grows with the window while the estimate prices it by the physical
+        # batch. The trade maximises that window, so the estimate it searches
+        # gets further from the truth the more it trades. Measured: the trade
+        # granted gemma-4-26B-A4B-eagle3 59648 tokens on a 1 GiB card against a
+        # real 1413 MiB.
+        fit, probed = self._staircase(24)
+        monkeypatch.setattr(planning_mod.fleet_ctx, "fit_single_ctx", fit)
+
+        assert planning_mod.fit_chat_ctx(
+            self.model,
+            {**self.meta, "architecture": "eagle3"},
+            available_bytes=2 * _GB,
+            ctx_ceiling=16384,
+        ) == ChatFit(gpu_layers=-1, ctx=512)
+        assert probed == [-1]
+
     def test_it_does_not_trade_without_a_layer_count(self, monkeypatch) -> None:
         # No block_count means no grid to search, so the configured offload stands.
         fit, probed = self._staircase(24)


### PR DESCRIPTION
## Problem

A chat model whose fitted window cannot hold a grounded prompt is refused. That is right for a model too big for the box, and wrong for one that would fit with a layer or two in system memory.

DeepSeek-R1-Distill-Qwen-1.5B Q4_K_M is 1.04 GiB and is refused on a 2 GiB card at 512 tokens. The same file serves a 16384-token window with all 28 of its blocks on the card and only the output layer off it. For a 151k-vocab model that one tensor is the whole difference.

Reported on a 2014 laptop, on a model that worked before 0.6.90b420. The window sizing moved to gguf-parser in that window, whose footprint adds a compute buffer the older header math did not charge. The newer estimate is the more accurate one; what was missing is the fallback.

## The window and the offload are chosen together

`fit_chat_ctx` asked what window fit at the configured offload. It now asks which offload and window serve together and returns the pair as a `ChatFit`, so the launch runs the offload its window was sized against rather than recomputing one. The search bisects the layer grid: the estimate charges less the fewer layers the card holds, so the fitted window is monotone in the offload.

## Layers are traded only while the weights fit

Past that the trade serves the model from system memory, which is the unusable load the refusal exists to prevent. A 70B Q4_K_M wanting 40.5 GiB against a 36 GiB budget still refuses.

A `num_ctx` pin, a window the user capped below the minimum, a tensor split, and an architecture that reports no layer count all keep the configured offload.

## Validation

3080 cells: 154 text models x 10 card sizes x both memory models, against 990 before. 23 rescued, 0 lost, 0 unified cells changed. `served_config_moved` is 0, so in every cell where the base already served, the branch chose the identical offload and window and no working model has its offload quietly reduced.

Monotonicity, which the binary search depends on, was walked in full rather than sampled: 10 models x 4 cards, 1320 offload points. Adding a layer to the card never increased the fitted window, and replaying the search over each measured curve returns the true best offload on all 40 curves.

Of the 23 traded configurations, 20 of the 21 measurable were loaded into a live llama-server at exactly their chosen offload and window, with model, KV and compute measured on the device, and verified to allocate under budget at a tightest genuine margin of +198.8 MiB. Two resist measurement for different reasons: `bge-m3` is an embedding model the server refuses to load as chat, so it never reaches allocation, and `PLM-1.8B` trips a `GGML_ASSERT` inside the engine before it finishes loading. The one wrong rescue was `gemma-4-26B-A4B-eagle3`, which the second commit fixes.

## Not covered

Answering through a discrete GPU. The traded configurations were verified to allocate under budget on a live llama-server, not to serve a chat turn. The budgets are also modelled rather than physical: every load ran on one MI300X, so a 1 GiB or 6 GiB card was a number given to the planner, not hardware the allocator faced. The tightest margin, +198.8 MiB on Ling-3.0-tiny against a 4608 MiB budget, is exactly the case a real 6 GiB card would test, with its own fragmentation and driver reserve.
