### PR TITLE
Let a keep-warm engine unload its weights on the idle window

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Measured with a small chat model (Qwen3 0.6B):
 | | Very first launch | Every launch after |
 |---|---|---|
 | Chat on screen | 15 to 20s, one-time unpack | 2 to 3s |
-| First answer of the session | 10 to 20s, the engine load plays in the bubble | the same, or instant with **Keep engine warm** |
+| First answer of the session | 10 to 20s, the engine load plays in the bubble | the same, or instant with **Keep engine warm** inside the idle window |
 | Answers after that | model speed | model speed |
 
 Bigger models load longer; the bubble shows real progress while the weights load.

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -309,9 +309,10 @@ def services_scope(services: Services) -> Iterator[None]:
 def mark_interactive_session() -> None:
     """Record that this process is an interactive session before services build.
 
-    The TUI owns the process for its whole lifetime, so the fleet it builds keeps
-    its weights resident rather than idle-unloading under a user who is still in
-    the app; closing lilbee releases it. Called by the interactive entry point
+    The TUI owns the process for its whole lifetime, so an engine bound to it
+    keeps its weights resident rather than idle-unloading under a user who is
+    still in the app; closing lilbee releases it. A keep-warm engine outlives the
+    session and keeps its idle window instead. Called by the interactive entry point
     before anything touches ``get_services``, so the provider is constructed with
     that intent; a one-shot CLI or the MCP server never calls it.
     """

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -580,9 +580,10 @@ class Config(BaseSettings):
     worker_pool_eager_start: bool = ConfigField(default=True, writable=True)
 
     # Leave the engine fleet running on quit so the next launch adopts it warm.
-    # On keeps the engine resident: it never idle-unloads and survives app close
-    # so the next launch binds instantly. Off (default): the engine stops when
-    # the last lilbee process exits, leaving the machine clean.
+    # On keeps the engine process alive across app close so the next launch
+    # binds instantly; its weights still follow engine_idle_ttl_minutes. Off
+    # (default): the engine stops when the last lilbee process exits, leaving
+    # the machine clean.
     keep_engine_warm: bool = ConfigField(default=False, writable=True)
 
     # Hugging Face's high-performance transfer mode: more connections and much

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -15,9 +15,10 @@ if TYPE_CHECKING:
 def create_provider(config: Config, *, hold_warm: bool = False) -> LLMProvider:
     """Create a new LLM provider instance from the given config.
 
-    *hold_warm* marks the provider as serving an interactive session, so the local
-    fleet it composes keeps its weights resident instead of idle-unloading for as
-    long as that session owns the process. Irrelevant to a remote provider, which
+    *hold_warm* marks the provider as serving an interactive session, so a local
+    fleet bound to that session keeps its weights resident instead of
+    idle-unloading for as long as the session owns the process (a keep-warm fleet
+    outlives it and keeps its idle window). Irrelevant to a remote provider, which
     has no local engine to hold.
     """
     match config.llm_provider:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -844,9 +844,11 @@ class FleetProvider:
 
     def __init__(self, *, hold_warm: bool = False) -> None:
         # An interactive session (the TUI) owns this process for its whole
-        # lifetime, so its fleet stays resident instead of idle-unloading under a
-        # user who is still in the app; closing lilbee releases it. Set by the
-        # container that built this provider, never mutated afterwards.
+        # lifetime, so a fleet bound to it stays resident instead of idle-unloading
+        # under a user who is still in the app; closing lilbee releases it. A
+        # keep-warm fleet outlives the session, so _warm_ttl_seconds ignores the
+        # hold for it. Set by the container that built this provider, never
+        # mutated afterwards.
         self._hold_warm_for_session = hold_warm
         # One llama-swap per placed group, so restarting one group's servers (a
         # placement or per-role model change) never unloads another group's. A

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -822,15 +822,19 @@ def _warm_ttl_seconds(*, hold_warm_for_session: bool = False) -> int:
 
     A ttl of 0 keeps weights resident until the engine is stopped; otherwise an
     idle engine releases its weights after ``engine_idle_ttl_minutes`` and reloads
-    transparently on the next prompt. The timer is held off (ttl 0) whenever
-    someone is actively depending on an instant response: *hold_warm_for_session*
-    is set for a provider serving an interactive session, which owns the process
-    for its whole lifetime (close lilbee to release the engine); a bulk ingest
-    holds the fleet resident for its run so an unevenly loaded replica cannot
-    idle-unload and reload cold mid-run; and ``keep_engine_warm`` pins the weights
-    for a process meant to stay ready.
+    transparently on the next prompt. The timer is held off (ttl 0) while someone
+    who owns the engine's lifetime depends on an instant response: an interactive
+    session (*hold_warm_for_session*) whose engine dies with it, or a bulk ingest
+    whose unevenly loaded replicas must not idle-unload and reload cold mid-run.
+
+    A ``keep_engine_warm`` engine outlives every holder, so no holder may pin its
+    weights: llama-swap's ttl is fixed at launch, and a session hold baked into a
+    detached engine would keep the weights loaded for as long as the machine
+    stays up. Keep-warm keeps the engine process (a small proxy, no weights)
+    alive across launches; the weights follow the idle window like every other
+    mode, and only the user's explicit 0 keeps them loaded.
     """
-    if hold_warm_for_session or ingest_keep_warm() or cfg.keep_engine_warm:
+    if not cfg.keep_engine_warm and (hold_warm_for_session or ingest_keep_warm()):
         return 0
     return cfg.engine_idle_ttl_minutes * 60
 

--- a/src/lilbee/runtime/launcher.py
+++ b/src/lilbee/runtime/launcher.py
@@ -53,8 +53,8 @@ def main() -> None:
     from lilbee.app.services import mark_interactive_session
     from lilbee.runtime.splash import start, stop
 
-    # A person is at the TUI for its whole lifetime, so hold the engine resident
-    # (no idle-unload) until they close lilbee. Recorded here, on the sole
+    # A person is at the TUI for its whole lifetime, so hold a bound engine
+    # resident (no idle-unload) until they close lilbee. Recorded here, on the sole
     # interactive entry point and before anything builds the services container,
     # so a one-shot CLI or the MCP server never trips it.
     mark_interactive_session()

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -3902,13 +3902,6 @@ def test_a_prior_runs_keep_warm_is_reclaimed_when_the_setting_goes_off(
     assert stopped == [machine]
 
 
-def test_warm_on_pins_weights_resident(monkeypatch) -> None:
-    # keep_engine_warm means the model stays loaded, so the idle unload is off.
-    monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", True, raising=False)
-    monkeypatch.setattr(prov_mod.cfg, "engine_idle_ttl_minutes", 7, raising=False)
-    assert prov_mod._warm_ttl_seconds() == 0
-
-
 def test_ttl_applies_with_warm_off(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod.cfg, "keep_engine_warm", False, raising=False)
     monkeypatch.setattr(prov_mod.cfg, "engine_idle_ttl_minutes", 7, raising=False)

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -212,18 +212,38 @@ class TestHealthCheckTimeoutScaling:
 
 
 class TestWarmTtlSeconds:
-    def test_keep_engine_warm_pins_weights_resident(self, monkeypatch) -> None:
-        # keep_engine_warm means the model stays ready, so the idle unload is off.
+    def test_keep_engine_warm_unloads_on_the_idle_window(self, monkeypatch) -> None:
+        # keep_engine_warm keeps the engine process alive across launches, not
+        # the weights: it outlives every holder, so its idle unload stays armed.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet.provider import _warm_ttl_seconds
 
         monkeypatch.setattr(cfg, "keep_engine_warm", True)
         monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
-        assert _warm_ttl_seconds() == 0
+        assert _warm_ttl_seconds() == 900
+
+    def test_keep_engine_warm_ignores_the_session_hold(self, monkeypatch) -> None:
+        # A session hold pins weights only in an engine bound to that session. A
+        # keep-warm engine survives the session, so the hold must not follow it.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
+        assert _warm_ttl_seconds(hold_warm_for_session=True) == 900
+
+    def test_keep_engine_warm_with_zero_ttl_keeps_weights_loaded(self, monkeypatch) -> None:
+        # The user's explicit 0 is the only way a keep-warm engine pins weights.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 0)
+        assert _warm_ttl_seconds(hold_warm_for_session=True) == 0
 
     def test_interactive_session_pins_weights_resident(self, monkeypatch) -> None:
-        # A provider serving an interactive session (the TUI) holds the engine warm
-        # for its whole lifetime, regardless of the idle window or keep_engine_warm.
+        # A provider serving an interactive session (the TUI) holds its bound
+        # engine warm for its whole lifetime, regardless of the idle window.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet.provider import _warm_ttl_seconds
 

--- a/tests/test_ingest_warmth.py
+++ b/tests/test_ingest_warmth.py
@@ -41,14 +41,14 @@ class TestKeepFleetWarm:
         assert not ingest_keep_warm()
         assert _warm_ttl_seconds() == 300
 
-    def test_keep_engine_warm_pins_weights_resident(self):
-        # keep_engine_warm keeps the model resident (ttl 0), not merely alive
-        # across restarts: a user who opted to keep it warm never waits out a
-        # mid-session reload. Independent of an active ingest.
+    def test_keep_engine_warm_ignores_the_ingest_hold(self):
+        # An ingest hold pins weights only in an engine bound to this process. A
+        # keep-warm engine outlives the ingest, so it keeps the idle window.
         cfg.keep_engine_warm = True
         cfg.engine_idle_ttl_minutes = 5
-        assert not ingest_keep_warm()
-        assert _warm_ttl_seconds() == 0
+        with keep_fleet_warm():
+            assert ingest_keep_warm()
+            assert _warm_ttl_seconds() == 300
 
     def test_nested_scopes_restore_correctly(self):
         cfg.keep_engine_warm = False


### PR DESCRIPTION
## Problem

With **Keep engine warm** on, the engine never unloads its weights. The setting is meant to keep the engine process alive across launches, and the docs say the idle TTL applies in every mode, warm included. The code disagreed: a keep-warm engine got a llama-swap `ttl` of 0, and a TUI session added a second ttl-0 source that a detached engine inherited for life. On a Mac, a chat engine sat 5.5 days after lilbee exited, fully paged to swap, and pinned the swap file.

## Solution

A keep-warm engine outlives every process that uses it, so no process may pin its weights. With keep-warm on, the llama-swap `ttl` is always **Engine idle ttl minutes**; the session and ingest holds keep weights resident only in an engine bound to that process, which dies with it. The small proxy stays up across launches and reloads the weights on the next prompt.

## Trade-off

With keep-warm on, a TUI user who idles past the TTL waits for a reload on the next prompt. Raising the TTL (or `0`) is the knob for a longer or unbounded hold.