### PR TITLE
Keep only the distro apt sources in CI jobs that install ubuntu packages

### DIFF
--- a/.github/actions/publish-flatpak/action.yml
+++ b/.github/actions/publish-flatpak/action.yml
@@ -45,6 +45,10 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # The runner image ships third-party apt repos this job never installs
+        # from, and packages.microsoft.com answers 403 often enough to kill the
+        # step. Only the distro sources stay.
+        sudo find /etc/apt/sources.list.d -type f ! -name 'ubuntu.sources' -delete
         sudo apt-get update -qq
         sudo apt-get install -y -qq flatpak flatpak-builder
         flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,10 @@ jobs:
 
       - name: Install Tesseract (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr
+        run: |
+          # Only the distro sources: the runner's third-party repos 403 intermittently.
+          sudo find /etc/apt/sources.list.d -type f ! -name 'ubuntu.sources' -delete
+          sudo apt-get update && sudo apt-get install -y tesseract-ocr
 
       - name: Install Tesseract (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -120,6 +120,10 @@ jobs:
     steps:
       - name: Install flatpak and Obsidian
         run: |
+          # The runner image ships third-party apt repos this job never installs
+          # from, and packages.microsoft.com answers 403 often enough to kill the
+          # step. Only the distro sources stay.
+          sudo find /etc/apt/sources.list.d -type f ! -name 'ubuntu.sources' -delete
           sudo apt-get update -qq
           sudo apt-get install -y -qq flatpak
           flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
## Problem

The Publish Flatpak cuda cell on v0.6.90b431 failed before building anything. The runner image preinstalls third-party apt repos, and packages.microsoft.com answered 403, which makes apt-get update exit 100. The affected jobs install ubuntu-archive packages only.

## Solution

The flatpak publish action, the flatpak validate workflow and the tesseract step each delete the runner's extra source lists before apt-get update. The distro's own sources survive: ubuntu.sources on noble, sources.list on jammy.