### PR TITLE
Turn off thinking in auxiliary calls and tighten the known-item match

### DIFF
--- a/src/lilbee/app/memory.py
+++ b/src/lilbee/app/memory.py
@@ -26,6 +26,7 @@ from lilbee.data.store import (
     human_recall_predicate,
     local_owner_predicate,
 )
+from lilbee.providers.base import aux_options
 
 
 def make_memory_row(
@@ -154,7 +155,7 @@ def auto_extract(question: str, answer: str) -> list[SavedMemory]:
     in ``/memories``. A no-op (returns ``[]``) unless both the master gate and
     ``memory_auto_extract`` are on.
     """
-    from lilbee.retrieval.query.memory_extract import extract_memories
+    from lilbee.retrieval.query.memory_extract import MEMORY_EXTRACT_MAX_TOKENS, extract_memories
 
     if not auto_extract_enabled():
         return []
@@ -162,7 +163,9 @@ def auto_extract(question: str, answer: str) -> list[SavedMemory]:
 
     def _chat_text(messages: list[dict[str, str]], **_kwargs: object) -> str:
         return services.provider.chat(
-            messages, stream=False, options={"response_format": json_reply_format()}
+            messages,
+            stream=False,
+            options=aux_options(MEMORY_EXTRACT_MAX_TOKENS, response_format=json_reply_format()),
         ).text
 
     extracted = extract_memories(question, answer, _chat_text)

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -1419,6 +1419,9 @@ class Config(BaseSettings):
     def generation_options(self, **overrides: Any) -> dict[str, Any]:
         """Merge model defaults, user config, and per-call overrides, dropping None."""
         result = _model_defaults_dict(self._model_defaults)
+        # One name for the output cap inside lilbee; the provider translators rename it.
+        if "max_tokens" in result:
+            result["num_predict"] = result.pop("max_tokens")
         user_fields: dict[str, Any] = {
             "temperature": self.temperature,
             "top_p": self.top_p,
@@ -1426,7 +1429,7 @@ class Config(BaseSettings):
             "repeat_penalty": self.repeat_penalty,
             "num_ctx": self.num_ctx,
             "seed": self.seed,
-            "max_tokens": self.max_tokens,
+            "num_predict": self.max_tokens,
         }
         for k, v in user_fields.items():
             if v is not None:

--- a/src/lilbee/data/extract/document.py
+++ b/src/lilbee/data/extract/document.py
@@ -24,6 +24,7 @@ from lilbee.data.types import (
     ExtractMode,
     OcrBackendName,
 )
+from lilbee.providers.base import aux_options
 from lilbee.runtime.progress import (
     DetailedProgressCallback,
     EventType,
@@ -144,7 +145,7 @@ def _enrich_texts(texts: list[str], doc_head: str, source_name: str) -> list[str
             response = provider.chat(
                 [{"role": "user", "content": prompt}],
                 stream=False,
-                options={"num_predict": _ENRICH_MAX_TOKENS},
+                options=aux_options(_ENRICH_MAX_TOKENS),
             )
             lines = strip_reasoning(response.text).strip().splitlines()
             sentence = lines[0].strip() if lines else ""

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -100,14 +100,10 @@ def filter_options(options: dict[str, Any]) -> dict[str, Any]:
 
 
 def aux_options(num_predict: int, **extra: Any) -> dict[str, Any]:
-    """Options for an auxiliary call: a token cap with thinking off.
+    """Options for an internal call: a cap sized for its answer, with thinking off.
 
-    The pipeline's internal calls (query expansion, HyDE, condensation,
-    classification, chunk enrichment, entity induction and extraction) each run
-    on a cap sized for their answer alone. A thinking model spends that whole
-    cap inside <think>, which llama.cpp force-closes at the limit and
-    ``strip_reasoning`` then deletes whole, so the call returns nothing at full
-    cost.
+    A thinking model spends a small cap inside <think>, which ``strip_reasoning``
+    then deletes whole, so the call returns nothing.
     """
     return {"num_predict": num_predict, "think": False, **extra}
 

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -99,6 +99,19 @@ def filter_options(options: dict[str, Any]) -> dict[str, Any]:
     return LLMOptions(**options).to_dict()
 
 
+def aux_options(num_predict: int, **extra: Any) -> dict[str, Any]:
+    """Options for an auxiliary call: a token cap with thinking off.
+
+    The pipeline's internal calls (query expansion, HyDE, condensation,
+    classification, chunk enrichment, entity induction and extraction) each run
+    on a cap sized for their answer alone. A thinking model spends that whole
+    cap inside <think>, which llama.cpp force-closes at the limit and
+    ``strip_reasoning`` then deletes whole, so the call returns nothing at full
+    cost.
+    """
+    return {"num_predict": num_predict, "think": False, **extra}
+
+
 def normalize_generation_options(options: dict[str, Any] | None) -> dict[str, Any]:
     """Validate options and map them to the per-call set an OpenAI/llama-server body takes.
 

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -83,7 +83,7 @@ class LLMOptions(BaseModel):
     # Thinking-template control for structured internal calls (schema
     # induction and similar): a small thinking model can burn its whole
     # token budget inside <think> and emit nothing. llama-server maps this
-    # to chat_template_kwargs; hosted-API translators drop it.
+    # to chat_template_kwargs and Ollama to its think field; hosted-API translators drop it.
     think: bool | None = None
     # Structured-output request for the internal calls that want a bare JSON
     # value back. Must be listed here or the allowlist above silently drops it.

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from lilbee.catalog.refs import GGUF_SUFFIX, NATIVE_GGUF_REF_MIN_SLASHES
+from lilbee.catalog.types import ModelSource
 from lilbee.providers.base import filter_options, normalize_generation_options
 from lilbee.providers.local_servers import (
     LOCAL_SERVER_KEYS,
@@ -35,6 +36,7 @@ PROVIDER_PREFIXES: frozenset[str] = frozenset(_API_PROVIDERS | LOCAL_SERVER_KEYS
 
 # Provider value for refs served from the local registry (native GGUF).
 LOCAL_PROVIDER = "local"
+OLLAMA_NO_THINKING = "none"
 
 
 def is_native_gguf_ref(raw: str) -> bool:
@@ -172,9 +174,11 @@ def translate_options(options: dict[str, Any], ref: ProviderModelRef) -> dict[st
     """
     if not ref.is_api:
         filtered = filter_options(options)
-        # litellm has no chat_template_kwargs passthrough; thinking control
-        # only exists on the native llama-server path.
-        filtered.pop("think", None)
+        think = filtered.pop("think", None)
+        if think is False and ref.provider == ModelSource.OLLAMA:
+            # litellm maps reasoning_effort onto Ollama's think field; any value
+            # outside low/medium/high turns thinking off.
+            filtered["reasoning_effort"] = OLLAMA_NO_THINKING
         return filtered
     api_options = normalize_generation_options(options)
     api_options.pop("top_k", None)

--- a/src/lilbee/retrieval/entities/extractor.py
+++ b/src/lilbee/retrieval/entities/extractor.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 import regex
 
 from lilbee.core.llm_json import first_json_object, json_reply_format
+from lilbee.providers.base import aux_options
 from lilbee.retrieval.entities.schema import (
     EntitySchema,
     EntityType,
@@ -129,16 +130,11 @@ def induce_schema(sample_texts: list[str], provider: LLMProvider) -> EntitySchem
         response = provider.chat(
             [{"role": "user", "content": prompt}],
             stream=False,
-            # think=False: a small thinking model can loop inside <think>
-            # until the budget is gone and emit no JSON at all. temperature 0:
-            # induction wants one deterministic, well-formed schema, not a
+            # Induction wants one deterministic, well-formed schema, not a
             # creative sample that parses only some of the time.
-            options={
-                "num_predict": INDUCTION_MAX_TOKENS,
-                "think": False,
-                "temperature": 0,
-                "response_format": json_reply_format(),
-            },
+            options=aux_options(
+                INDUCTION_MAX_TOKENS, temperature=0, response_format=json_reply_format()
+            ),
         )
     except Exception:
         log.warning("Entity schema induction failed at the provider", exc_info=True)
@@ -257,7 +253,7 @@ def _extract_llm_batch(
         response = provider.chat(
             [{"role": "user", "content": prompt}],
             stream=False,
-            options={"num_predict": LLM_EXTRACTION_MAX_TOKENS},
+            options=aux_options(LLM_EXTRACTION_MAX_TOKENS),
         )
     except Exception:
         log.warning("LLM entity extraction failed for a batch", exc_info=True)

--- a/src/lilbee/retrieval/query/intent.py
+++ b/src/lilbee/retrieval/query/intent.py
@@ -139,6 +139,33 @@ def _same_number(token: str, ref_token: str) -> bool:
     return token.lstrip("0") == ref_token.lstrip("0")
 
 
+# Shortest reference the loose arm accepts, counted over its alphanumerics.
+# Below this a reference is a common word as often as a document name.
+_MIN_LOOSE_REF_CHARS = 3
+
+
+def _tokens(text: str) -> list[str]:
+    """Lowercased alphanumeric tokens of *text*."""
+    return [t for t in _TOKEN_SPLIT_RE.split(text.lower()) if t]
+
+
+def contains_reference(ref: str, filename: str) -> bool:
+    """Whether *filename*'s stem carries *ref* as a run of whole tokens.
+
+    The loose arm of reference resolution: a quoted title never token-matches
+    a hyphenated filename, so "harbor survey 2010" still names
+    harbor-survey-2010.pdf. Whole tokens and a length floor keep a word inside
+    another word from routing: "we" sits in "DSO Web Hosting", and matching it
+    replaces the whole retrieval context with that one note.
+    """
+    ref_tokens = _tokens(ref)
+    if sum(len(t) for t in ref_tokens) < _MIN_LOOSE_REF_CHARS:
+        return False
+    stem_tokens = _tokens(Path(filename).stem)
+    span = len(ref_tokens)
+    return any(stem_tokens[i : i + span] == ref_tokens for i in range(len(stem_tokens) - span + 1))
+
+
 def title_candidates(question: str, lang: QueryLanguage | None = None) -> list[str]:
     """Document-title candidates from known-item question shapes.
 
@@ -159,8 +186,7 @@ def title_candidates(question: str, lang: QueryLanguage | None = None) -> list[s
 
 def _title_tokens(text: str, lang: QueryLanguage) -> list[str]:
     """Lowercased comparison tokens with the leading article stripped."""
-    stripped = lang.leading_article_pattern.sub("", text.strip())
-    return [t for t in _TOKEN_SPLIT_RE.split(stripped.lower()) if t]
+    return _tokens(lang.leading_article_pattern.sub("", text.strip()))
 
 
 def matches_title(title: str, filename: str, lang: QueryLanguage | None = None) -> bool:

--- a/src/lilbee/retrieval/query/intent.py
+++ b/src/lilbee/retrieval/query/intent.py
@@ -141,9 +141,6 @@ def _same_number(token: str, ref_token: str) -> bool:
 
 # Shortest reference the loose arm accepts, counted over its alphanumerics.
 # Below this a reference is a common word as often as a document name.
-_MIN_LOOSE_REF_CHARS = 3
-
-
 def _tokens(text: str) -> list[str]:
     """Lowercased alphanumeric tokens of *text*."""
     return [t for t in _TOKEN_SPLIT_RE.split(text.lower()) if t]
@@ -152,14 +149,12 @@ def _tokens(text: str) -> list[str]:
 def contains_reference(ref: str, filename: str) -> bool:
     """Whether *filename*'s stem carries *ref* as a run of whole tokens.
 
-    The loose arm of reference resolution: a quoted title never token-matches
-    a hyphenated filename, so "harbor survey 2010" still names
-    harbor-survey-2010.pdf. Whole tokens and a length floor keep a word inside
-    another word from routing: "we" sits in "DSO Web Hosting", and matching it
-    replaces the whole retrieval context with that one note.
+    A quoted title never token-matches a hyphenated filename, so "harbor survey
+    2010" still names harbor-survey-2010.pdf. Whole tokens keep "we" out of
+    "Web".
     """
     ref_tokens = _tokens(ref)
-    if sum(len(t) for t in ref_tokens) < _MIN_LOOSE_REF_CHARS:
+    if not ref_tokens:
         return False
     stem_tokens = _tokens(Path(filename).stem)
     span = len(ref_tokens)

--- a/src/lilbee/retrieval/query/memory_extract.py
+++ b/src/lilbee/retrieval/query/memory_extract.py
@@ -22,6 +22,7 @@ ChatFn = Callable[..., str]
 
 # Bounds mirror the prior-art auto-capture filter: too-short strings carry no
 # durable signal, too-long ones are usually the model restating the answer.
+MEMORY_EXTRACT_MAX_TOKENS = 800
 _MIN_MEMORY_CHARS = 10
 _MAX_MEMORY_CHARS = 500
 

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -780,7 +780,7 @@ class Searcher:
             summary = strip_reasoning(response.text).strip()
             if summary:
                 return summary
-            # Only the native llama-server path honors think=False; elsewhere a
+            # The llama-server and Ollama paths honor think=False; elsewhere a
             # reasoning model can leave nothing after the strip. Its reasoning
             # is itself a summary of these turns, so recover it rather than
             # strand them. Non-reasoning models never reach here.

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -29,6 +29,7 @@ from lilbee.providers.base import (
     LLMProvider,
     ProviderError,
     ProviderErrorKind,
+    aux_options,
     estimate_budget_tokens,
     prompt_token_budget,
 )
@@ -71,6 +72,7 @@ from lilbee.retrieval.query.intent import (
     INTENT_CLASSIFY_PROMPT,
     AggregateKind,
     AggregateQuery,
+    contains_reference,
     document_references,
     matches_reference,
     matches_stored_title,
@@ -321,7 +323,7 @@ class Searcher:
         prompt = EXPANSION_PROMPT.format(count=count, question=question)
         messages = [{"role": "user", "content": prompt}]
         response = self._provider.chat(
-            messages, stream=False, options={"num_predict": EXPANSION_MAX_TOKENS}
+            messages, stream=False, options=aux_options(EXPANSION_MAX_TOKENS)
         )
         text = strip_reasoning(response.text).strip()
         variants = [_strip_list_marker(line.strip()) for line in text.split("\n") if line.strip()]
@@ -429,7 +431,7 @@ class Searcher:
             response = self._provider.chat(
                 [{"role": "user", "content": self._config.hyde_prompt.format(question=question)}],
                 stream=False,
-                options={"num_predict": HYDE_MAX_TOKENS},
+                options=aux_options(HYDE_MAX_TOKENS),
             )
             # Reasoning models front-load deliberation; embedding it instead
             # of the passage would search for the model's thought process.
@@ -686,7 +688,7 @@ class Searcher:
             response = self._provider.chat(
                 [{"role": "user", "content": prompt}],
                 stream=False,
-                options={"num_predict": CONDENSE_MAX_TOKENS},
+                options=aux_options(CONDENSE_MAX_TOKENS),
             )
             rewritten = strip_reasoning(response.text).strip().splitlines()
             first_line = rewritten[0].strip() if rewritten else ""
@@ -769,15 +771,11 @@ class Searcher:
             response = self._provider.chat(
                 [{"role": "user", "content": prompt}],
                 stream=False,
-                options={
-                    "num_predict": summary_cap(self._config.chat_n_ctx_target),
-                    # A thinking model spends the whole budget in a <think>
-                    # block that llama.cpp force-closes and strip_reasoning
-                    # deletes whole, leaving "" and stranding the batch.
-                    "think": False,
+                options=aux_options(
+                    summary_cap(self._config.chat_n_ctx_target),
                     # Deterministic: the same conversation folds the same way.
-                    "temperature": 0,
-                },
+                    temperature=0,
+                ),
             )
             summary = strip_reasoning(response.text).strip()
             if summary:
@@ -881,9 +879,9 @@ class Searcher:
         Filename resolution first: substring search over-matches (a bare
         "482" hits every zero-padded id containing it), so token-exact
         matching disambiguates and only a unique winner routes. A unique
-        substring hit still routes for word refs (quoted titles never
-        token-match hyphenated filenames) but not numeric ones: "12" inside
-        "notes-2012" is the false match token comparison exists to reject.
+        candidate still routes when it carries the reference as whole tokens
+        (quoted titles never token-match hyphenated filenames), which is what
+        rejects "12" inside "notes-2012" and "we" inside "DSO Web Hosting".
 
         When no filename knows the reference, it may be a docket-style number
         living in the document's own text; a BM25 probe resolves it when the
@@ -893,8 +891,10 @@ class Searcher:
         matches = [s for s in candidates if matches_reference(ref, s["filename"])]
         if len(matches) == 1:
             return str(matches[0]["filename"])
-        if not matches and len(candidates) == 1 and not ref.strip().isdigit():
-            return str(candidates[0]["filename"])
+        if not matches and len(candidates) == 1:
+            unique = str(candidates[0]["filename"])
+            if contains_reference(ref, unique):
+                return unique
         if matches:
             return None  # several sources genuinely carry the reference
         return self._resolve_reference_by_content(ref, chunk_type)
@@ -1255,10 +1255,9 @@ class Searcher:
             response = self._provider.chat(
                 [{"role": "user", "content": prompt}],
                 stream=False,
-                options={
-                    "num_predict": INTENT_CLASSIFY_MAX_TOKENS,
-                    "response_format": json_reply_format(),
-                },
+                options=aux_options(
+                    INTENT_CLASSIFY_MAX_TOKENS, response_format=json_reply_format()
+                ),
             )
         except Exception:
             log.debug("LLM intent classification failed; using pattern result", exc_info=True)

--- a/tests/test_app_memory.py
+++ b/tests/test_app_memory.py
@@ -18,6 +18,7 @@ from lilbee.data.store import (
     local_owner_predicate,
 )
 from lilbee.providers.base import ChatResult, FinishReason
+from lilbee.retrieval.query.memory_extract import MEMORY_EXTRACT_MAX_TOKENS
 from tests.conftest import make_mock_services
 
 
@@ -172,6 +173,17 @@ class TestAutoExtract:
         assert stored[0].kind is MemoryKind.FACT
         record = svc.store.add_memory.call_args.args[0]
         assert record.source is MemorySource.EXTRACTED
+
+    def test_extraction_is_an_auxiliary_call(self, svc):
+        """The extraction call carries the auxiliary cap and thinking off."""
+        cfg.memory_enabled = True
+        cfg.memory_auto_extract = True
+        svc.provider.chat.return_value = _chat_result("[]")
+        app_memory.auto_extract("hi", "hello")
+        options = svc.provider.chat.call_args.kwargs["options"]
+        assert options["num_predict"] == MEMORY_EXTRACT_MAX_TOKENS
+        assert options["think"] is False
+        assert "response_format" in options
 
     def test_nothing_extracted_stores_nothing(self, svc):
         cfg.memory_enabled = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1137,10 +1137,24 @@ class TestGenerationOptions:
         opts = c.generation_options()
         assert opts == {"temperature": 0.3, "seed": 42}
 
-    def test_includes_max_tokens(self):
+    def test_max_tokens_reaches_the_providers_as_num_predict(self):
+        from lilbee.providers.base import filter_options, normalize_generation_options
+
         c = Config()
         opts = c.generation_options()
-        assert opts["max_tokens"] == 4096
+        assert opts["num_predict"] == 4096
+        assert "max_tokens" not in opts
+        assert filter_options(opts)["num_predict"] == 4096
+        assert normalize_generation_options(opts)["max_tokens"] == 4096
+
+    def test_model_default_cap_uses_the_same_name(self):
+        from lilbee.providers.model_defaults import ModelDefaults
+
+        c = Config()
+        c.apply_model_defaults(ModelDefaults(max_tokens=512))
+        assert c.generation_options()["num_predict"] == 4096
+        c.max_tokens = None
+        assert c.generation_options()["num_predict"] == 512
 
     def test_remaps_top_k_sampling(self):
         c = Config()

--- a/tests/test_entities_extractor.py
+++ b/tests/test_entities_extractor.py
@@ -447,6 +447,14 @@ class TestExtractEntities:
         assert stats.llm_batches == 1
         assert stats.llm_batches_failed == 0
 
+    def test_extraction_turns_thinking_off(self):
+        """The call wants one JSON object on a fixed cap. A thinking model
+        spends the cap inside <think> and every batch parses to nothing."""
+        provider = MagicMock()
+        provider.chat.return_value = _text_result(json.dumps({"0": []}))
+        extract_entities([_chunk("no ships here")], EntitySchema(types=[VESSEL]), provider=provider)
+        assert provider.chat.call_args.kwargs["options"]["think"] is False
+
     def test_poisoned_chunk_is_isolated_by_single_retry(self):
         """One chunk that deterministically fails the batch call must not fail
         the batch: the single-chunk retry keeps the other chunks' entities and

--- a/tests/test_ingest_title.py
+++ b/tests/test_ingest_title.py
@@ -162,6 +162,23 @@ class TestContextualEnrichment:
             cfg.contextual_enrichment = False
         assert out == ["This chunk covers the budget section of the annual report.\nchunk text"]
 
+    def test_turns_thinking_off(self):
+        """One situating sentence on a small cap: a thinking model spends the
+        cap deliberating and every chunk embeds bare."""
+        from unittest.mock import patch
+
+        from lilbee.core.config import cfg
+        from lilbee.data.extract.document import _enrich_texts
+
+        svc = self._services()
+        cfg.contextual_enrichment = True
+        try:
+            with patch("lilbee.data.extract.document.get_services", return_value=svc):
+                _enrich_texts(["chunk text"], "doc head", "a.pdf")
+        finally:
+            cfg.contextual_enrichment = False
+        assert svc.provider.chat.call_args.kwargs["options"]["think"] is False
+
     def test_failure_keeps_the_bare_chunk(self):
         from unittest.mock import patch
 

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -5,6 +5,7 @@ import pytest
 from lilbee.retrieval.query.intent import (
     AggregateKind,
     AggregateQuery,
+    contains_reference,
     document_references,
     matches_reference,
     parse_aggregate,
@@ -184,6 +185,32 @@ class TestMatchesReference:
         assert matches_reference("0482", "ARC-REC-482.pdf")
         assert matches_reference("482", "ARC-REC-00482.pdf")
         assert not matches_reference("482", "ARC-REC-483.pdf")
+
+
+class TestContainsReference:
+    def test_multi_word_reference_spans_whole_tokens(self):
+        assert contains_reference("harbor survey 2010", "harbor-survey-2010.pdf")
+
+    def test_reference_runs_inside_a_longer_stem(self):
+        assert contains_reference("harbor survey", "2010-harbor-survey-final.pdf")
+
+    def test_reference_inside_a_word_does_not_match(self):
+        """The failure this exists to stop: "we" is inside "Web", and a
+        substring hit routed the whole retrieval context to that one note."""
+        assert not contains_reference("we", "notes/DSO Web Hosting.md")
+        assert not contains_reference("port", "Airport Signage.md")
+
+    def test_short_reference_never_matches(self):
+        """Under three characters a reference is a common word as often as a
+        name, so it cannot route even when the stem is exactly it."""
+        assert not contains_reference("we", "we.md")
+        assert contains_reference("web", "web.md")
+
+    def test_reference_tokens_must_be_contiguous(self):
+        assert not contains_reference("harbor 2010", "harbor-survey-2010.pdf")
+
+    def test_reference_with_no_alphanumeric_tokens_does_not_match(self):
+        assert not contains_reference("--", "a-b.md")
 
 
 class TestParseAggregate:

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -188,29 +188,20 @@ class TestMatchesReference:
 
 
 class TestContainsReference:
-    def test_multi_word_reference_spans_whole_tokens(self):
-        assert contains_reference("harbor survey 2010", "harbor-survey-2010.pdf")
-
-    def test_reference_runs_inside_a_longer_stem(self):
-        assert contains_reference("harbor survey", "2010-harbor-survey-final.pdf")
-
-    def test_reference_inside_a_word_does_not_match(self):
-        """The failure this exists to stop: "we" is inside "Web", and a
-        substring hit routed the whole retrieval context to that one note."""
-        assert not contains_reference("we", "notes/DSO Web Hosting.md")
-        assert not contains_reference("port", "Airport Signage.md")
-
-    def test_short_reference_never_matches(self):
-        """Under three characters a reference is a common word as often as a
-        name, so it cannot route even when the stem is exactly it."""
-        assert not contains_reference("we", "we.md")
-        assert contains_reference("web", "web.md")
-
-    def test_reference_tokens_must_be_contiguous(self):
-        assert not contains_reference("harbor 2010", "harbor-survey-2010.pdf")
-
-    def test_reference_with_no_alphanumeric_tokens_does_not_match(self):
-        assert not contains_reference("--", "a-b.md")
+    @pytest.mark.parametrize(
+        ("ref", "filename", "expected"),
+        [
+            pytest.param("harbor survey 2010", "harbor-survey-2010.pdf", True, id="whole-stem"),
+            pytest.param("harbor survey", "2010-harbor-survey-final.pdf", True, id="inner-run"),
+            pytest.param("we", "we.md", True, id="single-token"),
+            pytest.param("we", "notes/DSO Web Hosting.md", False, id="inside-a-word"),
+            pytest.param("port", "Airport Signage.md", False, id="suffix-of-a-word"),
+            pytest.param("harbor 2010", "harbor-survey-2010.pdf", False, id="not-contiguous"),
+            pytest.param("--", "a-b.md", False, id="no-alphanumerics"),
+        ],
+    )
+    def test_matches_whole_token_runs(self, ref, filename, expected):
+        assert contains_reference(ref, filename) is expected
 
 
 class TestParseAggregate:

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -106,13 +106,13 @@ class TestGenerationOptions3LayerMerge:
     def test_max_tokens_from_config(self):
         cfg.max_tokens = 2048
         result = cfg.generation_options()
-        assert result["max_tokens"] == 2048
+        assert result["num_predict"] == 2048
 
     def test_max_tokens_from_model_defaults(self):
         cfg.max_tokens = None
         cfg.apply_model_defaults(ModelDefaults(max_tokens=1024))
         result = cfg.generation_options()
-        assert result["max_tokens"] == 1024
+        assert result["num_predict"] == 1024
 
     def test_all_three_layers(self):
         """Full 3-layer merge: model default -> user config -> per-call."""

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -326,11 +326,26 @@ class TestTranslateOptions:
         result = translate_options({"temperature": 0.5, "think": False}, ref)
         assert result == {"temperature": 0.5}
 
-    def test_local_ref_through_sdk_drops_think(self) -> None:
-        """litellm has no chat_template_kwargs passthrough either."""
-        ref = parse_model_ref(_LOCAL_REF)
+    @pytest.mark.parametrize(
+        ("raw", "reasoning_effort"),
+        [
+            pytest.param("ollama/llama3.2:1b", "none", id="ollama-turns-thinking-off"),
+            pytest.param("lm_studio/qwen3-8b", None, id="lm-studio-has-no-switch"),
+            pytest.param(_LOCAL_REF, None, id="native-ref-through-the-sdk"),
+        ],
+    )
+    def test_local_ref_through_sdk_translates_think(
+        self, raw: str, reasoning_effort: str | None
+    ) -> None:
+        """Ollama honors think through reasoning_effort; the other SDK paths have no switch."""
+        ref = parse_model_ref(raw)
         result = translate_options({"temperature": 0.5, "think": False}, ref)
         assert "think" not in result
+        assert result.get("reasoning_effort") == reasoning_effort
+
+    def test_think_left_on_sends_no_reasoning_effort(self) -> None:
+        ref = parse_model_ref("ollama/llama3.2:1b")
+        assert "reasoning_effort" not in translate_options({"think": True}, ref)
 
 
 class TestChatOptionsThink:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2566,6 +2566,28 @@ class TestFilterOptions:
         assert "top_p" not in result
 
 
+class TestAuxOptions:
+    def test_caps_tokens_and_turns_thinking_off(self) -> None:
+        from lilbee.providers.base import aux_options
+
+        assert aux_options(64) == {"num_predict": 64, "think": False}
+
+    def test_extra_options_are_carried_through(self) -> None:
+        from lilbee.providers.base import aux_options
+
+        opts = aux_options(64, temperature=0, response_format={"type": "json_object"})
+        assert opts["temperature"] == 0
+        assert opts["response_format"] == {"type": "json_object"}
+        assert opts["think"] is False
+
+    def test_result_survives_the_provider_allowlist(self) -> None:
+        """Options the allowlist drops never reach the provider, so the flag
+        must be a declared LLMOptions field, not a silently discarded key."""
+        from lilbee.providers.base import aux_options, filter_options
+
+        assert filter_options(aux_options(64))["think"] is False
+
+
 class TestTrainCtxFromMeta:
     """``train_ctx_from_meta`` is the single guard against ``context_length=0``.
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -662,6 +662,14 @@ class TestExpandQuery:
         variants = get_services().searcher._llm_expand("anything at all", 3)
         assert variants == ["first phrasing", "second phrasing", "third phrasing"]
 
+    def test_expansion_turns_thinking_off(self, mock_svc):
+        """The user's log: 9 of 18 completions in a day were expansion calls
+        that produced zero variants. A reasoning model spends the whole cap
+        inside <think>, and stripping it leaves nothing to split into lines."""
+        mock_svc.provider.chat.return_value = _text_result("A\nB")
+        get_services().searcher._llm_expand("explain pod scheduling", 2)
+        assert mock_svc.provider.chat.call_args.kwargs["options"]["think"] is False
+
     def test_returns_empty_on_error(self, mock_svc):
         mock_svc.provider.chat.side_effect = RuntimeError("no provider")
         assert (
@@ -1801,6 +1809,14 @@ class TestHydeSearch:
         get_services().searcher._hyde_search("explain X", top_k=5)
         assert mock_svc.provider.chat.call_args.kwargs["options"]["num_predict"] == HYDE_MAX_TOKENS
 
+    def test_turns_thinking_off(self, mock_svc):
+        """The passage is the whole point of the call; a reasoning model given
+        this cap spends it deliberating and hands back nothing to embed."""
+        mock_svc.provider.chat.return_value = _text_result("hypothetical passage")
+        mock_svc.store.search.return_value = []
+        get_services().searcher._hyde_search("explain X", top_k=5)
+        assert mock_svc.provider.chat.call_args.kwargs["options"]["think"] is False
+
     def test_returns_empty_on_error(self, mock_svc):
         mock_svc.provider.chat.side_effect = RuntimeError("fail")
         assert get_services().searcher._hyde_search("test", top_k=5) == []
@@ -2081,6 +2097,18 @@ class TestLlmIntentRouting:
             assert "count" in answer.lower()
         finally:
             cfg.intent_llm = False
+
+    def test_classification_turns_thinking_off(self, mock_svc):
+        """One short JSON verdict on a small cap: a thinking template burns the
+        cap before the JSON, and every question degrades to the pattern result."""
+        cfg.intent_llm = True
+        try:
+            mock_svc.provider.chat.return_value = _text_result(self._CLASSIFY_JSON)
+            mock_svc.store.count_term_mentions.return_value = (12, 5)
+            get_services().searcher.route_direct_answer("how many tomes mention blood?")
+        finally:
+            cfg.intent_llm = False
+        assert mock_svc.provider.chat.call_args.kwargs["options"]["think"] is False
 
 
 class TestSearchStructured:
@@ -2583,6 +2611,34 @@ class TestKnownItemRoute:
         mock_svc.store.get_chunks_by_source.assert_not_called()
         mock_svc.store.search.assert_called_once()
 
+    def test_short_common_word_reference_stays_topical(self, mock_svc):
+        """The user's log: "Known-item route: 'we' resolved to notes/DSO Web
+        Hosting.md". The pronoun after "file" became a reference, substring-hit
+        "We" inside "Web", and replaced the whole retrieval context with that
+        one note. A reference under three characters never routes."""
+        mock_svc.store.get_sources.return_value = [self._source("notes/DSO Web Hosting.md")]
+        mock_svc.store.search.return_value = [_make_result()]
+        cfg.query_expansion_count = 0
+        try:
+            get_services().searcher.build_rag_context("summarize the file we discussed")
+        finally:
+            cfg.query_expansion_count = 3
+        mock_svc.store.get_chunks_by_source.assert_not_called()
+        mock_svc.store.search.assert_called_once()
+
+    def test_reference_inside_a_longer_word_stays_topical(self, mock_svc):
+        """Length alone is not enough: a reference must land on whole tokens of
+        the filename, so "port" inside "Airport" is not the document named."""
+        mock_svc.store.get_sources.return_value = [self._source("Airport Signage.md")]
+        mock_svc.store.search.return_value = [_make_result()]
+        cfg.query_expansion_count = 0
+        try:
+            get_services().searcher.build_rag_context("summarize document port")
+        finally:
+            cfg.query_expansion_count = 3
+        mock_svc.store.get_chunks_by_source.assert_not_called()
+        mock_svc.store.search.assert_called_once()
+
     def test_ambiguous_reference_falls_back_to_topical(self, mock_svc):
         mock_svc.store.get_sources.return_value = [
             self._source("report_12a.pdf"),
@@ -2843,6 +2899,16 @@ class TestHistoryCondensation:
             cfg.query_expansion_count = 3
         expected = "when was the Split Rock journal written"
         assert mock_svc.store.search.call_args[1]["query_text"] == expected
+
+    def test_turns_thinking_off(self, mock_svc):
+        """A rewrite that comes back empty silently sends the pronouns to
+        retrieval, which is the failure the rewrite exists to prevent."""
+        mock_svc.provider.chat.return_value = _text_result("standalone question")
+        rewritten = get_services().searcher._condense_question(
+            "and when was it written?", list(self._HISTORY)
+        )
+        assert rewritten == "standalone question"
+        assert mock_svc.provider.chat.call_args.kwargs["options"]["think"] is False
 
 
 class TestAskRawWithReranker:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2611,29 +2611,22 @@ class TestKnownItemRoute:
         mock_svc.store.get_chunks_by_source.assert_not_called()
         mock_svc.store.search.assert_called_once()
 
-    def test_short_common_word_reference_stays_topical(self, mock_svc):
-        """The user's log: "Known-item route: 'we' resolved to notes/DSO Web
-        Hosting.md". The pronoun after "file" became a reference, substring-hit
-        "We" inside "Web", and replaced the whole retrieval context with that
-        one note. A reference under three characters never routes."""
-        mock_svc.store.get_sources.return_value = [self._source("notes/DSO Web Hosting.md")]
+    @pytest.mark.parametrize(
+        ("question", "filename"),
+        [
+            pytest.param("summarize the file we discussed", "notes/DSO Web Hosting.md", id="we"),
+            pytest.param("summarize document port", "Airport Signage.md", id="port"),
+        ],
+    )
+    def test_reference_inside_a_word_stays_topical(self, mock_svc, question, filename):
+        """A unique substring candidate routes only when the reference lands on
+        whole tokens of the stem: "we" inside "Web" once replaced the whole
+        retrieval context with that one note."""
+        mock_svc.store.get_sources.return_value = [self._source(filename)]
         mock_svc.store.search.return_value = [_make_result()]
         cfg.query_expansion_count = 0
         try:
-            get_services().searcher.build_rag_context("summarize the file we discussed")
-        finally:
-            cfg.query_expansion_count = 3
-        mock_svc.store.get_chunks_by_source.assert_not_called()
-        mock_svc.store.search.assert_called_once()
-
-    def test_reference_inside_a_longer_word_stays_topical(self, mock_svc):
-        """Length alone is not enough: a reference must land on whole tokens of
-        the filename, so "port" inside "Airport" is not the document named."""
-        mock_svc.store.get_sources.return_value = [self._source("Airport Signage.md")]
-        mock_svc.store.search.return_value = [_make_result()]
-        cfg.query_expansion_count = 0
-        try:
-            get_services().searcher.build_rag_context("summarize document port")
+            get_services().searcher.build_rag_context(question)
         finally:
             cfg.query_expansion_count = 3
         mock_svc.store.get_chunks_by_source.assert_not_called()


### PR DESCRIPTION
## Problem

**Auxiliary model calls left thinking on.** Query expansion, HyDE, history condensation, intent classification, entity extraction and memory extraction each run on a small token cap. Most of them left thinking on. A reasoning model spends the whole cap inside `<think>`, and the parser then strips it. The call returns nothing at full cost. In one user's day, nine of eighteen chat completions were expansion calls that produced zero variants.

**A two-letter word routed the whole query to one document.** When no filename matched a reference token by token, a unique substring hit still routed. In "the file we discussed", the pronoun after "file" became a reference. It matched "We" in `DSO Web Hosting.md` and replaced the entire retrieval context with that note.

## Solution

**One `aux_options` helper** carries the cap and `think: False` to every auxiliary call. No call site can forget it. The native llama-server and Ollama paths honor `think`. LM Studio and the hosted paths drop it.

**The output cap reaches every provider.** `generation_options` emitted `max_tokens`, a name the option filter dropped, so the user's cap never left the config. It now emits `num_predict`, the one name lilbee uses inside, and the provider translators rename it on the way out.

**Ollama turns thinking off too.** For an `ollama/` model the SDK path translates `think: False` into the reasoning setting litellm forwards, so auxiliary calls stop burning their cap there as well. LM Studio has no such switch.

**The loose match is a whole-token run.** `contains_reference` matches the reference as consecutive whole tokens of the filename stem. So "we" cannot match "Web", and "12" cannot match "2012". A quoted title still names its hyphenated file.
