### PR TITLE
Count held-out files separately and show them in status

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ flowchart TD
     H --> HC{"hash matches<br/>the stored row?"}
     HC -->|yes| BF["unchanged —<br/>backfill the fresh stat"]
     HC -->|no| SK{"hash matches a<br/>failed-file skip marker?"}
-    SK -->|yes| SKIP["held out — failed here last sync;<br/>counted apart from unchanged,<br/>reported with its reason"]
+    SK -->|yes| SKIP["held out: failed here last sync;<br/>counted apart from unchanged,<br/>reported with its reason"]
     SK -->|no| PR["process:<br/>extract → chunk → embed,<br/>store chunks keyed by this hash"]
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ flowchart TD
     H --> HC{"hash matches<br/>the stored row?"}
     HC -->|yes| BF["unchanged —<br/>backfill the fresh stat"]
     HC -->|no| SK{"hash matches a<br/>failed-file skip marker?"}
-    SK -->|yes| SKIP["skip — failed here last sync"]
+    SK -->|yes| SKIP["held out — failed here last sync;<br/>counted apart from unchanged,<br/>reported with its reason"]
     SK -->|no| PR["process:<br/>extract → chunk → embed,<br/>store chunks keyed by this hash"]
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -636,7 +636,7 @@ lilbee --json wiki wipe --yes                  # delete every generated page and
 ]}
 
 // lilbee --json status
-{"config": {...}, "sources": [{"filename": "manual.pdf", "chunk_count": 42}], "total_chunks": 42}
+{"config": {...}, "sources": [{"filename": "manual.pdf", "chunk_count": 42}], "total_chunks": 42, "skipped": [], "skipped_total": 0}
 
 // lilbee --json model pull <ref>  (streams events, then a final "done" line)
 {"event": "progress", "model": "...", "bytes": 12345678, "total": 999999999}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -636,7 +636,7 @@ lilbee --json wiki wipe --yes                  # delete every generated page and
 ]}
 
 // lilbee --json status
-{"config": {...}, "sources": [{"filename": "manual.pdf", "chunk_count": 42}], "total_chunks": 42, "skipped": [], "skipped_total": 0}
+{"config": {...}, "sources": [{"filename": "manual.pdf", "chunk_count": 42}], "document_count": 1, "total_chunks": 42, "skipped": [], "skipped_total": 0}
 
 // lilbee --json model pull <ref>  (streams events, then a final "done" line)
 {"event": "progress", "model": "...", "bytes": 12345678, "total": 999999999}

--- a/src/lilbee/app/status.py
+++ b/src/lilbee/app/status.py
@@ -18,8 +18,7 @@ LILBEE_LABEL_MAX_LEN = 40
 ellipsis when even the leaf alone would breach the cap."""
 
 STATUS_SKIPPED_LIMIT = 50
-"""Held-out files listed in one status response. A corpus of unextractable
-scans can hold out thousands; the payload stays bounded and reports the total."""
+"""Cap on held-out files in one status response; ``skipped_total`` carries the real count."""
 
 _ELLIPSIS = "…"
 
@@ -119,10 +118,7 @@ class StatusResult(BaseModel):
     total_chunks: int
     entities: EntityStatus | None = None
     skipped: list[SkippedSource] = []
-    """Files a skip marker currently holds out of the index, with the reason.
-
-    Capped at ``STATUS_SKIPPED_LIMIT``; ``skipped_total`` carries the real count.
-    """
+    """Files a skip marker holds out of the index, capped at ``STATUS_SKIPPED_LIMIT``."""
     skipped_total: int = 0
 
 

--- a/src/lilbee/app/status.py
+++ b/src/lilbee/app/status.py
@@ -10,10 +10,16 @@ from pydantic import BaseModel
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.system import LOCAL_ROOT_DIRNAME, default_data_dir
+from lilbee.data.ingest.skip_marker import describe_skips, load_skip_markers
+from lilbee.data.types import SkippedSource
 
 LILBEE_LABEL_MAX_LEN = 40
 """Hard cap on the compact-label width. The leaf gets its own internal
 ellipsis when even the leaf alone would breach the cap."""
+
+STATUS_SKIPPED_LIMIT = 50
+"""Held-out files listed in one status response. A corpus of unextractable
+scans can hold out thousands; the payload stays bounded and reports the total."""
 
 _ELLIPSIS = "…"
 
@@ -112,6 +118,12 @@ class StatusResult(BaseModel):
     sources: list[SourceInfo]
     total_chunks: int
     entities: EntityStatus | None = None
+    skipped: list[SkippedSource] = []
+    """Files a skip marker currently holds out of the index, with the reason.
+
+    Capped at ``STATUS_SKIPPED_LIMIT``; ``skipped_total`` carries the real count.
+    """
+    skipped_total: int = 0
 
 
 def gather_status() -> StatusResult:
@@ -119,6 +131,7 @@ def gather_status() -> StatusResult:
     sources = get_services().store.get_sources()
     sorted_sources = sorted(sources, key=lambda x: x["filename"])
     total_chunks = sum(s["chunk_count"] for s in sources)
+    held_out = sorted(load_skip_markers(cfg.data_root))
     return StatusResult(
         config=StatusConfig(
             documents_dir=str(cfg.documents_dir),
@@ -140,6 +153,8 @@ def gather_status() -> StatusResult:
         ],
         total_chunks=total_chunks,
         entities=entity_status(),
+        skipped=describe_skips(cfg.data_root, held_out[:STATUS_SKIPPED_LIMIT]),
+        skipped_total=len(held_out),
     )
 
 

--- a/src/lilbee/app/status.py
+++ b/src/lilbee/app/status.py
@@ -115,6 +115,7 @@ class StatusResult(BaseModel):
     command: str = "status"
     config: StatusConfig
     sources: list[SourceInfo]
+    document_count: int
     total_chunks: int
     entities: EntityStatus | None = None
     skipped: list[SkippedSource] = []
@@ -127,7 +128,7 @@ def gather_status() -> StatusResult:
     sources = get_services().store.get_sources()
     sorted_sources = sorted(sources, key=lambda x: x["filename"])
     total_chunks = sum(s["chunk_count"] for s in sources)
-    held_out = sorted(load_skip_markers(cfg.data_root))
+    skipped, skipped_total = held_out_sources()
     return StatusResult(
         config=StatusConfig(
             documents_dir=str(cfg.documents_dir),
@@ -147,11 +148,18 @@ def gather_status() -> StatusResult:
             )
             for s in sorted_sources
         ],
+        document_count=len(sources),
         total_chunks=total_chunks,
         entities=entity_status(),
-        skipped=describe_skips(cfg.data_root, held_out[:STATUS_SKIPPED_LIMIT]),
-        skipped_total=len(held_out),
+        skipped=skipped,
+        skipped_total=skipped_total,
     )
+
+
+def held_out_sources() -> tuple[list[SkippedSource], int]:
+    """Held-out files with reasons, capped at ``STATUS_SKIPPED_LIMIT``, and the real count."""
+    held_out = sorted(load_skip_markers(cfg.data_root))
+    return describe_skips(cfg.data_root, held_out[:STATUS_SKIPPED_LIMIT]), len(held_out)
 
 
 def entity_status() -> EntityStatus | None:

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -107,6 +107,22 @@ def render_status_result(status: StatusResult) -> Generator[RenderableType, None
         )
     yield ""
 
+    if status.skipped:
+        held = Table(title="Held out of the index")
+        held.add_column("File", style=theme.ACCENT)
+        held.add_column("Reason", style=theme.MUTED)
+        for skipped in status.skipped:
+            held.add_row(skipped.filename, skipped.reason)
+        yield held
+        b = theme.LABEL
+        hidden = status.skipped_total - len(status.skipped)
+        more = f" ({hidden} more not shown)" if hidden > 0 else ""
+        yield (
+            f"[{b}]{status.skipped_total}[/{b}] held out{more}; "
+            "run 'lilbee sync --retry-skipped' to try them again"
+        )
+        yield ""
+
     if not status.sources:
         yield (
             "No documents indexed. Drop files into the documents directory and run 'lilbee sync'."

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.console import Console, RenderableType
+from rich.markup import escape
 from rich.table import Table
 
 from lilbee.app.ingest import RegisterResult, register_sources
@@ -112,7 +113,7 @@ def render_status_result(status: StatusResult) -> Generator[RenderableType, None
         held.add_column("File", style=theme.ACCENT)
         held.add_column("Reason", style=theme.MUTED)
         for skipped in status.skipped:
-            held.add_row(skipped.filename, skipped.reason)
+            held.add_row(escape(skipped.filename), escape(skipped.reason))
         yield held
         b = theme.LABEL
         hidden = status.skipped_total - len(status.skipped)

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -69,6 +69,12 @@ SYNC_SKIPPED_NO_VISION = (
 SYNC_SKIPPED_VISION_FAILED = (
     "Skipped (vision OCR returned no text): {files}. See {log_path} for the underlying error."
 )
+SYNC_HELD_OUT = (
+    '{count} file(s) stay held out of the index. Run "Retry skipped documents" to index them again.'
+)
+STATUS_HELD_OUT_TITLE = "Held out of the index"
+STATUS_HELD_OUT_EMPTY = "No files are held out."
+STATUS_HELD_OUT_MORE = "{count} more held out"
 CMD_RETRY_SKIPPED_NONE = "No skipped files to retry; running a normal sync."
 CMD_RETRY_SKIPPED_SOME = "Cleared {count} skip marker(s); retrying those files."
 CMD_PRUNE_IGNORED_NONE = "Nothing indexed matches your ignore patterns."

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -2281,6 +2281,13 @@ class ChatScreen(Screen[None]):
                 msg.sync_skipped_message(", ".join(result.skipped)),
                 severity="warning",
             )
+        if result.held_out:
+            call_from_thread(
+                self,
+                self.notify,
+                msg.SYNC_HELD_OUT.format(count=len(result.held_out)),
+                severity="warning",
+            )
 
     def action_focus_commands(self) -> None:
         """Focus chat input and pre-fill with '/' for command entry."""

--- a/src/lilbee/cli/tui/screens/status.py
+++ b/src/lilbee/cli/tui/screens/status.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
@@ -22,11 +22,13 @@ from textual.widgets import Collapsible, DataTable, Static
 from textual.worker import Worker, WorkerState
 
 from lilbee.app.services import get_services
+from lilbee.app.status import held_out_sources
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.browse_bindings import BROWSE_LIST_BINDINGS, browse_back_bindings
 from lilbee.cli.tui.pill import pill
 from lilbee.core.config import cfg
 from lilbee.data.store import SourceRecord
+from lilbee.data.types import SkippedSource
 from lilbee.modelhub.model_info import ModelArchInfo, get_model_architecture
 
 log = logging.getLogger(__name__)
@@ -48,6 +50,8 @@ class _DocsResult:
 
     sources: list[SourceRecord]
     load_failed: bool
+    held_out: list[SkippedSource] = field(default_factory=list)
+    held_out_total: int = 0
 
 
 def _model_pill(name: str) -> Content:
@@ -241,6 +245,12 @@ class StatusScreen(Screen[None]):
                     collapsed=False,
                 ),
                 Collapsible(
+                    DataTable(id="held-out-table"),
+                    title=msg.STATUS_HELD_OUT_TITLE,
+                    id="held-out-section",
+                    collapsed=True,
+                ),
+                Collapsible(
                     Static(id="arch-info"),
                     title="Model Architecture",
                     id="arch-section",
@@ -302,7 +312,13 @@ class StatusScreen(Screen[None]):
         in bounded batches via :meth:`_render_doc_batch`.
         """
         try:
-            return _DocsResult(sources=get_services().store.get_sources(), load_failed=False)
+            held_out, held_out_total = held_out_sources()
+            return _DocsResult(
+                sources=get_services().store.get_sources(),
+                load_failed=False,
+                held_out=held_out,
+                held_out_total=held_out_total,
+            )
         except Exception:
             log.debug("Failed to read store for status screen", exc_info=True)
             return _DocsResult(sources=[], load_failed=True)
@@ -336,7 +352,26 @@ class StatusScreen(Screen[None]):
     def _apply_docs(self, docs: _DocsResult) -> None:
         """Render *docs* into the Documents table (batched) + storage section."""
         self._load_documents(docs)
+        self._load_held_out(docs)
         self._load_storage(len(docs.sources))
+
+    def _load_held_out(self, docs: _DocsResult) -> None:
+        """Fill the held-out table; the section opens only when something is held out."""
+        from textual.css.query import NoMatches
+
+        with contextlib.suppress(NoMatches):
+            table = self.query_one("#held-out-table", DataTable)
+            table.clear(columns=True)
+            table.add_columns("File", "Reason")
+            if not docs.held_out:
+                table.add_row(msg.STATUS_HELD_OUT_EMPTY, "")
+                return
+            for held in docs.held_out:
+                table.add_row(held.filename, held.reason)
+            hidden = docs.held_out_total - len(docs.held_out)
+            if hidden > 0:
+                table.add_row(msg.STATUS_HELD_OUT_MORE.format(count=hidden), "")
+            self.query_one("#held-out-section", Collapsible).collapsed = False
 
     def _load_arch(self, info: ModelArchInfo) -> None:
         """Populate the model architecture section from worker result."""

--- a/src/lilbee/data/ingest/fanout.py
+++ b/src/lilbee/data/ingest/fanout.py
@@ -409,6 +409,7 @@ def aggregate_results(verdicts: list[ShardDone]) -> SyncResult:
         relocated=[name for r in results for name in r.relocated],
         failed=[name for r in results for name in r.failed],
         skipped=[name for r in results for name in r.skipped],
+        held_out=[held for r in results for held in r.held_out],
         unchanged=sum(r.unchanged for r in results),
         truncated=sum(r.truncated for r in results),
     )

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -300,11 +300,9 @@ def _stat_unchanged(stored: SourceStat, current: SourceStat) -> bool:
 
 @dataclass(frozen=True)
 class _FileChangeVerdict:
-    """One file's sync verdict: process it, hold it out, or leave it unchanged.
+    """One file's sync verdict: process it, hold it out on its skip marker, or unchanged.
 
-    ``held`` marks a file a skip marker keeps out of this sync. It shares the
-    "nothing to ingest" shape with unchanged but not its meaning: the file is
-    not in the index, so the two are counted separately.
+    A held file is not in the index, so it is never counted as unchanged.
     """
 
     to_process: FileToProcess | None = None
@@ -684,8 +682,7 @@ class _StreamedPlan:
     # double-count and its dead chunk refs occupy the per-subject cap.
     relocated_from: list[str] = field(default_factory=list)
     unchanged: int = 0
-    # Files a skip marker held out of this run, in plan order. Ordered set, so a
-    # file cannot be reported twice if two batches ever cover it.
+    # Files a skip marker held out of this run, in plan order (ordered set).
     held_out: dict[str, None] = field(default_factory=dict)
     planned: int = 0
     # Files this pass's slice holds, from the discovery walk. Fixed before the
@@ -904,10 +901,10 @@ def _reconcile_missing(
     nor any of the accounting sets was dropped with no signal -- the silent
     data-loss case (a scanned PDF that never made it into the index yet reported no
     error). Everything legitimately not indexed is excluded: a failed extraction is in
-    ``failed``, a zero-text file this run attempted is in ``skipped``, a file an
-    earlier run skip-marked is in ``held`` (this run never attempted it, so it is in
-    neither of the other two), and an unsupported type was never returned by
-    discovery in the first place.
+    ``failed``, a zero-text file this run attempted is in ``skipped``, a file this run
+    held out on its skip marker is in ``held``, and an unsupported type was never
+    returned by discovery in the first place. ``held`` is the run's held-out set, not
+    the marker file: a stale marker (file edited since it failed) must not hide a drop.
     """
     accounted = {s["filename"] for s in sources} | set(failed) | set(skipped) | set(held)
     return sorted(name for name in disk_files if name not in accounted)
@@ -1243,10 +1240,8 @@ async def sync(
     # Reconciliation guard against silent data loss: any on-disk document file that
     # ended up in neither the index nor an accounting set was dropped without a
     # signal. Surface it loudly instead of letting a whole dataset vanish quietly.
-    # The persisted markers are subtracted, not just this run's lists: a file an
-    # earlier run marked is in neither, and would otherwise be reported every sync.
     if missing := _reconcile_missing(
-        disk_files, _store.get_sources(), failed, skipped, skip_markers
+        disk_files, _store.get_sources(), failed, skipped, state.held_out
     ):
         log.warning(
             "Sync reconciliation: %d document file(s) on disk are absent from the index "

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -62,6 +62,7 @@ from lilbee.data.ingest.fanout import (
 from lilbee.data.ingest.ignore import IgnoreRules
 from lilbee.data.ingest.skip_marker import (
     clear_skip_markers,
+    describe_skips,
     load_skip_markers,
     load_skip_reasons,
     write_skip_markers,
@@ -299,11 +300,17 @@ def _stat_unchanged(stored: SourceStat, current: SourceStat) -> bool:
 
 @dataclass(frozen=True)
 class _FileChangeVerdict:
-    """One file's sync verdict: process it, or unchanged (optionally backfilling its stat)."""
+    """One file's sync verdict: process it, hold it out, or leave it unchanged.
+
+    ``held`` marks a file a skip marker keeps out of this sync. It shares the
+    "nothing to ingest" shape with unchanged but not its meaning: the file is
+    not in the index, so the two are counted separately.
+    """
 
     to_process: FileToProcess | None = None
     backfill: SourceStatBackfill | None = None
     is_update: bool = False
+    held: bool = False
 
 
 def _classify_file_change(
@@ -338,7 +345,7 @@ def _classify_file_change(
         return _FileChangeVerdict(backfill=backfill)
     if skip_markers.get(name) == current_hash:
         # Failed last sync at this exact hash; skip the retry.
-        return _FileChangeVerdict()
+        return _FileChangeVerdict(held=True)
     # needs_cleanup=True unconditionally: delete_by_source is idempotent,
     # and this closes the race where a prior ingest wrote chunks but died
     # before upsert_source, leaving orphaned chunks that would duplicate.
@@ -510,8 +517,9 @@ def _plan_items(
     mtime predates the stat capture (see :func:`_stat_unchanged`), is unchanged
     without reading its bytes; everything else is SHA-256 hashed. A file whose
     current hash matches a marker in ``skip_markers`` (set by a prior failed
-    attempt) is treated as unchanged so we don't retry every sync. Edit the file
-    or run ``/sync --force-rebuild`` to clear the marker and try again.
+    attempt) is held out rather than retried every sync, and is reported as held
+    out rather than counted unchanged. Edit the file or run
+    ``/sync --force-rebuild`` to clear the marker and try again.
 
     Classification fans across a thread pool (see :func:`_classify_changes`); the
     plan is assembled from the results in the original sorted order, so a partial
@@ -526,6 +534,7 @@ def _plan_items(
     added: dict[str, None] = {}
     updated: dict[str, None] = {}
     stat_backfills: list[SourceStatBackfill] = []
+    held_out: list[str] = []
     unchanged = 0
     # Assemble in the original sorted order so a partial (cancelled) or reordered
     # completion never changes the plan the serial pass would have produced.
@@ -534,7 +543,10 @@ def _plan_items(
         if verdict is None:
             continue  # cancelled before this file was classified
         if verdict.to_process is None:
-            unchanged += 1
+            if verdict.held:
+                held_out.append(name)
+            else:
+                unchanged += 1
             if verdict.backfill is not None:
                 stat_backfills.append(verdict.backfill)
             continue
@@ -543,7 +555,7 @@ def _plan_items(
             updated[name] = None
         else:
             added[name] = None
-    return FileChangePlan(files_to_process, added, updated, unchanged, stat_backfills)
+    return FileChangePlan(files_to_process, added, updated, unchanged, stat_backfills, held_out)
 
 
 @dataclass(frozen=True)
@@ -672,6 +684,9 @@ class _StreamedPlan:
     # double-count and its dead chunk refs occupy the per-subject cap.
     relocated_from: list[str] = field(default_factory=list)
     unchanged: int = 0
+    # Files a skip marker held out of this run, in plan order. Ordered set, so a
+    # file cannot be reported twice if two batches ever cover it.
+    held_out: dict[str, None] = field(default_factory=dict)
     planned: int = 0
     # Files this pass's slice holds, from the discovery walk. Fixed before the
     # first batch is planned, so it is what progress is measured against: the
@@ -683,13 +698,13 @@ class _StreamedPlan:
     def resolved(self) -> int:
         """Files the plan disposed of without ingest, as it disposes of them.
 
-        Unchanged (or skip-marked) files and repointed moves are done as far as
-        the corpus is concerned, and nothing downstream reports them, so an
-        incremental sync would otherwise show a handful of changed files against
-        the whole corpus. Files a cancelled plan never classified are absent from
-        both counts and so are not claimed as done.
+        Unchanged files, skip-marker held-out files and repointed moves are done
+        as far as the corpus is concerned, and nothing downstream ingests them,
+        so an incremental sync would otherwise show a handful of changed files
+        against the whole corpus. Files a cancelled plan never classified are
+        absent from every count and so are not claimed as done.
         """
-        return self.unchanged + len(self.relocated)
+        return self.unchanged + len(self.held_out) + len(self.relocated)
 
 
 async def _absorb_plan_batch(
@@ -703,6 +718,7 @@ async def _absorb_plan_batch(
     store = get_services().store
     entries = plan.files_to_process
     state.unchanged += plan.unchanged
+    state.held_out.update(dict.fromkeys(plan.held_out))
     state.added.update(plan.added)
     state.updated.update(plan.updated)
 
@@ -880,17 +896,20 @@ def _reconcile_missing(
     sources: list[SourceRecord],
     failed: Iterable[str],
     skipped: Iterable[str],
+    held: Iterable[str],
 ) -> list[str]:
-    """On-disk document files absent from the store and not reported failed/skipped.
+    """On-disk document files absent from the store that no mechanism accounts for.
 
     A file discovery found and classified that ended up in neither the sources table
-    nor the run's failed/skipped lists was dropped with no signal -- the silent
+    nor any of the accounting sets was dropped with no signal -- the silent
     data-loss case (a scanned PDF that never made it into the index yet reported no
     error). Everything legitimately not indexed is excluded: a failed extraction is in
-    ``failed``, a zero-text file is in ``skipped``, and an unsupported type was never
-    returned by discovery in the first place.
+    ``failed``, a zero-text file this run attempted is in ``skipped``, a file an
+    earlier run skip-marked is in ``held`` (this run never attempted it, so it is in
+    neither of the other two), and an unsupported type was never returned by
+    discovery in the first place.
     """
-    accounted = {s["filename"] for s in sources} | set(failed) | set(skipped)
+    accounted = {s["filename"] for s in sources} | set(failed) | set(skipped) | set(held)
     return sorted(name for name in disk_files if name not in accounted)
 
 
@@ -1222,9 +1241,13 @@ async def sync(
         )
 
     # Reconciliation guard against silent data loss: any on-disk document file that
-    # ended up in neither the index nor the failed/skipped lists was dropped without
-    # a signal. Surface it loudly instead of letting a whole dataset vanish quietly.
-    if missing := _reconcile_missing(disk_files, _store.get_sources(), failed, skipped):
+    # ended up in neither the index nor an accounting set was dropped without a
+    # signal. Surface it loudly instead of letting a whole dataset vanish quietly.
+    # The persisted markers are subtracted, not just this run's lists: a file an
+    # earlier run marked is in neither, and would otherwise be reported every sync.
+    if missing := _reconcile_missing(
+        disk_files, _store.get_sources(), failed, skipped, skip_markers
+    ):
         log.warning(
             "Sync reconciliation: %d document file(s) on disk are absent from the index "
             "with no failure reported (possible silent drop): %s",
@@ -1240,6 +1263,7 @@ async def sync(
         relocated=relocated,
         failed=list(failed),
         skipped=list(skipped),
+        held_out=describe_skips(config.data_root, state.held_out),
         truncated=get_services().embedder.truncated_total - truncated_before,
     )
     on_progress(

--- a/src/lilbee/data/ingest/skip_marker.py
+++ b/src/lilbee/data/ingest/skip_marker.py
@@ -87,12 +87,7 @@ def write_skip_reasons(data_root: Path, reasons: dict[str, str]) -> None:
 
 
 def describe_skips(data_root: Path, names: Iterable[str]) -> list[SkippedSource]:
-    """Pair each name with its recorded reason, in the order given.
-
-    A marker written before the reasons sidecar existed, or one whose reason a
-    partial write lost, falls back to ``DEFAULT_SKIP_REASON`` so every held-out
-    file still carries an explanation.
-    """
+    """Pair each name with its recorded reason, in order; ``DEFAULT_SKIP_REASON`` when none."""
     reasons = load_skip_reasons(data_root)
     return [
         SkippedSource(filename=name, reason=reasons.get(name, DEFAULT_SKIP_REASON))

--- a/src/lilbee/data/ingest/skip_marker.py
+++ b/src/lilbee/data/ingest/skip_marker.py
@@ -20,12 +20,16 @@ import contextlib
 import json
 import logging
 import os
+from collections.abc import Iterable
 from pathlib import Path
+
+from lilbee.data.types import SkippedSource
 
 log = logging.getLogger(__name__)
 
 SKIP_MARKER_FILENAME = "skipped_sources.json"
 SKIP_REASON_FILENAME = "skip_reasons.json"
+DEFAULT_SKIP_REASON = "held out by an earlier sync"
 
 
 def _load_str_map(path: Path) -> dict[str, str]:
@@ -80,6 +84,20 @@ def load_skip_reasons(data_root: Path) -> dict[str, str]:
 def write_skip_reasons(data_root: Path, reasons: dict[str, str]) -> None:
     """Replace the reasons sidecar atomically. Best-effort: errors are logged, not raised."""
     _write_str_map(data_root / SKIP_REASON_FILENAME, reasons)
+
+
+def describe_skips(data_root: Path, names: Iterable[str]) -> list[SkippedSource]:
+    """Pair each name with its recorded reason, in the order given.
+
+    A marker written before the reasons sidecar existed, or one whose reason a
+    partial write lost, falls back to ``DEFAULT_SKIP_REASON`` so every held-out
+    file still carries an explanation.
+    """
+    reasons = load_skip_reasons(data_root)
+    return [
+        SkippedSource(filename=name, reason=reasons.get(name, DEFAULT_SKIP_REASON))
+        for name in names
+    ]
 
 
 def clear_skip_markers(data_root: Path) -> None:

--- a/src/lilbee/data/types.py
+++ b/src/lilbee/data/types.py
@@ -58,6 +58,13 @@ class FileToProcess(NamedTuple):
     stat: SourceStat | None = None
 
 
+class SkippedSource(BaseModel):
+    """One file a skip marker holds out of the index, and why."""
+
+    filename: str
+    reason: str
+
+
 class FileChangePlan(NamedTuple):
     """Outcome of diffing disk files against the tracked sources."""
 
@@ -66,6 +73,9 @@ class FileChangePlan(NamedTuple):
     updated: dict[str, None]
     unchanged: int
     stat_backfills: list[SourceStatBackfill]
+    # Files a skip marker holds out. Kept apart from ``unchanged``: a held-out
+    # file is not in the index, and counting it as unchanged hides it.
+    held_out: list[str]
 
 
 class OcrBackendName(StrEnum):
@@ -129,6 +139,10 @@ class SyncResult(BaseModel):
     relocated: list[str] = []
     failed: list[str] = []
     skipped: list[str] = []
+    # Files an earlier sync skip-marked, which this run therefore did not
+    # attempt. Reported apart from ``unchanged`` so a summary cannot present a
+    # file that is not in the index as one that is.
+    held_out: list[SkippedSource] = []
     # Chunks whose text exceeded the embedder's char budget and were truncated
     # before embedding. Non-zero means some tail content did not reach the index.
     truncated: int = 0
@@ -143,10 +157,13 @@ class SyncResult(BaseModel):
         if self.relocated:
             lines.append(f"Relocated: {len(self.relocated)}")
         lines += [
+            f"Held out: {len(self.held_out)}",
             f"Skipped: {len(self.skipped)}",
             f"Failed: {len(self.failed)}",
             f"Truncated: {self.truncated}",
         ]
+        for held in self.held_out:
+            lines.append(f"  [yellow]{held.filename}[/yellow]: {held.reason}")
         for f in self.skipped:
             lines.append(f"  [yellow]{f}[/yellow]")
         for f in self.failed:
@@ -157,8 +174,8 @@ class SyncResult(BaseModel):
         return (
             f"SyncResult(added={len(self.added)}, updated={len(self.updated)}, "
             f"removed={len(self.removed)}, unchanged={self.unchanged}, "
-            f"skipped={len(self.skipped)}, failed={len(self.failed)}, "
-            f"truncated={self.truncated})"
+            f"held_out={len(self.held_out)}, skipped={len(self.skipped)}, "
+            f"failed={len(self.failed)}, truncated={self.truncated})"
         )
 
     def __rich__(self) -> str:

--- a/src/lilbee/data/types.py
+++ b/src/lilbee/data/types.py
@@ -73,8 +73,7 @@ class FileChangePlan(NamedTuple):
     updated: dict[str, None]
     unchanged: int
     stat_backfills: list[SourceStatBackfill]
-    # Files a skip marker holds out. Kept apart from ``unchanged``: a held-out
-    # file is not in the index, and counting it as unchanged hides it.
+    # Files a skip marker holds out; not in the index, so never counted as unchanged.
     held_out: list[str]
 
 
@@ -139,9 +138,7 @@ class SyncResult(BaseModel):
     relocated: list[str] = []
     failed: list[str] = []
     skipped: list[str] = []
-    # Files an earlier sync skip-marked, which this run therefore did not
-    # attempt. Reported apart from ``unchanged`` so a summary cannot present a
-    # file that is not in the index as one that is.
+    # Files an earlier sync skip-marked, so this run did not attempt them.
     held_out: list[SkippedSource] = []
     # Chunks whose text exceeded the embedder's char budget and were truncated
     # before embedding. Non-zero means some tail content did not reach the index.

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import logging
+import os
 import re
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from pathlib import Path
@@ -298,7 +300,8 @@ async def _run_upload(files: list[tuple[str, bytes]], sse: SseStream) -> AddSumm
         for name, content in files:
             dest = cfg.documents_dir / name
             dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(content)
+            if not _move_same_content(name, content, dest):
+                dest.write_bytes(content)
             written.append(name)
         with temporary_ocr_config(None):
             sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
@@ -310,6 +313,24 @@ async def _run_upload(files: list[tuple[str, bytes]], sse: SseStream) -> AddSumm
         )
     finally:
         sse.queue.put_nowait(None)
+
+
+def _move_same_content(name: str, content: bytes, dest: Path) -> bool:
+    """Move the one indexed file holding *content* to *dest*, so sync repoints its key."""
+    digest = hashlib.sha256(content).hexdigest()
+    matches = [
+        s["filename"]
+        for s in get_services().store.get_sources()
+        if s["file_hash"] == digest and s["filename"] != name
+    ]
+    if len(matches) != 1:
+        return False
+    old_path = cfg.documents_dir / matches[0]
+    if not old_path.is_file():
+        return False
+    os.replace(old_path, dest)
+    log.info("Moved %s to %s: the same content arrived under a new name", matches[0], name)
+    return True
 
 
 async def add_uploads_stream(files: list[tuple[str, bytes]]) -> AsyncGenerator[str, None]:

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -189,6 +189,7 @@ class StatusResponse(BaseModel):
     command: str = "status"
     config: StatusConfigInfo
     sources: list[StatusSourceInfo]
+    document_count: int
     total_chunks: int
     entities: StatusEntityInfo | None = None
     skipped: list[SkippedSource] = []

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -13,6 +13,7 @@ from lilbee.app.agent_configs.document import AgentClient, AgentSurface, ConfigF
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.data.store import ChunkType, MemoryKind, scope_to_chunk_type
+from lilbee.data.types import SkippedSource
 from lilbee.providers.roles import WorkerRole
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 from lilbee.sessions import MessageRole
@@ -190,6 +191,13 @@ class StatusResponse(BaseModel):
     sources: list[StatusSourceInfo]
     total_chunks: int
     entities: StatusEntityInfo | None = None
+    skipped: list[SkippedSource] = []
+    """Files a skip marker currently holds out of the index, with the reason.
+
+    Capped so a corpus with thousands of unextractable files cannot bloat the
+    payload; ``skipped_total`` carries the real count.
+    """
+    skipped_total: int = 0
 
 
 class ShutdownResponse(BaseModel):
@@ -415,6 +423,7 @@ class SyncSummary(BaseModel):
     relocated: list[str] = []
     failed: list[str] = []
     skipped: list[str] = []
+    held_out: list[SkippedSource] = []
     truncated: int = 0
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -192,11 +192,7 @@ class StatusResponse(BaseModel):
     total_chunks: int
     entities: StatusEntityInfo | None = None
     skipped: list[SkippedSource] = []
-    """Files a skip marker currently holds out of the index, with the reason.
-
-    Capped so a corpus with thousands of unextractable files cannot bloat the
-    payload; ``skipped_total`` carries the real count.
-    """
+    """Files a skip marker holds out of the index, capped; ``skipped_total`` is the real count."""
     skipped_total: int = 0
 
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import hashlib
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
@@ -144,6 +145,78 @@ class TestAddEndpoint:
         assert "done" in event_types
         # The client's bytes landed in the corpus even though no server path existed.
         assert (isolated_env / "notes.txt").read_bytes() == content
+
+    @pytest.mark.parametrize(
+        ("indexed", "moved"),
+        [
+            pytest.param(["index.md"], True, id="one-match-moves"),
+            pytest.param(["index.md", "old/index.md"], False, id="two-matches-write-plainly"),
+        ],
+    )
+    async def test_add_upload_moves_the_one_file_with_the_same_content(
+        self, mock_extract_file, isolated_env, mock_svc, indexed, moved
+    ):
+        """The same bytes under a new name move the indexed file, so sync repoints its key."""
+        from lilbee.server.app import create_app
+
+        content = b"The same note, uploaded once by basename and once by path."
+        digest = hashlib.sha256(content).hexdigest()
+        for name in indexed:
+            (isolated_env / name).parent.mkdir(parents=True, exist_ok=True)
+            (isolated_env / name).write_bytes(content)
+        mock_svc.store.get_sources.return_value = [
+            {"filename": name, "file_hash": digest, "chunk_count": 1} for name in indexed
+        ]
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.post(
+                "/api/add/upload",
+                files=[("data", ("notes/alpha/index.md", content, "text/plain"))],
+                headers=_auth_headers(),
+            )
+
+        assert resp.status_code == 201
+        assert (isolated_env / "notes/alpha/index.md").read_bytes() == content
+        assert (isolated_env / "index.md").exists() is not moved
+
+    async def test_add_upload_writes_plainly_when_the_matching_file_is_gone(
+        self, mock_extract_file, isolated_env, mock_svc
+    ):
+        """A source row whose file left the disk cannot be moved; the upload is written as is."""
+        from lilbee.server.app import create_app
+
+        content = b"Indexed once, then its file was deleted by hand."
+        mock_svc.store.get_sources.return_value = [
+            {"filename": "gone.md", "file_hash": hashlib.sha256(content).hexdigest()}
+        ]
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.post(
+                "/api/add/upload",
+                files=[("data", ("notes/gone.md", content, "text/plain"))],
+                headers=_auth_headers(),
+            )
+
+        assert resp.status_code == 201
+        assert (isolated_env / "notes/gone.md").read_bytes() == content
+
+    async def test_add_upload_leaves_a_file_with_other_content_alone(
+        self, mock_extract_file, isolated_env, mock_svc
+    ):
+        from lilbee.server.app import create_app
+
+        (isolated_env / "index.md").write_bytes(b"different bytes")
+        mock_svc.store.get_sources.return_value = [
+            {"filename": "index.md", "file_hash": hashlib.sha256(b"different bytes").hexdigest()}
+        ]
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.post(
+                "/api/add/upload",
+                files=[("data", ("notes/index.md", b"new bytes", "text/plain"))],
+                headers=_auth_headers(),
+            )
+
+        assert resp.status_code == 201
+        assert (isolated_env / "index.md").read_bytes() == b"different bytes"
+        assert (isolated_env / "notes/index.md").read_bytes() == b"new bytes"
 
     async def test_add_upload_rejects_path_traversal_filename(
         self, mock_extract_file, isolated_env, tmp_path

--- a/tests/test_cli_status_held_out.py
+++ b/tests/test_cli_status_held_out.py
@@ -9,8 +9,8 @@ from lilbee.cli.helpers import render_status_result
 from lilbee.data.types import SkippedSource
 
 
-def _status(**overrides: object) -> StatusResult:
-    base = dict(
+def _status(skipped: list[SkippedSource] | None = None, skipped_total: int = 0) -> StatusResult:
+    return StatusResult(
         config=StatusConfig(
             documents_dir="docs",
             data_dir="data",
@@ -19,9 +19,9 @@ def _status(**overrides: object) -> StatusResult:
         ),
         sources=[],
         total_chunks=0,
+        skipped=skipped or [],
+        skipped_total=skipped_total,
     )
-    base.update(overrides)
-    return StatusResult(**base)  # type: ignore[arg-type]
 
 
 def _texts(status: StatusResult) -> tuple[list[Table], list[str]]:

--- a/tests/test_cli_status_held_out.py
+++ b/tests/test_cli_status_held_out.py
@@ -1,0 +1,54 @@
+"""The CLI status output lists held-out files, matching /api/status."""
+
+from __future__ import annotations
+
+from rich.table import Table
+
+from lilbee.app.status import StatusConfig, StatusResult
+from lilbee.cli.helpers import render_status_result
+from lilbee.data.types import SkippedSource
+
+
+def _status(**overrides: object) -> StatusResult:
+    base = dict(
+        config=StatusConfig(
+            documents_dir="docs",
+            data_dir="data",
+            chat_model="chat:latest",
+            embedding_model="embed:latest",
+        ),
+        sources=[],
+        total_chunks=0,
+    )
+    base.update(overrides)
+    return StatusResult(**base)  # type: ignore[arg-type]
+
+
+def _texts(status: StatusResult) -> tuple[list[Table], list[str]]:
+    tables = [r for r in render_status_result(status) if isinstance(r, Table)]
+    strings = [r for r in render_status_result(status) if isinstance(r, str)]
+    return tables, strings
+
+
+def test_held_out_files_are_listed_with_their_reasons() -> None:
+    status = _status(
+        skipped=[SkippedSource(filename="notes/Solo.md", reason="no text extracted (0 chunks)")],
+        skipped_total=1,
+    )
+    tables, strings = _texts(status)
+    assert any(t.title == "Held out of the index" for t in tables)
+    assert any("1" in s and "held out" in s and "--retry-skipped" in s for s in strings)
+
+
+def test_the_held_out_summary_names_what_the_cap_hid() -> None:
+    status = _status(
+        skipped=[SkippedSource(filename="a.md", reason="no text extracted (0 chunks)")],
+        skipped_total=12,
+    )
+    _tables, strings = _texts(status)
+    assert any("12" in s and "11 more not shown" in s for s in strings)
+
+
+def test_nothing_held_out_prints_no_table() -> None:
+    tables, _strings = _texts(_status())
+    assert not any(t.title == "Held out of the index" for t in tables)

--- a/tests/test_cli_status_held_out.py
+++ b/tests/test_cli_status_held_out.py
@@ -11,6 +11,7 @@ from lilbee.data.types import SkippedSource
 
 def _status(skipped: list[SkippedSource] | None = None, skipped_total: int = 0) -> StatusResult:
     return StatusResult(
+        document_count=0,
         config=StatusConfig(
             documents_dir="docs",
             data_dir="data",

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -226,8 +226,22 @@ def test_reconcile_missing_flags_only_silent_drops():
 
     disk = {n: Path(n) for n in ("a.pdf", "b.pdf", "c.pdf", "d.pdf")}
     # a indexed, b failed, c skipped, d dropped with no signal.
-    missing = _reconcile_missing(disk, [{"filename": "a.pdf"}], failed=["b.pdf"], skipped=["c.pdf"])
+    missing = _reconcile_missing(
+        disk, [{"filename": "a.pdf"}], failed=["b.pdf"], skipped=["c.pdf"], held=[]
+    )
     assert missing == ["d.pdf"]
+
+
+def test_reconcile_missing_accounts_for_persisted_skip_markers():
+    """A file an earlier run marked is in neither this run's failed nor skipped
+    lists, so without the marker set it reads as a silent drop every sync."""
+    from pathlib import Path
+
+    from lilbee.data.ingest.pipeline import _reconcile_missing
+
+    disk = {n: Path(n) for n in ("held.md", "dropped.md")}
+    missing = _reconcile_missing(disk, [], failed=[], skipped=[], held={"held.md": "deadbeef"})
+    assert missing == ["dropped.md"]
 
 
 @mock.patch(
@@ -1490,6 +1504,51 @@ class TestSkipMarkerLifecycle:
             assert "scanned.pdf" not in second.skipped
             assert "scanned.pdf" not in second.added
 
+    async def test_held_out_file_is_reported_apart_from_unchanged(self, isolated_env, mock_svc):
+        """A marker-held file must not be tallied as unchanged: it is not indexed,
+        and 'Unchanged: N' would present it as a file the index already holds."""
+        from lilbee.data.ingest import sync
+        from lilbee.data.ingest.pipeline import produce_records as orig
+
+        async def _zero_for_the_scan(path, name, content_type, **kwargs):
+            if name == "scanned.pdf":
+                return self._zero_chunks()
+            return await orig(path, name, content_type, **kwargs)
+
+        (isolated_env / "scanned.pdf").write_bytes(b"%PDF-1.4 not really text")
+        (isolated_env / "readable.txt").write_text("plenty of text", encoding="utf-8")
+        with mock.patch(
+            "lilbee.data.ingest.pipeline.produce_records", side_effect=_zero_for_the_scan
+        ):
+            first = await sync(quiet=True)
+            assert "readable.txt" in first.added
+            second = await sync(quiet=True)
+
+        assert [held.filename for held in second.held_out] == ["scanned.pdf"]
+        assert second.held_out[0].reason == "no text extracted (0 chunks)"
+        assert second.unchanged == 1  # readable.txt only; the held file is not counted here
+        assert "Held out: 1" in str(second)
+        assert "no text extracted (0 chunks)" in str(second)
+
+    async def test_held_out_file_does_not_trip_the_reconciliation_guard(
+        self, isolated_env, mock_svc, caplog
+    ):
+        """The marker accounts for the file, so the data-loss warning must stay
+        silent rather than naming the same file on every sync."""
+        import logging
+
+        from lilbee.data.ingest import sync
+
+        (isolated_env / "scanned.pdf").write_bytes(b"%PDF-1.4 not really text")
+        with mock.patch(
+            "lilbee.data.ingest.pipeline.produce_records", side_effect=self._zero_chunks
+        ):
+            await sync(quiet=True)
+            with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"):
+                await sync(quiet=True)
+
+        assert "possible silent drop" not in caplog.text
+
     async def test_retry_skipped_clears_markers(self, isolated_env, mock_svc):
         from lilbee.data.ingest import sync
 
@@ -1512,6 +1571,50 @@ class TestSkipMarkerLifecycle:
             await sync(quiet=True)
             rebuilt = await sync(quiet=True, force_rebuild=True)
             assert "scanned.pdf" in rebuilt.skipped  # attempted again after the wipe
+
+
+class TestStatusReportsHeldOutFiles:
+    """/api/status and `lilbee status --json` read the skip sidecars, so a client
+    can show which files are held out of the index and why."""
+
+    def test_status_lists_held_out_files_with_reasons(self):
+        from lilbee.app.status import gather_status
+        from lilbee.data.ingest.skip_marker import (
+            DEFAULT_SKIP_REASON,
+            write_skip_markers,
+            write_skip_reasons,
+        )
+
+        write_skip_markers(cfg.data_root, {"scan.pdf": "deadbeef", "blank.md": "cafef00d"})
+        write_skip_reasons(cfg.data_root, {"scan.pdf": "OCR timed out after 300s"})
+
+        status = gather_status()
+
+        assert [(s.filename, s.reason) for s in status.skipped] == [
+            ("blank.md", DEFAULT_SKIP_REASON),
+            ("scan.pdf", "OCR timed out after 300s"),
+        ]
+        assert status.skipped_total == 2
+
+    def test_status_caps_the_list_but_reports_the_real_total(self, monkeypatch):
+        from lilbee.app import status as status_mod
+        from lilbee.data.ingest.skip_marker import write_skip_markers
+
+        monkeypatch.setattr(status_mod, "STATUS_SKIPPED_LIMIT", 2)
+        write_skip_markers(cfg.data_root, {f"scan{i}.pdf": "hash" for i in range(5)})
+
+        status = status_mod.gather_status()
+
+        assert [s.filename for s in status.skipped] == ["scan0.pdf", "scan1.pdf"]
+        assert status.skipped_total == 5
+
+    def test_status_is_empty_when_nothing_is_held_out(self):
+        from lilbee.app.status import gather_status
+
+        status = gather_status()
+
+        assert status.skipped == []
+        assert status.skipped_total == 0
 
 
 class TestZeroChunkPageTextPersistence:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1549,6 +1549,36 @@ class TestSkipMarkerLifecycle:
 
         assert "possible silent drop" not in caplog.text
 
+    async def test_stale_marker_does_not_hide_a_silent_drop(self, isolated_env, mock_svc, caplog):
+        """A marker for an older hash accounts for nothing once the file changes.
+        Only the files this run held out are subtracted, so an edited file that
+        then vanishes without a failure is still reported."""
+        import logging
+
+        from lilbee.data.ingest import sync
+
+        scan = isolated_env / "scanned.pdf"
+        scan.write_bytes(b"%PDF-1.4 not really text")
+        with mock.patch(
+            "lilbee.data.ingest.pipeline.produce_records", side_effect=self._zero_chunks
+        ):
+            await sync(quiet=True)
+
+        async def _drop_everything(plan_batches, *_args, **_kwargs):
+            async for _batch in plan_batches:
+                pass
+
+        scan.write_bytes(b"%PDF-1.4 edited since it was marked")
+        with (
+            mock.patch("lilbee.data.ingest.pipeline.ingest_stream", side_effect=_drop_everything),
+            caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"),
+        ):
+            result = await sync(quiet=True)
+
+        assert result.held_out == []
+        assert "possible silent drop" in caplog.text
+        assert "scanned.pdf" in caplog.text
+
     async def test_retry_skipped_clears_markers(self, isolated_env, mock_svc):
         from lilbee.data.ingest import sync
 

--- a/tests/test_ingest_fanout.py
+++ b/tests/test_ingest_fanout.py
@@ -12,7 +12,7 @@ import pytest
 
 from lilbee.core.config import cfg
 from lilbee.data.ingest import fanout
-from lilbee.data.types import ShardId, SyncResult
+from lilbee.data.types import ShardId, SkippedSource, SyncResult
 from lilbee.runtime.progress import (
     BatchProgressEvent,
     BatchStatus,
@@ -533,7 +533,12 @@ class TestAggregateResults:
             fanout.ShardDone(
                 kind="done",
                 index=1,
-                result=SyncResult(updated=["b"], failed=["c"], unchanged=3),
+                result=SyncResult(
+                    updated=["b"],
+                    failed=["c"],
+                    unchanged=3,
+                    held_out=[SkippedSource(filename="d.pdf", reason="no text extracted")],
+                ),
                 error=None,
             ),
             fanout.ShardDone(kind="done", index=2, result=None, error="died"),
@@ -541,6 +546,9 @@ class TestAggregateResults:
         result = fanout.aggregate_results(verdicts)
         assert (result.added, result.updated, result.failed) == (["a"], ["b"], ["c"])
         assert (result.unchanged, result.truncated) == (5, 1)
+        # Each worker owns one slice, so the held-out files of every slice have to
+        # reach the one result or a shard's markers go unreported.
+        assert [held.filename for held in result.held_out] == ["d.pdf"]
 
 
 class TestDrain:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -281,6 +281,7 @@ class TestStatus:
         from lilbee.app.status import StatusConfig, StatusResult
 
         mock_status = StatusResult(
+            document_count=0,
             config=StatusConfig(
                 documents_dir="docs",
                 data_dir="data",
@@ -301,6 +302,7 @@ class TestStatus:
         from lilbee.app.status import EntityStatus, StatusConfig, StatusResult
 
         mock_status = StatusResult(
+            document_count=0,
             config=StatusConfig(
                 documents_dir="docs",
                 data_dir="data",
@@ -324,6 +326,7 @@ class TestStatus:
         from lilbee.data.types import SkippedSource
 
         mock_status = StatusResult(
+            document_count=0,
             config=StatusConfig(
                 documents_dir="docs",
                 data_dir="data",

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -317,6 +317,31 @@ class TestStatus:
         assert result.entities.types == ["part_number"]
         assert result.entities.rows == 3
 
+    async def test_status_carries_the_skipped_sources(self):
+        """The held-out list must survive the StatusResponse mapping; a missing
+        field there drops it from the HTTP surface without any error."""
+        from lilbee.app.status import StatusConfig, StatusResult
+        from lilbee.data.types import SkippedSource
+
+        mock_status = StatusResult(
+            config=StatusConfig(
+                documents_dir="docs",
+                data_dir="data",
+                chat_model="test:latest",
+                embedding_model="embed:latest",
+            ),
+            sources=[],
+            total_chunks=0,
+            skipped=[SkippedSource(filename="scan.pdf", reason="OCR timed out after 300s")],
+            skipped_total=7,
+        )
+        with patch("lilbee.server.handlers.gather_status", return_value=mock_status):
+            result = await handlers.status()
+        assert [(s.filename, s.reason) for s in result.skipped] == [
+            ("scan.pdf", "OCR timed out after 300s")
+        ]
+        assert result.skipped_total == 7
+
     async def test_exposes_all_four_model_roles(self):
         """/api/status config payload surfaces vision and reranker slots."""
         cfg.vision_model = ""
@@ -1480,6 +1505,27 @@ class TestAddFiles:
             async for event in handlers.add_files_stream([str(test_file)]):
                 events.append(event)
             assert any("done" in e for e in events)
+
+    async def test_done_frame_carries_the_held_out_files(self, isolated_env):
+        """SyncSummary mirrors SyncResult; a field missing there drops the held-out
+        list from the add response with no error to notice."""
+        from lilbee.data.types import SkippedSource
+
+        test_file = isolated_env / "documents" / "test.txt"
+        test_file.write_text("test content", encoding="utf-8")
+
+        async def fake_sync(**kwargs):
+            return SyncResult(
+                held_out=[SkippedSource(filename="scan.pdf", reason="OCR timed out after 300s")]
+            )
+
+        with patch("lilbee.data.ingest.sync", side_effect=fake_sync):
+            events = [e async for e in handlers.add_files_stream([str(test_file)])]
+
+        done = json.loads([e for e in events if e.startswith("event: done")][-1].split("data: ")[1])
+        assert done["sync"]["held_out"] == [
+            {"filename": "scan.pdf", "reason": "OCR timed out after 300s"}
+        ]
 
     async def test_stream_emits_sentinel_on_sync_failure(self, isolated_env):
         """Sync failure emits one error frame and closes the stream without a done frame."""

--- a/tests/test_skip_marker.py
+++ b/tests/test_skip_marker.py
@@ -12,9 +12,11 @@ from pathlib import Path
 import pytest
 
 from lilbee.data.ingest.skip_marker import (
+    DEFAULT_SKIP_REASON,
     SKIP_MARKER_FILENAME,
     SKIP_REASON_FILENAME,
     clear_skip_markers,
+    describe_skips,
     load_skip_markers,
     load_skip_reasons,
     write_skip_markers,
@@ -160,3 +162,22 @@ class TestSkipReasons:
     def test_load_handles_corrupt_json(self, tmp_path: Path) -> None:
         (tmp_path / SKIP_REASON_FILENAME).write_text("not json {{{", encoding="utf-8")
         assert load_skip_reasons(tmp_path) == {}
+
+
+class TestDescribeSkips:
+    """Pairing held-out filenames with their reasons, for the sync summary and
+    the status payload."""
+
+    def test_pairs_names_with_reasons_in_the_given_order(self, tmp_path: Path) -> None:
+        write_skip_reasons(tmp_path, {"a.pdf": "OCR timed out", "b.tiff": "decode failure"})
+        described = describe_skips(tmp_path, ["b.tiff", "a.pdf"])
+        assert [(d.filename, d.reason) for d in described] == [
+            ("b.tiff", "decode failure"),
+            ("a.pdf", "OCR timed out"),
+        ]
+
+    def test_falls_back_when_no_reason_was_recorded(self, tmp_path: Path) -> None:
+        # A marker written before the reasons sidecar existed still has to say
+        # something, or the user sees a held-out file with a blank explanation.
+        described = describe_skips(tmp_path, ["orphan.pdf"])
+        assert [(d.filename, d.reason) for d in described] == [("orphan.pdf", DEFAULT_SKIP_REASON)]

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2064,7 +2064,7 @@ async def test_status_screen_has_collapsible_sections(mock_svc):
         from textual.widgets import Collapsible
 
         sections = app.screen.query(Collapsible)
-        assert len(sections) == 4
+        assert len(sections) == 5
 
 
 async def test_status_screen_sections_start_expanded(mock_svc):
@@ -2075,8 +2075,9 @@ async def test_status_screen_sections_start_expanded(mock_svc):
 
         await pilot.pause()
         sections = list(app.screen.query(Collapsible))
-        assert len(sections) == 4
-        assert all(not section.collapsed for section in sections)
+        assert len(sections) == 5
+        # The held-out section opens only when the store holds something out.
+        assert all(section.collapsed is (section.id == "held-out-section") for section in sections)
 
 
 async def test_status_screen_config_shows_models(mock_svc):
@@ -2148,6 +2149,37 @@ async def test_status_screen_streams_documents_in_batches(mock_svc):
         table = app.screen.query_one("#docs-table", DataTable)
         # Every row arrives within a bounded number of refreshes.
         await _wait_for_row_count(pilot, table, total)
+
+
+async def test_status_screen_lists_held_out_files(mock_svc, monkeypatch):
+    """Held-out files show with their reason, the overflow count, and an open section."""
+    from textual.widgets import Collapsible, DataTable
+
+    from lilbee.cli.tui.screens import status as status_screen
+    from lilbee.data.types import SkippedSource
+
+    mock_svc.store.get_sources.return_value = []
+    held = [SkippedSource(filename="scan.pdf", reason="no text extracted")]
+    monkeypatch.setattr(status_screen, "held_out_sources", lambda: (held, 3))
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = app.screen.query_one("#held-out-table", DataTable)
+        await _wait_for_row_count(pilot, table, 2)
+        assert app.screen.query_one("#held-out-section", Collapsible).collapsed is False
+
+
+async def test_status_screen_keeps_the_held_out_section_closed_when_empty(mock_svc, monkeypatch):
+    from textual.widgets import Collapsible, DataTable
+
+    from lilbee.cli.tui.screens import status as status_screen
+
+    mock_svc.store.get_sources.return_value = []
+    monkeypatch.setattr(status_screen, "held_out_sources", lambda: ([], 0))
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        table = app.screen.query_one("#held-out-table", DataTable)
+        await _wait_for_row_count(pilot, table, 1)
+        assert app.screen.query_one("#held-out-section", Collapsible).collapsed is True
 
 
 async def test_status_screen_storage_section(mock_svc):
@@ -8099,6 +8131,36 @@ async def test_do_add_callback_routes_embed_and_extract_events(tmp_path):
         rendered = " | ".join(str(c) for c in update_calls)
         assert msg.SYNC_FILE_PROGRESS.format(current=12, total=12, file="scan.pdf") in rendered
         assert msg.SYNC_EMBEDDING.format(file="scan.pdf") in rendered
+
+
+async def test_do_sync_reports_held_out_files():
+    """A sync that held files out on their skip markers says so and names the retry command."""
+    import threading
+    from unittest.mock import MagicMock
+
+    from lilbee.cli.tui import messages as msg
+    from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
+    from lilbee.data.ingest import SyncResult
+    from lilbee.data.types import SkippedSource
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        held = [SkippedSource(filename="scan.pdf", reason="no text extracted")]
+
+        async def fake_sync(**_kw):
+            return SyncResult(unchanged=1, held_out=held)
+
+        app.screen.notify = MagicMock()
+        with patch("lilbee.data.ingest.sync", new=fake_sync):
+            thread = threading.Thread(
+                target=lambda: app.screen._do_sync(MagicMock(spec=ProgressReporter))
+            )
+            thread.start()
+            thread.join(timeout=5)
+            await _pilot.pause()
+
+        messages = [c.args[0] for c in app.screen.notify.call_args_list]
+        assert msg.SYNC_HELD_OUT.format(count=1) in messages
 
 
 async def test_do_add_raises_on_sync_failed(tmp_path):
@@ -14594,6 +14656,7 @@ def test_status_worker_state_changed_dispatches_when_sections_mounted():
     loaded_arch: list[ModelArchInfo] = []
     screen._load_documents = loaded_docs.append
     screen._load_storage = loaded_storage.append
+    screen._load_held_out = lambda _docs: None
     screen._load_arch = loaded_arch.append
 
     docs_result = _DocsResult(sources=[{"a": 1}, {"b": 2}], load_failed=False)


### PR DESCRIPTION
## Problem

A note that yields no text gets a skip marker once. Obsidian creates such a zero-byte file for every clicked unresolved wikilink. On every later sync, the summary counted the file as **Unchanged**. The reconciliation guard saw only that run's failed and skipped sets. So it reported the same files as a "possible silent drop" every time. A user with twelve such notes saw three wrong signals. The document count was twelve short. The summary said everything was unchanged. The data-loss warning cried wolf. The reasons sat in `skip_reasons.json`, which nothing read back.

## Solution

**Held out is its own state.** A marker-held file gets a `held` verdict. The summary counts it separately with its reason, never as unchanged.

**The guard subtracts the held-out files.** Reconciliation counts the files this run held out beside its failed and skipped sets. It fires only for a file that no mechanism explains.

**Skipped files reach the user.** `/api/status` carries the held-out files with reasons, capped, with the true total. `lilbee status` prints the same list, and the TUI status screen shows a "Held out of the index" section with the same rows. A TUI sync that held files out says so and names the retry command.

**The status response counts documents.** `document_count` joins `/api/status`, so a client no longer reads the whole `sources` list for one number. That list leaves the response in a later release.

**An upload under a new name moves the old file.** When exactly one indexed file holds the same bytes as an upload, the server moves it to the new path instead of writing a copy. The next sync repoints the source, so a note that changed its upload key is indexed once.
