### PR TITLE
Show the README demos as videos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: lint format format-check typecheck test test-ci test-ci-serial test-ci-forked test-integration imports-check fuzz-smoke engine-archs check clean install demo demo-prep demo-publish build publish release promote release-promote docs docs-api docs-site site site-serve site-tar dns-setup qa-pod-volume qa-pod-up qa-pod-logs qa-pod-down
 
 lint:
-	uv run ruff check src/ tests/ tools/qa/ scripts/qa/
+	uv run ruff check src/ tests/ tools/qa/ scripts/qa/ tools/readme_media.py hatch_build.py
 	uv run python scripts/check_style_rules.py
 
 format:
-	uv run ruff format src/ tests/ tools/qa/ scripts/qa/
+	uv run ruff format src/ tests/ tools/qa/ scripts/qa/ tools/readme_media.py hatch_build.py
 
 format-check:
-	uv run ruff format --check src/ tests/ tools/qa/ scripts/qa/
+	uv run ruff format --check src/ tests/ tools/qa/ scripts/qa/ tools/readme_media.py hatch_build.py
 
 typecheck:
 	uv run mypy src/lilbee/
@@ -16,6 +16,9 @@ typecheck:
 	# changes: multi_gpu_smoke crashed on its first check from #540 until this
 	# was added. The rest of tools/qa/ is not clean yet and is not listed.
 	uv run mypy tools/qa/placement_matrix/ tools/qa/multi_gpu_smoke.py
+	# hatch_build.py builds the PyPI long description, so a break here breaks
+	# the release rather than a test.
+	uv run mypy tools/readme_media.py hatch_build.py
 
 test:
 	uv run pytest --cov=lilbee --cov-report=term-missing -v -n logical --dist loadgroup

--- a/README.md
+++ b/README.md
@@ -366,13 +366,13 @@ of seconds.
 
 **Very first launch:** a one-time unpack bar, chat opens, and the first answer shows the engine loading in its bubble before it streams.
 
-<!-- demos/first-start.mp4 -->
+<!-- demo: first-start | First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams -->
 
 https://github.com/user-attachments/assets/e5ea75e2-1e91-47c2-9463-4b85d87408ea
 
 **Every launch after:** chat opens in about two seconds and the answer follows.
 
-<!-- demos/later-start.mp4 -->
+<!-- demo: later-start | Every later launch: chat opens in about two seconds and the answer follows -->
 
 https://github.com/user-attachments/assets/f07043ca-d9e6-40b0-a5ad-225013dfa3a0
 
@@ -394,13 +394,13 @@ lifecycle and how to keep the engine warm so relaunches skip the load.
 
 Point lilbee at a folder of PDFs, notes, ebooks, or code and it builds a searchable library, with citations that click back to the source line. The pattern works for anything you have a lot of text about: a shelf of appliance manuals, a field's research papers, a car's service manuals, your company's internal wiki. Whatever you give it becomes searchable, and you can talk to it.
 
-<!-- demos/tui-add.mp4 -->
+<!-- demo: tui-add | /add a PDF, watch the Task Center, ask a cited question -->
 
 https://github.com/user-attachments/assets/73903a5c-9c0a-42a8-9ffd-bdf34f719c29
 
 Ask it something with a real answer at stake and you get the answer, not a paraphrase of the question. Here it reads the towing section out of a car manual and answers with the page it came from, so you can check it. The panel on the right is the GPU doing it, on this machine.
 
-<!-- demos/tui-chat.mp4 -->
+<!-- demo: tui-chat | ask what the manual says about towing a trailer; lilbee answers from the indexed PDF and cites the page -->
 
 https://github.com/user-attachments/assets/284c316c-85f8-46d1-9531-59476f0db9f7
 
@@ -408,13 +408,13 @@ https://github.com/user-attachments/assets/284c316c-85f8-46d1-9531-59476f0db9f7
 
 Install the `[crawler]` extra, point lilbee at a docs site, a wiki, or a vendor's API reference, and the pages get fetched, converted to markdown, and added to your library. From then on you can search or chat with that copy of the site offline, even after it changes or goes down.
 
-<!-- demos/tui-crawl.mp4 -->
+<!-- demo: tui-crawl | /crawl a Wikipedia page, then ask a cited question against it -->
 
 https://github.com/user-attachments/assets/8380c49b-cc65-43ae-83d4-ba9e3aa84af4
 
 Or crawl a whole site, not just one page. With recursive crawling on, lilbee follows the links and indexes the lot; watch the page count climb in the Task Center, then ask one question that synthesizes across the whole site.
 
-<!-- demos/tui-crawl-site.mp4 -->
+<!-- demo: tui-crawl-site | crawl a whole site at depth 1, then ask a multipart question that spans it: a cited answer drawn from across the pages, with Qwen3-8B and a reranker -->
 
 https://github.com/user-attachments/assets/0c7fbed2-9b40-4976-9856-1720c4f9ffb0
 
@@ -489,7 +489,7 @@ lilbee's engine is llama.cpp, so lilbee runs what llama.cpp runs: any GGUF model
 
 One representative per family also runs the full pipeline end to end on real GPUs -- the models, method, and results are in [docs/tested-models.md](docs/tested-models.md).
 
-<!-- demos/tui-catalog.mp4 -->
+<!-- demo: tui-catalog | browse the model catalog, search Hugging Face Hub, pull a model live -->
 
 https://github.com/user-attachments/assets/993a63d4-9468-4a55-b9ed-e4b1ae1ed235
 
@@ -505,11 +505,11 @@ https://github.com/user-attachments/assets/993a63d4-9468-4a55-b9ed-e4b1ae1ed235
 
 Both reels run chat *and* embedding on the other manager's models, picked out of the catalog's Library tab where each row names the server it runs on.
 
-<!-- demos/tui-ollama-document.mp4 -->
+<!-- demo: tui-ollama-document | models served by Ollama, picked from the catalog, answering from an indexed manual -->
 
 https://github.com/user-attachments/assets/52635a74-b69f-42df-b427-3c8f8499323f
 
-<!-- demos/tui-lmstudio-document.mp4 -->
+<!-- demo: tui-lmstudio-document | models served by LM Studio, picked from the catalog, answering from an indexed manual -->
 
 https://github.com/user-attachments/assets/13ec8b12-f931-46ac-a500-8a7940d1a2bd
 
@@ -517,7 +517,7 @@ https://github.com/user-attachments/assets/13ec8b12-f931-46ac-a500-8a7940d1a2bd
 
 Hugging Face has thousands of GGUFs, but the bundled llama.cpp only supports a subset of architectures and brand-new ones take time to reach the pinned runtime. lilbee tags incompatible models in the catalog and refuses the download (with an override confirm), so you don't wait through a multi-GB pull only to hit "unsupported architecture" at load.
 
-<!-- demos/tui-unsupported.mp4 -->
+<!-- demo: tui-unsupported | search HF Hub for deepseek-v4, see the unsupported pill in grid and list view -->
 
 https://github.com/user-attachments/assets/b42effc3-a7f6-4391-904c-3ac897712172
 
@@ -540,25 +540,25 @@ lilbee serves your coding agents two ways, both local: it runs the models they t
 
 One model serves as many agents as you want to run. These reels show four working at once against a single local model, each in its own worktree, reading and searching this repository through lilbee.
 
-<!-- demos/agents-coder-next.mp4 -->
+<!-- demo: agents-coder-next | four agents at once on Qwen3 Coder Next, reading and searching this repository through lilbee -->
 
 https://github.com/user-attachments/assets/5f3fd1a4-f946-4008-bfd8-600142785327
 
 Qwen3 Coder Next, 45GB across three RTX 4090s: four agents on one model, 138 tokens a second warm.
 
-<!-- demos/agents-gemma4.mp4 -->
+<!-- demo: agents-gemma4 | four agents on Gemma 4 26B, its reasoning streamed as visible text -->
 
 https://github.com/user-attachments/assets/510a1691-4289-4d98-b749-7522c1f28559
 
 Gemma 4 26B is a thinking model, and lilbee streams its reasoning as visible text: every pane shows the model working through the problem before it answers.
 
-<!-- demos/agents-qwen36.mp4 -->
+<!-- demo: agents-qwen36 | four agents on Qwen3.6 27B, thinking out loud on the same tasks -->
 
 https://github.com/user-attachments/assets/06dbf829-1e1e-4a1f-9ca2-32aa65086f13
 
 Qwen3.6 27B on the same four tasks: each agent states what it expects, then reads the code to check itself.
 
-<!-- demos/agents-devstral-123b-solo.mp4 -->
+<!-- demo: agents-devstral-123b-solo | one agent on Devstral 2 123B, walking through lilbee's GPU placement code -->
 
 https://github.com/user-attachments/assets/46ce5440-ee9d-4420-a881-031a1ccccec8
 
@@ -566,7 +566,7 @@ And the same setup scales up: Devstral 2 123B, 70GB across two A100 80GB cards, 
 
 It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 
-<!-- demos/mcp-code-self-tune.mp4 -->
+<!-- demo: mcp-code-self-tune | agent fine-tunes lilbee mid-conversation: outline, then widened retrieval, then source with file:line citations -->
 
 https://github.com/user-attachments/assets/7bfec600-4c06-4a2f-8f77-be7e92f4f33f
 
@@ -580,7 +580,7 @@ Your files, the search index, and the embeddings stay on your computer. The agen
 
 When a chat model won't fit on a single GPU, lilbee spreads it across the ones you have. It sizes each role's memory with gguf-parser, keeps headroom on every card, and tensor-splits the chat model across the fewest GPUs that fit, with the embedder, reranker, and vision models placed alongside it behind a load-balancing router. This is automatic: ask a question and the model loads split across your cards, answering from your own indexed source. Here a 70B is spread across three consumer cards and answers a mechanic's question from an indexed car manual, citing the page it came from.
 
-<!-- demos/tui-auto-placement.mp4 -->
+<!-- demo: tui-auto-placement | a 70B spread across three cards without being asked, answering from an indexed manual with a citation -->
 
 https://github.com/user-attachments/assets/2a2232e6-d8ce-4302-92e4-6467f4fb1bee
 
@@ -590,35 +590,35 @@ You can also place it by hand. The placement editor pins each role to the cards 
 
 `lilbee` (no args) launches a full Textual terminal app: streaming chat with clickable citations, a model bar with searchable pickers and a Search/Chat toggle, a Task Center for background jobs, and screens for the model catalog, settings, and the generated wiki. Type `/` for the command list; tab completion works everywhere.
 
-<!-- demos/tui-tour.mp4 -->
+<!-- demo: tui-tour | sweep through every TUI screen -->
 
 https://github.com/user-attachments/assets/ab4c5847-2261-421d-91a0-e3838498901c
 
 `Ctrl+P` opens the Textual command palette, `?` on an empty prompt (or `F1` anywhere) toggles the keybinding cheat sheet, `/help` opens the slash-command catalog. Every action lilbee can take is reachable from one of those three.
 
-<!-- demos/tui-palette.mp4 -->
+<!-- demo: tui-palette | command palette, keybinding cheat sheet, slash-command catalog -->
 
 https://github.com/user-attachments/assets/7c4f1096-44a4-40b5-b511-0f6496c520c5
 
 Conversations are kept. Reopen an earlier one and it comes back with its history and citations intact.
 
-<!-- demos/sessions.mp4 -->
+<!-- demo: sessions | resume an earlier conversation from the sessions drawer -->
 
 https://github.com/user-attachments/assets/3ee7fb50-b983-4761-807c-2f024bbc3756
 
 Tell it something about yourself and it remembers, across conversations rather than only within one.
 
-<!-- demos/tui-memory.mp4 -->
+<!-- demo: tui-memory | remember a fact and a preference, then answer from them in a brand new chat -->
 
 https://github.com/user-attachments/assets/08a69c31-d74f-4e0a-97b6-340dc195848c
 
 Every setting is editable in the app, and the first run opens the model catalog to get you started.
 
-<!-- demos/tui-settings.mp4 -->
+<!-- demo: tui-settings | walk every settings pane without leaving the terminal -->
 
 https://github.com/user-attachments/assets/a578dfd1-61a5-4008-b9bf-e94539003b6e
 
-<!-- demos/tui-setup.mp4 -->
+<!-- demo: tui-setup | first run: pick a model from the catalog, and go -->
 
 https://github.com/user-attachments/assets/702975d8-5c1f-4fa7-92a6-bf594ef9d2e3
 
@@ -679,7 +679,7 @@ lilbee reads the documents you've indexed and writes a wiki about them: one page
 
 Pages are written on demand: open one that does not exist yet and lilbee writes it from the sources it has, then links it into the rest.
 
-<!-- demos/wiki-lazy.mp4 -->
+<!-- demo: wiki-lazy | browse a cited wiki, then watch lilbee write a new page on demand -->
 
 https://github.com/user-attachments/assets/3ba1478e-86b0-4a90-aba1-99384b4f92fb
 

--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ https://github.com/user-attachments/assets/a578dfd1-61a5-4008-b9bf-e94539003b6e
 
 https://github.com/user-attachments/assets/702975d8-5c1f-4fa7-92a6-bf594ef9d2e3
 
-Every video on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) with long-form captions. Tape sources are in [`demos/`](demos). For commands and settings, see the [usage guide](docs/usage.md).
+Every reel on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) with long-form captions. Tape sources are in [`demos/`](demos). For commands and settings, see the [usage guide](docs/usage.md).
 
 ## HTTP Server
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It's all one program: no separate model server, [vector database](#built-on), or
 
 Models are no different: lilbee has its own model manager and multi-GPU fleet, built on llama.cpp, so one executable does everything (browse Hugging Face, download a model, give it a role, run it on Metal / Vulkan / CUDA). You don't need [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai) at all: the [architectures lilbee runs](#supported-models) are behind most of the 190,000+ GGUF repos on Hugging Face, with representatives [verified on real GPUs](docs/tested-models.md). If you already use them, point lilbee at your existing setup and keep your models.
 
-> **Tutorial reel:** every demo on this page (and the extras) as a real video player at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial).
+> **Tutorial reel:** every demo on this page, plus the extras that don't fit here, with long-form captions at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial).
 
 > ## ⚠️ Beta software
 >
@@ -364,16 +364,17 @@ a progress bar, and the model loads before your first answer, shown live inside
 the answer bubble. Every launch after that opens straight to chat in a couple
 of seconds.
 
-<table>
-  <tr>
-    <th align="center">Very first launch</th>
-    <th align="center">Every launch after</th>
-  </tr>
-  <tr>
-    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="380"></td>
-    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="380"></td>
-  </tr>
-</table>
+**Very first launch:** a one-time unpack bar, chat opens, and the first answer shows the engine loading in its bubble before it streams.
+
+<!-- demos/first-start.mp4 -->
+
+https://github.com/user-attachments/assets/e5ea75e2-1e91-47c2-9463-4b85d87408ea
+
+**Every launch after:** chat opens in about two seconds and the answer follows.
+
+<!-- demos/later-start.mp4 -->
+
+https://github.com/user-attachments/assets/f07043ca-d9e6-40b0-a5ad-225013dfa3a0
 
 Measured with a small chat model (Qwen3 0.6B):
 
@@ -393,21 +394,29 @@ lifecycle and how to keep the engine warm so relaunches skip the load.
 
 Point lilbee at a folder of PDFs, notes, ebooks, or code and it builds a searchable library, with citations that click back to the source line. The pattern works for anything you have a lot of text about: a shelf of appliance manuals, a field's research papers, a car's service manuals, your company's internal wiki. Whatever you give it becomes searchable, and you can talk to it.
 
-![/add a PDF, watch the Task Center, ask a cited question](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-add.gif)
+<!-- demos/tui-add.mp4 -->
+
+https://github.com/user-attachments/assets/73903a5c-9c0a-42a8-9ffd-bdf34f719c29
 
 Ask it something with a real answer at stake and you get the answer, not a paraphrase of the question. Here it reads the towing section out of a car manual and answers with the page it came from, so you can check it. The panel on the right is the GPU doing it, on this machine.
 
-![ask what the manual says about towing a trailer; lilbee answers from the indexed PDF and cites the page](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
+<!-- demos/tui-chat.mp4 -->
+
+https://github.com/user-attachments/assets/284c316c-85f8-46d1-9531-59476f0db9f7
 
 ### Offline copies of websites
 
 Install the `[crawler]` extra, point lilbee at a docs site, a wiki, or a vendor's API reference, and the pages get fetched, converted to markdown, and added to your library. From then on you can search or chat with that copy of the site offline, even after it changes or goes down.
 
-![/crawl a Wikipedia page, then ask a cited question against it](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.gif)
+<!-- demos/tui-crawl.mp4 -->
+
+https://github.com/user-attachments/assets/8380c49b-cc65-43ae-83d4-ba9e3aa84af4
 
 Or crawl a whole site, not just one page. With recursive crawling on, lilbee follows the links and indexes the lot; watch the page count climb in the Task Center, then ask one question that synthesizes across the whole site.
 
-![crawl a whole site at depth 1, then ask a multipart question that spans it: a cited answer drawn from across the pages, with Qwen3-8B and a reranker](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.gif)
+<!-- demos/tui-crawl-site.mp4 -->
+
+https://github.com/user-attachments/assets/0c7fbed2-9b40-4976-9856-1720c4f9ffb0
 
 ### Documents, code, and scanned images
 
@@ -480,7 +489,9 @@ lilbee's engine is llama.cpp, so lilbee runs what llama.cpp runs: any GGUF model
 
 One representative per family also runs the full pipeline end to end on real GPUs -- the models, method, and results are in [docs/tested-models.md](docs/tested-models.md).
 
-![browse the model catalog, search Hugging Face Hub, pull a model live](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-catalog.gif)
+<!-- demos/tui-catalog.mp4 -->
+
+https://github.com/user-attachments/assets/993a63d4-9468-4a55-b9ed-e4b1ae1ed235
 
 ### Already running Ollama or LM Studio? Keep them.
 
@@ -494,15 +505,21 @@ One representative per family also runs the full pipeline end to end on real GPU
 
 Both reels run chat *and* embedding on the other manager's models, picked out of the catalog's Library tab where each row names the server it runs on.
 
-![models served by Ollama, picked from the catalog, answering from an indexed manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-ollama-document.gif)
+<!-- demos/tui-ollama-document.mp4 -->
 
-![models served by LM Studio, picked from the catalog, answering from an indexed manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-lmstudio-document.gif)
+https://github.com/user-attachments/assets/52635a74-b69f-42df-b427-3c8f8499323f
+
+<!-- demos/tui-lmstudio-document.mp4 -->
+
+https://github.com/user-attachments/assets/13ec8b12-f931-46ac-a500-8a7940d1a2bd
 
 ### See when a model won't load before you download it
 
 Hugging Face has thousands of GGUFs, but the bundled llama.cpp only supports a subset of architectures and brand-new ones take time to reach the pinned runtime. lilbee tags incompatible models in the catalog and refuses the download (with an override confirm), so you don't wait through a multi-GB pull only to hit "unsupported architecture" at load.
 
-![search HF Hub for deepseek-v4, see the unsupported pill in grid and list view](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-unsupported.gif)
+<!-- demos/tui-unsupported.mp4 -->
+
+https://github.com/user-attachments/assets/b42effc3-a7f6-4391-904c-3ac897712172
 
 ### Cloud models, when you want them
 
@@ -523,25 +540,35 @@ lilbee serves your coding agents two ways, both local: it runs the models they t
 
 One model serves as many agents as you want to run. These reels show four working at once against a single local model, each in its own worktree, reading and searching this repository through lilbee.
 
-![four agents at once on Qwen3 Coder Next, reading and searching this repository through lilbee](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-coder-next.gif)
+<!-- demos/agents-coder-next.mp4 -->
+
+https://github.com/user-attachments/assets/5f3fd1a4-f946-4008-bfd8-600142785327
 
 Qwen3 Coder Next, 45GB across three RTX 4090s: four agents on one model, 138 tokens a second warm.
 
-![four agents on Gemma 4 26B, its reasoning streamed as visible text](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-gemma4.gif)
+<!-- demos/agents-gemma4.mp4 -->
+
+https://github.com/user-attachments/assets/510a1691-4289-4d98-b749-7522c1f28559
 
 Gemma 4 26B is a thinking model, and lilbee streams its reasoning as visible text: every pane shows the model working through the problem before it answers.
 
-![four agents on Qwen3.6 27B, thinking out loud on the same tasks](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-qwen36.gif)
+<!-- demos/agents-qwen36.mp4 -->
+
+https://github.com/user-attachments/assets/06dbf829-1e1e-4a1f-9ca2-32aa65086f13
 
 Qwen3.6 27B on the same four tasks: each agent states what it expects, then reads the code to check itself.
 
-![one agent on Devstral 2 123B, walking through lilbee's GPU placement code](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/agents-devstral-123b-solo.gif)
+<!-- demos/agents-devstral-123b-solo.mp4 -->
+
+https://github.com/user-attachments/assets/46ce5440-ee9d-4420-a881-031a1ccccec8
 
 And the same setup scales up: Devstral 2 123B, 70GB across two A100 80GB cards, one agent at the model's full 14 tokens a second.
 
 It tunes itself, too. Tell a small local model to widen lilbee's search when a first result comes back thin, and the second pass returns full function bodies with file:line citations; a more capable model does the same from a prompt like "improve your search results." The [lilbee-mcp skill](src/lilbee/skills/lilbee_mcp/SKILL.md) teaches your own model the pattern.
 
-![agent fine-tunes lilbee mid-conversation: outline, then widened retrieval, then source with file:line citations](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/mcp-code-self-tune.gif)
+<!-- demos/mcp-code-self-tune.mp4 -->
+
+https://github.com/user-attachments/assets/7bfec600-4c06-4a2f-8f77-be7e92f4f33f
 
 ### A reference for AI agents
 
@@ -553,7 +580,9 @@ Your files, the search index, and the embeddings stay on your computer. The agen
 
 When a chat model won't fit on a single GPU, lilbee spreads it across the ones you have. It sizes each role's memory with gguf-parser, keeps headroom on every card, and tensor-splits the chat model across the fewest GPUs that fit, with the embedder, reranker, and vision models placed alongside it behind a load-balancing router. This is automatic: ask a question and the model loads split across your cards, answering from your own indexed source. Here a 70B is spread across three consumer cards and answers a mechanic's question from an indexed car manual, citing the page it came from.
 
-![a 70B spread across three cards without being asked, answering from an indexed manual with a citation](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-auto-placement.gif)
+<!-- demos/tui-auto-placement.mp4 -->
+
+https://github.com/user-attachments/assets/2a2232e6-d8ce-4302-92e4-6467f4fb1bee
 
 You can also place it by hand. The placement editor pins each role to the cards you choose, previews the fit before anything loads, and applies it live. Ask for a layout that can't fit and it tells you the exact shortfall instead of failing at load time.
 
@@ -561,27 +590,39 @@ You can also place it by hand. The placement editor pins each role to the cards 
 
 `lilbee` (no args) launches a full Textual terminal app: streaming chat with clickable citations, a model bar with searchable pickers and a Search/Chat toggle, a Task Center for background jobs, and screens for the model catalog, settings, and the generated wiki. Type `/` for the command list; tab completion works everywhere.
 
-![sweep through every TUI screen](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tour.gif)
+<!-- demos/tui-tour.mp4 -->
+
+https://github.com/user-attachments/assets/ab4c5847-2261-421d-91a0-e3838498901c
 
 `Ctrl+P` opens the Textual command palette, `?` on an empty prompt (or `F1` anywhere) toggles the keybinding cheat sheet, `/help` opens the slash-command catalog. Every action lilbee can take is reachable from one of those three.
 
-![command palette, keybinding cheat sheet, slash-command catalog](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-palette.gif)
+<!-- demos/tui-palette.mp4 -->
+
+https://github.com/user-attachments/assets/7c4f1096-44a4-40b5-b511-0f6496c520c5
 
 Conversations are kept. Reopen an earlier one and it comes back with its history and citations intact.
 
-![resume an earlier conversation from the sessions drawer](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/sessions.gif)
+<!-- demos/sessions.mp4 -->
+
+https://github.com/user-attachments/assets/3ee7fb50-b983-4761-807c-2f024bbc3756
 
 Tell it something about yourself and it remembers, across conversations rather than only within one.
 
-![remember a fact and a preference, then answer from them in a brand new chat](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-memory.gif)
+<!-- demos/tui-memory.mp4 -->
+
+https://github.com/user-attachments/assets/08a69c31-d74f-4e0a-97b6-340dc195848c
 
 Every setting is editable in the app, and the first run opens the model catalog to get you started.
 
-![walk every settings pane without leaving the terminal](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-settings.gif)
+<!-- demos/tui-settings.mp4 -->
 
-![first run: pick a model from the catalog, and go](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-setup.gif)
+https://github.com/user-attachments/assets/a578dfd1-61a5-4008-b9bf-e94539003b6e
 
-Every GIF on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) as an embedded video with long-form captions. Tape sources are in [`demos/`](demos). For commands and settings, see the [usage guide](docs/usage.md).
+<!-- demos/tui-setup.mp4 -->
+
+https://github.com/user-attachments/assets/702975d8-5c1f-4fa7-92a6-bf594ef9d2e3
+
+Every video on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) with long-form captions. Tape sources are in [`demos/`](demos). For commands and settings, see the [usage guide](docs/usage.md).
 
 ## HTTP Server
 
@@ -638,7 +679,9 @@ lilbee reads the documents you've indexed and writes a wiki about them: one page
 
 Pages are written on demand: open one that does not exist yet and lilbee writes it from the sources it has, then links it into the rest.
 
-![browse a cited wiki, then watch lilbee write a new page on demand](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/wiki-lazy.gif)
+<!-- demos/wiki-lazy.mp4 -->
+
+https://github.com/user-attachments/assets/3ba1478e-86b0-4a90-aba1-99384b4f92fb
 
 See the [usage guide](docs/usage.md#wiki) for commands and configuration, and [how the wiki is validated](docs/benchmarks/wiki-validation.md) for the evidence behind it.
 

--- a/README.md
+++ b/README.md
@@ -364,17 +364,16 @@ a progress bar, and the model loads before your first answer, shown live inside
 the answer bubble. Every launch after that opens straight to chat in a couple
 of seconds.
 
-**Very first launch:** a one-time unpack bar, chat opens, and the first answer shows the engine loading in its bubble before it streams.
-
-<!-- demo: first-start | First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams -->
-
-https://github.com/user-attachments/assets/e5ea75e2-1e91-47c2-9463-4b85d87408ea
-
-**Every launch after:** chat opens in about two seconds and the answer follows.
-
-<!-- demo: later-start | Every later launch: chat opens in about two seconds and the answer follows -->
-
-https://github.com/user-attachments/assets/f07043ca-d9e6-40b0-a5ad-225013dfa3a0
+<table>
+  <tr>
+    <th align="center">Very first launch</th>
+    <th align="center">Every launch after</th>
+  </tr>
+  <tr>
+    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="380"></td>
+    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="380"></td>
+  </tr>
+</table>
 
 Measured with a small chat model (Qwen3 0.6B):
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,29 @@
+"""Build the PyPI long description from README.md.
+
+The README's demos are GitHub video players, which only GitHub renders. This
+hook rewrites them to the gh-pages GIFs of the same reels so the PyPI page
+keeps its moving pictures. tools/readme_media.py has the details.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+# hatchling loads this file directly rather than importing it as part of the
+# project, so the repository root is not on sys.path and `tools` is invisible.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from tools.readme_media import to_gifs
+
+
+class CustomMetadataHook(MetadataHookInterface):
+    def update(self, metadata: dict[str, Any]) -> None:
+        readme = Path(self.root) / "README.md"
+        metadata["readme"] = {
+            "content-type": "text/markdown",
+            "text": to_gifs(readme.read_text(encoding="utf-8")),
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 name = "lilbee"
 version = "0.6.90b428"
 description = "The whole local AI stack in one executable: run and manage local AI models across every GPU you have, and search your files, code, and the web pages you crawl, with answers that cite the source. Per-project libraries, semantic and hybrid search, vision OCR, an auto-built wiki, CLI, TUI, MCP server, REST API, and Python library. No model server, no database server, no containers. Works with your own Ollama or LM Studio models too."
-readme = "README.md"
 license = "MIT"
 authors = [{ name = "tobocop2", email = "5562156+tobocop2@users.noreply.github.com" }]
 requires-python = ">=3.11"
+dynamic = ["readme"]
 keywords = [
     "rag", "local-rag", "local-llm", "local-ai",
     "mcp", "mcp-server", "model-context-protocol",
@@ -117,6 +117,11 @@ lilbee = "lilbee.runtime.launcher:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# The README shows each demo as a GitHub video player, which only GitHub
+# renders. hatch_build.py rewrites those back to the gh-pages GIFs so the PyPI
+# page keeps its moving pictures instead of a wall of links.
+[tool.hatch.metadata.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/lilbee"]

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -8,7 +8,13 @@ from tools.readme_media import GIF_BASE, VIDEO_BLOCK, to_gifs
 
 README = Path(__file__).resolve().parents[1] / "README.md"
 HERO = "what_is_lilbee"
+# The hero animates the top of the page on first paint, and the two launch
+# reels sit side by side in a comparison table, where a bare URL cannot become
+# a player. Every other demo is a video.
+KEPT_GIFS = {HERO, "first-start", "later-start"}
+
 GIF_IMAGE = re.compile(rf"!\[([^\]]*)\]\({re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif\)")
+GIF_REF = re.compile(rf"{re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif")
 
 
 def _readme() -> str:
@@ -24,6 +30,7 @@ def test_every_readme_video_becomes_its_own_captioned_gif() -> None:
 
     assert "user-attachments/assets" not in rendered
     assert "<!-- demo:" not in rendered
+    assert set(GIF_REF.findall(rendered)) >= KEPT_GIFS, "the kept GIFs pass through untouched"
     # Caption and demo must stay paired: a GIF carrying the wrong reel's caption
     # is the failure this rebuild exists to avoid, and counting cannot see it.
     hero, *rebuilt = [(demo, caption) for caption, demo in GIF_IMAGE.findall(rendered)]
@@ -31,9 +38,8 @@ def test_every_readme_video_becomes_its_own_captioned_gif() -> None:
     assert rebuilt == videos, "each video becomes its own captioned GIF, in order"
 
 
-def test_the_hero_is_the_only_gif_left_on_github() -> None:
-    demos = [demo for _, demo in GIF_IMAGE.findall(_readme())]
-    assert demos == [HERO], "every demo but the hero should be a video on GitHub"
+def test_only_the_kept_reels_are_still_gifs_on_github() -> None:
+    assert set(GIF_REF.findall(_readme())) == KEPT_GIFS
 
 
 def test_a_video_without_a_caption_comment_is_rejected() -> None:

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -8,28 +8,31 @@ from tools.readme_media import GIF_BASE, VIDEO_BLOCK, to_gifs
 
 README = Path(__file__).resolve().parents[1] / "README.md"
 HERO = "what_is_lilbee"
+GIF_IMAGE = re.compile(rf"!\[([^\]]*)\]\({re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif\)")
 
 
 def _readme() -> str:
     return README.read_text(encoding="utf-8")
 
 
-def test_every_readme_video_becomes_a_gif() -> None:
+def test_every_readme_video_becomes_its_own_captioned_gif() -> None:
     source = _readme()
-    videos = VIDEO_BLOCK.findall(source)
+    videos = [(m["demo"], m["caption"]) for m in VIDEO_BLOCK.finditer(source)]
     assert videos, "the README should still show its demos as GitHub video players"
 
     rendered = to_gifs(source)
 
     assert "user-attachments/assets" not in rendered
     assert "<!-- demo:" not in rendered
-    gifs = re.findall(rf"!\[([^\]]*)\]\({re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif\)", rendered)
-    assert len(gifs) == len(videos) + 1, "one GIF per video, plus the hero"
-    assert all(caption for caption, _ in gifs), "every GIF needs its caption as alt text"
+    # Caption and demo must stay paired: a GIF carrying the wrong reel's caption
+    # is the failure this rebuild exists to avoid, and counting cannot see it.
+    hero, *rebuilt = [(demo, caption) for caption, demo in GIF_IMAGE.findall(rendered)]
+    assert hero[0] == HERO, "the hero GIF still leads the page"
+    assert rebuilt == videos, "each video becomes its own captioned GIF, in order"
 
 
 def test_the_hero_is_the_only_gif_left_on_github() -> None:
-    demos = re.findall(rf"!\[[^\]]*\]\({re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif\)", _readme())
+    demos = [demo for _, demo in GIF_IMAGE.findall(_readme())]
     assert demos == [HERO], "every demo but the hero should be a video on GitHub"
 
 

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -1,0 +1,41 @@
+"""The README's videos must always survive the trip back to GIFs for PyPI."""
+
+import re
+from pathlib import Path
+
+import pytest
+from tools.readme_media import GIF_BASE, VIDEO_BLOCK, to_gifs
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+HERO = "what_is_lilbee"
+
+
+def _readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def test_every_readme_video_becomes_a_gif() -> None:
+    source = _readme()
+    videos = VIDEO_BLOCK.findall(source)
+    assert videos, "the README should still show its demos as GitHub video players"
+
+    rendered = to_gifs(source)
+
+    assert "user-attachments/assets" not in rendered
+    assert "<!-- demo:" not in rendered
+    gifs = re.findall(rf"!\[([^\]]*)\]\({re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif\)", rendered)
+    assert len(gifs) == len(videos) + 1, "one GIF per video, plus the hero"
+    assert all(caption for caption, _ in gifs), "every GIF needs its caption as alt text"
+
+
+def test_the_hero_is_the_only_gif_left_on_github() -> None:
+    demos = re.findall(rf"!\[[^\]]*\]\({re.escape(GIF_BASE)}([a-z0-9_-]+)\.gif\)", _readme())
+    assert demos == [HERO], "every demo but the hero should be a video on GitHub"
+
+
+def test_a_video_without_a_caption_comment_is_rejected() -> None:
+    orphan = (
+        "prose\n\nhttps://github.com/user-attachments/assets/0f3aac4b-51fa-4813-b2b9-000000000000\n"
+    )
+    with pytest.raises(ValueError, match="no GIF to fall back to"):
+        to_gifs(orphan)

--- a/tools/readme_media.py
+++ b/tools/readme_media.py
@@ -1,0 +1,40 @@
+"""Turn the README's GitHub video players back into GIFs.
+
+The README shows each demo as a GitHub video player: a bare
+``https://github.com/user-attachments/assets/<uuid>`` URL on its own line.
+GitHub is the only renderer that turns that into a player. PyPI prints it as a
+plain link, so the demos would go from moving pictures to a wall of URLs.
+
+Every video is preceded by a ``<!-- demo: <name> | <caption> -->`` comment, so
+the same reel's GIF on gh-pages is always recoverable, caption included. The
+PyPI long description is built through here (see hatch_build.py); GitHub gets
+the videos, PyPI keeps the GIFs, and the README stays the single source.
+"""
+
+from __future__ import annotations
+
+import re
+
+GIF_BASE = "https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/"
+
+VIDEO_BLOCK = re.compile(
+    r"<!-- demo: (?P<demo>[a-z0-9_-]+) \| (?P<caption>[^\n]*?) -->\n"
+    r"\n"
+    r"https://github\.com/user-attachments/assets/[0-9a-f-]+"
+)
+_ASSET_URL = "user-attachments/assets"
+
+
+def to_gifs(markdown: str) -> str:
+    """Replace every GitHub video block with the GIF of the same reel."""
+    result = VIDEO_BLOCK.sub(
+        lambda m: f"![{m['caption']}]({GIF_BASE}{m['demo']}.gif)",
+        markdown,
+    )
+    stray = [line for line in result.splitlines() if _ASSET_URL in line]
+    if stray:
+        raise ValueError(
+            "README video without a '<!-- demo: <name> | <caption> -->' comment "
+            f"above it, so it has no GIF to fall back to on PyPI: {stray}"
+        )
+    return result

--- a/tools/readme_media.py
+++ b/tools/readme_media.py
@@ -9,6 +9,11 @@ Every video is preceded by a ``<!-- demo: <name> | <caption> -->`` comment, so
 the same reel's GIF on gh-pages is always recoverable, caption included. The
 PyPI long description is built through here (see hatch_build.py); GitHub gets
 the videos, PyPI keeps the GIFs, and the README stays the single source.
+
+hatch-fancy-pypi-readme does the same substitution from pyproject.toml and was
+the obvious buy. It is one `re.sub` either way, and putting the pattern in TOML
+would either drop the missing-comment check below or make the test parse the
+pattern back out of pyproject. A build dependency is not worth that.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Problem

Every demo on the README was an animated GIF: heavy, unpausable, and all of them playing at once the moment the page loads.

## Solution

GitHub renders a bare `https://github.com/user-attachments/assets/<uuid>` URL as an inline video player with controls. That is the only shape that works. A `<video>` tag pointing at raw.githubusercontent.com or lilbee.sh is stripped by the markdown sanitizer, and raw or release-download URLs render as plain links. Each demo's mp4 already sat beside its GIF on gh-pages, so those are now uploaded to GitHub's attachment store and referenced by bare URL. 21 videos.

### What stays a GIF

Three reels. The "what is lilbee" hero, so the top of the page still moves on first paint. Then the two in the "very first launch" / "every launch after" comparison, which reads better as a side-by-side table. A bare URL only becomes a player at paragraph level, so it cannot sit in a table cell anyway.

### Captions

A video player carries no alt text, so each upload is named for what it shows. GitHub prints that filename above the player.

### PyPI keeps the GIFs

PyPI would print those URLs as plain links. A hatchling metadata hook builds the long description instead, rewriting each video back to the same reel's GIF and taking alt text from the `<!-- demo: name | caption -->` comment above it. A test fails the build if a video ever lands without one, and both files join `make lint` and `make typecheck`, since a break here fails the release rather than a test.

### Not covered

npm needs no change. `packages/lilbee/README.md` is its own file and shows only the hero GIF.
