### PR TITLE
Retry a release build cell that dies from an infra flake

### DIFF
--- a/.github/actions/attach-prerelease/action.yml
+++ b/.github/actions/attach-prerelease/action.yml
@@ -91,24 +91,25 @@ runs:
             gh api "repos/${GITHUB_REPOSITORY}/contents/${archs}?ref=${ref}" \
               -q .content | base64 -d > "${name}-archs.py"
           done
-          python3 tools/release_arch_table.py \
-            --old-file prev-archs.py --new-file new-archs.py > arch-table.md
-          if [ ! -s arch-table.md ]; then
-            echo "the engine pin added no architectures; notes unchanged"
-            return 0
-          fi
-          local body
+          local body updated
           body=$(mktemp)
+          updated=$(mktemp)
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body > "$body" || return 0
           # Guard the one destructive call. `set -e` does not abort a function
           # invoked as the left side of `||`, so a failed read above would
           # otherwise reach `gh release edit` with an empty file and replace the
           # notes with nothing but this table.
           [ -s "$body" ] || return 0
-          printf '\n\n' >> "$body"
-          cat arch-table.md >> "$body"
-          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$body"
-          echo "appended the new architectures to the notes:"
-          cat arch-table.md
+          python3 tools/release_arch_table.py \
+            --old-file prev-archs.py --new-file new-archs.py --body-file "$body" > "$updated"
+          # Only write when the notes would actually change. The section is
+          # replaced rather than appended, so a rerun of this job is a no-op
+          # instead of a second copy of the table.
+          if cmp -s "$body" "$updated"; then
+            echo "the architecture section is already current; nothing to write"
+            return 0
+          fi
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$updated"
+          echo "updated the architecture section in the notes"
         }
         append_arch_table || echo "could not append the architecture table; the release is unaffected"

--- a/.github/actions/attach-prerelease/action.yml
+++ b/.github/actions/attach-prerelease/action.yml
@@ -54,3 +54,61 @@ runs:
           schema/openapi.json
         generate_release_notes: ${{ inputs.generate-notes == 'true' }}
         prerelease: ${{ contains(inputs.version, 'a') || contains(inputs.version, 'b') || contains(inputs.version, 'rc') }}
+
+    # A llama.cpp pin bump reaches the notes as one line ("Bump the bundled
+    # llama.cpp engine to <ref>"), which hides the model support it adds. Append
+    # the architectures this tag gained over the previous one, read from the two
+    # tags' generated arch table. Runs after the step above regenerated the
+    # body, so a rerun of this job reproduces the same notes rather than
+    # stacking a second copy.
+    #
+    # Never fatal. The notes are cosmetic and this job is what puts the
+    # executables on the release, so a hiccup reading two blobs must not strand
+    # a release. Composite-action steps do not support continue-on-error, so the
+    # script contains its own failure.
+    - name: Append the new model architectures to the notes
+      if: inputs.generate-notes == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        append_arch_table() {
+          set -euo pipefail
+          local archs="src/lilbee/_generated/engine_archs.py"
+          local prev
+          prev=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts --limit 30 \
+            --json tagName -q "first(.[].tagName | select(startswith(\"v\") and . != \"${TAG}\"))")
+          if [ -z "${prev}" ]; then
+            echo "no previous release to diff architectures against"
+            return 0
+          fi
+          # Read both sides over the API: this job checks out at depth 1, so the
+          # previous tag's blob is not in the local history.
+          local side name ref
+          for side in "prev:${prev}" "new:${TAG}"; do
+            name="${side%%:*}"; ref="${side#*:}"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/${archs}?ref=${ref}" \
+              -q .content | base64 -d > "${name}-archs.py"
+          done
+          python3 tools/release_arch_table.py \
+            --old-file prev-archs.py --new-file new-archs.py > arch-table.md
+          if [ ! -s arch-table.md ]; then
+            echo "the engine pin added no architectures; notes unchanged"
+            return 0
+          fi
+          local body
+          body=$(mktemp)
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body -q .body > "$body" || return 0
+          # Guard the one destructive call. `set -e` does not abort a function
+          # invoked as the left side of `||`, so a failed read above would
+          # otherwise reach `gh release edit` with an empty file and replace the
+          # notes with nothing but this table.
+          [ -s "$body" ] || return 0
+          printf '\n\n' >> "$body"
+          cat arch-table.md >> "$body"
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file "$body"
+          echo "appended the new architectures to the notes:"
+          cat arch-table.md
+        }
+        append_arch_table || echo "could not append the architecture table; the release is unaffected"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -8,7 +8,9 @@ name: Release candidate
 # indexes or the downstream publish. publish.yml (PyPI) is auto-dispatched
 # once every artifact is attached and the wheel smoke passes; it just
 # downloads this run's artifacts, nothing downstream rebuilds. Promotion to
-# latest stays gated behind verify-release.yml (see make release-promote).
+# latest is verify-release.yml's last job, which runs once every artifact
+# check passes. A cell that dies from an infra flake is retried by
+# release-selfheal.yml rather than stranding the release.
 
 on:
   push:

--- a/.github/workflows/release-selfheal.yml
+++ b/.github/workflows/release-selfheal.yml
@@ -1,0 +1,111 @@
+name: Release self-heal
+
+run-name: Self-heal ${{ github.event.workflow_run.head_branch || inputs.run_id }}
+
+# A release candidate builds for hours across ~30 cells, and a cell that dies
+# from an infra flake (runner lost communication, no space left on device)
+# strands the release short of promotion until a human notices. This reruns the
+# cells that failed, so the candidate corrects itself.
+#
+# `gh run rerun --failed` is the whole mechanism. It reruns the failed jobs plus
+# the jobs skipped behind them and leaves the successful cells alone, which is
+# what both failure modes need:
+#
+#   - A soft cell (every cell in build-gpu-executables.yml is
+#     continue-on-error) carries conclusion=failure while the run stays green.
+#     Nothing is skipped, so only that cell reruns; its own release_tag step
+#     attaches the missing asset, and verify-release re-fires when the run
+#     completes again.
+#   - A hard cell takes the run red, which skips attach-prerelease and all five
+#     dispatch jobs. Rerunning the cell alone would leave them skipped forever,
+#     because a per-job rerun does not re-queue dependents. `--failed` picks the
+#     stranded cascade up with the cell.
+#
+# Every dispatch job on a tag build shares one `if` (push + refs/tags/v), so a
+# skipped job there always means "stranded", never "skipped by design". That is
+# what makes --failed safe to point at this workflow.
+#
+# The retry is blind: it does not read logs to guess whether a failure was a
+# flake or a defect. Signature matching against GitHub's error text is a list
+# that goes stale, and a defect just fails again and stops at the attempt bound
+# below, which costs one cell rebuild.
+
+on:
+  workflow_run:
+    workflows: ["Release candidate"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Release candidate run to heal."
+        required: true
+
+permissions:
+  actions: write
+
+concurrency:
+  group: release-selfheal-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+env:
+  # One retry. A second flake on the same cell is rare enough to be worth a
+  # human look, and this is the only thing standing between a real defect and
+  # an unbounded rebuild loop.
+  MAX_ATTEMPTS: 2
+
+jobs:
+  heal:
+    # Only tag builds: a workflow_dispatch candidate skips create-prerelease and
+    # the whole dispatch cascade by design, so "skipped" would not mean
+    # "stranded" there and --failed would fire dispatches that were never meant
+    # to run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun the cells that failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+        run: |
+          set -euo pipefail
+
+          attempt=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .run_attempt)
+          conclusion=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .conclusion)
+
+          failed=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --paginate -q '.jobs[] | select(.conclusion == "failure") | .name')
+
+          {
+            echo "## Release self-heal"
+            echo
+            echo "Run [${RUN_ID}](https://github.com/${REPO}/actions/runs/${RUN_ID}), attempt ${attempt}, concluded ${conclusion}."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "${failed}" ]; then
+            echo "no failed cells; nothing to heal" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "Failed cells:"
+            echo
+            echo "${failed}" | sed 's/^/- /'
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+            echo "attempt ${attempt} reached the bound of ${MAX_ATTEMPTS}; not retrying again" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "These cells failed twice. Read the logs before rerunning: a second failure is a defect until proven otherwise." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "rerunning the failed cells and anything stranded behind them"
+          gh run rerun "${RUN_ID}" --repo "${REPO}" --failed
+          echo "Retried as attempt $((attempt + 1))." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -5,10 +5,12 @@ run-name: Verify release ${{ inputs.tag || github.event.workflow_run.head_branch
 # Downloads the user-facing assets from the GH release at a tag (standalone
 # executables and the pip wheel pair) and runs the core-functionality sweep
 # against each one: engine inference (chat + embedding), document ingest,
-# search, a RAG ask, and an http-mode crawl. This is the promotion gate:
-# `make release-promote` refuses to mark a tag latest until this workflow has
-# passed for it. Fires automatically when a Release candidate run finishes
-# green on a tag, or on demand for any tag.
+# search, a RAG ask, and an http-mode crawl. This is the promotion gate, and
+# it promotes: the final job marks the tag latest once every check above has
+# passed against the assets a user downloads. Fires automatically when a
+# Release candidate run finishes green on a tag, or on demand for any tag.
+# `make release-promote` stays as the manual path for a tag this workflow did
+# not run for.
 
 on:
   workflow_dispatch:
@@ -254,3 +256,30 @@ jobs:
           # name from PyPI instead of the wheel under test.
           "${bin}/pip" install "${lilbee_whl}[crawler,litellm,graph]"
           LILBEE_EXE="${bin}/lilbee" bash tools/qa/artifact_smoke.sh
+
+  # The promotion gate itself. Every check above passed against the assets a
+  # user actually downloads, so the tag is promotable and nothing is left for a
+  # human to decide. `make release-promote` stays as the manual path for a tag
+  # this workflow did not run for, and for rewriting notes on purpose.
+  promote:
+    needs: [resolve, verify-cuda-bundles, verify-channel-assets, verify-openapi, verify-executables, verify-wheels]
+    # Only the candidate that just built. A workflow_dispatch run verifies any
+    # tag on demand, including an old one, and promoting there would move
+    # `latest` backwards onto a superseded release. Use `make release-promote`
+    # for a tag this workflow did not fire for on its own.
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Mark the release latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # The body is left exactly as it is. attach-prerelease already wrote
+          # the notes, including the new-architecture table, and regenerating
+          # here would overwrite anything written by hand since.
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease=false --latest
+          echo "promoted $TAG to latest" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,6 +459,16 @@ closure. These rules exist because each one shipped a broken artifact once.
   dispatch job in `release-candidate.yml`, and its assets belong in
   `verify-release.yml`. Adding the gate without the dispatcher makes every release
   unpromotable: the wait loop burns its full timeout, then promotion refuses.
+- **A failed build cell is retried once, not forever.** `release-selfheal.yml`
+  watches every Release candidate run and reruns the failed cells with
+  `gh run rerun --failed`, which also picks up whatever was skipped behind them.
+  It gives up at `run_attempt` 2, so a real defect surfaces instead of looping.
+  The retry is deliberately blind: matching GitHub's error text to tell a flake
+  from a defect is a list that goes stale, and a defect costs one rebuild.
+- **A skipped job on a tag build means stranded, never "skipped by design".**
+  Every dispatch job in `release-candidate.yml` shares one `if` (push +
+  `refs/tags/v`), which is what makes `--failed` safe to point at the run. A new
+  job with a narrower `if` breaks that, and self-heal would fire it.
 - **A new gate must be proven to fail.** Run it against the input it is supposed to
   reject before trusting it. A loader check that counted glob matches passed a bundle
   with no `llama-server` in it, and one that ignored `ldd`'s exit status read "not a
@@ -475,8 +485,8 @@ closure. These rules exist because each one shipped a broken artifact once.
   Executable cells, the `smoke-wheels` PyPI-channel job, and `verify-release.yml`
   (against the downloadable assets) all run it. `--version`/`--help` passing is
   the "test passes but covers nothing" smell applied to a binary — it does not
-  count as verification, and `make release-promote` refuses to mark a tag latest
-  without a green `verify-release` run.
+  count as verification, and nothing marks a tag latest without a green
+  `verify-release` run. That workflow promotes the tag itself as its last job.
 - **Never `continue-on-error` a smoke or correctness gate.** A swallowed gate is
   how the broken macOS bundle shipped. Skip a gate that genuinely can't run in
   an environment (GPU-driver backends link `libcuda.so.1` / `libamdhip64.so`

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ promote:  ## Re-release an existing tag's source under a new version (FROM=v0.6.
 	@[ -n "$(FROM)" ] && [ -n "$(TO)" ] || { echo "promote: FROM=v... TO=<new-version> required"; exit 1; }
 	bash scripts/promote_release.sh $(FROM) $(TO)
 
-release-promote:  ## Rewrite notes as headings and mark a release latest (TAG=... or newest); run after the PyPI publish is green
+release-promote:  ## Manual promote: rewrite notes as headings and mark a release latest (TAG=... or newest). verify-release.yml promotes on its own; use this to rewrite notes or to promote a tag it never ran for
 	@tag="$(TAG)"; \
 	[ -n "$$tag" ] || tag=$$(gh release list --repo tobocop2/lilbee --limit 30 --json tagName -q "first(.[].tagName | select(startswith(\"v\")))"); \
 	verified=$$(gh run list --repo tobocop2/lilbee --workflow=verify-release.yml --limit 50 --json displayTitle,conclusion -q "[.[] | select(.displayTitle == \"Verify release $$tag\" and .conclusion == \"success\")] | length"); \

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -25,3 +25,23 @@ gh api "repos/${repo}/releases/generate-notes" "${args[@]}" --jq .body | awk '
   /^\*\*Full Changelog/ { print; next }
   { next }
 '
+
+# A pin bump reaches the notes as one PR title, which hides the model support it
+# adds. Same section attach-prerelease appends to the pre-release body, so the
+# manual promote path does not silently drop it. Needs both tags in the local
+# history, which a release checkout has.
+if [ -n "$prev" ]; then
+  old_archs=$(mktemp)
+  new_archs=$(mktemp)
+  archs_path="src/lilbee/_generated/engine_archs.py"
+  root=$(cd "$(dirname "$0")/.." && pwd)
+  if git -C "$root" show "${prev}:${archs_path}" > "$old_archs" 2>/dev/null \
+    && git -C "$root" show "${tag}:${archs_path}" > "$new_archs" 2>/dev/null; then
+    table=$(python3 "${root}/tools/release_arch_table.py" \
+      --old-file "$old_archs" --new-file "$new_archs")
+    if [ -n "$table" ]; then
+      printf '\n%s\n' "$table"
+    fi
+  fi
+  rm -f "$old_archs" "$new_archs"
+fi

--- a/tests/test_release_arch_table.py
+++ b/tests/test_release_arch_table.py
@@ -1,0 +1,106 @@
+"""Tests for the new-architecture table that pin-bump release notes carry.
+
+A llama.cpp pin bump says only "Bump the bundled llama.cpp engine to <ref>".
+The model support it adds is the user-visible payload of that bump and is
+invisible in the notes otherwise, so the table is generated from the two tags'
+``engine_archs.py`` rather than written by hand.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "release_arch_table.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("release_arch_table", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rat = _load()
+
+
+def _archs_module(ref: str, commit: str, archs: tuple[str, ...]) -> str:
+    entries = "\n".join(f'        "{a}",' for a in archs)
+    return (
+        f'ENGINE_LLAMA_CPP_REF = "{ref}"\n'
+        f'LLAMA_CPP_COMMIT = "{commit}"\n\n'
+        "SUPPORTED_ARCHS: frozenset[str] = frozenset(\n"
+        "    {\n"
+        f"{entries}\n"
+        "    }\n"
+        ")\n"
+    )
+
+
+_OLD = _archs_module("memory-20260817-085323", "3890631", ("llama", "qwen3", "dots1"))
+_NEW = _archs_module(
+    "memory-20260828-212210", "cb6b3c7", ("llama", "qwen3", "dots1", "dots3note", "qwen4exp")
+)
+
+
+def test_added_archs_are_the_set_difference() -> None:
+    assert rat.added_archs(_OLD, _NEW) == ["dots3note", "qwen4exp"]
+
+
+def test_added_archs_ignores_removals_and_reordering() -> None:
+    shrunk = _archs_module("r", "c", ("qwen3", "llama"))
+    assert rat.added_archs(_NEW, shrunk) == []
+
+
+def test_parses_the_engine_ref_and_commit() -> None:
+    assert rat.engine_ref(_NEW) == "memory-20260828-212210"
+    assert rat.engine_commit(_NEW) == "cb6b3c7"
+
+
+def test_table_lists_every_new_arch_with_the_totals() -> None:
+    out = rat.render(_OLD, _NEW)
+    assert "| `dots3note` |" in out
+    assert "| `qwen4exp` |" in out
+    # Both totals are counted from the two sets, so a reader sees the size of
+    # the bump without opening the diff.
+    assert "runs 5 GGUF architectures, up from 3" in out
+    assert "adds 2 architectures" in out
+
+
+def test_table_links_each_arch_to_the_engine_source() -> None:
+    out = rat.render(_OLD, _NEW)
+    # Without a per-arch upstream PR to cite, the compare view between the two
+    # pinned commits is the honest source for what the bump contains.
+    assert "3890631" in out and "cb6b3c7" in out
+
+
+def test_no_table_when_the_pin_did_not_move() -> None:
+    assert rat.render(_OLD, _OLD) == ""
+
+
+def test_no_table_when_the_pin_moved_but_added_no_archs() -> None:
+    same_archs = _archs_module("memory-later", "deadbee", ("llama", "qwen3", "dots1"))
+    assert rat.render(_OLD, same_archs) == ""
+
+
+def test_render_tolerates_a_missing_previous_file() -> None:
+    # The first release after the generated file appears has no old side.
+    assert rat.render("", _NEW) == ""
+
+
+def test_cli_prints_the_table_for_two_files(tmp_path, capsys) -> None:
+    old = tmp_path / "old.py"
+    new = tmp_path / "new.py"
+    old.write_text(_OLD, encoding="utf-8")
+    new.write_text(_NEW, encoding="utf-8")
+    assert rat.main(["--old-file", str(old), "--new-file", str(new)]) == 0
+    assert "dots3note" in capsys.readouterr().out
+
+
+def test_cli_prints_nothing_when_the_pin_is_unchanged(tmp_path, capsys) -> None:
+    same = tmp_path / "same.py"
+    same.write_text(_OLD, encoding="utf-8")
+    assert rat.main(["--old-file", str(same), "--new-file", str(same)]) == 0
+    assert capsys.readouterr().out == ""

--- a/tests/test_release_arch_table.py
+++ b/tests/test_release_arch_table.py
@@ -104,3 +104,53 @@ def test_cli_prints_nothing_when_the_pin_is_unchanged(tmp_path, capsys) -> None:
     same.write_text(_OLD, encoding="utf-8")
     assert rat.main(["--old-file", str(same), "--new-file", str(same)]) == 0
     assert capsys.readouterr().out == ""
+
+
+_BODY = "## What's Changed\n* a PR\n\n**Full Changelog**: https://example/compare\n"
+
+
+def test_applying_a_table_to_a_body_appends_the_section() -> None:
+    out = rat.apply_to_body(_BODY, rat.render(_OLD, _NEW))
+    assert out.startswith(_BODY.rstrip("\n"))
+    assert "## New model architectures" in out
+
+
+def test_applying_twice_does_not_stack_a_second_copy() -> None:
+    # self-heal makes a rerun of attach-prerelease routine, so the append has to
+    # be idempotent or every retry adds another table.
+    table = rat.render(_OLD, _NEW)
+    once = rat.apply_to_body(_BODY, table)
+    twice = rat.apply_to_body(once, table)
+    assert once == twice
+    assert once.count("## New model architectures") == 1
+
+
+def test_an_empty_table_leaves_the_body_untouched() -> None:
+    assert rat.apply_to_body(_BODY, "") == _BODY
+
+
+def test_an_empty_table_strips_a_section_that_no_longer_applies() -> None:
+    stale = rat.apply_to_body(_BODY, rat.render(_OLD, _NEW))
+    assert rat.apply_to_body(stale, "") == _BODY
+
+
+def test_the_section_does_not_swallow_a_heading_that_follows_it() -> None:
+    body = _BODY + "\n## New model architectures\n\nold junk\n\n## Credits\n\nthanks\n"
+    out = rat.apply_to_body(body, rat.render(_OLD, _NEW))
+    assert "## Credits" in out
+    assert "old junk" not in out
+    assert out.count("## New model architectures") == 1
+
+
+def test_cli_body_mode_prints_the_updated_body(tmp_path, capsys) -> None:
+    old = tmp_path / "old.py"
+    new = tmp_path / "new.py"
+    body = tmp_path / "body.md"
+    old.write_text(_OLD, encoding="utf-8")
+    new.write_text(_NEW, encoding="utf-8")
+    body.write_text(_BODY, encoding="utf-8")
+    args = ["--old-file", str(old), "--new-file", str(new), "--body-file", str(body)]
+    assert rat.main(args) == 0
+    printed = capsys.readouterr().out
+    assert "## New model architectures" in printed
+    assert printed.count("What's Changed") == 1

--- a/tools/release_arch_table.py
+++ b/tools/release_arch_table.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Render the "New model architectures" section for a release's notes.
+
+A llama.cpp pin bump commit says only "Bump the bundled llama.cpp engine to
+<ref>". The model support that bump adds is its user-visible payload, so the
+notes generate the list rather than relying on someone to write it: this reads
+``SUPPORTED_ARCHS`` out of ``lilbee/_generated/engine_archs.py`` at two tags and
+tables the difference.
+
+Text parsing, not import: both sides come from a tag rather than the working
+tree, so neither is importable as a module.
+
+Usage:
+    release_arch_table.py --old-file <previous> --new-file <current>
+
+The caller supplies the two files, because the release job that needs this
+checks out at depth 1 and reads them over the API. To run it against two tags
+by hand::
+
+    git show <previous-tag>:src/lilbee/_generated/engine_archs.py > /tmp/old.py
+    git show <tag>:src/lilbee/_generated/engine_archs.py > /tmp/new.py
+    python tools/release_arch_table.py --old-file /tmp/old.py --new-file /tmp/new.py
+
+Prints nothing when the pin did not move or added no architectures, so the
+caller can append the output unconditionally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_REPO = "https://github.com/ggml-org/llama.cpp"
+
+_ARCH_ENTRY = re.compile(r'^\s*"([a-z0-9._-]+)",\s*$', re.IGNORECASE | re.MULTILINE)
+_SET_BLOCK = re.compile(r"SUPPORTED_ARCHS.*?frozenset\(\s*\{(.*?)\}\s*\)", re.DOTALL)
+_REF = re.compile(r'^ENGINE_LLAMA_CPP_REF\s*=\s*"([^"]+)"', re.MULTILINE)
+_COMMIT = re.compile(r'^LLAMA_CPP_COMMIT\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def _supported_archs(source: str) -> set[str]:
+    """The architecture names in ``source``'s SUPPORTED_ARCHS frozenset."""
+    block = _SET_BLOCK.search(source)
+    if not block:
+        return set()
+    return set(_ARCH_ENTRY.findall(block.group(1)))
+
+
+def engine_ref(source: str) -> str:
+    """The llama.cpp ref the engine was built from, or "" when absent."""
+    found = _REF.search(source)
+    return found.group(1) if found else ""
+
+
+def engine_commit(source: str) -> str:
+    """The llama.cpp commit the engine was built from, or "" when absent."""
+    found = _COMMIT.search(source)
+    return found.group(1) if found else ""
+
+
+def added_archs(old: str, new: str) -> list[str]:
+    """Architecture names present in ``new`` and not in ``old``, sorted.
+
+    Removals are not reported. An architecture leaving the engine's table is a
+    support regression, which belongs in the notes as prose, not in a table
+    headed "new".
+    """
+    old_set = _supported_archs(old)
+    if not old_set:
+        return []
+    return sorted(_supported_archs(new) - old_set)
+
+
+def render(old: str, new: str) -> str:
+    """The markdown section for this bump, or "" when there is nothing to say."""
+    added = added_archs(old, new)
+    if not added:
+        return ""
+    old_commit = engine_commit(old)
+    new_commit = engine_commit(new)
+    total_new = len(_supported_archs(new))
+    total_old = len(_supported_archs(old))
+
+    lines = [
+        "## New model architectures",
+        "",
+        f"The bundled llama.cpp engine moves to `{engine_ref(new)}`, which adds "
+        f"{len(added)} architecture{'s' if len(added) != 1 else ''}.",
+        "",
+        "| architecture |",
+        "|---|",
+    ]
+    lines += [f"| `{arch}` |" for arch in added]
+    lines += [
+        "",
+        f"lilbee now runs {total_new} GGUF architectures, up from {total_old}. "
+        "Pull any GGUF built on one of them and it works.",
+    ]
+    if old_commit and new_commit:
+        lines.append(
+            f"The engine changes are in [{old_commit[:9]}...{new_commit[:9]}]"
+            f"({_REPO}/compare/{old_commit}...{new_commit})."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--old-file", type=Path, required=True, help="engine_archs.py at the previous tag"
+    )
+    parser.add_argument(
+        "--new-file", type=Path, required=True, help="engine_archs.py at the tag being released"
+    )
+    args = parser.parse_args(argv)
+
+    sys.stdout.write(
+        render(
+            args.old_file.read_text(encoding="utf-8"),
+            args.new_file.read_text(encoding="utf-8"),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_arch_table.py
+++ b/tools/release_arch_table.py
@@ -33,6 +33,10 @@ import sys
 from pathlib import Path
 
 _REPO = "https://github.com/ggml-org/llama.cpp"
+_HEADING = "## New model architectures"
+# The section runs to the next second-level heading, so a body that already has
+# sections after it keeps them.
+_SECTION = re.compile(rf"\n*{re.escape(_HEADING)}\n.*?(?=\n## |\Z)", re.DOTALL)
 
 _ARCH_ENTRY = re.compile(r'^\s*"([a-z0-9._-]+)",\s*$', re.IGNORECASE | re.MULTILINE)
 _SET_BLOCK = re.compile(r"SUPPORTED_ARCHS.*?frozenset\(\s*\{(.*?)\}\s*\)", re.DOTALL)
@@ -106,6 +110,20 @@ def render(old: str, new: str) -> str:
     return "\n".join(lines) + "\n"
 
 
+def apply_to_body(body: str, table: str) -> str:
+    """``body`` carrying exactly ``table`` as its architecture section.
+
+    Idempotent: an existing section is replaced rather than appended to, because
+    release-selfheal.yml makes a rerun of the job that writes these notes
+    routine, and a plain append would stack a copy per retry. An empty ``table``
+    strips a section that no longer applies.
+    """
+    stripped = _SECTION.sub("", body).rstrip("\n")
+    if not table:
+        return stripped + "\n" if body.endswith("\n") else stripped
+    return f"{stripped}\n\n{table.strip()}\n"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -114,14 +132,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--new-file", type=Path, required=True, help="engine_archs.py at the tag being released"
     )
+    parser.add_argument(
+        "--body-file",
+        type=Path,
+        help="existing release body; prints that body with the section applied instead of the "
+        "section alone, so the caller can skip the write when nothing changed",
+    )
     args = parser.parse_args(argv)
 
-    sys.stdout.write(
-        render(
-            args.old_file.read_text(encoding="utf-8"),
-            args.new_file.read_text(encoding="utf-8"),
-        )
+    table = render(
+        args.old_file.read_text(encoding="utf-8"),
+        args.new_file.read_text(encoding="utf-8"),
     )
+    if args.body_file:
+        sys.stdout.write(apply_to_body(args.body_file.read_text(encoding="utf-8"), table))
+    else:
+        sys.stdout.write(table)
     return 0
 
 


### PR DESCRIPTION
## Problem

A GPU executable cell died with "The hosted runner lost communication with the server" three hours into the Nuitka build on the last release. `build-gpu-executables.yml` is entirely `continue-on-error`, so the run still concluded success, every channel published, and `verify-release` caught the missing cu124 asset hours later. The gate worked. Nothing retried the cell, so the release sat unpromotable until someone noticed and reran it by hand.

## Retrying the failed cell

`release-selfheal.yml` watches every candidate run and reruns the cells that failed with `gh run rerun --failed`, which also picks up whatever was skipped behind them. One primitive covers both shapes: a soft cell carries `conclusion=failure` while the run stays green and nothing is skipped, so only that cell reruns; a hard cell takes the run red and strands `attach-prerelease` plus the five dispatch jobs, which come back with it. It never touches the ~30 green cells.

Bounded at `run_attempt` 2. The retry is blind on purpose: matching GitHub's error text to tell a flake from a defect is a list that goes stale, and a defect just fails again and stops after one rebuild.

## Promotion

`verify-release.yml` marks the tag latest as its last job, once every artifact check passes, and leaves the release body alone. It is gated to the `workflow_run` path so re-verifying an old tag on demand cannot move `latest` backwards. `make release-promote` stays as the manual path.

## New model architectures in the notes

A pin bump reaches the notes as one PR title, which hides the model support it adds. Both note paths now carry the architectures the bump gained, read from the two tags' generated arch table.

The section is replaced rather than appended, and the job writes only when the body would actually change. An unchanged pin writes nothing, and a rerun is a no-op instead of a second copy of the table, which matters because self-heal makes reruns routine.

## What this does not cover

A cell that fails twice still needs a human. That is the intent.

