### PR TITLE
Add npm to the site install tabs and fix the README first-start layout on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,16 +364,13 @@ a progress bar, and the model loads before your first answer, shown live inside
 the answer bubble. Every launch after that opens straight to chat in a couple
 of seconds.
 
-<table>
-  <tr>
-    <th align="center">Very first launch</th>
-    <th align="center">Every launch after</th>
-  </tr>
-  <tr>
-    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="380"></td>
-    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="380"></td>
-  </tr>
-</table>
+**Very first launch**
+
+<img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="380">
+
+**Every launch after**
+
+<img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="380">
 
 Measured with a small chat model (Qwen3 0.6B):
 

--- a/site/code-search/index.html
+++ b/site/code-search/index.html
@@ -111,6 +111,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>

--- a/site/gpu/index.html
+++ b/site/gpu/index.html
@@ -111,6 +111,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -138,6 +138,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>
@@ -428,6 +429,7 @@
         <button type="button" class="tab" role="tab" id="tab-scoop" aria-controls="pane-scoop" aria-selected="false" tabindex="-1">scoop</button>
         <button type="button" class="tab" role="tab" id="tab-binary" aria-controls="pane-binary" aria-selected="false" tabindex="-1">binary</button>
         <button type="button" class="tab" role="tab" id="tab-source" aria-controls="pane-source" aria-selected="false" tabindex="-1">source</button>
+        <button type="button" class="tab" role="tab" id="tab-npm" aria-controls="pane-npm" aria-selected="false" tabindex="-1">npm</button>
         <button type="button" class="tab" role="tab" id="tab-pip" aria-controls="pane-pip" aria-selected="false" tabindex="-1">pip</button>
         <button type="button" class="tab" role="tab" id="tab-uv" aria-controls="pane-uv" aria-selected="false" tabindex="-1">uv</button>
       </div>
@@ -804,6 +806,24 @@
         </div>
       </div>
 
+      <div class="installpane" role="tabpanel" id="pane-npm" aria-labelledby="tab-npm" hidden>
+        <div class="oschips"><span class="oschip">macOS</span><span class="oschip">Linux x86_64</span><span class="oschip">Windows x86_64</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">npm install -g lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <p class="variant-note">a small launcher, not a Node rewrite: on first run it reads your hardware, downloads the matching standalone build of the latest release, verifies it, and caches it.</p>
+        <div class="variant cuda">
+          <span class="variant-tag">NVIDIA &middot; CUDA</span>
+          <p class="variant-note">picked for you. AMD ROCm, Apple Metal, and the AVX-baseline build are picked the same way; <code>LILBEE_VARIANT=default</code> forces the plain build.</p>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-npm">details</button>
+        <div class="notes-body" id="notes-npm" hidden>
+          <p class="extras">needs Node 18+ &nbsp;.&nbsp; <code>lilbee prepare</code> downloads the build ahead of time &nbsp;.&nbsp; <code>npx -y lilbee mcp</code> runs the MCP server for agent hosts &nbsp;.&nbsp; wraps the release binary, so the <code>[crawler]</code> / <code>[litellm]</code> / <code>[graph]</code> extras are already included</p>
+        </div>
+      </div>
+
       <div class="installpane" role="tabpanel" id="pane-pip" aria-labelledby="tab-pip" hidden>
         <div class="oschips"><span class="oschip">macOS</span><span class="oschip">Linux</span><span class="oschip">Windows</span></div>
         <div class="install">
@@ -886,7 +906,7 @@
 
       <div class="installextras">
         <div class="extras-h">optional extras</div>
-        <div class="extras-sub">For a <code>pip</code> / <code>uv</code> install, add the name in brackets, e.g. <code>'lilbee[crawler,litellm]'</code>. The binary, Homebrew, AUR, Nix, Docker, Flatpak, and Snap builds bundle all three already. lilbee works without them.</div>
+        <div class="extras-sub">For a <code>pip</code> / <code>uv</code> install, add the name in brackets, e.g. <code>'lilbee[crawler,litellm]'</code>. The binary, Homebrew, AUR, Nix, Docker, Flatpak, Snap, scoop, and npm builds bundle all three already. lilbee works without them.</div>
         <div class="extras-grid">
           <div class="extra"><span class="tag">[crawler]</span><span>index websites too: crawl a docs site or wiki to markdown, then search it offline</span></div>
           <div class="extra"><span class="tag">[litellm]</span><span>bridge to popular hosted model providers for chat, vision, or embeddings; you bring the key, the terminal app flags when one's active</span></div>

--- a/site/local-rag/index.html
+++ b/site/local-rag/index.html
@@ -111,6 +111,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -111,6 +111,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>

--- a/site/model-manager/index.html
+++ b/site/model-manager/index.html
@@ -111,6 +111,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -71,6 +71,7 @@
       <div class="menu">
         <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">install</button>
         <div class="menu-panel">
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
           <a href="/#install-brew">homebrew</a>

--- a/site/vs/index.html
+++ b/site/vs/index.html
@@ -111,6 +111,7 @@
           <a href="/#install-scoop">scoop</a>
           <a href="/#install-binary">binary</a>
           <a href="/#install-source">source</a>
+          <a href="/#install-npm">npm</a>
           <a href="/#install-pip">pip</a>
           <a href="/#install-uv">uv</a>
         </div>


### PR DESCRIPTION
## Problem

The install section on lilbee.sh lists every install method except npm, so the one-line `npm install -g lilbee` path is invisible to anyone who lands on the site. In the README, the first-start section puts its two GIFs in a two-column table, which forces a line wider than a phone screen and makes the section scroll sideways on mobile.

## Solution

### npm tab on the site

A new npm tab and pane sits between source and pip, with the global install command, the OS chips, and a note that the package is a launcher: it reads the hardware on first run, downloads the matching standalone build, verifies it, and caches it. The details line carries the Node 18+ floor, `lilbee prepare`, and `npx -y lilbee mcp`. The nav install menu gets the same entry on all eight pages; the existing hash router picks up `#install-npm` with no JS change.

### Extras blurb

The optional-extras note now lists npm and scoop among the builds that already bundle `[crawler]`, `[litellm]`, and `[graph]`.

### README first start

The two GIFs are stacked under their own labels instead of sitting in a table, so nothing forces a wide line and the section reads top to bottom on a phone. The `width="380"` cap still holds on desktop.