### PR TITLE
Give each build of a release its own onefile cache directory

### DIFF
--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -14,6 +14,7 @@ from lilbee.app.version import get_version
 from lilbee.cli.helpers import json_output as json_out
 from lilbee.core.config import cfg, config_load_error
 from lilbee.core.settings import overlay_persisted_settings
+from lilbee.runtime.onefile_cache import cleanup_stale_onefile_caches
 
 app = typer.Typer(help="lilbee: Local RAG knowledge base", invoke_without_command=True)
 console = Console()
@@ -196,6 +197,8 @@ def _default(
     )
     # basicConfig is a no-op when handlers already exist, so always set level explicitly
     logging.getLogger().setLevel(level)
+
+    cleanup_stale_onefile_caches()
 
     # Swallow lancedb's shutdown-time thread noise: opt-in side effect, not
     # imposed on library consumers of lilbee.

--- a/src/lilbee/runtime/onefile_cache.py
+++ b/src/lilbee/runtime/onefile_cache.py
@@ -1,0 +1,66 @@
+"""Startup sweep of the onefile extraction directories left by older releases."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+import lilbee
+from lilbee._frozen import is_frozen
+
+logger = logging.getLogger(__name__)
+
+# Written by tools/wheel-build/onefile-bootstrap-lilbee.patch into every payload directory.
+BOOTSTRAP_MANIFEST_NAME = ".lilbee-bootstrap-manifest"
+# Payload directories are named ``{VERSION}-<build key>`` by the build script.
+_BUILD_KEY_SEPARATOR = "-"
+
+
+def _extraction_dir() -> Path:
+    """The payload directory of the running binary; the compiled package sits directly inside it."""
+    return Path(lilbee.__file__).resolve().parent.parent
+
+
+def _release_version(directory: Path) -> str:
+    return directory.name.partition(_BUILD_KEY_SEPARATOR)[0]
+
+
+def _stale_siblings(running: Path) -> list[Path]:
+    """Payload directories beside *running* that another release wrote."""
+    running_version = _release_version(running)
+    return [
+        path
+        for path in running.parent.iterdir()
+        if path != running
+        and _release_version(path) != running_version
+        and (path / BOOTSTRAP_MANIFEST_NAME).is_file()
+    ]
+
+
+def _remove(path: Path) -> bool:
+    try:
+        shutil.rmtree(path)
+    except OSError as exc:
+        logger.debug("Left the onefile cache %s in place: %s", path, exc)
+        return False
+    return True
+
+
+def remove_stale_extractions(running: Path) -> list[Path]:
+    """Delete the payload directories of other releases beside *running*; never raises."""
+    try:
+        stale = _stale_siblings(running)
+    except OSError as exc:
+        logger.debug("Skipped the onefile cache sweep of %s: %s", running.parent, exc)
+        return []
+    removed = [path for path in stale if _remove(path)]
+    if removed:
+        logger.info("Removed the onefile cache of older releases: %s", ", ".join(map(str, removed)))
+    return removed
+
+
+def cleanup_stale_onefile_caches() -> None:
+    """Startup hook; a no-op outside the compiled binary."""
+    if is_frozen():
+        remove_stale_extractions(_extraction_dir())

--- a/tests/test_bootstrap_patch.py
+++ b/tests/test_bootstrap_patch.py
@@ -12,6 +12,7 @@ from lilbee.runtime.bee_logo import (
     ROSE_DIM_XTERM,
     ROSE_MID_XTERM,
 )
+from lilbee.runtime.onefile_cache import BOOTSTRAP_MANIFEST_NAME
 
 _PATCH = (
     pathlib.Path(__file__).resolve().parents[1] / "tools/wheel-build/onefile-bootstrap-lilbee.patch"
@@ -72,6 +73,12 @@ def test_progress_is_suppressed_off_a_terminal(added_lines):
     """A piped or redirected launch must not emit escape codes."""
     body = "\n".join(added_lines)
     assert "isatty(STDERR_FILENO)" in body
+
+
+def test_manifest_name_matches_the_startup_sweep(added_lines):
+    """The sweep only deletes a directory that holds the manifest this patch writes."""
+    body = "\n".join(added_lines)
+    assert f'#define LILBEE_MANIFEST_NAME "{BOOTSTRAP_MANIFEST_NAME}"' in body
 
 
 def test_stamp_fast_path_is_guarded_by_payload_size(added_lines):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 from pathlib import Path
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
@@ -1637,6 +1638,13 @@ class TestConfigLoadWarning:
         stderr = self._invoke_default(json_output=False, monkeypatch=monkeypatch)
         assert "Warning: persisted config" in stderr
         assert "stale-ref-xyz" in stderr
+
+    def test_callback_sweeps_stale_onefile_caches(self, monkeypatch):
+        """Every CLI, server and MCP launch passes the callback."""
+        sweep = mock.Mock()
+        monkeypatch.setattr(sys.modules["lilbee.cli.app"], "cleanup_stale_onefile_caches", sweep)
+        self._invoke_default(json_output=False, monkeypatch=monkeypatch)
+        sweep.assert_called_once_with()
 
     def test_warning_suppressed_in_json_mode(self, monkeypatch):
         stderr = self._invoke_default(json_output=True, monkeypatch=monkeypatch)

--- a/tests/test_onefile_cache.py
+++ b/tests/test_onefile_cache.py
@@ -63,7 +63,7 @@ def test_keeps_a_sibling_that_is_not_a_stale_extraction(
 
 def test_keeps_a_plain_file_beside_the_extractions(running: Path) -> None:
     config = running.parent / "config.toml"
-    config.write_text("")
+    config.write_text("", encoding="utf-8")
 
     assert remove_stale_extractions(running) == []
     assert config.is_file()

--- a/tests/test_onefile_cache.py
+++ b/tests/test_onefile_cache.py
@@ -22,7 +22,7 @@ def _extraction(root: Path, name: str, *, manifest: bool = True) -> Path:
     path = root / name
     (path / "lilbee").mkdir(parents=True)
     if manifest:
-        (path / BOOTSTRAP_MANIFEST_NAME).write_text("1\tlilbee/__init__.py\n")
+        (path / BOOTSTRAP_MANIFEST_NAME).write_text("1\tlilbee/__init__.py\n", encoding="utf-8")
     return path
 
 

--- a/tests/test_onefile_cache.py
+++ b/tests/test_onefile_cache.py
@@ -1,0 +1,124 @@
+"""Startup sweep of the onefile extraction directories left by older releases."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import lilbee.runtime.onefile_cache as onefile_cache
+from lilbee.runtime.onefile_cache import (
+    BOOTSTRAP_MANIFEST_NAME,
+    cleanup_stale_onefile_caches,
+    remove_stale_extractions,
+)
+
+_RUNNING = "0.6.91.0-macos-arm64"
+
+
+def _extraction(root: Path, name: str, *, manifest: bool = True) -> Path:
+    path = root / name
+    (path / "lilbee").mkdir(parents=True)
+    if manifest:
+        (path / BOOTSTRAP_MANIFEST_NAME).write_text("1\tlilbee/__init__.py\n")
+    return path
+
+
+@pytest.fixture
+def running(tmp_path: Path) -> Path:
+    return _extraction(tmp_path, _RUNNING)
+
+
+def test_removes_the_extraction_of_an_older_release(running: Path, caplog) -> None:
+    stale = _extraction(running.parent, "0.6.90.0-macos-arm64")
+
+    with caplog.at_level(logging.INFO, logger=onefile_cache.__name__):
+        removed = remove_stale_extractions(running)
+
+    assert removed == [stale]
+    assert not stale.exists()
+    assert running.is_dir()
+    assert any(str(stale) in record.message for record in caplog.records)
+
+
+@pytest.mark.parametrize(
+    ("name", "manifest"),
+    [
+        pytest.param("0.6.91.0-linux-x86_64", True, id="same-version-other-build"),
+        pytest.param("0.6.91.0", True, id="same-version-unkeyed"),
+        pytest.param("0.6.90.0-macos-arm64", False, id="no-manifest"),
+        pytest.param("bin", False, id="shared-root-bin"),
+    ],
+)
+def test_keeps_a_sibling_that_is_not_a_stale_extraction(
+    running: Path, name: str, manifest: bool
+) -> None:
+    kept = _extraction(running.parent, name, manifest=manifest)
+
+    assert remove_stale_extractions(running) == []
+    assert kept.is_dir()
+
+
+def test_keeps_a_plain_file_beside_the_extractions(running: Path) -> None:
+    config = running.parent / "config.toml"
+    config.write_text("")
+
+    assert remove_stale_extractions(running) == []
+    assert config.is_file()
+
+
+def test_tolerates_an_oserror_and_keeps_going(running: Path, caplog) -> None:
+    locked = _extraction(running.parent, "0.6.89.0-macos-arm64")
+    free = _extraction(running.parent, "0.6.90.0-macos-arm64")
+    real_rmtree = onefile_cache.shutil.rmtree
+
+    def rmtree(path: Path) -> None:
+        if path == locked:
+            raise PermissionError("mapped DLL")
+        real_rmtree(path)
+
+    with (
+        mock.patch.object(onefile_cache.shutil, "rmtree", side_effect=rmtree),
+        caplog.at_level(logging.DEBUG, logger=onefile_cache.__name__),
+    ):
+        removed = remove_stale_extractions(running)
+
+    assert removed == [free]
+    assert locked.is_dir()
+    assert any("mapped DLL" in record.message for record in caplog.records)
+
+
+def test_tolerates_an_unreadable_cache_root(tmp_path: Path, caplog) -> None:
+    missing = tmp_path / "gone" / _RUNNING
+
+    with caplog.at_level(logging.DEBUG, logger=onefile_cache.__name__):
+        assert remove_stale_extractions(missing) == []
+
+    assert any(record.levelno == logging.DEBUG for record in caplog.records)
+
+
+def test_startup_hook_is_a_noop_outside_the_compiled_binary() -> None:
+    with (
+        mock.patch.object(onefile_cache, "is_frozen", return_value=False),
+        mock.patch.object(onefile_cache, "remove_stale_extractions") as remove,
+    ):
+        cleanup_stale_onefile_caches()
+
+    remove.assert_not_called()
+
+
+def test_startup_hook_sweeps_beside_the_running_extraction(running: Path) -> None:
+    stale = _extraction(running.parent, "0.6.90.0-macos-arm64")
+
+    with (
+        mock.patch.object(onefile_cache, "is_frozen", return_value=True),
+        mock.patch.object(
+            onefile_cache.lilbee, "__file__", str(running / "lilbee" / "__init__.py")
+        ),
+    ):
+        cleanup_stale_onefile_caches()
+
+    assert not stale.exists()
+    assert running.is_dir()

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -117,6 +117,11 @@ CHILD_MODULE_FLAGS=(
     --include-module=lilbee.providers.fleet.vulkan_probe
 )
 
+# One cache directory per build: two builds of one version sharing {VERSION}
+# rewrite each other's files, which fails on Windows while the other build runs.
+ONEFILE_BUILD_KEY=${ASSET_NAME#lilbee-}
+ONEFILE_BUILD_KEY=${ONEFILE_BUILD_KEY%.exe}
+
 # litellm.proxy is not trimmable, despite nothing in lilbee importing it:
 # litellm/__init__.py pulls in 9 of its modules on a bare import, so
 # --nofollow-import-to=litellm.proxy is an ImportError at startup.
@@ -124,12 +129,6 @@ CHILD_MODULE_FLAGS=(
 # hf_xet is included explicitly so the package configuration's hf_xet metadata
 # is emitted: Nuitka only ships metadata for a distribution whose top-level
 # module it actually compiled.
-
-# One cache directory per build: two builds of one version sharing {VERSION}
-# rewrite each other's files, which fails on Windows while the other build runs.
-ONEFILE_BUILD_KEY=${ASSET_NAME#lilbee-}
-ONEFILE_BUILD_KEY=${ONEFILE_BUILD_KEY%.exe}
-
 uv run --no-sync python -m nuitka \
     --mode=onefile \
     --user-plugin=tools/wheel-build/playwright_node_verbatim.py \

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -124,6 +124,12 @@ CHILD_MODULE_FLAGS=(
 # hf_xet is included explicitly so the package configuration's hf_xet metadata
 # is emitted: Nuitka only ships metadata for a distribution whose top-level
 # module it actually compiled.
+
+# One cache directory per build: two builds of one version sharing {VERSION}
+# rewrite each other's files, which fails on Windows while the other build runs.
+ONEFILE_BUILD_KEY=${ASSET_NAME#lilbee-}
+ONEFILE_BUILD_KEY=${ONEFILE_BUILD_KEY%.exe}
+
 uv run --no-sync python -m nuitka \
     --mode=onefile \
     --user-plugin=tools/wheel-build/playwright_node_verbatim.py \
@@ -131,7 +137,7 @@ uv run --no-sync python -m nuitka \
     --no-deployment-flag=self-execution \
     --onefile-as-archive \
     --onefile-cache-mode=cached \
-    --onefile-tempdir-spec='{CACHE_DIR}/lilbee/{VERSION}' \
+    --onefile-tempdir-spec="{CACHE_DIR}/lilbee/{VERSION}-${ONEFILE_BUILD_KEY}" \
     --product-name=lilbee \
     --product-version="$PRODUCT_VERSION" \
     --output-filename="$ASSET_NAME" \

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,16 +1,16 @@
 --- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
 +++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
-@@ -447,7 +447,298 @@
+@@ -447,7 +447,297 @@
  #if _NUITKA_ONEFILE_TEMP_BOOL
  static bool payload_created = false;
  #endif
 +
 +// lilbee: cold-start feedback and a warm-start fast path.
 +//
-+// The onefile cache is keyed on {VERSION}, so a populated payload directory whose
-+// stamp records this payload's size was written by this exact binary. Trusting it
-+// skips the per-file CRC32 of the whole payload, which otherwise costs seconds of
-+// pure CPU on every launch. Cold starts still verify normally.
++// The cache directory is keyed on version and build, so a populated payload
++// directory whose stamp records this payload's size was written by this binary.
++// Trusting it skips the per-file CRC32 of the whole payload, which otherwise
++// costs seconds of pure CPU on every launch. Cold starts still verify normally.
 +#if !defined(_WIN32) && !defined(__MSYS__)
 +#include <sys/ioctl.h>
 +#include <unistd.h>
@@ -57,14 +57,13 @@
 +// The manifest lists every payload entry ("<size>\t<path>" per line, -1 for
 +// symlinks). The warm-start path stats each entry before trusting the cache:
 +// without this, a damaged cached tree (a file deleted by a cache cleanup, or
-+// a re-extraction over the shared {VERSION} dir interrupted mid-write when
-+// switching binary variants) is reused on every later launch, because the
-+// stamp alone only proves the payload size. Stock Nuitka re-verifies the CRC32
-+// of every file on every launch and self-heals; the stat sweep restores that
-+// self-healing for missing and resized files at microseconds instead of
-+// seconds. A same-size content change still slips through until a cold pass
-+// runs; only the full CRC path can catch that, and paying it per launch is
-+// what this fast path exists to avoid.
++// an extraction interrupted mid-write) is reused on every later launch,
++// because the stamp alone only proves the payload size. Stock Nuitka
++// re-verifies the CRC32 of every file on every launch and self-heals; the
++// stat sweep restores that self-healing for missing and resized files at
++// microseconds instead of seconds. A same-size content change still slips
++// through until a cold pass runs; only the full CRC path can catch that,
++// and paying it per launch is what this fast path exists to avoid.
 +#define LILBEE_MANIFEST_NAME ".lilbee-bootstrap-manifest"
 +
 +// Defined further down; needed on the first-ever run before any file lands.


### PR DESCRIPTION
## Problem

Every build of a release extracts into the same onefile cache directory, `{CACHE_DIR}/lilbee/{VERSION}`. The bootstrap rewrites every cached file whose checksum differs from the payload. The default build and the CUDA build of one release have different payloads. When a machine holds both builds, each launch of the other build rewrites the files that differ.

On Windows that rewrite fails while the other build runs, because Windows locks a mapped DLL against writes:

```
Error, failed to open 'C:\Users\...\AppData\Local\lilbee\0.6.90.432\msvcp140.dll' for writing.
server exited (exit code 2)
```

One user hit this eight times in two days and never got a working server. The plugin installs the CUDA build on NVIDIA hosts. The scoop manifest installs the default build. One machine with both builds is a normal setup.

I reproduced the failure on a clean Windows Server 2025 VM with the v0.6.90b432 assets. The same build launched twice never fails. With the default build serving, a launch of the CUDA build fails with exactly that line.

## Solution

Key the cache directory by build, not by version alone. `ASSET_NAME` is unique per build, and every workflow already passes it. The spec becomes `{CACHE_DIR}/lilbee/{VERSION}-<asset>`. For example, `0.6.90.432-windows-x86_64-cu125` sits beside `0.6.90.432-windows-x86_64`. Each build keeps its cached fast start and never touches another build's files.

**Old caches go away.** At startup the compiled binary removes the extraction directories of other releases beside its own. It deletes only a sibling that holds the bootstrap manifest and carries a different version, so `bin/`, `models/` and the other build of the same release are never touched. A directory it cannot remove is logged and left in place.

Closes tobocop2/obsidian-lilbee#237.
