### PR TITLE
Expose the npm launcher as a library with download progress, cancel, and release listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - 'engine-versions.env'
       - 'scripts/check_style_rules.py'
       - 'tools/qa/**'
+      - 'packages/lilbee/**'
       - 'tools/wheel-build/**'
       - 'packaging/tools/**'
       - 'scripts/qa/**'

--- a/packages/lilbee/README.md
+++ b/packages/lilbee/README.md
@@ -128,6 +128,8 @@ const binary = await ensureBinary({
 console.log(binary.path, binary.release, binary.variant);
 ```
 
+Every host and every resolved release carries a detection report that says why the launcher chose the build it did. `detectHost()` returns it as `host.detection`: how the `nvidia-smi` probe ended (skipped, missing with the error text, sandboxed, unreadable, or detected with the driver's CUDA ceiling), how the AMD probe ended (with the gfx targets it found), whether the CPU has AVX2, and when the probes ran. A resolved release refines the AMD entry to `unsupported` with the reason its ROCm build was refused: no ROCm asset, no readable kernel manifest, or a host GPU the manifest does not list. `ensureBinary()` returns the report as `detection` on every download or forced reinstall, so an embedder can show it or write it to a diagnostics bundle.
+
 ## Uninstall
 
 `npm uninstall -g lilbee` removes only the launcher — the npm package is a small shim, and the lilbee binary it downloaded stays in the cache (up to ~1.2GB). npm runs no uninstall scripts, so no package can clean its own cache on uninstall. Delete the binaries first, then the package:

--- a/packages/lilbee/README.md
+++ b/packages/lilbee/README.md
@@ -106,7 +106,7 @@ Remote:
 | `LILBEE_DATA_DIR` | Library location for `mcp`; same as `--data-dir`. |
 | `LILBEE_VARIANT` | Override the detected download variant: `default` (the plain build), `cu121`, `cu124`, `cu125`, `rocm`, `compat`. |
 | `LILBEE_RELEASE` | Run an exact lilbee release tag instead of the latest. `lilbee prepare <tag>` does the same for one install. |
-| `LILBEE_DEV_BUILDS` | `=1` lets "latest" pick in-development (`.dev`) builds. Off by default, so a dev build never lands unasked. |
+| `LILBEE_CHANNEL` | `stable` (default) or `dev`: whether "latest" may pick an in-development (`.dev`) build. |
 | `LILBEE_DEBUG` | `=1` prints binary resolution detail on every run. |
 | `LILBEE_MCP_CACHE` | Override the download cache directory. |
 

--- a/packages/lilbee/README.md
+++ b/packages/lilbee/README.md
@@ -50,7 +50,7 @@ The [usage guide](https://github.com/tobocop2/lilbee/blob/main/docs/usage.md) co
 
 The package is a small launcher with zero runtime dependencies. On first use it detects your hardware and downloads the matching standalone binary of the **latest lilbee release** — CUDA on NVIDIA, ROCm on AMD, Metal on Apple silicon, and an AVX-baseline build on older x86-64 CPUs — sha256-verified against the release manifest and cached. Every later run execs the cached binary directly, with no network.
 
-The first download is large (about 370MB on macOS, more for CUDA builds). Run `lilbee prepare` once to do it ahead of time; run it again any time to upgrade to the newest release (the old binary is removed). If the latest-release lookup is unreachable, the launcher falls back to the release pinned in `package.json` — the one this launcher version was tested against.
+The first download is large (about 370MB on macOS, more for CUDA builds). Run `lilbee prepare` once to do it ahead of time; run it again any time to upgrade to the newest release (the old binary is removed). `lilbee prepare <tag>` installs one exact release instead. If the latest-release lookup is unreachable, the launcher falls back to the release pinned in `package.json`, the one this launcher version was tested against.
 
 ## MCP
 
@@ -105,13 +105,28 @@ Remote:
 | `LILBEE_BIN` | Explicit path to a lilbee binary. |
 | `LILBEE_DATA_DIR` | Library location for `mcp`; same as `--data-dir`. |
 | `LILBEE_VARIANT` | Override the detected download variant: `default` (the plain build), `cu121`, `cu124`, `cu125`, `rocm`, `compat`. |
-| `LILBEE_RELEASE` | Run an exact lilbee release tag instead of the latest. |
+| `LILBEE_RELEASE` | Run an exact lilbee release tag instead of the latest. `lilbee prepare <tag>` does the same for one install. |
+| `LILBEE_DEV_BUILDS` | `=1` lets "latest" pick in-development (`.dev`) builds. Off by default, so a dev build never lands unasked. |
 | `LILBEE_DEBUG` | `=1` prints binary resolution detail on every run. |
 | `LILBEE_MCP_CACHE` | Override the download cache directory. |
 
 These are the launcher's own variables. Everything else in your environment passes through to the lilbee binary unchanged, so every lilbee environment variable (`LILBEE_DATA_DIR`, `LILBEE_MODELS_DIR`, …) works exactly as it does with any other install.
 
 The launcher always runs its own sha256-verified download; it ignores lilbee installs from other package managers, so `npm install` means a fresh, known binary. `LILBEE_BIN` is the one escape hatch: set it to run a specific binary instead. The fallback release lives in `package.json` under `lilbee.release`; it is used only when the latest-release lookup fails.
+
+## Embedding
+
+The launcher is also a library. `import { ensureBinary, listReleases, detectHost } from "lilbee"` gives a Node program the same host detection, release selection, verified download, and cache layout the CLI uses, with progress and cancel callbacks and no console output. The [Obsidian plugin](https://obsidian.lilbee.sh/) installs its server this way. Inside an Electron renderer, pass your own `fetch` so the download goes through the transport the renderer allows. The full contract is in `lib/api.d.ts`.
+
+```js
+import { ensureBinary, cacheDir } from "lilbee";
+
+const binary = await ensureBinary({
+  cacheDir: cacheDir(),
+  onProgress: ({ done, total }) => console.log(done, total),
+});
+console.log(binary.path, binary.release, binary.variant);
+```
 
 ## Uninstall
 

--- a/packages/lilbee/docs/shim-audit.md
+++ b/packages/lilbee/docs/shim-audit.md
@@ -22,12 +22,15 @@ audits reject), no wasted download in CI paths that never run the binary.
 
 - Platform/arch mapping at run time, like every shim above.
 - **Hardware detection on top** (new): NVIDIA driver's CUDA level →
-  `cu121/cu124/cu125`, ROCm userland → `rocm`, missing AVX2 → `-compat`
+  `cu121/cu124/cu125`, an AMD GPU in the amdgpu KFD topology → `rocm`, missing AVX2 → `-compat`
   builds, composed (`compat-cu124`). No mainstream npm shim does this —
   they don't need to; lilbee's builds differ by GPU stack the way
   distro packages do, so the launcher behaves like `brew`/`flatpak`
   and picks for you. `LILBEE_VARIANT` remains the explicit override,
   and detection failing means the universal build, which runs anywhere.
+- ROCm is confirmed per release: the launcher reads the gfx manifest
+  published beside the build and takes it only when every host GPU is
+  listed, so a card the build has no kernels for gets the default build.
 
 ## Integrity
 

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -72,7 +72,8 @@ export interface Host {
 /**
  * Probe the host: NVIDIA driver CUDA level (`nvidia-smi` on PATH, then the Windows install
  * locations, with a 10 s timeout), AMD KFD topology, AVX2 baseline (Linux, Intel macOS, Windows).
- * Detection failures fall back to the default build; an unknown LILBEE_VARIANT in `env` throws.
+ * Detection failures fall back to the default build; an unknown LILBEE_VARIANT in `env` throws,
+ * and a valid one skips every probe, so the report shows each as "skipped".
  */
 export function detectHost(env?: NodeJS.ProcessEnv): Promise<Host>;
 

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -58,7 +58,7 @@ export interface FetchResponseLike {
 export interface ReleaseQuery {
     /** GitHub "owner/repo"; defaults to tobocop2/lilbee. */
     repo?: string;
-    /** Offer `.dev` builds as well as stable releases. Default false. */
+    /** Offer `.dev` builds as well as stable releases. Default false (what LILBEE_CHANNEL=stable means on the CLI). */
     includeDev?: boolean;
     /** The host to resolve builds for; defaults to detectHost(). */
     host?: Host;
@@ -109,10 +109,11 @@ export interface InstalledBinary {
 }
 
 /**
- * The newest cached binary for this host, or null when none is cached. Within a release,
- * a binary matching `host.variant` wins over any other build of the host's platform.
+ * The newest cached binary for this machine, or null when none is cached. Within a release,
+ * a binary matching `host.variant` wins over any other build of the platform; without `host`
+ * the platform and arch come from `process` and any build of the release qualifies.
  */
-export function installedBinary(options: { cacheDir: string; host: Host }): InstalledBinary | null;
+export function installedBinary(options: { cacheDir: string; host?: Host }): InstalledBinary | null;
 
 export interface DownloadProgress {
     /** Bytes received so far. */
@@ -134,6 +135,8 @@ export interface EnsureOptions extends ReleaseQuery {
     signal?: AbortSignal;
     /** Human-readable download lifecycle lines; silent by default. */
     log?: (message: string) => void;
+    /** Refuse an asset GitHub publishes no sha256 digest for, instead of installing it unverified. Default false. */
+    requireDigest?: boolean;
 }
 
 export interface EnsureResult extends InstalledBinary {
@@ -148,6 +151,27 @@ export interface EnsureResult extends InstalledBinary {
  * is retried once, then rejected.
  */
 export function ensureBinary(options: EnsureOptions): Promise<EnsureResult>;
+
+/** Why a release query or download failed, for callers that word their own messages. */
+export type LauncherErrorCode =
+    | "rate-limited"
+    | "http"
+    | "no-release"
+    | "no-space"
+    | "stalled"
+    | "no-digest"
+    | "digest-mismatch";
+
+/** A failure the launcher can name. `message` is the CLI's wording; `code` lets an embedder word its own. */
+export class LauncherError extends Error {
+    readonly name: "LauncherError";
+    readonly code: LauncherErrorCode;
+    /** The HTTP status for "http" and "rate-limited". */
+    readonly status?: number;
+    /** Bytes for "no-space": what the download needs and what the filesystem has. */
+    readonly neededBytes?: number;
+    readonly freeBytes?: number;
+}
 
 /** Thrown when `signal` aborts an ensureBinary download. `name` is "AbortError". */
 export class DownloadCanceledError extends Error {

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -10,6 +10,53 @@ export type Arch = "arm64" | "x64";
 /** A release build. "default" is the plain build every host can run. */
 export type Variant = "default" | "cu121" | "cu124" | "cu125" | "rocm" | "compat" | "compat-cu124" | "compat-rocm";
 
+/** How the `nvidia-smi` probe ended. */
+export type NvidiaProbe =
+    /** macOS: one build ships there, so nothing is probed. */
+    | { status: "skipped" }
+    /** `nvidia-smi` is absent or exited non-zero at every location tried; `error` is the first failure, one line. */
+    | { status: "missing"; error: string }
+    /** Linux: the kernel module is loaded but no `nvidia-smi` is reachable (Flatpak, Snap). */
+    | { status: "sandboxed" }
+    /** `nvidia-smi` ran but its output names no CUDA version. */
+    | { status: "unreadable" }
+    /** The driver's newest supported CUDA version as major*100+minor (12.4 is 1204). */
+    | { status: "detected"; cudaCeiling: number };
+
+/** Why a release's ROCm build cannot serve the host's GPUs. */
+export type RocmRefusal = "no-asset" | "no-manifest" | "missing-kernels";
+
+/** How the AMD probe ended. "unsupported" is set per release, once the manifest has been read. */
+export type AmdProbe =
+    /** lilbee ships a ROCm build for Linux only, so other platforms probe nothing. */
+    | { status: "skipped" }
+    /** No amdgpu module and no compute device. */
+    | { status: "missing" }
+    /** The amdgpu module is loaded but `/dev/kfd` is not visible (Flatpak, Snap). */
+    | { status: "sandboxed" }
+    /** `/dev/kfd` is present but its topology could not be read. */
+    | { status: "unreadable" }
+    /** The driver named the gfx targets. */
+    | { status: "detected"; gfxTargets: string[] }
+    /** The driver named the gfx targets but the release's ROCm build cannot serve them. */
+    | { status: "unsupported"; gfxTargets: string[]; reason: RocmRefusal };
+
+/** How the CPU baseline probe ended. Only x86-64 hosts are probed; a missing AVX2 selects the compat builds. */
+export type CpuProbe =
+    | { status: "skipped" }
+    /** The probe could not run; the default build is assumed. */
+    | { status: "unreadable" }
+    | { status: "detected"; avx2: boolean };
+
+/** Why detection chose the build it did. */
+export interface GpuDetection {
+    nvidia: NvidiaProbe;
+    amd: AmdProbe;
+    cpu: CpuProbe;
+    /** When the probes ran, ISO 8601. */
+    detectedAt: string;
+}
+
 /** What this machine can run, resolved once and passed to every release query. */
 export interface Host {
     platform: Platform;
@@ -18,12 +65,14 @@ export interface Host {
     variant: Variant;
     /** The gfx targets of the host's AMD GPUs; empty when there are none. */
     amdGfxTargets: string[];
+    /** Why detection picked `variant`. */
+    detection: GpuDetection;
 }
 
 /**
- * Probe the host: NVIDIA driver CUDA level, AMD KFD topology, AVX2 baseline.
- * A non-empty LILBEE_VARIANT in `env` replaces the detected variant; an unknown
- * value throws. Detection failures fall back to the default build.
+ * Probe the host: NVIDIA driver CUDA level (`nvidia-smi` on PATH, then the Windows install
+ * locations, with a 10 s timeout), AMD KFD topology, AVX2 baseline (Linux, Intel macOS, Windows).
+ * Detection failures fall back to the default build; an unknown LILBEE_VARIANT in `env` throws.
  */
 export function detectHost(env?: NodeJS.ProcessEnv): Promise<Host>;
 
@@ -74,6 +123,8 @@ export interface ResolvedRelease {
     dev: boolean;
     assetName: string;
     variant: Variant;
+    /** The host's detection with `amd` refined for this release: "unsupported" carries why ROCm was refused. */
+    detection: GpuDetection;
     /** Asset size in bytes as GitHub reports it. */
     size: number;
     /** GitHub's sha256 hex digest of the asset, or null on releases that carry none. */
@@ -142,6 +193,8 @@ export interface EnsureOptions extends ReleaseQuery {
 
 export interface EnsureResult extends InstalledBinary {
     source: "cache" | "download";
+    /** Present when a release was resolved for this call (a download or a forced reinstall); absent on a cache hit. */
+    detection?: GpuDetection;
 }
 
 /**

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -115,6 +115,7 @@ export interface InstalledBinary {
  */
 export function installedBinary(options: { cacheDir: string; host?: Host }): InstalledBinary | null;
 
+/** Reported once with `done` 0 when the transfer opens, then after every chunk. */
 export interface DownloadProgress {
     /** Bytes received so far. */
     done: number;

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -22,7 +22,8 @@ export interface Host {
 
 /**
  * Probe the host: NVIDIA driver CUDA level, AMD KFD topology, AVX2 baseline.
- * Never throws; detection failures fall back to the default build.
+ * A non-empty LILBEE_VARIANT in `env` replaces the detected variant; an unknown
+ * value throws. Detection failures fall back to the default build.
  */
 export function detectHost(env?: NodeJS.ProcessEnv): Promise<Host>;
 

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -1,0 +1,157 @@
+/**
+ * Programmatic API of the lilbee npm launcher: resolve, download, and list
+ * lilbee release binaries with the CLI's detection, verification, and cache
+ * layout. Safe in a renderer: no console output, nothing blocks the event loop.
+ */
+
+export type Platform = "darwin" | "linux" | "win32";
+export type Arch = "arm64" | "x64";
+
+/** A release build. "default" is the plain build every host can run. */
+export type Variant = "default" | "cu121" | "cu124" | "cu125" | "rocm" | "compat" | "compat-cu124" | "compat-rocm";
+
+/** What this machine can run, resolved once and passed to every release query. */
+export interface Host {
+    platform: Platform;
+    arch: Arch;
+    /** The build detection picked; "default" when nothing better applies. */
+    variant: Variant;
+    /** The gfx targets of the host's AMD GPUs; empty when there are none. */
+    amdGfxTargets: string[];
+}
+
+/**
+ * Probe the host: NVIDIA driver CUDA level, AMD KFD topology, AVX2 baseline.
+ * Never throws; detection failures fall back to the default build.
+ */
+export function detectHost(env?: NodeJS.ProcessEnv): Promise<Host>;
+
+/** The release asset name for a host, e.g. "lilbee-linux-x86_64-cu124". Throws on an unsupported host. */
+export function assetNameFor(platform: string, arch: string, variant?: Variant | ""): string;
+
+/** The host and variant an asset name encodes, or null for an asset that is not a lilbee binary. */
+export function parseAssetName(name: string): { platform: Platform; arch: Arch; variant: Variant } | null;
+
+/** An in-development build, tagged with a trailing `.dev<n>` (e.g. v0.6.90b420.dev711). */
+export function isDevBuild(tag: string): boolean;
+
+/** Order release tags newest-first; numeric segments compare numerically. */
+export function compareReleaseTags(a: string, b: string): number;
+
+/** The minimum of the Fetch API the launcher uses: GET with headers and an abort signal. */
+export type FetchLike = (
+    url: string,
+    init?: { headers?: Record<string, string>; signal?: AbortSignal },
+) => Promise<FetchResponseLike>;
+
+/** A fetch response whose body is a web ReadableStream or a Node Readable. */
+export interface FetchResponseLike {
+    ok: boolean;
+    status: number;
+    headers: { get(name: string): string | null };
+    body: ReadableStream<Uint8Array> | NodeJS.ReadableStream | null;
+    json(): Promise<unknown>;
+    text(): Promise<string>;
+}
+
+export interface ReleaseQuery {
+    /** GitHub "owner/repo"; defaults to tobocop2/lilbee. */
+    repo?: string;
+    /** Offer `.dev` builds as well as stable releases. Default false. */
+    includeDev?: boolean;
+    /** The host to resolve builds for; defaults to detectHost(). */
+    host?: Host;
+    /** Transport for the GitHub API and the asset manifests; defaults to global fetch. */
+    fetch?: FetchLike;
+    /** Read for GITHUB_TOKEN / GH_TOKEN (sent as a bearer to the GitHub API). Defaults to process.env. */
+    env?: NodeJS.ProcessEnv;
+}
+
+/** A release with the build this host should run resolved. */
+export interface ResolvedRelease {
+    tag: string;
+    dev: boolean;
+    assetName: string;
+    variant: Variant;
+    /** Asset size in bytes as GitHub reports it. */
+    size: number;
+    /** GitHub's sha256 hex digest of the asset, or null on releases that carry none. */
+    digest: string | null;
+    url: string;
+}
+
+/**
+ * Published releases that ship a build for the host, newest first: up to `limit` stable
+ * releases plus up to `limit` dev builds when `includeDev` is set. Drafts, prereleases,
+ * and releases without a build for the host are left out. Throws with a plain message
+ * when GitHub rate-limits the request.
+ */
+export function listReleases(query?: ReleaseQuery & { limit?: number }): Promise<ResolvedRelease[]>;
+
+/** The newest installable release on the chosen channel. Throws when none exists. */
+export function latestRelease(query?: ReleaseQuery): Promise<ResolvedRelease>;
+
+/** One release by tag, resolved for the host. Throws when the tag or the host's build is missing. */
+export function releaseByTag(tag: string, query?: ReleaseQuery): Promise<ResolvedRelease>;
+
+/** Where the launcher caches binaries: LILBEE_MCP_CACHE, else the platform cache dir. */
+export function cacheDir(env?: NodeJS.ProcessEnv): string;
+
+/** Path of a cached binary: `<cacheDir>/<release>/<assetName>`. */
+export function cachedBinaryPath(cacheDir: string, release: string, assetName: string): string;
+
+export interface InstalledBinary {
+    path: string;
+    release: string;
+    assetName: string;
+    variant: Variant;
+}
+
+/**
+ * The newest cached binary for this host, or null when none is cached. Within a release,
+ * a binary matching `host.variant` wins over any other build of the host's platform.
+ */
+export function installedBinary(options: { cacheDir: string; host: Host }): InstalledBinary | null;
+
+export interface DownloadProgress {
+    /** Bytes received so far. */
+    done: number;
+    /** Total bytes when known (Content-Length, else the release's asset size), or null. */
+    total: number | null;
+}
+
+export interface EnsureOptions extends ReleaseQuery {
+    cacheDir: string;
+    /** An exact release tag to install; default: the cached binary, else the latest release. */
+    release?: string;
+    /** Re-resolve the latest release even when a binary is cached (what `lilbee prepare` does). */
+    refresh?: boolean;
+    /** Download even when the resolved release is already cached (reinstall). */
+    force?: boolean;
+    onProgress?: (progress: DownloadProgress) => void;
+    /** Aborting rejects with DownloadCanceledError and discards the partial file. */
+    signal?: AbortSignal;
+    /** Human-readable download lifecycle lines; silent by default. */
+    log?: (message: string) => void;
+}
+
+export interface EnsureResult extends InstalledBinary {
+    source: "cache" | "download";
+}
+
+/**
+ * Make a lilbee binary available in `cacheDir` and return it. Downloads stream to a temp
+ * file, verify sha256 against the release digest, land by atomic rename, then remove
+ * every other cached release and every other build of the same release. Rejects with
+ * DownloadCanceledError when `signal` aborts; a stalled transfer (no bytes for 60 s)
+ * is retried once, then rejected.
+ */
+export function ensureBinary(options: EnsureOptions): Promise<EnsureResult>;
+
+/** Thrown when `signal` aborts an ensureBinary download. `name` is "AbortError". */
+export class DownloadCanceledError extends Error {
+    readonly name: "AbortError";
+}
+
+/** True for a DownloadCanceledError, or any error whose name is "AbortError". */
+export function isDownloadCanceled(err: unknown): boolean;

--- a/packages/lilbee/lib/api.mjs
+++ b/packages/lilbee/lib/api.mjs
@@ -30,5 +30,6 @@ export async function ensureBinary({ cacheDir, release, refresh = false, force =
     if (installed && !force) return { ...installed, source: "cache" };
     resolved = installed ? await releaseByTag(installed.release, q) : await latestRelease(q);
   }
-  return installRelease(resolved, { cacheDir, force, repo: q.repo, fetch: q.fetch, env, onProgress, signal, log, requireDigest });
+  const installed = await installRelease(resolved, { cacheDir, force, repo: q.repo, fetch: q.fetch, env, onProgress, signal, log, requireDigest });
+  return installed.source === "download" ? { ...installed, detection: resolved.detection } : installed;
 }

--- a/packages/lilbee/lib/api.mjs
+++ b/packages/lilbee/lib/api.mjs
@@ -1,0 +1,33 @@
+/**
+ * The lilbee npm launcher's programmatic API: resolve, download, and list
+ * lilbee release binaries with the CLI's detection, verification, and cache
+ * layout. Silent, and nothing blocks the event loop.
+ */
+
+import { cacheDir, cachedBinaryPath, installedBinary, installRelease } from "./cache.mjs";
+import { detectHost } from "./detect.mjs";
+import { compareReleaseTags, isDevBuild, latestRelease, listReleases, releaseByTag } from "./releases.mjs";
+
+export { assetNameFor, parseAssetName } from "./assets.mjs";
+export { DownloadCanceledError, isDownloadCanceled } from "./download.mjs";
+export { cacheDir, cachedBinaryPath, compareReleaseTags, detectHost, installedBinary, isDevBuild, latestRelease, listReleases, releaseByTag };
+
+/**
+ * Make a lilbee binary available in `cacheDir` and return it. Without `release`
+ * the cached binary is used as is; `refresh` re-resolves the latest release and
+ * `force` downloads again even when the resolved release is cached.
+ */
+export async function ensureBinary({ cacheDir, release, refresh = false, force = false, onProgress, signal, log = () => {}, ...query }) {
+  const env = query.env ?? process.env;
+  const host = query.host ?? (await detectHost(env));
+  const q = { ...query, env, host };
+  let resolved;
+  if (release) {
+    resolved = await releaseByTag(release, q);
+  } else {
+    const installed = refresh ? null : installedBinary({ cacheDir, host });
+    if (installed && !force) return { ...installed, source: "cache" };
+    resolved = installed ? await releaseByTag(installed.release, q) : await latestRelease(q);
+  }
+  return installRelease(resolved, { cacheDir, force, fetch: q.fetch, env, onProgress, signal, log });
+}

--- a/packages/lilbee/lib/api.mjs
+++ b/packages/lilbee/lib/api.mjs
@@ -10,6 +10,7 @@ import { compareReleaseTags, isDevBuild, latestRelease, listReleases, releaseByT
 
 export { assetNameFor, parseAssetName } from "./assets.mjs";
 export { DownloadCanceledError, isDownloadCanceled } from "./download.mjs";
+export { LauncherError } from "./errors.mjs";
 export { cacheDir, cachedBinaryPath, compareReleaseTags, detectHost, installedBinary, isDevBuild, latestRelease, listReleases, releaseByTag };
 
 /**
@@ -17,7 +18,7 @@ export { cacheDir, cachedBinaryPath, compareReleaseTags, detectHost, installedBi
  * the cached binary is used as is; `refresh` re-resolves the latest release and
  * `force` downloads again even when the resolved release is cached.
  */
-export async function ensureBinary({ cacheDir, release, refresh = false, force = false, onProgress, signal, log = () => {}, ...query }) {
+export async function ensureBinary({ cacheDir, release, refresh = false, force = false, onProgress, signal, log = () => {}, requireDigest = false, ...query }) {
   const env = query.env ?? process.env;
   const host = query.host ?? (await detectHost(env));
   const q = { ...query, env, host };
@@ -29,5 +30,5 @@ export async function ensureBinary({ cacheDir, release, refresh = false, force =
     if (installed && !force) return { ...installed, source: "cache" };
     resolved = installed ? await releaseByTag(installed.release, q) : await latestRelease(q);
   }
-  return installRelease(resolved, { cacheDir, force, fetch: q.fetch, env, onProgress, signal, log });
+  return installRelease(resolved, { cacheDir, force, repo: q.repo, fetch: q.fetch, env, onProgress, signal, log, requireDigest });
 }

--- a/packages/lilbee/lib/assets.mjs
+++ b/packages/lilbee/lib/assets.mjs
@@ -1,23 +1,28 @@
 /**
- * Release-asset naming for the standalone lilbee binaries.
- *
- * Mirrors the asset matrix the release pipeline publishes (see the GitHub
- * releases): plain CPU builds per platform, CUDA/ROCm variants on Linux and
- * Windows, and `-compat` AVX-baseline builds for older x86-64 CPUs.
+ * Release-asset naming for the standalone lilbee binaries: plain CPU builds
+ * per platform, CUDA/ROCm variants on Linux and Windows, and `-compat`
+ * AVX-baseline builds for older x86-64 CPUs.
  */
 
 const VARIANTS = new Set(["", "cu121", "cu124", "cu125", "rocm", "compat", "compat-cu124", "compat-rocm"]);
+
+const HOST_BY_TARGET = {
+  "macos-arm64": { platform: "darwin", arch: "arm64" },
+  "macos-x86_64": { platform: "darwin", arch: "x64" },
+  "linux-x86_64": { platform: "linux", arch: "x64" },
+  "windows-x86_64": { platform: "win32", arch: "x64" },
+};
+
+const ASSET_NAME = /^lilbee(-compat)?-(macos-arm64|macos-x86_64|linux-x86_64|windows-x86_64)(?:-(cu121|cu124|cu125|rocm))?(\.exe)?$/;
 
 /**
  * Return the release asset name for a host, or throw with a clear message.
  *
  * @param {string} platform - process.platform value ("darwin" | "linux" | "win32")
  * @param {string} arch - process.arch value ("arm64" | "x64")
- * @param {string} variant - "" (auto), "default" (plain build) | "cu121" | "cu124" | "cu125" | "rocm" | "compat"
+ * @param {string} variant - "" or "default" (plain build) | "cu121" | "cu124" | "cu125" | "rocm" | "compat" | "compat-cu124" | "compat-rocm"
  */
 export function assetNameFor(platform, arch, variant = "") {
-  // "default" forces the plain build on hosts where detection would pick a
-  // GPU variant (the other channels offer the same choice).
   if (variant === "default") variant = "";
   if (!VARIANTS.has(variant)) {
     throw new Error(
@@ -52,4 +57,19 @@ export function assetNameFor(platform, arch, variant = "") {
     `No standalone lilbee build for ${platform}/${arch}. ` +
       "Install lilbee yourself (pip/uv/brew) and point LILBEE_BIN at the binary."
   );
+}
+
+/** The host and variant an asset name encodes, or null for an asset that is not a lilbee binary. */
+export function parseAssetName(name) {
+  const m = ASSET_NAME.exec(name);
+  if (!m) return null;
+  const [, compat, target, gpu] = m;
+  const { platform, arch } = HOST_BY_TARGET[target];
+  const variant = compat ? (gpu ? `compat-${gpu}` : "compat") : gpu || "default";
+  try {
+    if (assetNameFor(platform, arch, variant) !== name) return null;
+  } catch {
+    return null;
+  }
+  return { platform, arch, variant };
 }

--- a/packages/lilbee/lib/cache.mjs
+++ b/packages/lilbee/lib/cache.mjs
@@ -52,7 +52,7 @@ function hostBinaries(cacheDir, release, host) {
  * The newest cached binary for this host, or null when none is cached. Within a
  * release, a binary matching `host.variant` wins over any other build of the host's platform.
  */
-export function installedBinary({ cacheDir, host }) {
+export function installedBinary({ cacheDir, host = { platform: process.platform, arch: process.arch, variant: null } }) {
   for (const release of entriesOf(cacheDir).sort(compareReleaseTags)) {
     const [best] = hostBinaries(cacheDir, release, host);
     if (best) return best;

--- a/packages/lilbee/lib/cache.mjs
+++ b/packages/lilbee/lib/cache.mjs
@@ -1,0 +1,86 @@
+/**
+ * The launcher's binary cache: `<cacheDir>/<release>/<assetName>`, one
+ * release at a time, with lookup and install on top of the download.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { parseAssetName } from "./assets.mjs";
+import { download } from "./download.mjs";
+import { compareReleaseTags } from "./releases.mjs";
+
+const CACHE_DIR_NAME = "lilbee-npm";
+
+/** Where the launcher caches binaries: LILBEE_MCP_CACHE, else the platform cache dir. */
+export function cacheDir(env = process.env, platform = process.platform) {
+  if (env.LILBEE_MCP_CACHE) return env.LILBEE_MCP_CACHE;
+  const home = os.homedir();
+  if (platform === "darwin") return path.join(home, "Library", "Caches", CACHE_DIR_NAME);
+  if (platform === "win32") {
+    return path.join(env.LOCALAPPDATA || path.join(home, "AppData", "Local"), CACHE_DIR_NAME);
+  }
+  return path.join(env.XDG_CACHE_HOME || path.join(home, ".cache"), CACHE_DIR_NAME);
+}
+
+/** Path of a cached binary: `<cacheDir>/<release>/<assetName>`. */
+export function cachedBinaryPath(cacheDir, release, assetName) {
+  return path.join(cacheDir, release, assetName);
+}
+
+function entriesOf(dir) {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+/** The binaries of one release dir that run on the host, the host's own variant first. */
+function hostBinaries(cacheDir, release, host) {
+  const found = [];
+  for (const name of entriesOf(path.join(cacheDir, release)).sort()) {
+    const parsed = parseAssetName(name);
+    if (!parsed || parsed.platform !== host.platform || parsed.arch !== host.arch) continue;
+    found.push({ path: cachedBinaryPath(cacheDir, release, name), release, assetName: name, variant: parsed.variant });
+  }
+  return found.sort((a, b) => Number(b.variant === host.variant) - Number(a.variant === host.variant));
+}
+
+/**
+ * The newest cached binary for this host, or null when none is cached. Within a
+ * release, a binary matching `host.variant` wins over any other build of the host's platform.
+ */
+export function installedBinary({ cacheDir, host }) {
+  for (const release of entriesOf(cacheDir).sort(compareReleaseTags)) {
+    const [best] = hostBinaries(cacheDir, release, host);
+    if (best) return best;
+  }
+  return null;
+}
+
+/** Delete every cached release dir but `keep`. */
+export function pruneOtherReleases(cacheDir, keep) {
+  for (const release of entriesOf(cacheDir)) {
+    if (release === keep) continue;
+    try {
+      fs.rmSync(path.join(cacheDir, release), { recursive: true, force: true });
+    } catch {
+      // a busy file on Windows: a stale release is a nuisance, not an error
+    }
+  }
+}
+
+/**
+ * Put a resolved release's binary in the cache and return it with its `source`:
+ * "cache" when it is already there (unless `force`), else "download".
+ */
+export async function installRelease(release, { cacheDir, force = false, ...transfer }) {
+  const dest = cachedBinaryPath(cacheDir, release.tag, release.assetName);
+  const installed = { path: dest, release: release.tag, assetName: release.assetName, variant: release.variant };
+  if (!force && fs.existsSync(dest)) return { ...installed, source: "cache" };
+  await download({ ...transfer, release, dest });
+  pruneOtherReleases(cacheDir, release.tag);
+  return { ...installed, source: "download" };
+}

--- a/packages/lilbee/lib/cli.mjs
+++ b/packages/lilbee/lib/cli.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 import { cacheDir, installRelease } from "./cache.mjs";
 import { detectHost } from "./detect.mjs";
 import { progressReporter } from "./download.mjs";
-import { exitCodeForSignal, HELP, mcpExec, passthroughExec, remoteExec, routeArgv, selectMode } from "./plan.mjs";
+import { channelIncludesDev, exitCodeForSignal, HELP, mcpExec, passthroughExec, remoteExec, routeArgv, selectMode } from "./plan.mjs";
 import { resolveBinary } from "./resolve.mjs";
 
 const log = (msg) => console.error(msg);
@@ -157,7 +157,7 @@ async function resolveLocalBinary(env, { refresh = false, tag = null } = {}) {
     pinned,
     tag,
     refresh,
-    includeDev: env.LILBEE_DEV_BUILDS === "1",
+    includeDev: channelIncludesDev(env),
     repo: env.LILBEE_REPO || repo,
     log: say,
   });
@@ -166,7 +166,7 @@ async function resolveLocalBinary(env, { refresh = false, tag = null } = {}) {
     assertGlibcFloor();
     const report = progressReporter(log);
     try {
-      await installRelease(plan.download, { cacheDir: dir, env, onProgress: report, log });
+      await installRelease(plan.download, { cacheDir: dir, repo: env.LILBEE_REPO || repo, env, onProgress: report, log });
     } finally {
       report.finish();
     }

--- a/packages/lilbee/lib/cli.mjs
+++ b/packages/lilbee/lib/cli.mjs
@@ -9,15 +9,14 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { assetNameFor } from "./assets.mjs";
-import { detectVariant } from "./detect.mjs";
-import { download, latestReleaseTag } from "./download.mjs";
+import { cacheDir, installRelease } from "./cache.mjs";
+import { detectHost } from "./detect.mjs";
+import { progressReporter } from "./download.mjs";
 import { exitCodeForSignal, HELP, mcpExec, passthroughExec, remoteExec, routeArgv, selectMode } from "./plan.mjs";
-import { cacheDir, resolveBinary } from "./resolve.mjs";
+import { resolveBinary } from "./resolve.mjs";
 
 const log = (msg) => console.error(msg);
 
@@ -142,48 +141,40 @@ export function spawnAndForward({ cmd, args }, { tieToStdin = false } = {}) {
   }
 }
 
-async function resolveLocalBinary(env, { refresh = false } = {}) {
+async function resolveLocalBinary(env, { refresh = false, tag = null } = {}) {
   const debug = env.LILBEE_DEBUG === "1";
   // Routine runs are silent: detection and resolution chatter buffers here
   // and prints only when a download actually happens (or LILBEE_DEBUG=1).
   const pending = [];
   const say = debug ? log : (msg) => pending.push(msg);
-  const { release, repo } = pinnedRelease();
-  // Explicit LILBEE_VARIANT wins; otherwise detect the host's GPU and CPU
-  // baseline so the bootstrap grabs the right build automatically, the way
-  // brew or flatpak would.
-  const variant =
-    env.LILBEE_VARIANT !== undefined && env.LILBEE_VARIANT !== ""
-      ? env.LILBEE_VARIANT
-      : detectVariant(
-          process.platform,
-          process.arch,
-          { execFileSync, existsSync: fs.existsSync, readFileSync: fs.readFileSync, readdirSync: fs.readdirSync },
-          say
-        );
-  const assetName = assetNameFor(process.platform, process.arch, variant);
-  const resolved = await resolveBinary({
-    env: { LILBEE_REPO: repo, ...env },
-    release,
-    assetName,
+  const { release: pinned, repo } = pinnedRelease();
+  const host = await detectHost(env, say);
+  const dir = cacheDir(env);
+  const plan = await resolveBinary({
+    env,
+    cacheDir: dir,
+    host,
+    pinned,
+    tag,
     refresh,
-    deps: {
-      existsSync: fs.existsSync,
-      readdirSync: fs.readdirSync,
-      rmSync: fs.rmSync,
-      latestTag: () => latestReleaseTag(repo),
-      log: say,
-      download: async (o) => {
-        for (const msg of pending.splice(0)) log(msg);
-        assertGlibcFloor();
-        return download({ ...o, log });
-      },
-    },
+    includeDev: env.LILBEE_DEV_BUILDS === "1",
+    repo: env.LILBEE_REPO || repo,
+    log: say,
   });
-  if (debug || resolved.source === "download") {
-    log(`lilbee: using binary from ${resolved.source} (${resolved.path})`);
+  if (plan.download) {
+    for (const msg of pending.splice(0)) log(msg);
+    assertGlibcFloor();
+    const report = progressReporter(log);
+    try {
+      await installRelease(plan.download, { cacheDir: dir, env, onProgress: report, log });
+    } finally {
+      report.finish();
+    }
   }
-  return resolved;
+  if (debug || plan.source === "download") {
+    log(`lilbee: using binary from ${plan.source} (${plan.path})`);
+  }
+  return plan;
 }
 
 export async function run(argv) {
@@ -208,7 +199,7 @@ export async function run(argv) {
   if (route.kind === "prepare") {
     // prepare is the explicit "get me the newest release": it re-resolves
     // latest even when a binary is already cached.
-    const resolved = await resolveLocalBinary(env, { refresh: true });
+    const resolved = await resolveLocalBinary(env, { refresh: true, tag: route.tag });
     log(`lilbee: ready (${resolved.path}).`);
     return;
   }

--- a/packages/lilbee/lib/detect.mjs
+++ b/packages/lilbee/lib/detect.mjs
@@ -1,21 +1,40 @@
 /**
  * Hardware detection for the bootstrap download: the build a host can run,
  * read from the NVIDIA driver, the amdgpu KFD topology, and the CPU flags.
- * Detection fails toward the default build, which runs everywhere.
+ * Every probe records how it ended in a detection report; the build is then
+ * chosen from the report. Detection fails toward the default build, which
+ * runs everywhere.
  */
 
 import { execFile } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 
 import { assetNameFor } from "./assets.mjs";
 
+const KFD_DEVICE = "/dev/kfd";
 const KFD_NODES = "/sys/class/kfd/kfd/topology/nodes";
-const PROBE_TIMEOUT_MS = 5000;
+const AMDGPU_MODULE = "/sys/module/amdgpu";
+const ROCM_USERLAND = "/opt/rocm";
+const NVIDIA_DEVICE = "/dev/nvidia0";
+const NVIDIA_DRIVER_VERSION = "/proc/driver/nvidia/version";
+const PROBE_TIMEOUT_MS = 10000;
+const NVIDIA_SMI_TIMED_OUT = `nvidia-smi did not answer within ${PROBE_TIMEOUT_MS / 1000} s`;
+/** kernel32 IsProcessorFeaturePresent: PF_AVX2_INSTRUCTIONS_AVAILABLE. */
+const PF_AVX2_INSTRUCTIONS_AVAILABLE = 40;
+const AVX2_PROBE_SCRIPT = [
+  "Add-Type -Namespace Lilbee -Name Cpu -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern bool IsProcessorFeaturePresent(int feature);'",
+  `[Lilbee.Cpu]::IsProcessorFeaturePresent(${PF_AVX2_INSTRUCTIONS_AVAILABLE})`,
+].join("\n");
+const AVX2_PROBE_ARGS = ["-NoProfile", "-NonInteractive", "-EncodedCommand", Buffer.from(AVX2_PROBE_SCRIPT, "utf16le").toString("base64")];
+
+const COMPAT_BUILD_LOG = "lilbee: this CPU has no AVX2 — using the -compat build (override with LILBEE_VARIANT).";
+const COMPAT_FAMILY_LOG = "lilbee: this CPU has no AVX2 — using the -compat build family (override with LILBEE_VARIANT).";
 
 const execFileAsync = promisify(execFile);
 
-/** The probes detection runs on the real host: `execFile` resolves to stdout. */
+/** The probes detection runs on the real host: `execFile` resolves to stdout and rejects with the raw error. */
 const nodeIo = {
   execFile: async (cmd, args) => {
     const { stdout } = await execFileAsync(cmd, args, {
@@ -32,10 +51,13 @@ const nodeIo = {
 
 /** Map the driver-reported CUDA version to the newest runnable build, or null when it runs none. */
 export function cudaVariantFor(major, minor) {
-  const v = major * 100 + minor;
-  if (v >= 1205) return "cu125";
-  if (v >= 1204) return "cu124";
-  if (v >= 1201) return "cu121";
+  return cudaVariantForCeiling(major * 100 + minor);
+}
+
+function cudaVariantForCeiling(ceiling) {
+  if (ceiling >= 1205) return "cu125";
+  if (ceiling >= 1204) return "cu124";
+  if (ceiling >= 1201) return "cu121";
   return null;
 }
 
@@ -54,13 +76,62 @@ export function gfxNameFor(version) {
   return `gfx${major}${minor.toString(16)}${step.toString(16)}`;
 }
 
-/** The gfx names of every GPU node the KFD topology reports, unique and sorted; unreadable nodes are skipped. */
+/** Windows installers put `nvidia-smi` here but leave it off PATH: DCH drivers in System32, older layouts in NVSMI. */
+function windowsNvidiaSmiPaths(env) {
+  const systemRoot = env.SystemRoot || "C:\\Windows";
+  const programFiles = env.ProgramFiles || "C:\\Program Files";
+  return [
+    path.win32.join(systemRoot, "System32", "nvidia-smi.exe"),
+    path.win32.join(programFiles, "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe"),
+  ];
+}
+
+/** Where to look for `nvidia-smi`: PATH first, then the Windows install locations. */
+export function nvidiaSmiCandidates(platform, env) {
+  return platform === "win32" ? ["nvidia-smi", ...windowsNvidiaSmiPaths(env)] : ["nvidia-smi"];
+}
+
+/** One line for the report: execFile's message carries the command's stderr on later lines. */
+function probeFailureText(err) {
+  if (err && err.killed) return NVIDIA_SMI_TIMED_OUT;
+  const text = err instanceof Error ? err.message : String(err);
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Run `nvidia-smi` at each candidate: its stdout, or the first failure and whether no candidate existed at all. */
+async function runNvidiaSmi(platform, io, env) {
+  let error = "";
+  let notFound = true;
+  for (const command of nvidiaSmiCandidates(platform, env)) {
+    try {
+      return { stdout: await io.execFile(command, []), error: null, notFound: false };
+    } catch (err) {
+      if (!error) error = probeFailureText(err);
+      if (!err || err.code !== "ENOENT") notFound = false;
+    }
+  }
+  return { stdout: null, error, notFound };
+}
+
+async function probeNvidia(platform, io, env, exists) {
+  if (platform === "darwin") return { status: "skipped" };
+  const { stdout, error, notFound } = await runNvidiaSmi(platform, io, env);
+  if (stdout === null) {
+    if (notFound && platform === "linux" && exists(NVIDIA_DRIVER_VERSION)) return { status: "sandboxed" };
+    return { status: "missing", error };
+  }
+  const v = parseCudaVersion(stdout);
+  if (!v) return { status: "unreadable" };
+  return { status: "detected", cudaCeiling: v.major * 100 + v.minor };
+}
+
+/** The gfx names of every GPU node the KFD topology reports, unique and sorted; null when the topology is unreadable. */
 function kfdGfxTargets(io) {
   let nodes;
   try {
     nodes = io.readdirSync(KFD_NODES);
   } catch {
-    return [];
+    return null;
   }
   const targets = new Set();
   for (const node of nodes) {
@@ -76,12 +147,116 @@ function kfdGfxTargets(io) {
   return [...targets].sort();
 }
 
+function probeAmd(platform, io, exists) {
+  if (platform !== "linux") return { status: "skipped" };
+  if (!exists(KFD_DEVICE)) return { status: exists(AMDGPU_MODULE) ? "sandboxed" : "missing" };
+  const gfxTargets = kfdGfxTargets(io);
+  if (gfxTargets === null) return { status: "unreadable" };
+  if (gfxTargets.length === 0) return { status: "missing" };
+  return { status: "detected", gfxTargets };
+}
+
+function probeCpuLinux(io) {
+  let cpuinfo;
+  try {
+    cpuinfo = io.readFileSync("/proc/cpuinfo", "utf8");
+  } catch {
+    return { status: "unreadable" };
+  }
+  const flagsLine = /^flags\s*:\s*(.+)$/m.exec(cpuinfo);
+  if (!flagsLine) return { status: "unreadable" };
+  return { status: "detected", avx2: /\bavx2\b/.test(flagsLine[1]) };
+}
+
+/** A probe that prints one token for AVX2 present and one for absent; anything else is unreadable. */
+async function probeCpuByCommand(tryExec, cmd, args, present, absent) {
+  const output = await tryExec(cmd, args);
+  const answer = output === null ? null : output.trim();
+  if (answer === present) return { status: "detected", avx2: true };
+  if (answer === absent) return { status: "detected", avx2: false };
+  return { status: "unreadable" };
+}
+
+async function probeCpu(platform, arch, io, tryExec) {
+  if (arch !== "x64") return { status: "skipped" };
+  if (platform === "linux") return probeCpuLinux(io);
+  if (platform === "darwin") return probeCpuByCommand(tryExec, "sysctl", ["-n", "hw.optional.avx2_0"], "1", "0");
+  if (platform === "win32") return probeCpuByCommand(tryExec, "powershell", AVX2_PROBE_ARGS, "True", "False");
+  return { status: "skipped" };
+}
+
+/** The report of a host whose build was forced: nothing was probed. */
+function skippedDetection() {
+  return { nvidia: { status: "skipped" }, amd: { status: "skipped" }, cpu: { status: "skipped" }, detectedAt: new Date().toISOString() };
+}
+
+/** The CUDA build the NVIDIA probe calls for, or null; logs the CLI's line for the choice. */
+function cudaBuild(nvidia, platform, exists, log) {
+  if (nvidia.status === "detected" || nvidia.status === "unreadable") {
+    const ceiling = nvidia.status === "detected" ? nvidia.cudaCeiling : null;
+    const cuda = ceiling === null ? "cu121" : cudaVariantForCeiling(ceiling);
+    const label = ceiling === null ? "unknown" : `${Math.floor(ceiling / 100)}.${ceiling % 100}`;
+    if (cuda) log(`lilbee: detected NVIDIA driver (CUDA ${label}) — using the ${cuda} build (override with LILBEE_VARIANT).`);
+    return cuda;
+  }
+  if (platform === "linux" && (exists(NVIDIA_DEVICE) || exists(NVIDIA_DRIVER_VERSION))) {
+    log("lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT).");
+    return "cu121";
+  }
+  return null;
+}
+
+/** Whether the ROCm build applies (Linux, no CUDA, a compute device plus named GPUs or a ROCm userland). */
+async function rocmBuild(amd, platform, cuda, exists, tryExec, log) {
+  if (platform !== "linux" || cuda || !exists(KFD_DEVICE)) return { rocm: false, amdGfxTargets: [] };
+  if (amd.status === "detected") {
+    log(`lilbee: detected an AMD GPU (${amd.gfxTargets.join(", ")}) — using the rocm build (override with LILBEE_VARIANT).`);
+    return { rocm: true, amdGfxTargets: amd.gfxTargets };
+  }
+  const rocm = exists(ROCM_USERLAND) || (await tryExec("rocminfo", [])) !== null;
+  if (rocm) log("lilbee: detected a ROCm userland — using the rocm build (override with LILBEE_VARIANT).");
+  return { rocm, amdGfxTargets: [] };
+}
+
+function linuxVariant(cuda, rocm, noAvx2, log) {
+  if (noAvx2) {
+    log(COMPAT_FAMILY_LOG);
+    // compat ships cu124 and rocm flavors only
+    if (cuda) return "compat-cu124";
+    return rocm ? "compat-rocm" : "compat";
+  }
+  if (cuda) return cuda;
+  return rocm ? "rocm" : "default";
+}
+
+function windowsVariant(cuda, noAvx2, log) {
+  // Windows ships cu124 and cu125, and a compat build with no GPU flavor
+  if (noAvx2) {
+    log(COMPAT_BUILD_LOG);
+    return "compat";
+  }
+  if (cuda === "cu121") {
+    log("lilbee: this NVIDIA driver predates CUDA 12.4 — using the universal Windows build (override with LILBEE_VARIANT).");
+    return "default";
+  }
+  return cuda ?? "default";
+}
+
+/** Probe the host and return its detection report. */
+async function probeHost(platform, arch, io, env, exists, tryExec) {
+  const nvidia = await probeNvidia(platform, io, env, exists);
+  const amd = probeAmd(platform, io, exists);
+  const cpu = await probeCpu(platform, arch, io, tryExec);
+  return { nvidia, amd, cpu, detectedAt: new Date().toISOString() };
+}
+
 /**
- * Detect the build for a host: `{ variant, amdGfxTargets }`. `io` carries the
- * probes ({ execFile, existsSync, readFileSync, readdirSync }) so tests can
- * simulate any host; `log` receives one line per decision.
+ * Detect the build for a host: `{ variant, amdGfxTargets, detection }`. `io`
+ * carries the probes ({ execFile, existsSync, readFileSync, readdirSync }) so
+ * tests can simulate any host; `log` receives one line per decision; `env`
+ * supplies the Windows install locations of `nvidia-smi`.
  */
-export async function detectVariant(platform, arch, io = nodeIo, log = () => {}) {
+export async function detectVariant(platform, arch, io = nodeIo, log = () => {}, env = process.env) {
   const tryExec = async (cmd, args) => {
     try {
       return await io.execFile(cmd, args);
@@ -96,89 +271,34 @@ export async function detectVariant(platform, arch, io = nodeIo, log = () => {})
       return false;
     }
   };
-  const host = (variant, amdGfxTargets = []) => ({ variant, amdGfxTargets });
+  const detection = await probeHost(platform, arch, io, env, exists, tryExec);
+  const noAvx2 = detection.cpu.status === "detected" && !detection.cpu.avx2;
+  const host = (variant, amdGfxTargets = []) => ({ variant, amdGfxTargets, detection });
 
   if (platform === "darwin") {
-    if (arch !== "x64") return host("default");
-    const avx2 = await tryExec("sysctl", ["-n", "hw.optional.avx2_0"]);
-    if (avx2 !== null && avx2.trim() === "0") {
-      log("lilbee: this CPU has no AVX2 — using the -compat build (override with LILBEE_VARIANT).");
-      return host("compat");
-    }
-    return host("default");
+    if (noAvx2) log(COMPAT_BUILD_LOG);
+    return host(noAvx2 ? "compat" : "default");
   }
 
-  let cuda = null;
-  const smi = await tryExec("nvidia-smi", []);
-  if (smi) {
-    const v = parseCudaVersion(smi);
-    cuda = v ? cudaVariantFor(v.major, v.minor) : "cu121";
-    if (cuda) log(`lilbee: detected NVIDIA driver (CUDA ${v ? `${v.major}.${v.minor}` : "unknown"}) — using the ${cuda} build (override with LILBEE_VARIANT).`);
-  } else if (platform === "linux" && (exists("/dev/nvidia0") || exists("/proc/driver/nvidia/version"))) {
-    cuda = "cu121";
-    log("lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT).");
-  }
+  const cuda = cudaBuild(detection.nvidia, platform, exists, log);
+  const { rocm, amdGfxTargets } = await rocmBuild(detection.amd, platform, cuda, exists, tryExec, log);
 
-  let rocm = false;
-  let amdGfxTargets = [];
-  if (platform === "linux" && !cuda && exists("/dev/kfd")) {
-    amdGfxTargets = kfdGfxTargets(io);
-    if (amdGfxTargets.length) {
-      rocm = true;
-      log(`lilbee: detected an AMD GPU (${amdGfxTargets.join(", ")}) — using the rocm build (override with LILBEE_VARIANT).`);
-    } else {
-      rocm = exists("/opt/rocm") || (await tryExec("rocminfo", [])) !== null;
-      if (rocm) log("lilbee: detected a ROCm userland — using the rocm build (override with LILBEE_VARIANT).");
-    }
-  }
-
-  let noAvx2 = false;
-  if (platform === "linux") {
-    try {
-      const cpuinfo = io.readFileSync("/proc/cpuinfo", "utf8");
-      const flagsLine = /^flags\s*:\s*(.+)$/m.exec(cpuinfo);
-      noAvx2 = !!flagsLine && !/\bavx2\b/.test(flagsLine[1]);
-    } catch {
-      noAvx2 = false;
-    }
-    if (noAvx2) log("lilbee: this CPU has no AVX2 — using the -compat build family (override with LILBEE_VARIANT).");
-  }
-
-  if (platform === "linux") {
-    if (noAvx2) {
-      // compat ships cu124 and rocm flavors only
-      if (cuda) return host("compat-cu124", amdGfxTargets);
-      if (rocm) return host("compat-rocm", amdGfxTargets);
-      return host("compat", amdGfxTargets);
-    }
-    if (cuda) return host(cuda);
-    if (rocm) return host("rocm", amdGfxTargets);
-    return host("default");
-  }
-
-  if (platform === "win32") {
-    // Windows ships cu124 and cu125 only
-    if (cuda === "cu121") {
-      log("lilbee: this NVIDIA driver predates CUDA 12.4 — using the universal Windows build (override with LILBEE_VARIANT).");
-      return host("default");
-    }
-    return host(cuda ?? "default");
-  }
-
+  if (platform === "linux") return host(linuxVariant(cuda, rocm, noAvx2, log), amdGfxTargets);
+  if (platform === "win32") return host(windowsVariant(cuda, noAvx2, log));
   return host("default");
 }
 
 /**
- * The host to resolve releases for: `{ platform, arch, variant, amdGfxTargets }`.
- * A non-empty LILBEE_VARIANT in `env` replaces the detected variant; an unknown
- * value throws. Detection failures fall back to the default build.
+ * The host to resolve releases for: `{ platform, arch, variant, amdGfxTargets, detection }`.
+ * A non-empty LILBEE_VARIANT in `env` replaces the detected variant and skips
+ * every probe; an unknown value throws. Detection failures fall back to the default build.
  */
 export async function detectHost(env = process.env, log = () => {}, io = nodeIo, platform = process.platform, arch = process.arch) {
   const forced = env.LILBEE_VARIANT;
   if (forced) {
     assetNameFor(platform, arch, forced);
-    return { platform, arch, variant: forced, amdGfxTargets: [] };
+    return { platform, arch, variant: forced, amdGfxTargets: [], detection: skippedDetection() };
   }
-  const { variant, amdGfxTargets } = await detectVariant(platform, arch, io, log);
-  return { platform, arch, variant, amdGfxTargets };
+  const { variant, amdGfxTargets, detection } = await detectVariant(platform, arch, io, log, env);
+  return { platform, arch, variant, amdGfxTargets, detection };
 }

--- a/packages/lilbee/lib/detect.mjs
+++ b/packages/lilbee/lib/detect.mjs
@@ -12,7 +12,6 @@ import { assetNameFor } from "./assets.mjs";
 
 const KFD_NODES = "/sys/class/kfd/kfd/topology/nodes";
 const PROBE_TIMEOUT_MS = 5000;
-const VARIANT_HINT = "(override with LILBEE_VARIANT)";
 
 const execFileAsync = promisify(execFile);
 
@@ -103,7 +102,7 @@ export async function detectVariant(platform, arch, io = nodeIo, log = () => {})
     if (arch !== "x64") return host("default");
     const avx2 = await tryExec("sysctl", ["-n", "hw.optional.avx2_0"]);
     if (avx2 !== null && avx2.trim() === "0") {
-      log(`lilbee: this CPU has no AVX2; using the compat build ${VARIANT_HINT}.`);
+      log("lilbee: this CPU has no AVX2 — using the -compat build (override with LILBEE_VARIANT).");
       return host("compat");
     }
     return host("default");
@@ -114,10 +113,10 @@ export async function detectVariant(platform, arch, io = nodeIo, log = () => {})
   if (smi) {
     const v = parseCudaVersion(smi);
     cuda = v ? cudaVariantFor(v.major, v.minor) : "cu121";
-    if (cuda) log(`lilbee: detected an NVIDIA driver (CUDA ${v ? `${v.major}.${v.minor}` : "unknown"}); using the ${cuda} build ${VARIANT_HINT}.`);
+    if (cuda) log(`lilbee: detected NVIDIA driver (CUDA ${v ? `${v.major}.${v.minor}` : "unknown"}) — using the ${cuda} build (override with LILBEE_VARIANT).`);
   } else if (platform === "linux" && (exists("/dev/nvidia0") || exists("/proc/driver/nvidia/version"))) {
     cuda = "cu121";
-    log(`lilbee: an NVIDIA device is present but nvidia-smi does not run; using the cu121 build ${VARIANT_HINT}.`);
+    log("lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT).");
   }
 
   let rocm = false;
@@ -126,10 +125,10 @@ export async function detectVariant(platform, arch, io = nodeIo, log = () => {})
     amdGfxTargets = kfdGfxTargets(io);
     if (amdGfxTargets.length) {
       rocm = true;
-      log(`lilbee: detected an AMD GPU (${amdGfxTargets.join(", ")}); using the rocm build when the release supports it ${VARIANT_HINT}.`);
+      log(`lilbee: detected an AMD GPU (${amdGfxTargets.join(", ")}) — using the rocm build (override with LILBEE_VARIANT).`);
     } else {
       rocm = exists("/opt/rocm") || (await tryExec("rocminfo", [])) !== null;
-      if (rocm) log(`lilbee: detected a ROCm userland; using the rocm build ${VARIANT_HINT}.`);
+      if (rocm) log("lilbee: detected a ROCm userland — using the rocm build (override with LILBEE_VARIANT).");
     }
   }
 
@@ -142,7 +141,7 @@ export async function detectVariant(platform, arch, io = nodeIo, log = () => {})
     } catch {
       noAvx2 = false;
     }
-    if (noAvx2) log(`lilbee: this CPU has no AVX2; using the compat build family ${VARIANT_HINT}.`);
+    if (noAvx2) log("lilbee: this CPU has no AVX2 — using the -compat build family (override with LILBEE_VARIANT).");
   }
 
   if (platform === "linux") {
@@ -160,7 +159,7 @@ export async function detectVariant(platform, arch, io = nodeIo, log = () => {})
   if (platform === "win32") {
     // Windows ships cu124 and cu125 only
     if (cuda === "cu121") {
-      log(`lilbee: this NVIDIA driver predates CUDA 12.4; using the default Windows build ${VARIANT_HINT}.`);
+      log("lilbee: this NVIDIA driver predates CUDA 12.4 — using the universal Windows build (override with LILBEE_VARIANT).");
       return host("default");
     }
     return host(cuda ?? "default");

--- a/packages/lilbee/lib/detect.mjs
+++ b/packages/lilbee/lib/detect.mjs
@@ -1,31 +1,43 @@
 /**
- * Hardware detection for the bootstrap download: pick the release variant
- * the way a package manager would, so `npx lilbee` lands the right build
- * with zero configuration. An explicit LILBEE_VARIANT always wins.
- *
- * Detection is best-effort and fails toward the universal default build:
- * a wrong "default" still runs everywhere, a wrong CUDA build does not.
- *
- * Probes (all cheap, no network):
- * - NVIDIA: `nvidia-smi` reports "CUDA Version: N.M" (the driver's max
- *   supported runtime); map it to the newest cuNNN asset it can run.
- *   A visible /dev/nvidia0 or /proc/driver/nvidia/version without a
- *   working nvidia-smi falls back to the oldest CUDA build.
- * - AMD: the rocm build bundles its own userspace, so a host only needs the
- *   amdgpu kernel driver: /dev/kfd plus a supported gfx target read from the
- *   kernel's KFD topology. A host ROCm userland (rocminfo or /opt/rocm) is
- *   the fallback signal when the topology is unreadable.
- * - CPU baseline: x86-64 hosts without AVX2 get the -compat build
- *   (Linux: /proc/cpuinfo flags; macOS x86_64: sysctl hw.optional.avx2_0).
+ * Hardware detection for the bootstrap download: the build a host can run,
+ * read from the NVIDIA driver, the amdgpu KFD topology, and the CPU flags.
+ * Detection fails toward the default build, which runs everywhere.
  */
 
-/** Map the driver-reported CUDA version to the newest runnable asset variant. */
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { promisify } from "node:util";
+
+import { assetNameFor } from "./assets.mjs";
+
+const KFD_NODES = "/sys/class/kfd/kfd/topology/nodes";
+const PROBE_TIMEOUT_MS = 5000;
+const VARIANT_HINT = "(override with LILBEE_VARIANT)";
+
+const execFileAsync = promisify(execFile);
+
+/** The probes detection runs on the real host: `execFile` resolves to stdout. */
+const nodeIo = {
+  execFile: async (cmd, args) => {
+    const { stdout } = await execFileAsync(cmd, args, {
+      encoding: "utf8",
+      timeout: PROBE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    return stdout;
+  },
+  existsSync: fs.existsSync,
+  readFileSync: fs.readFileSync,
+  readdirSync: fs.readdirSync,
+};
+
+/** Map the driver-reported CUDA version to the newest runnable build, or null when it runs none. */
 export function cudaVariantFor(major, minor) {
   const v = major * 100 + minor;
   if (v >= 1205) return "cu125";
   if (v >= 1204) return "cu124";
   if (v >= 1201) return "cu121";
-  return ""; // driver too old for any shipped CUDA build; universal build works
+  return null;
 }
 
 /** Parse "CUDA Version: 12.6" out of nvidia-smi's banner. */
@@ -34,28 +46,16 @@ export function parseCudaVersion(smiOutput) {
   return m ? { major: Number(m[1]), minor: Number(m[2]) } : null;
 }
 
-/** The gfx targets the pinned rocm build ships kernels for (its published
- * <asset>-rocm.gfx.txt). Update alongside the release pin. */
-const ROCM_GFX = new Set([
-  "gfx908", "gfx90a", "gfx942", "gfx950",
-  "gfx1030", "gfx1100", "gfx1101", "gfx1102",
-  "gfx1150", "gfx1151", "gfx1200", "gfx1201",
-]);
-
-const KFD_NODES = "/sys/class/kfd/kfd/topology/nodes";
-
-/** Map a KFD gfx_target_version (major*10000 + minor*100 + step) to its gfx
- * name, e.g. 90402 -> gfx942, 90010 -> gfx90a. CPU nodes report 0 -> null. */
+/** Map a KFD gfx_target_version (major*10000 + minor*100 + step) to its gfx name, e.g. 90402 -> gfx942. */
 export function gfxNameFor(version) {
   if (!Number.isInteger(version) || version <= 0) return null;
   const major = Math.floor(version / 10000);
   const minor = Math.floor(version / 100) % 100;
   const step = version % 100;
-  return `gfx${major}${minor}${step.toString(16)}`;
+  return `gfx${major}${minor.toString(16)}${step.toString(16)}`;
 }
 
-/** The gfx names of every GPU node the kernel's KFD topology reports.
- * Unreadable nodes (a container may only expose its own GPU) are skipped. */
+/** The gfx names of every GPU node the KFD topology reports, unique and sorted; unreadable nodes are skipped. */
 function kfdGfxTargets(io) {
   let nodes;
   try {
@@ -63,28 +63,29 @@ function kfdGfxTargets(io) {
   } catch {
     return [];
   }
-  const targets = [];
+  const targets = new Set();
   for (const node of nodes) {
     try {
       const props = io.readFileSync(`${KFD_NODES}/${node}/properties`, "utf8");
       const m = /^gfx_target_version\s+(\d+)$/m.exec(props);
       const name = m && gfxNameFor(Number(m[1]));
-      if (name) targets.push(name);
+      if (name) targets.add(name);
     } catch {
       // node not visible from this container
     }
   }
-  return targets;
+  return [...targets].sort();
 }
 
 /**
- * Detect the variant for this host. `io` carries the probes so tests can
- * simulate any host: { execFileSync, existsSync, readFileSync }.
+ * Detect the build for a host: `{ variant, amdGfxTargets }`. `io` carries the
+ * probes ({ execFile, existsSync, readFileSync, readdirSync }) so tests can
+ * simulate any host; `log` receives one line per decision.
  */
-export function detectVariant(platform, arch, io, log = () => {}) {
-  const tryExec = (cmd, args) => {
+export async function detectVariant(platform, arch, io = nodeIo, log = () => {}) {
+  const tryExec = async (cmd, args) => {
     try {
-      return io.execFileSync(cmd, args, { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
+      return await io.execFile(cmd, args);
     } catch {
       return null;
     }
@@ -96,41 +97,39 @@ export function detectVariant(platform, arch, io, log = () => {}) {
       return false;
     }
   };
+  const host = (variant, amdGfxTargets = []) => ({ variant, amdGfxTargets });
 
   if (platform === "darwin") {
-    if (arch !== "x64") return ""; // arm64: single Metal build
-    const avx2 = tryExec("sysctl", ["-n", "hw.optional.avx2_0"]);
+    if (arch !== "x64") return host("default");
+    const avx2 = await tryExec("sysctl", ["-n", "hw.optional.avx2_0"]);
     if (avx2 !== null && avx2.trim() === "0") {
-      log("lilbee: this CPU has no AVX2 — using the -compat build (override with LILBEE_VARIANT).");
-      return "compat";
+      log(`lilbee: this CPU has no AVX2; using the compat build ${VARIANT_HINT}.`);
+      return host("compat");
     }
-    return "";
+    return host("default");
   }
 
-  // NVIDIA first: a machine with both an NVIDIA card and /dev/kfd is rare,
-  // and the CUDA build is the better pick when it happens.
-  let cuda = "";
-  const smi = tryExec("nvidia-smi", []);
+  let cuda = null;
+  const smi = await tryExec("nvidia-smi", []);
   if (smi) {
     const v = parseCudaVersion(smi);
     cuda = v ? cudaVariantFor(v.major, v.minor) : "cu121";
-    if (cuda) log(`lilbee: detected NVIDIA driver (CUDA ${v ? `${v.major}.${v.minor}` : "unknown"}) — using the ${cuda} build (override with LILBEE_VARIANT).`);
+    if (cuda) log(`lilbee: detected an NVIDIA driver (CUDA ${v ? `${v.major}.${v.minor}` : "unknown"}); using the ${cuda} build ${VARIANT_HINT}.`);
   } else if (platform === "linux" && (exists("/dev/nvidia0") || exists("/proc/driver/nvidia/version"))) {
     cuda = "cu121";
-    log("lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT).");
+    log(`lilbee: an NVIDIA device is present but nvidia-smi does not run; using the cu121 build ${VARIANT_HINT}.`);
   }
 
   let rocm = false;
+  let amdGfxTargets = [];
   if (platform === "linux" && !cuda && exists("/dev/kfd")) {
-    const gfx = io.readdirSync ? kfdGfxTargets(io) : [];
-    if (gfx.length) {
-      const supported = gfx.find((g) => ROCM_GFX.has(g));
-      rocm = Boolean(supported);
-      if (rocm) log(`lilbee: detected an AMD GPU (${supported}) — using the rocm build (override with LILBEE_VARIANT).`);
-      else log(`lilbee: the rocm build does not support this AMD GPU (${gfx.join(", ")}) — using the default build (override with LILBEE_VARIANT).`);
+    amdGfxTargets = kfdGfxTargets(io);
+    if (amdGfxTargets.length) {
+      rocm = true;
+      log(`lilbee: detected an AMD GPU (${amdGfxTargets.join(", ")}); using the rocm build when the release supports it ${VARIANT_HINT}.`);
     } else {
-      rocm = exists("/opt/rocm") || tryExec("rocminfo", []) !== null;
-      if (rocm) log("lilbee: detected a ROCm userland — using the rocm build (override with LILBEE_VARIANT).");
+      rocm = exists("/opt/rocm") || (await tryExec("rocminfo", [])) !== null;
+      if (rocm) log(`lilbee: detected a ROCm userland; using the rocm build ${VARIANT_HINT}.`);
     }
   }
 
@@ -143,29 +142,44 @@ export function detectVariant(platform, arch, io, log = () => {}) {
     } catch {
       noAvx2 = false;
     }
-    if (noAvx2) log("lilbee: this CPU has no AVX2 — using the -compat build family (override with LILBEE_VARIANT).");
+    if (noAvx2) log(`lilbee: this CPU has no AVX2; using the compat build family ${VARIANT_HINT}.`);
   }
 
   if (platform === "linux") {
     if (noAvx2) {
-      // compat ships with cu124 and rocm flavors only.
-      if (cuda) return "compat-cu124";
-      if (rocm) return "compat-rocm";
-      return "compat";
+      // compat ships cu124 and rocm flavors only
+      if (cuda) return host("compat-cu124", amdGfxTargets);
+      if (rocm) return host("compat-rocm", amdGfxTargets);
+      return host("compat", amdGfxTargets);
     }
-    if (cuda) return cuda;
-    if (rocm) return "rocm";
-    return "";
+    if (cuda) return host(cuda);
+    if (rocm) return host("rocm", amdGfxTargets);
+    return host("default");
   }
 
   if (platform === "win32") {
-    // Windows ships cu124/cu125 only; older drivers get the universal build.
+    // Windows ships cu124 and cu125 only
     if (cuda === "cu121") {
-      log("lilbee: this NVIDIA driver predates CUDA 12.4 — using the universal Windows build (override with LILBEE_VARIANT).");
-      return "";
+      log(`lilbee: this NVIDIA driver predates CUDA 12.4; using the default Windows build ${VARIANT_HINT}.`);
+      return host("default");
     }
-    return cuda;
+    return host(cuda ?? "default");
   }
 
-  return "";
+  return host("default");
+}
+
+/**
+ * The host to resolve releases for: `{ platform, arch, variant, amdGfxTargets }`.
+ * A non-empty LILBEE_VARIANT in `env` replaces the detected variant; an unknown
+ * value throws. Detection failures fall back to the default build.
+ */
+export async function detectHost(env = process.env, log = () => {}, io = nodeIo, platform = process.platform, arch = process.arch) {
+  const forced = env.LILBEE_VARIANT;
+  if (forced) {
+    assetNameFor(platform, arch, forced);
+    return { platform, arch, variant: forced, amdGfxTargets: [] };
+  }
+  const { variant, amdGfxTargets } = await detectVariant(platform, arch, io, log);
+  return { platform, arch, variant, amdGfxTargets };
 }

--- a/packages/lilbee/lib/download.mjs
+++ b/packages/lilbee/lib/download.mjs
@@ -159,12 +159,26 @@ function toReadable(body) {
   return typeof body.pipe === "function" ? body : Readable.fromWeb(body);
 }
 
-/** Remove every entry of the release dir but the landed binary. */
+const TEMP_INFIX = ".download.";
+
+/** True while the process that owns a `.download.<pid>` temp file is still running. */
+function tempOwnerAlive(name) {
+  const pid = Number(name.slice(name.lastIndexOf(TEMP_INFIX) + TEMP_INFIX.length));
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
+
+/** Remove every other build in the release dir; a live rival's in-progress temp file stays. */
 function removeSiblings(dest) {
   const dir = path.dirname(dest);
   const keep = path.basename(dest);
   for (const entry of fs.readdirSync(dir)) {
-    if (entry === keep) continue;
+    if (entry === keep || (entry.includes(TEMP_INFIX) && tempOwnerAlive(entry))) continue;
     try {
       fs.rmSync(path.join(dir, entry), { recursive: true, force: true });
     } catch {
@@ -257,7 +271,7 @@ export async function download({
     log(`lilbee: release asset ${release.assetName} has no published digest; skipping sha256 verification.`);
   }
   // Per-process temp file: concurrent first runs must not interleave writes into one path.
-  const tmp = `${dest}.download.${process.pid}`;
+  const tmp = `${dest}${TEMP_INFIX}${process.pid}`;
 
   for (let attempt = 1; ; attempt += 1) {
     try {
@@ -278,8 +292,16 @@ export async function download({
     }
   }
 
-  fs.chmodSync(tmp, 0o755);
-  fs.renameSync(tmp, dest);
+  try {
+    fs.chmodSync(tmp, 0o755);
+    fs.renameSync(tmp, dest);
+  } catch (err) {
+    if (err.code === "ENOENT" && fs.existsSync(dest)) {
+      log("lilbee: another process finished this download first; using it.");
+      return;
+    }
+    throw err;
+  }
   removeSiblings(dest);
   log(`lilbee: installed ${dest}`);
 }

--- a/packages/lilbee/lib/download.mjs
+++ b/packages/lilbee/lib/download.mjs
@@ -204,6 +204,7 @@ async function transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeo
     const total = totalBytes(res, release);
     const hash = createHash("sha256");
     let done = 0;
+    onProgress?.({ done, total });
     const meter = new Transform({
       transform(chunk, _enc, cb) {
         restartClock();

--- a/packages/lilbee/lib/download.mjs
+++ b/packages/lilbee/lib/download.mjs
@@ -1,10 +1,6 @@
 /**
- * Download a standalone lilbee release asset with sha256 verification.
- *
- * The GitHub API reports a `digest` ("sha256:<hex>") per asset; the download
- * streams to a temp file, the hash is checked against that digest, and the
- * file lands at its final path via atomic rename. All progress goes to
- * stderr — stdout belongs to the MCP wire.
+ * Download a release asset with sha256 verification: stream to a temp file,
+ * check the hash against the release digest, land by atomic rename.
  */
 
 import fs from "node:fs";
@@ -13,60 +9,17 @@ import { pipeline } from "node:stream/promises";
 import { Readable, Transform } from "node:stream";
 import { createHash } from "node:crypto";
 
-/**
- * Corporate proxies: Node's built-in fetch ignores HTTP(S)_PROXY env vars
- * (unlike curl and npm itself). Route through undici's env-aware agent when
- * a proxy is configured, so the bootstrap works behind the same proxy npm
- * installed the package through.
- */
-async function configureProxyFromEnv() {
-  const proxy =
-    process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
-  if (!proxy) return;
-  try {
-    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
-    setGlobalDispatcher(new EnvHttpProxyAgent());
-  } catch {
-    console.error("lilbee: HTTPS_PROXY is set but the proxy agent is unavailable; downloading directly.");
-  }
-}
-const proxyReady = configureProxyFromEnv();
+import { launcherFetch } from "./fetch.mjs";
+import { USER_AGENT } from "./releases.mjs";
 
-const USER_AGENT = "lilbee-npm-launcher";
 const DOWNLOAD_ATTEMPTS = 2;
-
-async function fetchJson(url) {
-  await proxyReady;
-  const res = await fetch(url, {
-    headers: { "user-agent": USER_AGENT, accept: "application/vnd.github+json" },
-  });
-  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
-  return res.json();
-}
-
-/** The tag of the newest published release, e.g. "v0.6.90b425". */
-export async function latestReleaseTag(repo) {
-  const info = await fetchJson(`https://api.github.com/repos/${repo}/releases/latest`);
-  if (!info.tag_name) throw new Error(`releases/latest for ${repo} has no tag_name`);
-  return info.tag_name;
-}
-
-/** Look up the asset's browser_download_url and sha256 digest for a release tag. */
-export async function releaseAsset(repo, release, assetName) {
-  const info = await fetchJson(`https://api.github.com/repos/${repo}/releases/tags/${release}`);
-  const asset = (info.assets ?? []).find((a) => a.name === assetName);
-  if (!asset) {
-    const names = (info.assets ?? []).map((a) => a.name).join(", ");
-    throw new Error(`Release ${release} has no asset "${assetName}". Available: ${names}`);
-  }
-  const digest =
-    typeof asset.digest === "string" && asset.digest.startsWith("sha256:")
-      ? asset.digest.slice("sha256:".length)
-      : null;
-  return { url: asset.browser_download_url, size: asset.size, digest };
-}
+const DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
+const DISK_SPACE_FACTOR = 1.1;
+const DOWNLOAD_STALLED = "The lilbee download stalled: no data arrived for 60 seconds. Check your connection and try again.";
+const DOWNLOAD_CANCELED = "The lilbee download was cancelled.";
 
 const MB = 1048576;
+const GB = 1073741824;
 const BAR_FULL = "━";
 const BAR_HALF = "╸";
 const BAR_REST = "─";
@@ -80,6 +33,20 @@ const LOG_STEP_PCT = 10;
 
 const mbCount = (bytes) => Math.floor(bytes / MB);
 const formatMB = (bytes) => `${mbCount(bytes)}MB`;
+const formatSize = (bytes) => (bytes >= GB ? `${(bytes / GB).toFixed(1)}GB` : formatMB(bytes));
+
+/** Thrown when the caller's signal aborts a download. */
+export class DownloadCanceledError extends Error {
+  constructor() {
+    super(DOWNLOAD_CANCELED);
+    this.name = "AbortError";
+  }
+}
+
+/** True for a DownloadCanceledError, or any error whose name is "AbortError". */
+export function isDownloadCanceled(err) {
+  return err instanceof DownloadCanceledError || (typeof err === "object" && err !== null && err.name === "AbortError");
+}
 
 /** "m:ss" for a duration in seconds. */
 function formatEta(seconds) {
@@ -102,7 +69,7 @@ function barGlyphs(frac, width, color) {
  * Pure; rate and eta are omitted when unknown.
  */
 export function progressLine({ done, total, bytesPerSec, barWidth = BAR_WIDTH, color = false }) {
-  if (!total) return `lilbee: downloading… ${formatMB(done)}`;
+  if (!total) return `lilbee: downloading... ${formatMB(done)}`;
   const frac = Math.min(done / total, 1);
   const pct = `${Math.floor(frac * 100)}%`.padStart(5);
   const line = `lilbee │${barGlyphs(frac, barWidth, color)}│${pct} ${mbCount(done)}/${formatMB(total)}`;
@@ -110,114 +77,198 @@ export function progressLine({ done, total, bytesPerSec, barWidth = BAR_WIDTH, c
   return `${line} ${(bytesPerSec / MB).toFixed(1)}MB/s eta ${formatEta((total - done) / bytesPerSec)}`;
 }
 
-/** Stream stage that redraws one bar line in place and ends it with a newline. */
-function ttyProgress(total, stream) {
+/** A progress consumer that redraws one bar line in place and ends it with a newline. */
+function ttyProgress(stream) {
   const started = Date.now();
-  let done = 0;
   let lastDraw = 0;
-  const draw = () => {
+  let open = false;
+  const draw = ({ done, total }) => {
     const elapsed = (Date.now() - started) / 1000;
     stream.write(CLEAR_LINE + progressLine({ done, total, bytesPerSec: elapsed ? done / elapsed : 0, color: true }));
+    open = true;
   };
-  return new Transform({
-    transform(chunk, _enc, cb) {
-      done += chunk.length;
-      if (Date.now() - lastDraw >= DRAW_INTERVAL_MS) {
-        lastDraw = Date.now();
-        draw();
-      }
-      cb(null, chunk);
-    },
-    flush(cb) {
-      draw();
-      stream.write("\n");
-      cb();
-    },
-  });
+  const finish = () => {
+    if (!open) return;
+    stream.write("\n");
+    open = false;
+  };
+  const report = (progress) => {
+    const complete = progress.total !== null && progress.done >= progress.total;
+    if (complete || Date.now() - lastDraw >= DRAW_INTERVAL_MS) {
+      lastDraw = Date.now();
+      draw(progress);
+    }
+    if (complete) finish();
+  };
+  report.finish = finish;
+  return report;
 }
 
-/** Stream stage that logs one line per LOG_STEP_PCT of progress. */
-function lineProgress(total, log) {
-  let done = 0;
+/** A progress consumer that logs one line per LOG_STEP_PCT of progress. */
+function lineProgress(log) {
   let lastPct = -LOG_STEP_PCT;
-  return new Transform({
-    transform(chunk, _enc, cb) {
-      done += chunk.length;
-      const pct = total ? Math.floor((done / total) * 100) : 0;
-      if (pct >= lastPct + LOG_STEP_PCT) {
-        lastPct = pct;
-        log(`lilbee: downloading… ${pct}% (${formatMB(done)})`);
-      }
-      cb(null, chunk);
-    },
-  });
+  const report = ({ done, total }) => {
+    const pct = total ? Math.floor((done / total) * 100) : 0;
+    if (pct < lastPct) lastPct = -LOG_STEP_PCT;
+    if (pct >= lastPct + LOG_STEP_PCT) {
+      lastPct = pct;
+      log(`lilbee: downloading... ${pct}% (${formatMB(done)})`);
+    }
+  };
+  report.finish = () => {};
+  return report;
 }
 
-/**
- * Progress for the download pipeline: an in-place bar on a TTY, log lines elsewhere.
- * Local, not a library: keeps the zero-runtime-dependency publish.
- */
-export function progressReporter(total, log, stream = process.stderr) {
-  return stream.isTTY ? ttyProgress(total, stream) : lineProgress(total, log);
+/** An onProgress consumer for the CLI: an in-place bar on a TTY, log lines elsewhere. Call `finish()` when the download ends. */
+export function progressReporter(log, stream = process.stderr) {
+  return stream.isTTY ? ttyProgress(stream) : lineProgress(log);
 }
 
-/**
- * Download the asset for `release` to `dest`. One retry on a failed attempt —
- * these are multi-hundred-MB files and transient resets happen.
- */
-export async function download({ env, release, assetName, dest, log = console.error }) {
-  const repo = env.LILBEE_REPO || "tobocop2/lilbee";
-  const { url, size, digest } = await releaseAsset(repo, release, assetName);
-  log(
-    `lilbee: downloading ${assetName} (${formatMB(size)}) ` +
-      `from ${repo}@${release}. One-time per release; cached after that.`
-  );
-
-  if (!digest) {
-    log(`lilbee: release asset ${assetName} has no published digest; skipping sha256 verification.`);
+/** Refuse a download the filesystem holding `dir` cannot fit; silent when free space is unknown. */
+async function assertFreeSpace(dir, size) {
+  if (typeof fs.promises.statfs !== "function") return;
+  let stats;
+  try {
+    stats = await fs.promises.statfs(dir);
+  } catch {
+    return;
   }
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
-  // Per-process temp file: concurrent first runs (e.g. two agents spawning at
-  // once) must not interleave writes into one temp path.
+  const free = Number(stats.bavail) * Number(stats.bsize);
+  const needed = Math.ceil(size * DISK_SPACE_FACTOR);
+  if (free < needed) {
+    throw new Error(
+      `Not enough disk space for the lilbee binary: it needs about ${formatSize(needed)} free in ${dir}, ` +
+        `and ${formatSize(free)} is available.`
+    );
+  }
+}
+
+/** The total a transfer reports: Content-Length, else the release's asset size, else null. */
+function totalBytes(res, release) {
+  const header = Number(res.headers.get("content-length"));
+  if (Number.isFinite(header) && header > 0) return header;
+  return release.size > 0 ? release.size : null;
+}
+
+/** A Node stream over a response body that is either a web ReadableStream or a Node Readable. */
+function toReadable(body) {
+  return typeof body.pipe === "function" ? body : Readable.fromWeb(body);
+}
+
+/** Remove every entry of the release dir but the landed binary. */
+function removeSiblings(dest) {
+  const dir = path.dirname(dest);
+  const keep = path.basename(dest);
+  for (const entry of fs.readdirSync(dir)) {
+    if (entry === keep) continue;
+    try {
+      fs.rmSync(path.join(dir, entry), { recursive: true, force: true });
+    } catch {
+      // a busy file on Windows: a stale build is a nuisance, not an error
+    }
+  }
+}
+
+/**
+ * One transfer of `release.url` to `tmp`. Resolves with the hex sha256 of what
+ * landed; rejects with DownloadCanceledError on `signal`, or a stall error when
+ * no bytes arrive for `idleTimeoutMs`.
+ */
+async function transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeoutMs }) {
+  const controller = new AbortController();
+  let source = null;
+  let failure = null;
+  let timer = null;
+  const fail = (err) => {
+    if (!failure) failure = err;
+    clearTimeout(timer);
+    controller.abort(err);
+    source?.destroy(err);
+  };
+  const restartClock = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fail(new Error(DOWNLOAD_STALLED)), idleTimeoutMs);
+  };
+  const onAbort = () => fail(new DownloadCanceledError());
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    if (signal?.aborted) throw new DownloadCanceledError();
+    restartClock();
+    const res = await fetchImpl(release.url, { headers: { "user-agent": USER_AGENT }, signal: controller.signal });
+    if (!res.ok || !res.body) throw new Error(`GET ${release.url} -> HTTP ${res.status}`);
+    const total = totalBytes(res, release);
+    const hash = createHash("sha256");
+    let done = 0;
+    const meter = new Transform({
+      transform(chunk, _enc, cb) {
+        restartClock();
+        hash.update(chunk);
+        done += chunk.length;
+        onProgress?.({ done, total });
+        cb(null, chunk);
+      },
+    });
+    source = toReadable(res.body);
+    await pipeline(source, meter, fs.createWriteStream(tmp));
+    return hash.digest("hex");
+  } catch (err) {
+    throw failure ?? err;
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+/**
+ * Download `release` to `dest`: verified, landed by rename, with every other
+ * file of the release dir removed afterwards. One retry on a failed transfer;
+ * none after a cancel. A rival process that lands `dest` first is adopted.
+ */
+export async function download({
+  release,
+  dest,
+  fetch,
+  env = process.env,
+  onProgress,
+  signal,
+  log = () => {},
+  idleTimeoutMs = DOWNLOAD_IDLE_TIMEOUT_MS,
+}) {
+  if (signal?.aborted) throw new DownloadCanceledError();
+  const dir = path.dirname(dest);
+  fs.mkdirSync(dir, { recursive: true });
+  await assertFreeSpace(dir, release.size);
+  const fetchImpl = fetch ?? (await launcherFetch(env, log));
+
+  log(`lilbee: downloading ${release.assetName} (${formatMB(release.size)}) for release ${release.tag}. One-time per release; cached after that.`);
+  if (!release.digest) {
+    log(`lilbee: release asset ${release.assetName} has no published digest; skipping sha256 verification.`);
+  }
+  // Per-process temp file: concurrent first runs must not interleave writes into one path.
   const tmp = `${dest}.download.${process.pid}`;
 
-  let attempt = 0;
-  for (;;) {
-    attempt += 1;
+  for (let attempt = 1; ; attempt += 1) {
     try {
-      await proxyReady;
-      const res = await fetch(url, { headers: { "user-agent": USER_AGENT } });
-      if (!res.ok || !res.body) throw new Error(`GET ${url} -> HTTP ${res.status}`);
-      const hash = createHash("sha256");
-      const hasher = new Transform({
-        transform(chunk, _enc, cb) {
-          hash.update(chunk);
-          cb(null, chunk);
-        },
-      });
-      await pipeline(
-        Readable.fromWeb(res.body),
-        hasher,
-        progressReporter(size, log),
-        fs.createWriteStream(tmp)
-      );
-      const got = hash.digest("hex");
-      if (digest && got !== digest) {
-        throw new Error(`sha256 mismatch for ${assetName}: expected ${digest}, got ${got}`);
+      const got = await transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeoutMs });
+      if (release.digest && got !== release.digest) {
+        throw new Error(`sha256 mismatch for ${release.assetName}: expected ${release.digest}, got ${got}`);
       }
       break;
     } catch (err) {
       fs.rmSync(tmp, { force: true });
+      if (isDownloadCanceled(err)) throw err;
       if (fs.existsSync(dest)) {
         log("lilbee: another process finished this download first; using it.");
         return;
       }
       if (attempt >= DOWNLOAD_ATTEMPTS) throw err;
-      log(`lilbee: download failed (${err.message}), retrying once…`);
+      log(`lilbee: download failed (${err.message}), retrying once...`);
     }
   }
 
   fs.chmodSync(tmp, 0o755);
   fs.renameSync(tmp, dest);
+  removeSiblings(dest);
   log(`lilbee: installed ${dest}`);
 }

--- a/packages/lilbee/lib/download.mjs
+++ b/packages/lilbee/lib/download.mjs
@@ -9,13 +9,15 @@ import { pipeline } from "node:stream/promises";
 import { Readable, Transform } from "node:stream";
 import { createHash } from "node:crypto";
 
+import { LauncherError } from "./errors.mjs";
 import { launcherFetch } from "./fetch.mjs";
-import { USER_AGENT } from "./releases.mjs";
+import { DEFAULT_REPO, USER_AGENT } from "./releases.mjs";
 
 const DOWNLOAD_ATTEMPTS = 2;
 const DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
 const DISK_SPACE_FACTOR = 1.1;
 const DOWNLOAD_STALLED = "The lilbee download stalled: no data arrived for 60 seconds. Check your connection and try again.";
+const NO_DIGEST = (assetName) => `Release asset ${assetName} has no published digest, so the download cannot be verified.`;
 const DOWNLOAD_CANCELED = "The lilbee download was cancelled.";
 
 const MB = 1048576;
@@ -69,7 +71,7 @@ function barGlyphs(frac, width, color) {
  * Pure; rate and eta are omitted when unknown.
  */
 export function progressLine({ done, total, bytesPerSec, barWidth = BAR_WIDTH, color = false }) {
-  if (!total) return `lilbee: downloading... ${formatMB(done)}`;
+  if (!total) return `lilbee: downloading… ${formatMB(done)}`;
   const frac = Math.min(done / total, 1);
   const pct = `${Math.floor(frac * 100)}%`.padStart(5);
   const line = `lilbee │${barGlyphs(frac, barWidth, color)}│${pct} ${mbCount(done)}/${formatMB(total)}`;
@@ -112,7 +114,7 @@ function lineProgress(log) {
     if (pct < lastPct) lastPct = -LOG_STEP_PCT;
     if (pct >= lastPct + LOG_STEP_PCT) {
       lastPct = pct;
-      log(`lilbee: downloading... ${pct}% (${formatMB(done)})`);
+      log(`lilbee: downloading… ${pct}% (${formatMB(done)})`);
     }
   };
   report.finish = () => {};
@@ -136,9 +138,11 @@ async function assertFreeSpace(dir, size) {
   const free = Number(stats.bavail) * Number(stats.bsize);
   const needed = Math.ceil(size * DISK_SPACE_FACTOR);
   if (free < needed) {
-    throw new Error(
+    throw new LauncherError(
+      "no-space",
       `Not enough disk space for the lilbee binary: it needs about ${formatSize(needed)} free in ${dir}, ` +
-        `and ${formatSize(free)} is available.`
+        `and ${formatSize(free)} is available.`,
+      { neededBytes: needed, freeBytes: free }
     );
   }
 }
@@ -187,7 +191,7 @@ async function transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeo
   };
   const restartClock = () => {
     clearTimeout(timer);
-    timer = setTimeout(() => fail(new Error(DOWNLOAD_STALLED)), idleTimeoutMs);
+    timer = setTimeout(() => fail(new LauncherError("stalled", DOWNLOAD_STALLED)), idleTimeoutMs);
   };
   const onAbort = () => fail(new DownloadCanceledError());
   signal?.addEventListener("abort", onAbort, { once: true });
@@ -196,7 +200,7 @@ async function transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeo
     if (signal?.aborted) throw new DownloadCanceledError();
     restartClock();
     const res = await fetchImpl(release.url, { headers: { "user-agent": USER_AGENT }, signal: controller.signal });
-    if (!res.ok || !res.body) throw new Error(`GET ${release.url} -> HTTP ${res.status}`);
+    if (!res.ok || !res.body) throw new LauncherError("http", `GET ${release.url} -> HTTP ${res.status}`, { status: res.status });
     const total = totalBytes(res, release);
     const hash = createHash("sha256");
     let done = 0;
@@ -228,20 +232,26 @@ async function transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeo
 export async function download({
   release,
   dest,
+  repo = DEFAULT_REPO,
   fetch,
   env = process.env,
   onProgress,
   signal,
   log = () => {},
+  requireDigest = false,
   idleTimeoutMs = DOWNLOAD_IDLE_TIMEOUT_MS,
 }) {
   if (signal?.aborted) throw new DownloadCanceledError();
+  if (!release.digest && requireDigest) throw new LauncherError("no-digest", NO_DIGEST(release.assetName));
   const dir = path.dirname(dest);
   fs.mkdirSync(dir, { recursive: true });
   await assertFreeSpace(dir, release.size);
   const fetchImpl = fetch ?? (await launcherFetch(env, log));
 
-  log(`lilbee: downloading ${release.assetName} (${formatMB(release.size)}) for release ${release.tag}. One-time per release; cached after that.`);
+  log(
+    `lilbee: downloading ${release.assetName} (${formatMB(release.size)}) ` +
+      `from ${repo}@${release.tag}. One-time per release; cached after that.`
+  );
   if (!release.digest) {
     log(`lilbee: release asset ${release.assetName} has no published digest; skipping sha256 verification.`);
   }
@@ -252,7 +262,7 @@ export async function download({
     try {
       const got = await transfer({ release, tmp, fetchImpl, onProgress, signal, idleTimeoutMs });
       if (release.digest && got !== release.digest) {
-        throw new Error(`sha256 mismatch for ${release.assetName}: expected ${release.digest}, got ${got}`);
+        throw new LauncherError("digest-mismatch", `sha256 mismatch for ${release.assetName}: expected ${release.digest}, got ${got}`);
       }
       break;
     } catch (err) {
@@ -263,7 +273,7 @@ export async function download({
         return;
       }
       if (attempt >= DOWNLOAD_ATTEMPTS) throw err;
-      log(`lilbee: download failed (${err.message}), retrying once...`);
+      log(`lilbee: download failed (${err.message}), retrying once…`);
     }
   }
 

--- a/packages/lilbee/lib/errors.mjs
+++ b/packages/lilbee/lib/errors.mjs
@@ -1,0 +1,9 @@
+/** A failure the launcher can name: the CLI's wording in `message`, a stable `code` for embedders. */
+export class LauncherError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "LauncherError";
+    this.code = code;
+    Object.assign(this, details);
+  }
+}

--- a/packages/lilbee/lib/fetch.mjs
+++ b/packages/lilbee/lib/fetch.mjs
@@ -1,0 +1,19 @@
+/** The launcher's default transport: global fetch, routed through the env proxy when one is set. */
+
+const PROXY_VARS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"];
+
+/**
+ * Global fetch, with undici's env proxy agent installed first when the
+ * environment names a proxy. Node's fetch ignores HTTP(S)_PROXY on its own.
+ */
+export async function launcherFetch(env = process.env, log = () => {}) {
+  if (PROXY_VARS.some((name) => env[name])) {
+    try {
+      const { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } = await import("undici");
+      if (!(getGlobalDispatcher() instanceof EnvHttpProxyAgent)) setGlobalDispatcher(new EnvHttpProxyAgent());
+    } catch {
+      log("lilbee: HTTPS_PROXY is set but the proxy agent is unavailable; downloading directly.");
+    }
+  }
+  return globalThis.fetch;
+}

--- a/packages/lilbee/lib/plan.mjs
+++ b/packages/lilbee/lib/plan.mjs
@@ -2,7 +2,7 @@
  * Pure planning: turn argv + env into the command this launcher runs.
  *
  * Routing:
- *  - `prepare`            download/verify the binary, then exit (launcher-only)
+ *  - `prepare [<tag>]`    download/verify the binary, then exit (launcher-only)
  *  - `mcp [...]`          run the MCP server; with LILBEE_URL set, bridge
  *                         stdio <-> streamable-http via mcp-remote instead
  *  - anything else        resolve the binary and exec argv verbatim
@@ -13,7 +13,7 @@
 /** Classify argv into a launcher route. */
 export function routeArgv(argv) {
   const [head, ...rest] = argv;
-  if (head === "prepare") return { kind: "prepare" };
+  if (head === "prepare") return { kind: "prepare", tag: rest[0] ?? null };
   if (head === "unprepare") return { kind: "unprepare" };
   if (head === "mcp") return { kind: "mcp", args: parseMcpArgs(rest) };
   return { kind: "exec", argv };
@@ -84,18 +84,20 @@ export const HELP = `lilbee (npm launcher) — run lilbee anywhere
 Usage:
   lilbee <any lilbee command>     bootstrap the binary if needed, then run it
   lilbee mcp [--data-dir <dir>]   start the MCP server (stdio)
-  lilbee prepare                  download (or upgrade to) the latest lilbee binary and exit
+  lilbee prepare [<tag>]          download (or upgrade to) the latest lilbee binary and exit;
+                                  with a release tag, install exactly that release
   lilbee unprepare                delete every downloaded binary (run before npm uninstall)
   lilbee-mcp [...]                same as \`lilbee mcp [...]\`
 
 Environment:
-  LILBEE_URL       remote lilbee server; \`mcp\` bridges to <url> instead of a local binary
-  LILBEE_TOKEN     bearer session token for LILBEE_URL
-  LILBEE_BIN       explicit path to a lilbee binary
-  LILBEE_DATA_DIR  library location for \`mcp\` (same as --data-dir)
-  LILBEE_VARIANT   download variant override: default | cu121 | cu124 | cu125 |
-                   rocm | compat | compat-cu124 | compat-rocm (unset =
-                   auto-detect; default = the plain build on any host)
-  LILBEE_RELEASE   run an exact lilbee release tag instead of the latest
-  LILBEE_DEBUG     =1 prints binary resolution detail on every run
+  LILBEE_URL         remote lilbee server; \`mcp\` bridges to <url> instead of a local binary
+  LILBEE_TOKEN       bearer session token for LILBEE_URL
+  LILBEE_BIN         explicit path to a lilbee binary
+  LILBEE_DATA_DIR    library location for \`mcp\` (same as --data-dir)
+  LILBEE_VARIANT     download variant override: default | cu121 | cu124 | cu125 |
+                     rocm | compat | compat-cu124 | compat-rocm (unset =
+                     auto-detect; default = the plain build on any host)
+  LILBEE_RELEASE     run an exact lilbee release tag instead of the latest
+  LILBEE_DEV_BUILDS  =1 lets "latest" pick in-development (.dev) builds
+  LILBEE_DEBUG       =1 prints binary resolution detail on every run
 `;

--- a/packages/lilbee/lib/plan.mjs
+++ b/packages/lilbee/lib/plan.mjs
@@ -38,6 +38,11 @@ export function exitCodeForSignal(signal) {
   return EXIT_CODE_BY_SIGNAL[signal] ?? EXIT_CODE_SIGNAL_DEFAULT;
 }
 
+/** True when LILBEE_CHANNEL asks for the dev channel, so "latest" may be a .dev build. */
+export function channelIncludesDev(env) {
+  return env.LILBEE_CHANNEL === "dev";
+}
+
 /** "remote" when LILBEE_URL is set (non-empty), else "local". */
 export function selectMode(env) {
   return env.LILBEE_URL ? "remote" : "local";
@@ -84,20 +89,20 @@ export const HELP = `lilbee (npm launcher) — run lilbee anywhere
 Usage:
   lilbee <any lilbee command>     bootstrap the binary if needed, then run it
   lilbee mcp [--data-dir <dir>]   start the MCP server (stdio)
-  lilbee prepare [<tag>]          download (or upgrade to) the latest lilbee binary and exit;
-                                  with a release tag, install exactly that release
+  lilbee prepare [<tag>]          download (or upgrade to) the latest lilbee binary and exit
+                                  (with a release tag: install exactly that release)
   lilbee unprepare                delete every downloaded binary (run before npm uninstall)
   lilbee-mcp [...]                same as \`lilbee mcp [...]\`
 
 Environment:
-  LILBEE_URL         remote lilbee server; \`mcp\` bridges to <url> instead of a local binary
-  LILBEE_TOKEN       bearer session token for LILBEE_URL
-  LILBEE_BIN         explicit path to a lilbee binary
-  LILBEE_DATA_DIR    library location for \`mcp\` (same as --data-dir)
-  LILBEE_VARIANT     download variant override: default | cu121 | cu124 | cu125 |
-                     rocm | compat | compat-cu124 | compat-rocm (unset =
-                     auto-detect; default = the plain build on any host)
-  LILBEE_RELEASE     run an exact lilbee release tag instead of the latest
-  LILBEE_DEV_BUILDS  =1 lets "latest" pick in-development (.dev) builds
-  LILBEE_DEBUG       =1 prints binary resolution detail on every run
+  LILBEE_URL       remote lilbee server; \`mcp\` bridges to <url> instead of a local binary
+  LILBEE_TOKEN     bearer session token for LILBEE_URL
+  LILBEE_BIN       explicit path to a lilbee binary
+  LILBEE_DATA_DIR  library location for \`mcp\` (same as --data-dir)
+  LILBEE_VARIANT   download variant override: default | cu121 | cu124 | cu125 |
+                   rocm | compat | compat-cu124 | compat-rocm (unset =
+                   auto-detect; default = the plain build on any host)
+  LILBEE_RELEASE   run an exact lilbee release tag instead of the latest
+  LILBEE_CHANNEL   stable (default) | dev: whether "latest" may pick a .dev build
+  LILBEE_DEBUG     =1 prints binary resolution detail on every run
 `;

--- a/packages/lilbee/lib/releases.mjs
+++ b/packages/lilbee/lib/releases.mjs
@@ -7,6 +7,7 @@
 import { assetNameFor } from "./assets.mjs";
 import { detectHost } from "./detect.mjs";
 import { launcherFetch } from "./fetch.mjs";
+import { LauncherError } from "./errors.mjs";
 
 export const DEFAULT_REPO = "tobocop2/lilbee";
 export const USER_AGENT = "lilbee-npm-launcher";
@@ -45,7 +46,7 @@ function githubHeaders(env) {
 
 async function fetchGitHub(fetchImpl, url, env) {
   const res = await fetchImpl(url, { headers: githubHeaders(env) });
-  if (RATE_LIMIT_STATUSES.has(res.status)) throw new Error(GITHUB_RATE_LIMITED);
+  if (RATE_LIMIT_STATUSES.has(res.status)) throw new LauncherError("rate-limited", GITHUB_RATE_LIMITED, { status: res.status });
   return res;
 }
 
@@ -137,7 +138,7 @@ async function collectInstallable(q, limit) {
   for (let page = 1; page <= RELEASE_PAGE_BUDGET; page += 1) {
     const url = `${GITHUB_API}/repos/${q.repo}/releases?per_page=${RELEASE_PAGE_SIZE}&page=${page}`;
     const res = await fetchGitHub(q.fetchImpl, url, q.env);
-    if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+    if (!res.ok) throw new LauncherError("http", `GET ${url} -> HTTP ${res.status}`, { status: res.status });
     const releases = await res.json();
     for (const data of releases) {
       if (data.draft || data.prerelease) continue;
@@ -170,7 +171,7 @@ export async function listReleases(query = {}) {
 /** The newest installable release on the chosen channel. Throws when none exists. */
 export async function latestRelease(query = {}) {
   const [newest] = await listReleases({ ...query, limit: 1 });
-  if (!newest) throw new Error("No installable lilbee release was found.");
+  if (!newest) throw new LauncherError("no-release", "No installable lilbee release was found.");
   return newest;
 }
 
@@ -179,10 +180,10 @@ export async function releaseByTag(tag, query = {}) {
   const q = await resolveQuery(query);
   const url = `${GITHUB_API}/repos/${q.repo}/releases/tags/${tag}`;
   const res = await fetchGitHub(q.fetchImpl, url, q.env);
-  if (res.status === 404) throw new Error(`Release ${tag} was not found in ${q.repo}.`);
-  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  if (res.status === 404) throw new LauncherError("no-release", `Release ${tag} was not found in ${q.repo}.`, { status: res.status });
+  if (!res.ok) throw new LauncherError("http", `GET ${url} -> HTTP ${res.status}`, { status: res.status });
   const data = await res.json();
   const fallback = baselineAsset(data, q.host);
-  if (!fallback) throw new Error(`Release ${tag} has no build for ${q.host.platform}/${q.host.arch}.`);
+  if (!fallback) throw new LauncherError("no-release", `Release ${tag} has no build for ${q.host.platform}/${q.host.arch}.`);
   return resolveBuild(data, fallback, q.host, q.fetchImpl);
 }

--- a/packages/lilbee/lib/releases.mjs
+++ b/packages/lilbee/lib/releases.mjs
@@ -94,29 +94,36 @@ async function resolveBuild(data, fallback, host, fetchImpl) {
   const { baseline, gpu } = buildsFor(host);
   const find = (name) => (data.assets ?? []).find((a) => a.name === name);
   let pick = { variant: baseline, asset: fallback };
+  let amd = host.detection.amd;
   if (gpu) {
-    const gpuName = assetNameFor(host.platform, host.arch, gpu);
-    const gpuAsset = find(gpuName);
-    if (gpuAsset && (await hostCanRun(gpu, host, find(gpuName + GFX_MANIFEST_SUFFIX), fetchImpl))) {
-      pick = { variant: gpu, asset: gpuAsset };
-    }
+    const gpuAsset = find(assetNameFor(host.platform, host.arch, gpu));
+    const refusal = await gpuRefusal(gpu, gpuAsset, host, find, fetchImpl);
+    if (refusal === null) pick = { variant: gpu, asset: gpuAsset };
+    else if (isRocm(gpu) && amd.status === "detected") amd = { status: "unsupported", gfxTargets: amd.gfxTargets, reason: refusal };
   }
   return {
     tag: data.tag_name,
     dev: isDevBuild(data.tag_name),
     assetName: pick.asset.name,
     variant: pick.variant,
+    detection: { ...host.detection, amd },
     size: pick.asset.size,
     digest: digestOf(pick.asset),
     url: pick.asset.browser_download_url,
   };
 }
 
-/** A ROCm build must ship kernels for every host GPU it is known to have; other builds always qualify. */
-async function hostCanRun(variant, host, manifest, fetchImpl) {
-  if (!variant.endsWith("rocm") || host.amdGfxTargets.length === 0) return true;
-  const shipped = await shippedGfxTargets(fetchImpl, manifest);
-  return shipped !== null && host.amdGfxTargets.every((target) => shipped.has(target));
+function isRocm(variant) {
+  return variant.endsWith("rocm");
+}
+
+/** Why the release's GPU build cannot serve the host, or null when it can. */
+async function gpuRefusal(gpu, gpuAsset, host, find, fetchImpl) {
+  if (!gpuAsset) return "no-asset";
+  if (!isRocm(gpu) || host.amdGfxTargets.length === 0) return null;
+  const shipped = await shippedGfxTargets(fetchImpl, find(gpuAsset.name + GFX_MANIFEST_SUFFIX));
+  if (shipped === null) return "no-manifest";
+  return host.amdGfxTargets.every((target) => shipped.has(target)) ? null : "missing-kernels";
 }
 
 async function resolveQuery(query) {

--- a/packages/lilbee/lib/releases.mjs
+++ b/packages/lilbee/lib/releases.mjs
@@ -1,0 +1,188 @@
+/**
+ * GitHub release listing with the build each release ships for a host:
+ * the CUDA build the driver supports, the ROCm build when its gfx manifest
+ * covers every host GPU, else the baseline build of the host's CPU family.
+ */
+
+import { assetNameFor } from "./assets.mjs";
+import { detectHost } from "./detect.mjs";
+import { launcherFetch } from "./fetch.mjs";
+
+export const DEFAULT_REPO = "tobocop2/lilbee";
+export const USER_AGENT = "lilbee-npm-launcher";
+
+const GITHUB_API = "https://api.github.com";
+const RELEASE_HISTORY_LIMIT = 10;
+const RELEASE_PAGE_SIZE = 100;
+const RELEASE_PAGE_BUDGET = 3;
+const RATE_LIMIT_STATUSES = new Set([403, 429]);
+const GITHUB_RATE_LIMITED = "GitHub's rate limit was reached; release checks reset within the hour.";
+const GFX_MANIFEST_SUFFIX = ".gfx.txt";
+
+/** An in-development build, tagged with a trailing `.dev<n>` (e.g. v0.6.90b420.dev711). */
+export function isDevBuild(tag) {
+  return /\.dev\d*$/i.test(tag);
+}
+
+/** Order release tags like v0.6.90b423 newest-first; numeric segments compare numerically. */
+export function compareReleaseTags(a, b) {
+  const nums = (t) => (String(t).match(/\d+/g) || []).map(Number);
+  const na = nums(a);
+  const nb = nums(b);
+  for (let i = 0; i < Math.max(na.length, nb.length); i += 1) {
+    const d = (nb[i] ?? -1) - (na[i] ?? -1);
+    if (d) return d;
+  }
+  return 0;
+}
+
+function githubHeaders(env) {
+  const headers = { "user-agent": USER_AGENT, accept: "application/vnd.github+json" };
+  const token = env.GITHUB_TOKEN || env.GH_TOKEN;
+  if (token) headers.authorization = `Bearer ${token}`;
+  return headers;
+}
+
+async function fetchGitHub(fetchImpl, url, env) {
+  const res = await fetchImpl(url, { headers: githubHeaders(env) });
+  if (RATE_LIMIT_STATUSES.has(res.status)) throw new Error(GITHUB_RATE_LIMITED);
+  return res;
+}
+
+/** The hex sha256 GitHub reports for an asset, or null when the release carries none. */
+function digestOf(asset) {
+  const digest = asset.digest;
+  return typeof digest === "string" && digest.startsWith("sha256:") ? digest.slice("sha256:".length) : null;
+}
+
+/** The gfx targets a manifest lists, or null when it is missing, unreachable, or empty. */
+async function shippedGfxTargets(fetchImpl, manifest) {
+  if (!manifest) return null;
+  try {
+    const res = await fetchImpl(manifest.browser_download_url, { headers: { "user-agent": USER_AGENT } });
+    if (!res.ok) return null;
+    const targets = (await res.text()).split("\n").map((line) => line.trim()).filter(Boolean);
+    return targets.length ? new Set(targets) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The GPU build the host's variant asks for, and the baseline build it falls back to. */
+function buildsFor(host) {
+  const compat = host.variant === "compat" || host.variant.startsWith("compat-");
+  const baseline = compat ? "compat" : "default";
+  const gpu = host.variant === baseline ? null : host.variant;
+  return { baseline, gpu };
+}
+
+/** The baseline asset of `data` for the host, or null when the release ships none for it. */
+function baselineAsset(data, host) {
+  const { baseline } = buildsFor(host);
+  let name;
+  try {
+    name = assetNameFor(host.platform, host.arch, baseline);
+  } catch {
+    return null;
+  }
+  return (data.assets ?? []).find((a) => a.name === name) ?? null;
+}
+
+/** The build of `data` this host should run: its GPU build when the release ships one it can run, else `fallback`. */
+async function resolveBuild(data, fallback, host, fetchImpl) {
+  const { baseline, gpu } = buildsFor(host);
+  const find = (name) => (data.assets ?? []).find((a) => a.name === name);
+  let pick = { variant: baseline, asset: fallback };
+  if (gpu) {
+    const gpuName = assetNameFor(host.platform, host.arch, gpu);
+    const gpuAsset = find(gpuName);
+    if (gpuAsset && (await hostCanRun(gpu, host, find(gpuName + GFX_MANIFEST_SUFFIX), fetchImpl))) {
+      pick = { variant: gpu, asset: gpuAsset };
+    }
+  }
+  return {
+    tag: data.tag_name,
+    dev: isDevBuild(data.tag_name),
+    assetName: pick.asset.name,
+    variant: pick.variant,
+    size: pick.asset.size,
+    digest: digestOf(pick.asset),
+    url: pick.asset.browser_download_url,
+  };
+}
+
+/** A ROCm build must ship kernels for every host GPU it is known to have; other builds always qualify. */
+async function hostCanRun(variant, host, manifest, fetchImpl) {
+  if (!variant.endsWith("rocm") || host.amdGfxTargets.length === 0) return true;
+  const shipped = await shippedGfxTargets(fetchImpl, manifest);
+  return shipped !== null && host.amdGfxTargets.every((target) => shipped.has(target));
+}
+
+async function resolveQuery(query) {
+  const env = query.env ?? process.env;
+  return {
+    repo: query.repo ?? DEFAULT_REPO,
+    includeDev: query.includeDev ?? false,
+    env,
+    host: query.host ?? (await detectHost(env)),
+    fetchImpl: query.fetch ?? (await launcherFetch(env)),
+  };
+}
+
+/** Releases that ship a baseline build for the host, newest first, within the per-kind quotas. */
+async function collectInstallable(q, limit) {
+  const found = [];
+  let stable = 0;
+  let dev = 0;
+  for (let page = 1; page <= RELEASE_PAGE_BUDGET; page += 1) {
+    const url = `${GITHUB_API}/repos/${q.repo}/releases?per_page=${RELEASE_PAGE_SIZE}&page=${page}`;
+    const res = await fetchGitHub(q.fetchImpl, url, q.env);
+    if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+    const releases = await res.json();
+    for (const data of releases) {
+      if (data.draft || data.prerelease) continue;
+      const isDev = isDevBuild(data.tag_name);
+      if (isDev && !q.includeDev) continue;
+      if (isDev ? dev >= limit : stable >= limit) continue;
+      const fallback = baselineAsset(data, q.host);
+      if (!fallback) continue;
+      found.push({ data, fallback });
+      if (isDev) dev += 1;
+      else stable += 1;
+      if (stable >= limit && (!q.includeDev || dev >= limit)) return found;
+    }
+    if (releases.length < RELEASE_PAGE_SIZE) break;
+  }
+  return found;
+}
+
+/**
+ * Published releases that ship a build for the host, newest first: up to `limit`
+ * stable releases plus up to `limit` dev builds when `includeDev` is set.
+ */
+export async function listReleases(query = {}) {
+  const q = await resolveQuery(query);
+  const limit = query.limit ?? RELEASE_HISTORY_LIMIT;
+  const candidates = await collectInstallable(q, limit);
+  return Promise.all(candidates.map(({ data, fallback }) => resolveBuild(data, fallback, q.host, q.fetchImpl)));
+}
+
+/** The newest installable release on the chosen channel. Throws when none exists. */
+export async function latestRelease(query = {}) {
+  const [newest] = await listReleases({ ...query, limit: 1 });
+  if (!newest) throw new Error("No installable lilbee release was found.");
+  return newest;
+}
+
+/** One release by tag, resolved for the host. Throws when the tag or the host's build is missing. */
+export async function releaseByTag(tag, query = {}) {
+  const q = await resolveQuery(query);
+  const url = `${GITHUB_API}/repos/${q.repo}/releases/tags/${tag}`;
+  const res = await fetchGitHub(q.fetchImpl, url, q.env);
+  if (res.status === 404) throw new Error(`Release ${tag} was not found in ${q.repo}.`);
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  const data = await res.json();
+  const fallback = baselineAsset(data, q.host);
+  if (!fallback) throw new Error(`Release ${tag} has no build for ${q.host.platform}/${q.host.arch}.`);
+  return resolveBuild(data, fallback, q.host, q.fetchImpl);
+}

--- a/packages/lilbee/lib/resolve.mjs
+++ b/packages/lilbee/lib/resolve.mjs
@@ -1,132 +1,44 @@
 /**
- * Local-mode binary resolution.
- *
- * The launcher tracks the LATEST lilbee release: a fresh install (and
- * `lilbee prepare`) asks GitHub for the newest release and downloads its
- * binary. Every later run execs the newest cached binary with no network.
- * The pinned release in package.json is the tested fallback when the
- * latest-release lookup fails (offline, rate limit, release mid-upload).
- *
- * Order:
- *   1. LILBEE_BIN (explicit override; must exist)
- *   2. LILBEE_RELEASE (explicit release tag: cache, then download)
- *   3. newest already-cached release (skipped when refresh is set)
- *   4. the latest GitHub release, falling back to the pin — cache, then
- *      download (old cached releases are pruned after a download lands)
- *
- * The launcher deliberately ignores lilbee installs from other package
- * managers (PATH, the shared data root): npm always runs its own verified
- * download, so `npm install` means a fresh, known binary.
- *
- * Dependencies are injected so tests never touch the real fs/network.
+ * Binary resolution for the CLI: LILBEE_BIN, else an exact release tag, else
+ * the newest cached binary, else the latest release on the channel with the
+ * package's pinned release as the fallback when that lookup fails.
  */
 
-import path from "node:path";
-import os from "node:os";
+import fs from "node:fs";
 
-const CACHE_DIR_NAME = "lilbee-npm";
-
-export function cacheDir(env, platform = process.platform) {
-  if (env.LILBEE_MCP_CACHE) return env.LILBEE_MCP_CACHE;
-  const home = os.homedir();
-  if (platform === "darwin") return path.join(home, "Library", "Caches", CACHE_DIR_NAME);
-  if (platform === "win32") {
-    return path.join(env.LOCALAPPDATA || path.join(home, "AppData", "Local"), CACHE_DIR_NAME);
-  }
-  return path.join(env.XDG_CACHE_HOME || path.join(home, ".cache"), CACHE_DIR_NAME);
-}
-
-export function cachedBinaryPath(env, release, assetName, platform = process.platform) {
-  return path.join(cacheDir(env, platform), release, assetName);
-}
-
-/** Order release tags like v0.6.90b423 newest-first (numeric segments compared numerically). */
-export function compareReleaseTags(a, b) {
-  const nums = (t) => (String(t).match(/\d+/g) || []).map(Number);
-  const na = nums(a);
-  const nb = nums(b);
-  for (let i = 0; i < Math.max(na.length, nb.length); i += 1) {
-    const d = (nb[i] ?? -1) - (na[i] ?? -1);
-    if (d) return d;
-  }
-  return 0;
-}
-
-/** The releases already cached for this asset, newest first. */
-function cachedReleases(env, assetName, deps) {
-  let entries;
-  try {
-    entries = deps.readdirSync(cacheDir(env));
-  } catch {
-    return [];
-  }
-  return entries.filter((r) => deps.existsSync(cachedBinaryPath(env, r, assetName))).sort(compareReleaseTags);
-}
-
-/** Delete cached release dirs other than `keep` — an upgrade replaces, not accumulates. */
-function pruneOtherReleases(env, keep, deps) {
-  if (!deps.rmSync) return;
-  let entries;
-  try {
-    entries = deps.readdirSync(cacheDir(env));
-  } catch {
-    return;
-  }
-  for (const r of entries) {
-    if (r === keep) continue;
-    try {
-      deps.rmSync(path.join(cacheDir(env), r), { recursive: true, force: true });
-    } catch {
-      // a busy file on Windows: stale cache is a nuisance, not an error
-    }
-  }
-}
+import { cachedBinaryPath, installedBinary } from "./cache.mjs";
+import { latestRelease, releaseByTag } from "./releases.mjs";
 
 /**
- * Resolve the binary to run. Returns { path, source, release } where source
- * is "env" | "cache" | "download". Throws when LILBEE_BIN is set but missing
- * (an explicit override silently falling through would be worse).
- *
- * @param {object} opts
- * @param {object} opts.env
- * @param {string} opts.release   pinned fallback release tag
- * @param {string} opts.assetName release asset for this host
- * @param {boolean} [opts.refresh] re-resolve latest even when a binary is cached
- * @param {object} opts.deps      { existsSync, readdirSync, rmSync, latestTag, log, download }
+ * Plan the binary to run: `{ path, source, release, download }` where `source`
+ * is "env" | "cache" | "download" and `download` is the ResolvedRelease to
+ * install when `source` is "download". Throws when LILBEE_BIN is set but missing.
  */
-export async function resolveBinary({ env, release, assetName, refresh = false, deps }) {
+export async function resolveBinary({ env, cacheDir, host, pinned, tag = null, refresh = false, includeDev = false, repo, fetch, log = () => {} }) {
   if (env.LILBEE_BIN) {
-    if (!deps.existsSync(env.LILBEE_BIN)) {
+    if (!fs.existsSync(env.LILBEE_BIN)) {
       throw new Error(`LILBEE_BIN points at "${env.LILBEE_BIN}" but nothing is there.`);
     }
-    return { path: env.LILBEE_BIN, source: "env", release: null };
+    return { path: env.LILBEE_BIN, source: "env", release: null, download: null };
   }
 
-  const log = deps.log ?? (() => {});
-  const cached = cachedReleases(env, assetName, deps);
-
-  let tag;
-  if (env.LILBEE_RELEASE) {
-    tag = env.LILBEE_RELEASE;
+  const query = { repo, env, host, includeDev, fetch };
+  const wanted = tag || env.LILBEE_RELEASE;
+  let resolved;
+  if (wanted) {
+    resolved = await releaseByTag(wanted, query);
   } else {
-    // Runs with a usable binary stay off the network; prepare re-resolves.
-    if (!refresh && cached.length) {
-      return { path: cachedBinaryPath(env, cached[0], assetName), source: "cache", release: cached[0] };
-    }
+    const installed = refresh ? null : installedBinary({ cacheDir, host });
+    if (installed) return { path: installed.path, source: "cache", release: installed.release, download: null };
     try {
-      tag = await deps.latestTag();
-    } catch {
-      tag = release;
-      log(`lilbee: could not look up the latest release; using the tested ${release}.`);
+      resolved = await latestRelease(query);
+    } catch (err) {
+      log(`lilbee: could not look up the latest release (${err.message}); using the tested ${pinned}.`);
+      resolved = await releaseByTag(pinned, query);
     }
   }
 
-  if (cached.includes(tag)) {
-    return { path: cachedBinaryPath(env, tag, assetName), source: "cache", release: tag };
-  }
-
-  const dest = cachedBinaryPath(env, tag, assetName);
-  await deps.download({ env, release: tag, assetName, dest });
-  pruneOtherReleases(env, tag, deps);
-  return { path: dest, source: "download", release: tag };
+  const dest = cachedBinaryPath(cacheDir, resolved.tag, resolved.assetName);
+  if (fs.existsSync(dest)) return { path: dest, source: "cache", release: resolved.tag, download: null };
+  return { path: dest, source: "download", release: resolved.tag, download: resolved };
 }

--- a/packages/lilbee/lib/resolve.mjs
+++ b/packages/lilbee/lib/resolve.mjs
@@ -33,7 +33,7 @@ export async function resolveBinary({ env, cacheDir, host, pinned, tag = null, r
     try {
       resolved = await latestRelease(query);
     } catch (err) {
-      log(`lilbee: could not look up the latest release (${err.message}); using the tested ${pinned}.`);
+      log(`lilbee: could not look up the latest release; using the tested ${pinned}.`);
       resolved = await releaseByTag(pinned, query);
     }
   }

--- a/packages/lilbee/package-lock.json
+++ b/packages/lilbee/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lilbee",
-  "version": "0.6.97",
+  "version": "0.6.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lilbee",
-      "version": "0.6.97",
+      "version": "0.6.98",
       "license": "MIT",
       "bin": {
         "lilbee": "bin/lilbee.mjs",

--- a/packages/lilbee/package-lock.json
+++ b/packages/lilbee/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lilbee",
-  "version": "0.6.92",
+  "version": "0.6.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lilbee",
-      "version": "0.6.92",
+      "version": "0.6.97",
       "license": "MIT",
       "bin": {
         "lilbee": "bin/lilbee.mjs",

--- a/packages/lilbee/package.json
+++ b/packages/lilbee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lilbee",
-  "version": "0.6.97",
+  "version": "0.6.98",
   "description": "The whole local AI stack in one executable: run and manage local models across every GPU you have, and search your files, notes, code, and crawled sites with answers that cite the source. Terminal app, CLI, MCP server, and REST API. Auto-detects your hardware (CUDA, ROCm, Metal) and fetches the matching standalone binary on first use.",
   "license": "MIT",
   "homepage": "https://lilbee.sh",

--- a/packages/lilbee/package.json
+++ b/packages/lilbee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lilbee",
-  "version": "0.6.96",
+  "version": "0.6.97",
   "description": "The whole local AI stack in one executable: run and manage local models across every GPU you have, and search your files, notes, code, and crawled sites with answers that cite the source. Terminal app, CLI, MCP server, and REST API. Auto-detects your hardware (CUDA, ROCm, Metal) and fetches the matching standalone binary on first use.",
   "license": "MIT",
   "homepage": "https://lilbee.sh",

--- a/packages/lilbee/package.json
+++ b/packages/lilbee/package.json
@@ -6,6 +6,15 @@
   "homepage": "https://lilbee.sh",
   "bugs": "https://github.com/tobocop2/lilbee/issues",
   "type": "module",
+  "main": "./lib/api.mjs",
+  "types": "./lib/api.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/api.d.ts",
+      "default": "./lib/api.mjs"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "lilbee": "bin/lilbee.mjs",
     "lilbee-mcp": "bin/lilbee-mcp.mjs"

--- a/packages/lilbee/package.json
+++ b/packages/lilbee/package.json
@@ -15,6 +15,7 @@
     },
     "./package.json": "./package.json"
   },
+  "sideEffects": false,
   "bin": {
     "lilbee": "bin/lilbee.mjs",
     "lilbee-mcp": "bin/lilbee-mcp.mjs"

--- a/packages/lilbee/test/api.test.mjs
+++ b/packages/lilbee/test/api.test.mjs
@@ -9,7 +9,8 @@ import * as api from "../lib/api.mjs";
 
 const PAYLOAD = Buffer.from("binary ".repeat(32));
 const DIGEST = createHash("sha256").update(PAYLOAD).digest("hex");
-const HOST = { platform: "linux", arch: "x64", variant: "cu125", amdGfxTargets: [] };
+const DETECTION = { nvidia: { status: "detected", cudaCeiling: 1206 }, amd: { status: "missing" }, cpu: { status: "detected", avx2: true }, detectedAt: "2026-09-04T12:00:00.000Z" };
+const HOST = { platform: "linux", arch: "x64", variant: "cu125", amdGfxTargets: [], detection: DETECTION };
 const ASSETS = ["lilbee-linux-x86_64", "lilbee-linux-x86_64-cu125"];
 
 const tmpCache = () => fs.mkdtempSync(path.join(os.tmpdir(), "lilbee-api-"));
@@ -69,6 +70,7 @@ test("a fresh cache downloads the latest release for the host", async () => {
     assetName: "lilbee-linux-x86_64-cu125",
     variant: "cu125",
     source: "download",
+    detection: DETECTION,
   });
   assert.ok(Buffer.from(fs.readFileSync(got.path)).equals(PAYLOAD));
   assert.ok(progress.length > 0);
@@ -154,5 +156,24 @@ test("a cancelled download rejects and leaves the previously cached release in p
   assert.deepEqual(fs.readdirSync(cache).sort(), ["v1", "v2"]);
   assert.deepEqual(fs.readdirSync(path.join(cache, "v2")), []);
   assert.equal(fs.readFileSync(path.join(cache, "v1", "lilbee-linux-x86_64-cu125"), "utf8"), "cached");
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("the result carries the release's detection on a download or a forced reinstall, not on a cache hit", async () => {
+  const cache = tmpCache();
+  const gh = stub(["v2"]);
+  const fresh = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch });
+  assert.deepEqual(fresh.detection, DETECTION);
+  const hit = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch });
+  assert.equal(hit.source, "cache");
+  assert.equal("detection" in hit, false);
+  const refreshed = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, refresh: true });
+  assert.equal(refreshed.source, "cache");
+  assert.equal("detection" in refreshed, false);
+  const pinned = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, release: "v2" });
+  assert.equal("detection" in pinned, false);
+  const forced = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, force: true });
+  assert.equal(forced.source, "download");
+  assert.deepEqual(forced.detection, DETECTION);
   fs.rmSync(cache, { recursive: true, force: true });
 });

--- a/packages/lilbee/test/api.test.mjs
+++ b/packages/lilbee/test/api.test.mjs
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import * as api from "../lib/api.mjs";
+
+const PAYLOAD = Buffer.from("binary ".repeat(32));
+const DIGEST = createHash("sha256").update(PAYLOAD).digest("hex");
+const HOST = { platform: "linux", arch: "x64", variant: "cu125", amdGfxTargets: [] };
+const ASSETS = ["lilbee-linux-x86_64", "lilbee-linux-x86_64-cu125"];
+
+const tmpCache = () => fs.mkdtempSync(path.join(os.tmpdir(), "lilbee-api-"));
+
+/** GitHub plus the asset host: release pages by tag list, binaries served from PAYLOAD. */
+function stub(tags) {
+  const calls = [];
+  const releases = tags.map((tag) => ({
+    tag_name: tag,
+    assets: ASSETS.map((name) => ({ name, size: PAYLOAD.length, digest: `sha256:${DIGEST}`, browser_download_url: `https://dl/${tag}/${name}` })),
+  }));
+  const fetch = async (url, init = {}) => {
+    calls.push(url);
+    const respond = (status, json = null, body = null) => ({
+      ok: status < 400,
+      status,
+      headers: { get: () => null },
+      body,
+      json: async () => json,
+      text: async () => "",
+    });
+    if (/\/releases\?/.test(url)) return respond(200, releases);
+    const byTag = /\/releases\/tags\/(.+)$/.exec(url);
+    if (byTag) {
+      const found = releases.find((r) => r.tag_name === byTag[1]);
+      return found ? respond(200, found) : respond(404, {});
+    }
+    if (url.startsWith("https://dl/")) return respond(200, null, Readable.from([PAYLOAD]));
+    throw new Error(`unexpected ${url}`);
+  };
+  return { fetch, calls };
+}
+
+const seed = (cache, release, assetName) => {
+  fs.mkdirSync(path.join(cache, release), { recursive: true });
+  fs.writeFileSync(path.join(cache, release, assetName), "cached");
+};
+
+test("the package entry exports the whole contract", () => {
+  for (const name of [
+    "detectHost", "assetNameFor", "parseAssetName", "isDevBuild", "compareReleaseTags",
+    "listReleases", "latestRelease", "releaseByTag", "cacheDir", "cachedBinaryPath",
+    "installedBinary", "ensureBinary", "DownloadCanceledError", "isDownloadCanceled",
+  ]) {
+    assert.equal(typeof api[name], "function", name);
+  }
+});
+
+test("a fresh cache downloads the latest release for the host", async () => {
+  const cache = tmpCache();
+  const gh = stub(["v2", "v1"]);
+  const progress = [];
+  const got = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, onProgress: (p) => progress.push(p) });
+  assert.deepEqual(got, {
+    path: path.join(cache, "v2", "lilbee-linux-x86_64-cu125"),
+    release: "v2",
+    assetName: "lilbee-linux-x86_64-cu125",
+    variant: "cu125",
+    source: "download",
+  });
+  assert.ok(Buffer.from(fs.readFileSync(got.path)).equals(PAYLOAD));
+  assert.ok(progress.length > 0);
+  assert.deepEqual(gh.calls.filter((u) => u.includes("api.github.com")).length, 1);
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("a cached binary of any variant is returned without touching the network", async () => {
+  const cache = tmpCache();
+  seed(cache, "v1", "lilbee-linux-x86_64");
+  const gh = stub(["v2", "v1"]);
+  const got = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch });
+  assert.equal(got.source, "cache");
+  assert.equal(got.variant, "default");
+  assert.equal(gh.calls.length, 0);
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("refresh re-resolves latest: a matching cache is kept, an older one is replaced and pruned", async () => {
+  const cache = tmpCache();
+  seed(cache, "v2", "lilbee-linux-x86_64-cu125");
+  const same = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: stub(["v2"]).fetch, refresh: true });
+  assert.equal(same.source, "cache");
+  assert.equal(fs.readFileSync(same.path, "utf8"), "cached");
+
+  seed(cache, "v1", "lilbee-linux-x86_64-cu125");
+  const newer = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: stub(["v3", "v2"]).fetch, refresh: true });
+  assert.equal(newer.source, "download");
+  assert.equal(newer.release, "v3");
+  assert.deepEqual(fs.readdirSync(cache), ["v3"]);
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("after a hardware change, refresh switches builds within the same release and drops the old one", async () => {
+  const cache = tmpCache();
+  seed(cache, "v2", "lilbee-linux-x86_64");
+  const got = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: stub(["v2"]).fetch, refresh: true });
+  assert.equal(got.source, "download");
+  assert.equal(got.assetName, "lilbee-linux-x86_64-cu125");
+  assert.deepEqual(fs.readdirSync(path.join(cache, "v2")), ["lilbee-linux-x86_64-cu125"]);
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("an explicit release tag installs that release, cached or not", async () => {
+  const cache = tmpCache();
+  const gh = stub(["v3", "v2", "v1"]);
+  const got = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, release: "v1" });
+  assert.equal(got.release, "v1");
+  assert.equal(got.source, "download");
+  assert.match(gh.calls[0], /releases\/tags\/v1$/);
+  const again = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, release: "v1" });
+  assert.equal(again.source, "cache");
+  await assert.rejects(api.ensureBinary({ cacheDir: cache, host: HOST, fetch: gh.fetch, release: "v0" }), /was not found/);
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("force reinstalls the resolved release over the cached copy", async () => {
+  const cache = tmpCache();
+  seed(cache, "v2", "lilbee-linux-x86_64-cu125");
+  const got = await api.ensureBinary({ cacheDir: cache, host: HOST, fetch: stub(["v2"]).fetch, force: true });
+  assert.equal(got.source, "download");
+  assert.equal(got.release, "v2");
+  assert.ok(Buffer.from(fs.readFileSync(got.path)).equals(PAYLOAD));
+  fs.rmSync(cache, { recursive: true, force: true });
+});
+
+test("a cancelled download rejects and leaves the previously cached release in place", async () => {
+  const cache = tmpCache();
+  seed(cache, "v1", "lilbee-linux-x86_64-cu125");
+  const controller = new AbortController();
+  const gh = stub(["v2", "v1"]);
+  const fetch = async (url, init) => {
+    const res = await gh.fetch(url, init);
+    if (url.startsWith("https://dl/")) {
+      const body = new Readable({ read() {} });
+      body.push(PAYLOAD.subarray(0, 8));
+      setTimeout(() => controller.abort(), 10);
+      return { ...res, body };
+    }
+    return res;
+  };
+  await assert.rejects(api.ensureBinary({ cacheDir: cache, host: HOST, fetch, refresh: true, signal: controller.signal }), (e) => api.isDownloadCanceled(e));
+  assert.deepEqual(fs.readdirSync(cache).sort(), ["v1", "v2"]);
+  assert.deepEqual(fs.readdirSync(path.join(cache, "v2")), []);
+  assert.equal(fs.readFileSync(path.join(cache, "v1", "lilbee-linux-x86_64-cu125"), "utf8"), "cached");
+  fs.rmSync(cache, { recursive: true, force: true });
+});

--- a/packages/lilbee/test/assets.test.mjs
+++ b/packages/lilbee/test/assets.test.mjs
@@ -34,3 +34,87 @@ test("rejects impossible combinations with clear messages", () => {
   assert.throws(() => assetNameFor("linux", "arm64"), /No standalone lilbee build/);
   assert.throws(() => assetNameFor("linux", "x64", "cu999"), /Unknown LILBEE_VARIANT/);
 });
+
+import { parseAssetName } from "../lib/assets.mjs";
+
+/** Every asset of the v0.6.90b432 release: the binaries and the files published beside them. */
+const RELEASE_ASSETS = [
+  "lilbee-0.6.90b432-py3-none-any.whl",
+  "lilbee-compat-linux-x86_64",
+  "lilbee-compat-linux-x86_64-cu124",
+  "lilbee-compat-linux-x86_64-rocm",
+  "lilbee-compat-linux-x86_64-rocm.gfx.txt",
+  "lilbee-compat-linux-x86_64.snap",
+  "lilbee-compat-macos-x86_64",
+  "lilbee-compat-windows-x86_64.exe",
+  "lilbee-compat.flatpakref",
+  "lilbee-cuda.flatpakref",
+  "lilbee-linux-x86_64",
+  "lilbee-linux-x86_64-cu121",
+  "lilbee-linux-x86_64-cu124",
+  "lilbee-linux-x86_64-cu125",
+  "lilbee-linux-x86_64-cu125.snap",
+  "lilbee-linux-x86_64-rocm",
+  "lilbee-linux-x86_64-rocm.gfx.txt",
+  "lilbee-linux-x86_64-rocm.snap",
+  "lilbee-linux-x86_64.snap",
+  "lilbee-macos-arm64",
+  "lilbee-macos-x86_64",
+  "lilbee-rocm.flatpakref",
+  "lilbee-windows-x86_64-cu124.exe",
+  "lilbee-windows-x86_64-cu125.exe",
+  "lilbee-windows-x86_64.exe",
+  "lilbee.flatpakref",
+  "lilbee_engine-0.6.90b432-1.cpu-py3-none-macosx_11_0_arm64.whl",
+  "lilbee_engine-0.6.90b432-1.rocm-py3-none-manylinux_2_17_x86_64.whl",
+  "openapi.json",
+];
+
+const BINARIES = {
+  "lilbee-compat-linux-x86_64": ["linux", "x64", "compat"],
+  "lilbee-compat-linux-x86_64-cu124": ["linux", "x64", "compat-cu124"],
+  "lilbee-compat-linux-x86_64-rocm": ["linux", "x64", "compat-rocm"],
+  "lilbee-compat-macos-x86_64": ["darwin", "x64", "compat"],
+  "lilbee-compat-windows-x86_64.exe": ["win32", "x64", "compat"],
+  "lilbee-linux-x86_64": ["linux", "x64", "default"],
+  "lilbee-linux-x86_64-cu121": ["linux", "x64", "cu121"],
+  "lilbee-linux-x86_64-cu124": ["linux", "x64", "cu124"],
+  "lilbee-linux-x86_64-cu125": ["linux", "x64", "cu125"],
+  "lilbee-linux-x86_64-rocm": ["linux", "x64", "rocm"],
+  "lilbee-macos-arm64": ["darwin", "arm64", "default"],
+  "lilbee-macos-x86_64": ["darwin", "x64", "default"],
+  "lilbee-windows-x86_64-cu124.exe": ["win32", "x64", "cu124"],
+  "lilbee-windows-x86_64-cu125.exe": ["win32", "x64", "cu125"],
+  "lilbee-windows-x86_64.exe": ["win32", "x64", "default"],
+};
+
+test("parseAssetName recognises every binary of the release and nothing else", () => {
+  for (const name of RELEASE_ASSETS) {
+    const expected = BINARIES[name];
+    const parsed = parseAssetName(name);
+    if (expected) {
+      const [platform, arch, variant] = expected;
+      assert.deepEqual(parsed, { platform, arch, variant }, name);
+    } else {
+      assert.equal(parsed, null, name);
+    }
+  }
+});
+
+test("parseAssetName inverts assetNameFor and reports the plain build as 'default'", () => {
+  for (const [name, [platform, arch, variant]] of Object.entries(BINARIES)) {
+    assert.equal(assetNameFor(platform, arch, variant), name);
+    assert.equal(parseAssetName(name).variant, variant);
+  }
+  assert.equal(parseAssetName("lilbee-linux-x86_64").variant, "default");
+});
+
+test("parseAssetName rejects names outside the published matrix", () => {
+  assert.equal(parseAssetName("lilbee-windows-x86_64"), null);
+  assert.equal(parseAssetName("lilbee-linux-x86_64.exe"), null);
+  assert.equal(parseAssetName("lilbee-macos-arm64-cu124"), null);
+  assert.equal(parseAssetName("lilbee-compat-windows-x86_64-cu124.exe"), null);
+  assert.equal(parseAssetName("lilbee-compat-linux-x86_64-cu121"), null);
+  assert.equal(parseAssetName("lilbee-linux-x86_64.download.123"), null);
+  assert.equal(parseAssetName(""), null);
+});

--- a/packages/lilbee/test/cache.test.mjs
+++ b/packages/lilbee/test/cache.test.mjs
@@ -71,3 +71,12 @@ test("pruneOtherReleases keeps one release dir and removes the rest", () => {
   pruneOtherReleases(path.join(dir, "missing"), "v2");
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test("installedBinary without a host uses the running platform and takes any build of the newest release", () => {
+  const cuda = process.platform === "linux" ? "lilbee-linux-x86_64-cu125" : process.platform === "win32" ? "lilbee-windows-x86_64-cu125.exe" : null;
+  const plain = { darwin: process.arch === "arm64" ? "lilbee-macos-arm64" : "lilbee-macos-x86_64", linux: "lilbee-linux-x86_64", win32: "lilbee-windows-x86_64.exe" }[process.platform];
+  const dir = cacheWith([`v1/${plain}`, ...(cuda ? [`v2/${cuda}`] : [])]);
+  const found = installedBinary({ cacheDir: dir });
+  assert.equal(found.release, cuda ? "v2" : "v1");
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/packages/lilbee/test/cache.test.mjs
+++ b/packages/lilbee/test/cache.test.mjs
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { cacheDir, cachedBinaryPath, installedBinary, pruneOtherReleases } from "../lib/cache.mjs";
+import { compareReleaseTags } from "../lib/releases.mjs";
+
+const LINUX = { platform: "linux", arch: "x64", variant: "cu125", amdGfxTargets: [] };
+
+function cacheWith(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lilbee-cache-"));
+  for (const file of files) {
+    fs.mkdirSync(path.dirname(path.join(dir, file)), { recursive: true });
+    fs.writeFileSync(path.join(dir, file), "");
+  }
+  return dir;
+}
+
+test("cacheDir honors LILBEE_MCP_CACHE and platform conventions", () => {
+  assert.equal(cacheDir({ LILBEE_MCP_CACHE: "/tmp/c" }), "/tmp/c");
+  assert.ok(cacheDir({}, "darwin").endsWith(path.join("Library", "Caches", "lilbee-npm")));
+  assert.ok(cacheDir({ XDG_CACHE_HOME: "/xdg" }, "linux").startsWith("/xdg"));
+  assert.ok(cacheDir({ LOCALAPPDATA: "C:\\LA" }, "win32").includes("lilbee-npm"));
+});
+
+test("cachedBinaryPath is <cacheDir>/<release>/<assetName>", () => {
+  assert.equal(cachedBinaryPath("/c", "v1", "lilbee-macos-arm64"), path.join("/c", "v1", "lilbee-macos-arm64"));
+});
+
+test("release tags order numerically, newest first", () => {
+  const tags = ["v0.6.90b423", "v0.6.90b425", "v0.7.0", "v0.6.91"];
+  assert.deepEqual(tags.sort(compareReleaseTags), ["v0.7.0", "v0.6.91", "v0.6.90b425", "v0.6.90b423"]);
+});
+
+test("installedBinary picks the newest release and, within it, the host's variant", () => {
+  const dir = cacheWith([
+    "v0.6.90b423/lilbee-linux-x86_64-cu125",
+    "v0.6.90b425/lilbee-linux-x86_64",
+    "v0.6.90b425/lilbee-linux-x86_64-cu125",
+    "v0.6.90b425/lilbee-linux-x86_64-cu125.download.4242",
+  ]);
+  assert.deepEqual(installedBinary({ cacheDir: dir, host: LINUX }), {
+    path: path.join(dir, "v0.6.90b425", "lilbee-linux-x86_64-cu125"),
+    release: "v0.6.90b425",
+    assetName: "lilbee-linux-x86_64-cu125",
+    variant: "cu125",
+  });
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a cached build of another variant still counts as installed after a hardware change", () => {
+  const dir = cacheWith(["v0.6.90b425/lilbee-linux-x86_64", "v0.6.90b425/lilbee-macos-arm64"]);
+  const found = installedBinary({ cacheDir: dir, host: LINUX });
+  assert.equal(found.assetName, "lilbee-linux-x86_64");
+  assert.equal(found.variant, "default");
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("installedBinary ignores other platforms, temp files, and a missing cache", () => {
+  const dir = cacheWith(["v1/lilbee-macos-arm64", "v1/lilbee-linux-x86_64.download.7", "v2/notes.txt"]);
+  assert.equal(installedBinary({ cacheDir: dir, host: LINUX }), null);
+  assert.equal(installedBinary({ cacheDir: path.join(dir, "missing"), host: LINUX }), null);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("pruneOtherReleases keeps one release dir and removes the rest", () => {
+  const dir = cacheWith(["v1/lilbee-macos-arm64", "v2/lilbee-macos-arm64", "v3/lilbee-macos-arm64"]);
+  pruneOtherReleases(dir, "v2");
+  assert.deepEqual(fs.readdirSync(dir), ["v2"]);
+  pruneOtherReleases(path.join(dir, "missing"), "v2");
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/packages/lilbee/test/detect.test.mjs
+++ b/packages/lilbee/test/detect.test.mjs
@@ -1,12 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { cudaVariantFor, detectVariant, gfxNameFor, parseCudaVersion } from "../lib/detect.mjs";
+import { cudaVariantFor, detectHost, detectVariant, gfxNameFor, parseCudaVersion } from "../lib/detect.mjs";
 import { assetNameFor } from "../lib/assets.mjs";
 
 const KFD_NODES = "/sys/class/kfd/kfd/topology/nodes";
 
 const io = ({ smi = null, files = [], cpuflags = "fpu avx avx2", sysctlAvx2 = "1", rocminfo = false, kfdNodes = null } = {}) => ({
-  execFileSync: (cmd) => {
+  execFile: async (cmd) => {
     if (cmd === "nvidia-smi") {
       if (smi === null) throw new Error("not found");
       return smi;
@@ -34,21 +34,23 @@ const io = ({ smi = null, files = [], cpuflags = "fpu avx avx2", sysctlAvx2 = "1
   },
 });
 
+const variant = async (platform, arch, probes) => (await detectVariant(platform, arch, io(probes))).variant;
+
 test("driver CUDA version maps to the newest runnable build", () => {
   assert.equal(cudaVariantFor(12, 6), "cu125");
   assert.equal(cudaVariantFor(12, 4), "cu124");
   assert.equal(cudaVariantFor(12, 1), "cu121");
-  assert.equal(cudaVariantFor(11, 8), "");
+  assert.equal(cudaVariantFor(11, 8), null);
   assert.deepEqual(parseCudaVersion("| NVIDIA-SMI 550.54  Driver Version: 550.54  CUDA Version: 12.4 |"), { major: 12, minor: 4 });
 });
 
-test("linux NVIDIA hosts get the matching CUDA build", () => {
-  assert.equal(detectVariant("linux", "x64", io({ smi: "CUDA Version: 12.6" })), "cu125");
-  assert.equal(detectVariant("linux", "x64", io({ smi: "CUDA Version: 12.4" })), "cu124");
+test("linux NVIDIA hosts get the matching CUDA build", async () => {
+  assert.equal(await variant("linux", "x64", { smi: "CUDA Version: 12.6" }), "cu125");
+  assert.equal(await variant("linux", "x64", { smi: "CUDA Version: 12.4" }), "cu124");
 });
 
-test("visible NVIDIA device without runnable nvidia-smi falls back to cu121", () => {
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/nvidia0"] })), "cu121");
+test("visible NVIDIA device without runnable nvidia-smi falls back to cu121", async () => {
+  assert.equal(await variant("linux", "x64", { files: ["/dev/nvidia0"] }), "cu121");
 });
 
 test("gfx_target_version maps to gfx names", () => {
@@ -59,47 +61,49 @@ test("gfx_target_version maps to gfx names", () => {
   assert.equal(gfxNameFor(0), null);
 });
 
-test("a supported AMD GPU in the KFD topology picks rocm without any host userland", () => {
+test("an AMD GPU in the KFD topology proposes rocm and reports its gfx targets", async () => {
   const mi300x = { 0: 0, 1: 90402 }; // CPU node + GPU node, as RunPod MI300X pods report
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: mi300x })), "rocm");
+  const host = await detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: mi300x }));
+  assert.deepEqual(host, { variant: "rocm", amdGfxTargets: ["gfx942"] });
 });
 
-test("an unsupported AMD GPU falls back to the default build", () => {
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: { 0: 0, 1: 90006 } })), ""); // MI50
+test("gfx targets are unique and sorted, whatever the release later decides about them", async () => {
+  const host = await detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: { 0: 0, 1: 90006, 2: 90402, 3: 90006 } }));
+  assert.deepEqual(host, { variant: "rocm", amdGfxTargets: ["gfx906", "gfx942"] });
 });
 
-test("unreadable topology nodes are skipped, readable GPU node still wins", () => {
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: { 0: 0, 1: 90402, 2: null } })), "rocm");
+test("unreadable topology nodes are skipped, readable GPU node still wins", async () => {
+  assert.equal(await variant("linux", "x64", { files: ["/dev/kfd"], kfdNodes: { 0: 0, 1: 90402, 2: null } }), "rocm");
 });
 
-test("without KFD topology, ROCm needs /dev/kfd plus a userland; bare /dev/kfd is not enough", () => {
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/kfd", "/opt/rocm"] })), "rocm");
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/kfd"], rocminfo: true })), "rocm");
-  assert.equal(detectVariant("linux", "x64", io({ files: ["/dev/kfd"] })), "");
+test("without KFD topology, ROCm needs /dev/kfd plus a userland; bare /dev/kfd is not enough", async () => {
+  assert.deepEqual(await detectVariant("linux", "x64", io({ files: ["/dev/kfd", "/opt/rocm"] })), { variant: "rocm", amdGfxTargets: [] });
+  assert.equal(await variant("linux", "x64", { files: ["/dev/kfd"], rocminfo: true }), "rocm");
+  assert.equal(await variant("linux", "x64", { files: ["/dev/kfd"] }), "default");
 });
 
-test("no-AVX2 CPUs get the compat family, composed with the GPU", () => {
-  assert.equal(detectVariant("linux", "x64", io({ cpuflags: "fpu sse4_2" })), "compat");
-  assert.equal(detectVariant("linux", "x64", io({ cpuflags: "fpu sse4_2", smi: "CUDA Version: 12.6" })), "compat-cu124");
-  assert.equal(detectVariant("linux", "x64", io({ cpuflags: "fpu sse4_2", files: ["/dev/kfd", "/opt/rocm"] })), "compat-rocm");
-  assert.equal(detectVariant("linux", "x64", io({ cpuflags: "fpu sse4_2", files: ["/dev/kfd"], kfdNodes: { 1: 90402 } })), "compat-rocm");
+test("no-AVX2 CPUs get the compat family, composed with the GPU", async () => {
+  assert.equal(await variant("linux", "x64", { cpuflags: "fpu sse4_2" }), "compat");
+  assert.equal(await variant("linux", "x64", { cpuflags: "fpu sse4_2", smi: "CUDA Version: 12.6" }), "compat-cu124");
+  assert.equal(await variant("linux", "x64", { cpuflags: "fpu sse4_2", files: ["/dev/kfd", "/opt/rocm"] }), "compat-rocm");
+  assert.equal(await variant("linux", "x64", { cpuflags: "fpu sse4_2", files: ["/dev/kfd"], kfdNodes: { 1: 90402 } }), "compat-rocm");
 });
 
-test("plain linux hosts get the universal build", () => {
-  assert.equal(detectVariant("linux", "x64", io()), "");
+test("plain linux hosts get the universal build", async () => {
+  assert.equal(await variant("linux", "x64", {}), "default");
 });
 
-test("windows maps CUDA to shipped builds only", () => {
-  assert.equal(detectVariant("win32", "x64", io({ smi: "CUDA Version: 12.5" })), "cu125");
-  assert.equal(detectVariant("win32", "x64", io({ smi: "CUDA Version: 12.4" })), "cu124");
-  assert.equal(detectVariant("win32", "x64", io({ smi: "CUDA Version: 12.2" })), "");
-  assert.equal(detectVariant("win32", "x64", io()), "");
+test("windows maps CUDA to shipped builds only", async () => {
+  assert.equal(await variant("win32", "x64", { smi: "CUDA Version: 12.5" }), "cu125");
+  assert.equal(await variant("win32", "x64", { smi: "CUDA Version: 12.4" }), "cu124");
+  assert.equal(await variant("win32", "x64", { smi: "CUDA Version: 12.2" }), "default");
+  assert.equal(await variant("win32", "x64", {}), "default");
 });
 
-test("intel macs without AVX2 get the compat build", () => {
-  assert.equal(detectVariant("darwin", "x64", io({ sysctlAvx2: "0" })), "compat");
-  assert.equal(detectVariant("darwin", "x64", io()), "");
-  assert.equal(detectVariant("darwin", "arm64", io({ sysctlAvx2: "0" })), "");
+test("intel macs without AVX2 get the compat build", async () => {
+  assert.equal(await variant("darwin", "x64", { sysctlAvx2: "0" }), "compat");
+  assert.equal(await variant("darwin", "x64", {}), "default");
+  assert.equal(await variant("darwin", "arm64", { sysctlAvx2: "0" }), "default");
 });
 
 test("detected variants all map to real release assets", () => {
@@ -108,4 +112,29 @@ test("detected variants all map to real release assets", () => {
   assert.equal(assetNameFor("linux", "x64", "cu125"), "lilbee-linux-x86_64-cu125");
   assert.equal(assetNameFor("win32", "x64", "cu125"), "lilbee-windows-x86_64-cu125.exe");
   assert.equal(assetNameFor("darwin", "x64", "compat"), "lilbee-compat-macos-x86_64");
+});
+
+test("detectHost reports the running platform and never logs on its own", async () => {
+  const host = await detectHost({});
+  assert.equal(host.platform, process.platform);
+  assert.equal(host.arch, process.arch);
+  assert.ok(typeof host.variant === "string" && host.variant !== "");
+  assert.ok(Array.isArray(host.amdGfxTargets));
+});
+
+test("detectHost honors LILBEE_VARIANT and rejects an unknown value", async () => {
+  const lines = [];
+  const host = await detectHost({ LILBEE_VARIANT: "cu124" }, (m) => lines.push(m), io(), "linux", "x64");
+  assert.equal(host.variant, "cu124");
+  assert.deepEqual(lines, []);
+  assert.equal((await detectHost({ LILBEE_VARIANT: "default" }, () => {}, io({ smi: "CUDA Version: 12.6" }), "linux", "x64")).variant, "default");
+  assert.equal((await detectHost({ LILBEE_VARIANT: "" }, () => {}, io({ smi: "CUDA Version: 12.6" }), "linux", "x64")).variant, "cu125");
+  await assert.rejects(detectHost({ LILBEE_VARIANT: "cu999" }, () => {}, io(), "linux", "x64"), /Unknown LILBEE_VARIANT/);
+});
+
+test("detectHost logs what it picked through the given logger", async () => {
+  const lines = [];
+  await detectHost({}, (m) => lines.push(m), io({ smi: "CUDA Version: 12.6" }), "linux", "x64");
+  assert.match(lines.join("\n"), /cu125 build/);
+  assert.doesNotMatch(lines.join("\n"), /\u2014/);
 });

--- a/packages/lilbee/test/detect.test.mjs
+++ b/packages/lilbee/test/detect.test.mjs
@@ -1,40 +1,57 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { cudaVariantFor, detectHost, detectVariant, gfxNameFor, parseCudaVersion } from "../lib/detect.mjs";
+import { cudaVariantFor, detectHost, detectVariant, gfxNameFor, nvidiaSmiCandidates, parseCudaVersion } from "../lib/detect.mjs";
+import { parseAssetName } from "../lib/assets.mjs";
 import { assetNameFor } from "../lib/assets.mjs";
 
 const KFD_NODES = "/sys/class/kfd/kfd/topology/nodes";
 
-const io = ({ smi = null, files = [], cpuflags = "fpu avx avx2", sysctlAvx2 = "1", rocminfo = false, kfdNodes = null } = {}) => ({
-  execFile: async (cmd) => {
-    if (cmd === "nvidia-smi") {
-      if (smi === null) throw new Error("not found");
-      return smi;
-    }
-    if (cmd === "rocminfo") {
-      if (!rocminfo) throw new Error("not found");
-      return "ROCk module is loaded";
-    }
-    if (cmd === "sysctl") return sysctlAvx2;
-    throw new Error("not found");
-  },
-  existsSync: (p) => files.includes(p),
-  readFileSync: (p) => {
-    if (p === "/proc/cpuinfo") return `processor : 0\nflags\t\t: ${cpuflags}\n`;
-    const node = kfdNodes && /^\/sys\/class\/kfd\/kfd\/topology\/nodes\/(\w+)\/properties$/.exec(p)?.[1];
-    if (node && node in kfdNodes) {
-      if (kfdNodes[node] === null) throw new Error("Operation not permitted");
-      return `simd_count 0\ngfx_target_version ${kfdNodes[node]}\n`;
-    }
-    throw new Error("no file");
-  },
-  readdirSync: (p) => {
-    if (p === KFD_NODES && kfdNodes) return Object.keys(kfdNodes);
-    throw new Error("no dir");
-  },
-});
+/**
+ * A simulated host. `smi` is nvidia-smi's stdout, an Error to throw, a function of the
+ * command tried, or null for "not installed"; `powershell` answers the Windows AVX2 probe
+ * the same way. Every command run lands in `calls`.
+ */
+const io = ({ smi = null, files = [], cpuflags = "fpu avx avx2", cpuinfo = null, sysctlAvx2 = "1", powershell = null, rocminfo = false, kfdNodes = null, kfdUnreadable = false } = {}) => {
+  const calls = [];
+  const notFound = (cmd) => Object.assign(new Error(`spawn ${cmd} ENOENT`), { code: "ENOENT" });
+  const answer = (cmd, response) => {
+    if (response === null) throw notFound(cmd);
+    if (response instanceof Error) throw response;
+    return typeof response === "function" ? response(cmd) : response;
+  };
+  return {
+    calls,
+    execFile: async (cmd) => {
+      calls.push(cmd);
+      if (cmd === "nvidia-smi" || cmd.endsWith("nvidia-smi.exe")) return answer(cmd, smi);
+      if (cmd === "rocminfo") {
+        if (!rocminfo) throw notFound(cmd);
+        return "ROCk module is loaded";
+      }
+      if (cmd === "sysctl") return answer(cmd, sysctlAvx2);
+      if (cmd === "powershell") return answer(cmd, powershell);
+      throw notFound(cmd);
+    },
+    existsSync: (p) => files.includes(p),
+    readFileSync: (p) => {
+      if (p === "/proc/cpuinfo") return cpuinfo ?? `processor : 0\nflags\t\t: ${cpuflags}\n`;
+      const node = kfdNodes && /^\/sys\/class\/kfd\/kfd\/topology\/nodes\/(\w+)\/properties$/.exec(p)?.[1];
+      if (node && node in kfdNodes) {
+        if (kfdNodes[node] === null) throw new Error("Operation not permitted");
+        return `simd_count 0\ngfx_target_version ${kfdNodes[node]}\n`;
+      }
+      throw new Error("no file");
+    },
+    readdirSync: (p) => {
+      if (p === KFD_NODES && kfdNodes && !kfdUnreadable) return Object.keys(kfdNodes);
+      throw new Error("no dir");
+    },
+  };
+};
 
 const variant = async (platform, arch, probes) => (await detectVariant(platform, arch, io(probes))).variant;
+const picked = ({ variant, amdGfxTargets }) => ({ variant, amdGfxTargets });
+const report = async (platform, arch, probes, env = {}) => (await detectVariant(platform, arch, io(probes), () => {}, env)).detection;
 
 test("driver CUDA version maps to the newest runnable build", () => {
   assert.equal(cudaVariantFor(12, 6), "cu125");
@@ -64,12 +81,12 @@ test("gfx_target_version maps to gfx names", () => {
 test("an AMD GPU in the KFD topology proposes rocm and reports its gfx targets", async () => {
   const mi300x = { 0: 0, 1: 90402 }; // CPU node + GPU node, as RunPod MI300X pods report
   const host = await detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: mi300x }));
-  assert.deepEqual(host, { variant: "rocm", amdGfxTargets: ["gfx942"] });
+  assert.deepEqual(picked(host), { variant: "rocm", amdGfxTargets: ["gfx942"] });
 });
 
 test("gfx targets are unique and sorted, whatever the release later decides about them", async () => {
   const host = await detectVariant("linux", "x64", io({ files: ["/dev/kfd"], kfdNodes: { 0: 0, 1: 90006, 2: 90402, 3: 90006 } }));
-  assert.deepEqual(host, { variant: "rocm", amdGfxTargets: ["gfx906", "gfx942"] });
+  assert.deepEqual(picked(host), { variant: "rocm", amdGfxTargets: ["gfx906", "gfx942"] });
 });
 
 test("unreadable topology nodes are skipped, readable GPU node still wins", async () => {
@@ -77,7 +94,7 @@ test("unreadable topology nodes are skipped, readable GPU node still wins", asyn
 });
 
 test("without KFD topology, ROCm needs /dev/kfd plus a userland; bare /dev/kfd is not enough", async () => {
-  assert.deepEqual(await detectVariant("linux", "x64", io({ files: ["/dev/kfd", "/opt/rocm"] })), { variant: "rocm", amdGfxTargets: [] });
+  assert.deepEqual(picked(await detectVariant("linux", "x64", io({ files: ["/dev/kfd", "/opt/rocm"] }))), { variant: "rocm", amdGfxTargets: [] });
   assert.equal(await variant("linux", "x64", { files: ["/dev/kfd"], rocminfo: true }), "rocm");
   assert.equal(await variant("linux", "x64", { files: ["/dev/kfd"] }), "default");
 });
@@ -120,6 +137,8 @@ test("detectHost reports the running platform and never logs on its own", async 
   assert.equal(host.arch, process.arch);
   assert.ok(typeof host.variant === "string" && host.variant !== "");
   assert.ok(Array.isArray(host.amdGfxTargets));
+  assert.equal(typeof host.detection.detectedAt, "string");
+  for (const probe of ["nvidia", "amd", "cpu"]) assert.equal(typeof host.detection[probe].status, "string");
 });
 
 test("detectHost honors LILBEE_VARIANT and rejects an unknown value", async () => {
@@ -136,4 +155,156 @@ test("detectHost logs what it picked through the given logger", async () => {
   const lines = [];
   await detectHost({}, (m) => lines.push(m), io({ smi: "CUDA Version: 12.6" }), "linux", "x64");
   assert.deepEqual(lines, ["lilbee: detected NVIDIA driver (CUDA 12.6) — using the cu125 build (override with LILBEE_VARIANT)."]);
+});
+
+const KFD = ["/dev/kfd"];
+const NVIDIA_MODULE = "/proc/driver/nvidia/version";
+
+test("the NVIDIA probe records why it ended: skipped, missing, sandboxed, unreadable, detected", async () => {
+  assert.deepEqual((await report("darwin", "x64", { smi: "CUDA Version: 12.6" })).nvidia, { status: "skipped" });
+  assert.deepEqual((await report("linux", "x64", {})).nvidia, { status: "missing", error: "spawn nvidia-smi ENOENT" });
+  assert.deepEqual((await report("linux", "x64", { files: [NVIDIA_MODULE] })).nvidia, { status: "sandboxed" });
+  assert.deepEqual((await report("linux", "x64", { smi: "NVIDIA-SMI has failed" })).nvidia, { status: "unreadable" });
+  assert.deepEqual((await report("linux", "x64", { smi: "CUDA Version: 12.4" })).nvidia, { status: "detected", cudaCeiling: 1204 });
+  assert.deepEqual((await report("win32", "x64", { smi: "CUDA Version: 12.6" })).nvidia, { status: "detected", cudaCeiling: 1206 });
+});
+
+test("a failing nvidia-smi is missing, not sandboxed, and its first error is one line", async () => {
+  const crash = new Error("Command failed: nvidia-smi\nNVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver.\n  Make sure it is installed.\n");
+  const probe = (await report("linux", "x64", { smi: crash, files: [NVIDIA_MODULE] })).nvidia;
+  assert.deepEqual(probe, { status: "missing", error: "Command failed: nvidia-smi NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure it is installed." });
+});
+
+test("a timed-out nvidia-smi records the timeout", async () => {
+  const hung = Object.assign(new Error("spawn nvidia-smi ETIMEDOUT"), { killed: true, signal: "SIGTERM" });
+  assert.deepEqual((await report("linux", "x64", { smi: hung })).nvidia, { status: "missing", error: "nvidia-smi did not answer within 10 s" });
+  assert.equal(await variant("linux", "x64", { smi: hung, files: ["/dev/nvidia0"] }), "cu121");
+});
+
+test("Windows looks for nvidia-smi on PATH, then in System32, then in the NVSMI directory", async () => {
+  const env = { SystemRoot: "D:\\Win", ProgramFiles: "D:\\Programs" };
+  assert.deepEqual(nvidiaSmiCandidates("win32", env), ["nvidia-smi", "D:\\Win\\System32\\nvidia-smi.exe", "D:\\Programs\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe"]);
+  assert.deepEqual(nvidiaSmiCandidates("win32", {}), ["nvidia-smi", "C:\\Windows\\System32\\nvidia-smi.exe", "C:\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe"]);
+  assert.deepEqual(nvidiaSmiCandidates("linux", env), ["nvidia-smi"]);
+
+  const offPath = io({ smi: (cmd) => (cmd.startsWith("D:\\Programs") ? "CUDA Version: 12.5" : (() => { throw Object.assign(new Error(`spawn ${cmd} ENOENT`), { code: "ENOENT" }); })()) });
+  const host = await detectVariant("win32", "x64", offPath, () => {}, env);
+  assert.equal(host.variant, "cu125");
+  assert.deepEqual(host.detection.nvidia, { status: "detected", cudaCeiling: 1205 });
+  assert.deepEqual(offPath.calls.filter((c) => /nvidia-smi/.test(c)), ["nvidia-smi", "D:\\Win\\System32\\nvidia-smi.exe", "D:\\Programs\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe"]);
+
+  const none = io();
+  await detectVariant("win32", "x64", none, () => {}, env);
+  assert.equal(none.calls.filter((c) => /nvidia-smi/.test(c)).length, 3);
+  const onLinux = io();
+  await detectVariant("linux", "x64", onLinux, () => {}, env);
+  assert.deepEqual(onLinux.calls.filter((c) => /nvidia-smi/.test(c)), ["nvidia-smi"]);
+});
+
+test("the AMD probe records why it ended: skipped, missing, sandboxed, unreadable, detected", async () => {
+  assert.deepEqual((await report("win32", "x64", { files: KFD })).amd, { status: "skipped" });
+  assert.deepEqual((await report("darwin", "x64", {})).amd, { status: "skipped" });
+  assert.deepEqual((await report("linux", "x64", {})).amd, { status: "missing" });
+  assert.deepEqual((await report("linux", "x64", { files: ["/sys/module/amdgpu"] })).amd, { status: "sandboxed" });
+  assert.deepEqual((await report("linux", "x64", { files: KFD })).amd, { status: "unreadable" });
+  assert.deepEqual((await report("linux", "x64", { files: KFD, kfdNodes: { 0: 0 }, kfdUnreadable: true })).amd, { status: "unreadable" });
+  assert.deepEqual((await report("linux", "x64", { files: KFD, kfdNodes: { 0: 0 } })).amd, { status: "missing" });
+  assert.deepEqual((await report("linux", "x64", { files: KFD, kfdNodes: { 0: 0, 1: 90402, 2: 90006, 3: 90402 } })).amd, { status: "detected", gfxTargets: ["gfx906", "gfx942"] });
+});
+
+test("the AMD probe runs beside a CUDA driver, though CUDA still picks the build", async () => {
+  const host = await detectVariant("linux", "x64", io({ smi: "CUDA Version: 12.6", files: KFD, kfdNodes: { 1: 90402 } }));
+  assert.equal(host.variant, "cu125");
+  assert.deepEqual(host.amdGfxTargets, []);
+  assert.deepEqual(host.detection.amd, { status: "detected", gfxTargets: ["gfx942"] });
+});
+
+test("the CPU probe records why it ended: skipped, unreadable, detected", async () => {
+  assert.deepEqual((await report("darwin", "arm64", {})).cpu, { status: "skipped" });
+  assert.deepEqual((await report("linux", "arm64", {})).cpu, { status: "skipped" });
+  assert.deepEqual((await report("linux", "x64", {})).cpu, { status: "detected", avx2: true });
+  assert.deepEqual((await report("linux", "x64", { cpuflags: "fpu sse4_2" })).cpu, { status: "detected", avx2: false });
+  assert.deepEqual((await report("linux", "x64", { cpuinfo: "processor : 0\n" })).cpu, { status: "unreadable" });
+  assert.deepEqual((await report("darwin", "x64", {})).cpu, { status: "detected", avx2: true });
+  assert.deepEqual((await report("darwin", "x64", { sysctlAvx2: "0" })).cpu, { status: "detected", avx2: false });
+  assert.deepEqual((await report("darwin", "x64", { sysctlAvx2: null })).cpu, { status: "unreadable" });
+  assert.deepEqual((await report("darwin", "x64", { sysctlAvx2: "sysctl: unknown oid" })).cpu, { status: "unreadable" });
+});
+
+test("Windows asks kernel32 for AVX2 through PowerShell and takes the compat build without it", async () => {
+  assert.deepEqual((await report("win32", "x64", { powershell: "True\r\n" })).cpu, { status: "detected", avx2: true });
+  assert.deepEqual((await report("win32", "x64", { powershell: "False\r\n" })).cpu, { status: "detected", avx2: false });
+  assert.deepEqual((await report("win32", "x64", { powershell: null })).cpu, { status: "unreadable" });
+  assert.deepEqual((await report("win32", "x64", { powershell: new Error("Add-Type : Cannot add type.") })).cpu, { status: "unreadable" });
+  assert.deepEqual((await report("linux", "x64", {})).cpu, { status: "detected", avx2: true });
+
+  assert.equal(await variant("win32", "x64", { powershell: "False" }), "compat");
+  assert.equal(await variant("win32", "x64", { powershell: "False", smi: "CUDA Version: 12.6" }), "compat");
+  assert.equal(await variant("win32", "x64", { powershell: "False", smi: "CUDA Version: 12.2" }), "compat");
+  assert.equal(await variant("win32", "x64", { powershell: "True", smi: "CUDA Version: 12.6" }), "cu125");
+  assert.equal(await variant("win32", "x64", { powershell: null, smi: "CUDA Version: 12.6" }), "cu125");
+  assert.equal(assetNameFor("win32", "x64", "compat"), "lilbee-compat-windows-x86_64.exe");
+  assert.deepEqual(parseAssetName("lilbee-compat-windows-x86_64.exe"), { platform: "win32", arch: "x64", variant: "compat" });
+  assert.throws(() => assetNameFor("win32", "x64", "compat-cu124"), /Windows compat build has no GPU variants/);
+});
+
+test("the Windows AVX2 probe is a PowerShell one-liner calling IsProcessorFeaturePresent(40)", async () => {
+  const host = io({ powershell: "True" });
+  await detectVariant("win32", "x64", host);
+  assert.deepEqual(host.calls, ["nvidia-smi", "C:\\Windows\\System32\\nvidia-smi.exe", "C:\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe", "powershell"]);
+  const probe = io({ powershell: "True" });
+  probe.execFile = async (cmd, args) => {
+    if (cmd !== "powershell") throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    assert.deepEqual(args.slice(0, 3), ["-NoProfile", "-NonInteractive", "-EncodedCommand"]);
+    const script = Buffer.from(args[3], "base64").toString("utf16le");
+    assert.match(script, /Add-Type .*kernel32\.dll.*IsProcessorFeaturePresent/);
+    assert.match(script, /IsProcessorFeaturePresent\(40\)$/);
+    return "True";
+  };
+  assert.deepEqual((await detectVariant("win32", "x64", probe)).detection.cpu, { status: "detected", avx2: true });
+  assert.equal(io().calls.length, 0);
+});
+
+test("the report is stamped with an ISO 8601 time", async () => {
+  const before = Date.now();
+  const { detectedAt } = await report("linux", "x64", {});
+  assert.match(detectedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  assert.ok(Date.parse(detectedAt) >= before);
+});
+
+test("detectHost carries the report, and a forced LILBEE_VARIANT probes nothing", async () => {
+  const probes = io({ smi: "CUDA Version: 12.6", cpuflags: "fpu sse4_2" });
+  const host = await detectHost({}, () => {}, probes, "linux", "x64");
+  assert.equal(host.variant, "compat-cu124");
+  assert.deepEqual(host.detection.nvidia, { status: "detected", cudaCeiling: 1206 });
+  assert.deepEqual(host.detection.cpu, { status: "detected", avx2: false });
+
+  const forced = io({ smi: "CUDA Version: 12.6" });
+  const pinned = await detectHost({ LILBEE_VARIANT: "rocm" }, () => {}, forced, "linux", "x64");
+  assert.deepEqual(forced.calls, []);
+  assert.equal(pinned.variant, "rocm");
+  assert.deepEqual({ ...pinned.detection, detectedAt: "" }, { nvidia: { status: "skipped" }, amd: { status: "skipped" }, cpu: { status: "skipped" }, detectedAt: "" });
+});
+
+test("the log lines the CLI prints are unchanged by the report", async () => {
+  const lines = async (platform, probes) => {
+    const out = [];
+    await detectVariant(platform, "x64", io(probes), (m) => out.push(m));
+    return out;
+  };
+  assert.deepEqual(await lines("linux", { smi: "CUDA Version: 12.6", cpuflags: "fpu sse4_2" }), [
+    "lilbee: detected NVIDIA driver (CUDA 12.6) — using the cu125 build (override with LILBEE_VARIANT).",
+    "lilbee: this CPU has no AVX2 — using the -compat build family (override with LILBEE_VARIANT).",
+  ]);
+  assert.deepEqual(await lines("linux", { smi: "no version here" }), ["lilbee: detected NVIDIA driver (CUDA unknown) — using the cu121 build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("linux", { files: [NVIDIA_MODULE] }), ["lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("linux", { files: KFD, kfdNodes: { 1: 90402 } }), ["lilbee: detected an AMD GPU (gfx942) — using the rocm build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("linux", { files: [...KFD, "/opt/rocm"] }), ["lilbee: detected a ROCm userland — using the rocm build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("linux", {}), []);
+  assert.deepEqual(await lines("darwin", { sysctlAvx2: "0" }), ["lilbee: this CPU has no AVX2 — using the -compat build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("win32", { smi: "CUDA Version: 12.2" }), [
+    "lilbee: detected NVIDIA driver (CUDA 12.2) — using the cu121 build (override with LILBEE_VARIANT).",
+    "lilbee: this NVIDIA driver predates CUDA 12.4 — using the universal Windows build (override with LILBEE_VARIANT).",
+  ]);
+  assert.deepEqual(await lines("win32", { powershell: "False" }), ["lilbee: this CPU has no AVX2 — using the -compat build (override with LILBEE_VARIANT)."]);
 });

--- a/packages/lilbee/test/detect.test.mjs
+++ b/packages/lilbee/test/detect.test.mjs
@@ -135,6 +135,5 @@ test("detectHost honors LILBEE_VARIANT and rejects an unknown value", async () =
 test("detectHost logs what it picked through the given logger", async () => {
   const lines = [];
   await detectHost({}, (m) => lines.push(m), io({ smi: "CUDA Version: 12.6" }), "linux", "x64");
-  assert.match(lines.join("\n"), /cu125 build/);
-  assert.doesNotMatch(lines.join("\n"), /\u2014/);
+  assert.deepEqual(lines, ["lilbee: detected NVIDIA driver (CUDA 12.6) — using the cu125 build (override with LILBEE_VARIANT)."]);
 });

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -274,16 +274,22 @@ test("a landed download leaves a live rival's in-progress temp file alone", asyn
 test("a download whose temp file vanished adopts the binary a rival landed", async () => {
   const dir = tmpDir();
   const dest = path.join(dir, "v9", "bin");
-  const logs = [];
-  const body = () => { const r = webBody(chunks(PAYLOAD)); fs.mkdirSync(path.dirname(dest), { recursive: true }); return r; };
-  const { fetch } = fetchWith([body]);
-  // The rival lands dest and removes our temp file while our stream is still open.
   const tmp = `${dest}.download.${process.pid}`;
-  const timer = setInterval(() => { if (fs.existsSync(tmp)) { fs.writeFileSync(dest, PAYLOAD); fs.rmSync(tmp, { force: true }); clearInterval(timer); } }, 1);
-  await download({ release: release(), dest, fetch, log: (m) => logs.push(m) });
-  clearInterval(timer);
-  assert.ok(fs.existsSync(dest));
+  const logs = [];
+  // The rival lands dest and removes our temp file from inside our own stream, just before it ends.
+  const parts = chunks(PAYLOAD);
+  const body = new Readable({
+    read() {
+      if (parts.length) return this.push(parts.shift());
+      fs.writeFileSync(dest, PAYLOAD);
+      fs.rmSync(tmp, { force: true });
+      this.push(null);
+    },
+  });
+  await download({ release: release(), dest, fetch: fetchWith([body]).fetch, log: (m) => logs.push(m) });
+  assert.ok(Buffer.from(fs.readFileSync(dest)).equals(PAYLOAD));
   assert.ok(logs.some((l) => /another process finished/.test(l)));
+  assert.ok(!fs.existsSync(tmp));
   fs.rmSync(dir, { recursive: true, force: true });
 });
 

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { Readable } from "node:stream";
 import { DownloadCanceledError, download, isDownloadCanceled, progressLine, progressReporter } from "../lib/download.mjs";
+import { LauncherError } from "../lib/errors.mjs";
 
 const MB = 1048576;
 const PAYLOAD = Buffer.from("lilbee binary bytes ".repeat(64));
@@ -104,7 +105,10 @@ test("a digest mismatch is retried once, then rejected with nothing left on disk
   const dest = path.join(dir, "v9", "bin");
   const logs = [];
   const { fetch, calls } = fetchWith([() => webBody(chunks(PAYLOAD))]);
-  await assert.rejects(download({ release: release({ digest: "0".repeat(64) }), dest, fetch, log: (m) => logs.push(m) }), /sha256 mismatch/);
+  await assert.rejects(
+    download({ release: release({ digest: "0".repeat(64) }), dest, fetch, log: (m) => logs.push(m) }),
+    (err) => err instanceof LauncherError && err.code === "digest-mismatch" && /sha256 mismatch/.test(err.message)
+  );
   assert.equal(calls.length, 2);
   assert.deepEqual(fs.readdirSync(path.join(dir, "v9")), []);
   assert.ok(logs.some((l) => /retrying once/.test(l)));
@@ -118,6 +122,29 @@ test("a release without a digest lands unverified and says so", async () => {
   await download({ release: release({ digest: null }), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch, log: (m) => logs.push(m) });
   assert.ok(fs.existsSync(dest));
   assert.ok(logs.some((l) => /no published digest/.test(l)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("requireDigest refuses a release without a digest before any request", async () => {
+  const dir = tmpDir();
+  const { fetch, calls } = fetchWith([webBody(chunks(PAYLOAD))]);
+  await assert.rejects(
+    download({ release: release({ digest: null }), dest: path.join(dir, "v9", "bin"), fetch, requireDigest: true }),
+    (err) => err instanceof LauncherError && err.code === "no-digest"
+  );
+  assert.equal(calls.length, 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("the download banner and the non-TTY progress lines read as they did in 0.6.96", async () => {
+  const dir = tmpDir();
+  const logs = [];
+  await download({ release: release(), dest: path.join(dir, "v9", "bin"), fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch, log: (m) => logs.push(m) });
+  assert.equal(logs[0], "lilbee: downloading lilbee-macos-arm64 (0MB) from tobocop2/lilbee@v9. One-time per release; cached after that.");
+  assert.equal(progressLine({ done: 3 * MB, total: 0, bytesPerSec: 0 }), "lilbee: downloading… 3MB");
+  const lines = [];
+  progressReporter((m) => lines.push(m), { isTTY: false })({ done: 5 * MB, total: 10 * MB });
+  assert.deepEqual(lines, ["lilbee: downloading… 50% (5MB)"]);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -332,4 +359,16 @@ test("off a TTY the reporter logs a line per 10% and starts over when a retry re
   assert.match(lines.at(-1), /10% \(1MB\)/);
   report.finish();
   assert.equal(lines.length, 11);
+});
+
+test("stall, HTTP, and disk-space failures carry their LauncherError codes", async () => {
+  const dir = tmpDir();
+  const stalled = download({ release: release(), dest: path.join(dir, "v9", "a"), fetch: fetchWith([() => hangingBody([])]).fetch, idleTimeoutMs: 5 });
+  await assert.rejects(stalled, (err) => err instanceof LauncherError && err.code === "stalled");
+  const http = download({ release: release(), dest: path.join(dir, "v9", "b"), fetch: fetchWith([null], { status: 502 }).fetch });
+  await assert.rejects(http, (err) => err instanceof LauncherError && err.code === "http" && err.status === 502);
+  const space = new LauncherError("no-space", "full", { neededBytes: 10, freeBytes: 1 });
+  assert.equal(space.name, "LauncherError");
+  assert.deepEqual([space.code, space.neededBytes, space.freeBytes], ["no-space", 10, 1]);
+  fs.rmSync(dir, { recursive: true, force: true });
 });

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -276,17 +276,20 @@ test("a download whose temp file vanished adopts the binary a rival landed", asy
   const dest = path.join(dir, "v9", "bin");
   const tmp = `${dest}.download.${process.pid}`;
   const logs = [];
-  // The rival lands dest and removes our temp file from inside our own stream, just before it ends.
-  const parts = chunks(PAYLOAD);
-  const body = new Readable({
-    read() {
-      if (parts.length) return this.push(parts.shift());
-      fs.writeFileSync(dest, PAYLOAD);
-      fs.rmSync(tmp, { force: true });
-      this.push(null);
-    },
-  });
-  await download({ release: release(), dest, fetch: fetchWith([body]).fetch, log: (m) => logs.push(m) });
+  // The rival lands dest and removes our temp file at the moment we go to chmod it.
+  const realChmod = fs.chmodSync;
+  fs.chmodSync = (target, mode) => {
+    if (target !== tmp) return realChmod(target, mode);
+    fs.chmodSync = realChmod;
+    fs.writeFileSync(dest, PAYLOAD);
+    fs.rmSync(tmp, { force: true });
+    return realChmod(target, mode);
+  };
+  try {
+    await download({ release: release(), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch, log: (m) => logs.push(m) });
+  } finally {
+    fs.chmodSync = realChmod;
+  }
   assert.ok(Buffer.from(fs.readFileSync(dest)).equals(PAYLOAD));
   assert.ok(logs.some((l) => /another process finished/.test(l)));
   assert.ok(!fs.existsSync(tmp));

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -259,6 +259,34 @@ test("a rival process that lands the file first is adopted instead of retried", 
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
+test("a landed download leaves a live rival's in-progress temp file alone", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "lilbee-macos-arm64");
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  const rival = `${dest}.download.${process.ppid}`;
+  fs.writeFileSync(rival, "partial");
+  fs.writeFileSync(path.join(dir, "v9", "lilbee-macos-x86_64"), "old build");
+  await download({ release: release(), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch });
+  assert.deepEqual(fs.readdirSync(path.join(dir, "v9")).sort(), ["lilbee-macos-arm64", `lilbee-macos-arm64.download.${process.ppid}`]);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a download whose temp file vanished adopts the binary a rival landed", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  const logs = [];
+  const body = () => { const r = webBody(chunks(PAYLOAD)); fs.mkdirSync(path.dirname(dest), { recursive: true }); return r; };
+  const { fetch } = fetchWith([body]);
+  // The rival lands dest and removes our temp file while our stream is still open.
+  const tmp = `${dest}.download.${process.pid}`;
+  const timer = setInterval(() => { if (fs.existsSync(tmp)) { fs.writeFileSync(dest, PAYLOAD); fs.rmSync(tmp, { force: true }); clearInterval(timer); } }, 1);
+  await download({ release: release(), dest, fetch, log: (m) => logs.push(m) });
+  clearInterval(timer);
+  assert.ok(fs.existsSync(dest));
+  assert.ok(logs.some((l) => /another process finished/.test(l)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
 test("a landed download removes the other builds of the same release", async () => {
   const dir = tmpDir();
   const releaseDir = path.join(dir, "v9");

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -72,11 +72,22 @@ test("download streams to the destination, verifies sha256, and reports done/tot
   assert.equal(fs.statSync(dest).mode & 0o111, 0o111);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].url, "https://dl/lilbee-macos-arm64");
-  assert.equal(progress.length, 4);
+  assert.equal(progress.length, 5);
+  assert.deepEqual(progress[0], { done: 0, total: PAYLOAD.length });
   assert.deepEqual(progress.at(-1), { done: PAYLOAD.length, total: PAYLOAD.length });
   assert.ok(progress.every((p) => p.total === PAYLOAD.length));
   assert.ok(logs.some((l) => /downloading lilbee-macos-arm64/.test(l)));
   assert.ok(fs.readdirSync(path.join(dir, "v9")).every((f) => !f.includes(".download.")));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("progress starts with a zero-byte event when the transfer opens", async () => {
+  const dir = tmpDir();
+  const events = [];
+  await download({ release: release(), dest: path.join(dir, "v9", "bin"), fetch: fetchWith([webBody(chunks(PAYLOAD, 2))]).fetch, onProgress: (p) => events.push(p) });
+  assert.deepEqual(events[0], { done: 0, total: PAYLOAD.length });
+  assert.equal(events.length, 3);
+  assert.equal(events.at(-1).done, PAYLOAD.length);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -1,40 +1,255 @@
-import { test, afterEach } from "node:test";
+import { test } from "node:test";
 import assert from "node:assert/strict";
-import { releaseAsset } from "../lib/download.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { DownloadCanceledError, download, isDownloadCanceled, progressLine, progressReporter } from "../lib/download.mjs";
 
-const realFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = realFetch; });
+const MB = 1048576;
+const PAYLOAD = Buffer.from("lilbee binary bytes ".repeat(64));
+const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
 
-function stubFetch(payload, ok = true, status = 200) {
-  globalThis.fetch = async () => ({ ok, status, json: async () => payload });
+const tmpDir = () => fs.mkdtempSync(path.join(os.tmpdir(), "lilbee-dl-"));
+
+function release(overrides = {}) {
+  return {
+    tag: "v9",
+    dev: false,
+    assetName: "lilbee-macos-arm64",
+    variant: "default",
+    size: PAYLOAD.length,
+    digest: sha256(PAYLOAD),
+    url: "https://dl/lilbee-macos-arm64",
+    ...overrides,
+  };
 }
 
-test("releaseAsset finds the asset and parses the sha256 digest", async () => {
-  stubFetch({ assets: [{ name: "lilbee-macos-arm64", size: 7, digest: "sha256:abc123", browser_download_url: "https://x/y" }] });
-  const a = await releaseAsset("o/r", "v1", "lilbee-macos-arm64");
-  assert.deepEqual(a, { url: "https://x/y", size: 7, digest: "abc123" });
+/** Split a buffer into `n` chunks for a streamed body. */
+function chunks(buf, n = 4) {
+  const size = Math.ceil(buf.length / n);
+  return Array.from({ length: n }, (_, i) => buf.subarray(i * size, (i + 1) * size));
+}
+
+/** A fetch stub: `bodies` are consumed one per call; each is a web stream, a Node Readable, or a function. */
+function fetchWith(bodies, { status = 200, contentLength = undefined } = {}) {
+  const calls = [];
+  const fetch = async (url, init = {}) => {
+    calls.push({ url, init });
+    const next = bodies[Math.min(calls.length - 1, bodies.length - 1)];
+    const body = typeof next === "function" ? next(init) : next;
+    return {
+      ok: status < 400,
+      status,
+      headers: { get: (name) => (name === "content-length" && contentLength !== undefined ? String(contentLength) : null) },
+      body,
+      json: async () => ({}),
+      text: async () => "",
+    };
+  };
+  return { fetch, calls };
+}
+
+const webBody = (parts) => Readable.toWeb(Readable.from(parts));
+
+/** A body that delivers `parts` and then never ends, like a dead socket. */
+function hangingBody(parts) {
+  const body = new Readable({ read() {} });
+  for (const part of parts) body.push(part);
+  return body;
+}
+
+test("download streams to the destination, verifies sha256, and reports done/total per chunk", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "lilbee-macos-arm64");
+  const progress = [];
+  const logs = [];
+  const { fetch, calls } = fetchWith([webBody(chunks(PAYLOAD))], { contentLength: PAYLOAD.length });
+  await download({ release: release(), dest, fetch, onProgress: (p) => progress.push(p), log: (m) => logs.push(m) });
+  assert.ok(Buffer.from(fs.readFileSync(dest)).equals(PAYLOAD));
+  assert.equal(fs.statSync(dest).mode & 0o111, 0o111);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://dl/lilbee-macos-arm64");
+  assert.equal(progress.length, 4);
+  assert.deepEqual(progress.at(-1), { done: PAYLOAD.length, total: PAYLOAD.length });
+  assert.ok(progress.every((p) => p.total === PAYLOAD.length));
+  assert.ok(logs.some((l) => /downloading lilbee-macos-arm64/.test(l)));
+  assert.ok(fs.readdirSync(path.join(dir, "v9")).every((f) => !f.includes(".download.")));
+  fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test("releaseAsset without a digest returns null digest", async () => {
-  stubFetch({ assets: [{ name: "a", size: 1, browser_download_url: "u" }] });
-  assert.equal((await releaseAsset("o/r", "v1", "a")).digest, null);
+test("total falls back to the release size without Content-Length, and to null without either", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  let seen = [];
+  await download({ release: release(), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch, onProgress: (p) => seen.push(p) });
+  assert.equal(seen[0].total, PAYLOAD.length);
+  seen = [];
+  await download({ release: release({ size: 0 }), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch, onProgress: (p) => seen.push(p) });
+  assert.equal(seen[0].total, null);
+  fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test("releaseAsset names the available assets when the requested one is missing", async () => {
-  stubFetch({ assets: [{ name: "other", size: 1, browser_download_url: "u" }] });
-  await assert.rejects(releaseAsset("o/r", "v1", "nope"), /no asset "nope".*other/);
+test("a Node Readable body works as well as a web stream", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  await download({ release: release(), dest, fetch: fetchWith([Readable.from(chunks(PAYLOAD))]).fetch });
+  assert.ok(Buffer.from(fs.readFileSync(dest)).equals(PAYLOAD));
+  fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test("releaseAsset surfaces HTTP failures with the status", async () => {
-  stubFetch({}, false, 404);
-  await assert.rejects(releaseAsset("o/r", "vX", "a"), /HTTP 404/);
+test("a digest mismatch is retried once, then rejected with nothing left on disk", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  const logs = [];
+  const { fetch, calls } = fetchWith([() => webBody(chunks(PAYLOAD))]);
+  await assert.rejects(download({ release: release({ digest: "0".repeat(64) }), dest, fetch, log: (m) => logs.push(m) }), /sha256 mismatch/);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(fs.readdirSync(path.join(dir, "v9")), []);
+  assert.ok(logs.some((l) => /retrying once/.test(l)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a release without a digest lands unverified and says so", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  const logs = [];
+  await download({ release: release({ digest: null }), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch, log: (m) => logs.push(m) });
+  assert.ok(fs.existsSync(dest));
+  assert.ok(logs.some((l) => /no published digest/.test(l)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("aborting mid-stream rejects with DownloadCanceledError, removes the temp file, and never retries", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  const controller = new AbortController();
+  const { fetch, calls } = fetchWith([() => hangingBody([chunks(PAYLOAD)[0]])]);
+  setTimeout(() => controller.abort(), 20);
+  const err = await download({ release: release(), dest, fetch, signal: controller.signal }).then(
+    () => assert.fail("must reject"),
+    (e) => e
+  );
+  assert.ok(err instanceof DownloadCanceledError);
+  assert.equal(err.name, "AbortError");
+  assert.ok(isDownloadCanceled(err));
+  assert.equal(calls.length, 1);
+  assert.deepEqual(fs.readdirSync(path.join(dir, "v9")), []);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("an already-aborted signal rejects before any request is made", async () => {
+  const dir = tmpDir();
+  const controller = new AbortController();
+  controller.abort();
+  const { fetch, calls } = fetchWith([webBody(chunks(PAYLOAD))]);
+  await assert.rejects(download({ release: release(), dest: path.join(dir, "v9", "bin"), fetch, signal: controller.signal }), (e) => isDownloadCanceled(e));
+  assert.equal(calls.length, 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("the abort signal reaches the transport so a web fetch can drop its socket", async () => {
+  const dir = tmpDir();
+  const controller = new AbortController();
+  const { fetch, calls } = fetchWith([webBody(chunks(PAYLOAD))]);
+  await download({ release: release(), dest: path.join(dir, "v9", "bin"), fetch, signal: controller.signal });
+  assert.ok(calls[0].init.signal instanceof AbortSignal);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a stalled transfer is retried once, then rejected with a stall message", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  const logs = [];
+  const { fetch, calls } = fetchWith([() => hangingBody([chunks(PAYLOAD)[0]])]);
+  await assert.rejects(download({ release: release(), dest, fetch, log: (m) => logs.push(m), idleTimeoutMs: 30 }), /download stalled/);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(fs.readdirSync(path.join(dir, "v9")), []);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a stall while waiting for headers is covered by the same clock", async () => {
+  const dir = tmpDir();
+  const calls = [];
+  const fetch = (url, init) =>
+    new Promise((_, reject) => {
+      calls.push(url);
+      init.signal.addEventListener("abort", () => reject(init.signal.reason ?? new Error("aborted")));
+    });
+  await assert.rejects(download({ release: release(), dest: path.join(dir, "v9", "bin"), fetch, idleTimeoutMs: 30 }), /download stalled/);
+  assert.equal(calls.length, 2);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a transfer error is retried once and the second attempt lands", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  async function* broken() {
+    yield chunks(PAYLOAD)[0];
+    throw new Error("ECONNRESET");
+  }
+  const { fetch, calls } = fetchWith([Readable.from(broken()), webBody(chunks(PAYLOAD))]);
+  await download({ release: release(), dest, fetch });
+  assert.equal(calls.length, 2);
+  assert.ok(Buffer.from(fs.readFileSync(dest)).equals(PAYLOAD));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("an HTTP error on the asset counts as a failed attempt", async () => {
+  const dir = tmpDir();
+  const { fetch, calls } = fetchWith([null], { status: 502 });
+  await assert.rejects(download({ release: release(), dest: path.join(dir, "v9", "bin"), fetch }), /HTTP 502/);
+  assert.equal(calls.length, 2);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a rival process that lands the file first is adopted instead of retried", async () => {
+  const dir = tmpDir();
+  const dest = path.join(dir, "v9", "bin");
+  const logs = [];
+  async function* losing() {
+    yield chunks(PAYLOAD)[0];
+    fs.writeFileSync(dest, "rival");
+    throw new Error("ECONNRESET");
+  }
+  const { fetch, calls } = fetchWith([Readable.from(losing())]);
+  await download({ release: release(), dest, fetch, log: (m) => logs.push(m) });
+  assert.equal(calls.length, 1);
+  assert.equal(fs.readFileSync(dest, "utf8"), "rival");
+  assert.ok(logs.some((l) => /another process finished/.test(l)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a landed download removes the other builds of the same release", async () => {
+  const dir = tmpDir();
+  const releaseDir = path.join(dir, "v9");
+  fs.mkdirSync(releaseDir, { recursive: true });
+  fs.writeFileSync(path.join(releaseDir, "lilbee-linux-x86_64"), "old default build");
+  fs.writeFileSync(path.join(releaseDir, "lilbee-linux-x86_64.download.999"), "stale temp");
+  const dest = path.join(releaseDir, "lilbee-linux-x86_64-cu125");
+  await download({ release: release({ assetName: "lilbee-linux-x86_64-cu125" }), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch });
+  assert.deepEqual(fs.readdirSync(releaseDir), ["lilbee-linux-x86_64-cu125"]);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a download that cannot fit on the disk is refused before any request", { skip: typeof fs.promises.statfs !== "function" }, async () => {
+  const dir = tmpDir();
+  const { fetch, calls } = fetchWith([webBody(chunks(PAYLOAD))]);
+  const huge = release({ size: 2 ** 52 });
+  await assert.rejects(download({ release: huge, dest: path.join(dir, "v9", "bin"), fetch }), /Not enough disk space.*needs about .*free.*is available/);
+  assert.equal(calls.length, 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("isDownloadCanceled accepts any AbortError and nothing else", () => {
+  assert.equal(isDownloadCanceled(new DownloadCanceledError()), true);
+  assert.equal(isDownloadCanceled(Object.assign(new Error("x"), { name: "AbortError" })), true);
+  assert.equal(isDownloadCanceled(new Error("boom")), false);
+  assert.equal(isDownloadCanceled(null), false);
 });
 
 // --- progress line rendering (TTY bar) ---
-
-import { progressLine } from "../lib/download.mjs";
-
-const MB = 1048576;
 
 test("progressLine draws an empty, half, and full bar at a fixed width", () => {
   const at = (done) => progressLine({ done, total: 100 * MB, bytesPerSec: 0, barWidth: 10, color: false });
@@ -52,7 +267,7 @@ test("progressLine shows sizes, rate, and eta", () => {
   const line = progressLine({ done: 523 * MB, total: 1246 * MB, bytesPerSec: 87 * MB, barWidth: 10, color: false });
   assert.match(line, /523\/1246MB/);
   assert.match(line, /87\.0MB\/s/);
-  assert.match(line, /eta 0:0[89]/); // (1246-523)/87 ≈ 8.3s
+  assert.match(line, /eta 0:0[89]/); // (1246-523)/87 is about 8.3s
 });
 
 test("progressLine clamps overshoot and hides rate/eta when unknown", () => {
@@ -75,35 +290,46 @@ test("progressLine colors the bar only when asked", () => {
   assert.doesNotMatch(plain, /\x1b\[/);
 });
 
-// --- progress as a stream stage ---
+// --- progress as an onProgress consumer ---
 
-import { progressReporter } from "../lib/download.mjs";
-import { pipeline } from "node:stream/promises";
-import { Readable } from "node:stream";
-
-async function pump(reporter, chunks) {
-  const sink = [];
-  await pipeline(Readable.from(chunks), reporter, async function* (src) {
-    for await (const c of src) sink.push(c);
-  });
-  return sink;
-}
-
-test("on a TTY the reporter redraws one line in place and ends it with a newline", async () => {
+test("on a TTY the reporter redraws one line in place and ends it with a newline once the total lands", () => {
   const writes = [];
   const stream = { isTTY: true, write: (s) => writes.push(s) };
-  await pump(progressReporter(4 * MB, () => {}, stream), [Buffer.alloc(2 * MB), Buffer.alloc(2 * MB)]);
+  const report = progressReporter(() => {}, stream);
+  report({ done: 2 * MB, total: 4 * MB });
+  report({ done: 4 * MB, total: 4 * MB });
   assert.ok(writes.length >= 2);
   assert.ok(writes.slice(0, -1).every((w) => w.startsWith("\r")));
   assert.match(writes.at(-2), /100% 4\/4MB/);
   assert.equal(writes.at(-1), "\n");
+  report.finish();
+  assert.equal(writes.at(-1), "\n");
+  assert.equal(writes.filter((w) => w === "\n").length, 1);
 });
 
-test("off a TTY the reporter logs a line per 10%", async () => {
+test("on a TTY finish() closes a bar that stopped short, and does nothing when nothing was drawn", () => {
+  const writes = [];
+  const stream = { isTTY: true, write: (s) => writes.push(s) };
+  const report = progressReporter(() => {}, stream);
+  report({ done: MB, total: 4 * MB });
+  report.finish();
+  assert.equal(writes.at(-1), "\n");
+  const untouched = [];
+  progressReporter(() => {}, { isTTY: true, write: (s) => untouched.push(s) }).finish();
+  assert.deepEqual(untouched, []);
+});
+
+test("off a TTY the reporter logs a line per 10% and starts over when a retry restarts the count", () => {
   const lines = [];
   const stream = { isTTY: false, write: () => assert.fail("must not draw") };
-  await pump(progressReporter(10 * MB, (m) => lines.push(m), stream), Array.from({ length: 10 }, () => Buffer.alloc(MB)));
+  const report = progressReporter((m) => lines.push(m), stream);
+  for (let i = 1; i <= 10; i += 1) report({ done: i * MB, total: 10 * MB });
   assert.equal(lines.length, 10);
   assert.match(lines[0], /10% \(1MB\)/);
   assert.match(lines.at(-1), /100% \(10MB\)/);
+  report({ done: MB, total: 10 * MB });
+  assert.equal(lines.length, 11);
+  assert.match(lines.at(-1), /10% \(1MB\)/);
+  report.finish();
+  assert.equal(lines.length, 11);
 });

--- a/packages/lilbee/test/download.test.mjs
+++ b/packages/lilbee/test/download.test.mjs
@@ -292,7 +292,8 @@ test("a landed download removes the other builds of the same release", async () 
   const releaseDir = path.join(dir, "v9");
   fs.mkdirSync(releaseDir, { recursive: true });
   fs.writeFileSync(path.join(releaseDir, "lilbee-linux-x86_64"), "old default build");
-  fs.writeFileSync(path.join(releaseDir, "lilbee-linux-x86_64.download.999"), "stale temp");
+  // 4194305 is above Linux's pid_max, so no runner can have a process with this pid
+  fs.writeFileSync(path.join(releaseDir, "lilbee-linux-x86_64.download.4194305"), "stale temp");
   const dest = path.join(releaseDir, "lilbee-linux-x86_64-cu125");
   await download({ release: release({ assetName: "lilbee-linux-x86_64-cu125" }), dest, fetch: fetchWith([webBody(chunks(PAYLOAD))]).fetch });
   assert.deepEqual(fs.readdirSync(releaseDir), ["lilbee-linux-x86_64-cu125"]);

--- a/packages/lilbee/test/plan.test.mjs
+++ b/packages/lilbee/test/plan.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  channelIncludesDev,
   exitCodeForSignal,
   routeArgv,
   parseMcpArgs,
@@ -77,6 +78,12 @@ test("exitCodeForSignal maps known signals and defaults to 128", () => {
   assert.equal(exitCodeForSignal("SIGINT"), 130);
   assert.equal(exitCodeForSignal("SIGTERM"), 143);
   assert.equal(exitCodeForSignal("SIGWEIRD"), 128);
+});
+
+test("channelIncludesDev: only LILBEE_CHANNEL=dev opens the dev channel", () => {
+  assert.equal(channelIncludesDev({}), false);
+  assert.equal(channelIncludesDev({ LILBEE_CHANNEL: "stable" }), false);
+  assert.equal(channelIncludesDev({ LILBEE_CHANNEL: "dev" }), true);
 });
 
 test("routeArgv: prepare takes an optional release tag", () => {

--- a/packages/lilbee/test/plan.test.mjs
+++ b/packages/lilbee/test/plan.test.mjs
@@ -12,7 +12,7 @@ import {
 } from "../lib/plan.mjs";
 
 test("routeArgv: prepare, mcp, and passthrough", () => {
-  assert.deepEqual(routeArgv(["prepare"]), { kind: "prepare" });
+  assert.deepEqual(routeArgv(["prepare"]), { kind: "prepare", tag: null });
   assert.deepEqual(routeArgv(["unprepare"]), { kind: "unprepare" });
   assert.equal(routeArgv(["mcp"]).kind, "mcp");
   assert.equal(routeArgv(["mcp", "--data-dir", "/x"]).args.dataDir, "/x");
@@ -77,4 +77,9 @@ test("exitCodeForSignal maps known signals and defaults to 128", () => {
   assert.equal(exitCodeForSignal("SIGINT"), 130);
   assert.equal(exitCodeForSignal("SIGTERM"), 143);
   assert.equal(exitCodeForSignal("SIGWEIRD"), 128);
+});
+
+test("routeArgv: prepare takes an optional release tag", () => {
+  assert.deepEqual(routeArgv(["prepare", "v0.6.90b432"]), { kind: "prepare", tag: "v0.6.90b432" });
+  assert.deepEqual(routeArgv(["prepare"]), { kind: "prepare", tag: null });
 });

--- a/packages/lilbee/test/releases.test.mjs
+++ b/packages/lilbee/test/releases.test.mjs
@@ -2,9 +2,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { isDevBuild, latestRelease, listReleases, releaseByTag } from "../lib/releases.mjs";
 
-const LINUX = { platform: "linux", arch: "x64", variant: "default", amdGfxTargets: [] };
-const CUDA = { ...LINUX, variant: "cu125" };
-const ROCM = { ...LINUX, variant: "rocm", amdGfxTargets: ["gfx942", "gfx1100"] };
+const DETECTED_AT = "2026-09-04T12:00:00.000Z";
+const DETECTION = { nvidia: { status: "missing", error: "spawn nvidia-smi ENOENT" }, amd: { status: "missing" }, cpu: { status: "detected", avx2: true }, detectedAt: DETECTED_AT };
+const LINUX = { platform: "linux", arch: "x64", variant: "default", amdGfxTargets: [], detection: DETECTION };
+const CUDA = { ...LINUX, variant: "cu125", detection: { ...DETECTION, nvidia: { status: "detected", cudaCeiling: 1206 } } };
+const AMD_DETECTED = { status: "detected", gfxTargets: ["gfx942", "gfx1100"] };
+const ROCM = { ...LINUX, variant: "rocm", amdGfxTargets: AMD_DETECTED.gfxTargets, detection: { ...DETECTION, amd: AMD_DETECTED } };
 
 const asset = (name, extra = {}) => ({
   name,
@@ -96,6 +99,7 @@ test("a CUDA host takes the matching CUDA build and falls back to the default bu
     dev: false,
     assetName: "lilbee-linux-x86_64-cu125",
     variant: "cu125",
+    detection: CUDA.detection,
     size: 100,
     digest: "lilbee-linux-x86_64-cu125",
     url: "https://dl/lilbee-linux-x86_64-cu125",
@@ -198,4 +202,54 @@ test("release query failures carry LauncherError codes: rate-limited, http, no-r
   const empty = github({ pages: [[]] });
   await assert.rejects(latestRelease({ host: LINUX, fetch: empty.fetch }), (err) => err instanceof LauncherError && err.code === "no-release");
   await assert.rejects(releaseByTag("v404", { host: LINUX, fetch: empty.fetch }), (err) => err instanceof LauncherError && err.code === "no-release" && err.status === 404);
+});
+
+test("a release refines the AMD probe: unsupported names why its ROCm build was refused", async () => {
+  const manifest = "lilbee-linux-x86_64-rocm.gfx.txt";
+  const withManifest = [...LINUX_ASSETS, manifest];
+  const resolve = (assets, manifests = {}) => listReleases({ host: ROCM, fetch: github({ pages: [[release("v3", assets)]], manifests }).fetch });
+  const unsupported = (reason) => ({ status: "unsupported", gfxTargets: ["gfx942", "gfx1100"], reason });
+
+  const [taken] = await resolve(withManifest, { [manifest]: "gfx942\ngfx1100\n" });
+  assert.equal(taken.variant, "rocm");
+  assert.deepEqual(taken.detection, ROCM.detection);
+
+  const [noAsset] = await resolve(["lilbee-linux-x86_64"]);
+  assert.equal(noAsset.variant, "default");
+  assert.deepEqual(noAsset.detection, { ...ROCM.detection, amd: unsupported("no-asset") });
+
+  const [noManifest] = await resolve(LINUX_ASSETS);
+  assert.deepEqual(noManifest.detection.amd, unsupported("no-manifest"));
+  const [emptyManifest] = await resolve(withManifest, { [manifest]: "\n" });
+  assert.deepEqual(emptyManifest.detection.amd, unsupported("no-manifest"));
+  const unreachable = github({ pages: [[release("v3", withManifest)]] });
+  const fetchDown = async (url, init) => (url.endsWith(manifest) ? Promise.reject(new Error("offline")) : unreachable.fetch(url, init));
+  const [downManifest] = await listReleases({ host: ROCM, fetch: fetchDown });
+  assert.deepEqual(downManifest.detection.amd, unsupported("no-manifest"));
+
+  const [partial] = await resolve(withManifest, { [manifest]: "gfx942\n" });
+  assert.equal(partial.variant, "default");
+  assert.deepEqual(partial.detection.amd, unsupported("missing-kernels"));
+  assert.deepEqual(ROCM.detection.amd, AMD_DETECTED);
+  assert.deepEqual(ROCM.amdGfxTargets, ["gfx942", "gfx1100"]);
+});
+
+test("refinement leaves every other probe alone and applies per release", async () => {
+  const compatRocm = { ...ROCM, variant: "compat-rocm" };
+  const covered = ["lilbee-compat-linux-x86_64", "lilbee-compat-linux-x86_64-rocm", "lilbee-compat-linux-x86_64-rocm.gfx.txt"];
+  const manifests = { "lilbee-compat-linux-x86_64-rocm.gfx.txt": "gfx942\ngfx1100\n" };
+  const gh = github({ pages: [[release("v2", covered), release("v1", ["lilbee-compat-linux-x86_64"])]], manifests });
+  const [v2, v1] = await listReleases({ host: compatRocm, fetch: gh.fetch });
+  assert.deepEqual([v2.variant, v2.detection.amd], ["compat-rocm", AMD_DETECTED]);
+  assert.deepEqual([v1.variant, v1.detection.amd], ["compat", { status: "unsupported", gfxTargets: ["gfx942", "gfx1100"], reason: "no-asset" }]);
+
+  const blind = { ...ROCM, amdGfxTargets: [], detection: { ...ROCM.detection, amd: { status: "unreadable" } } };
+  const [noRocm] = await listReleases({ host: blind, fetch: github({ pages: [[release("v1", ["lilbee-linux-x86_64"])]] }).fetch });
+  assert.deepEqual([noRocm.variant, noRocm.detection.amd], ["default", { status: "unreadable" }]);
+
+  const [cuda] = await listReleases({ host: CUDA, fetch: github({ pages: [[release("v1", ["lilbee-linux-x86_64"])]] }).fetch });
+  assert.deepEqual([cuda.variant, cuda.detection], ["default", CUDA.detection]);
+
+  const byTag = await releaseByTag("v1", { host: ROCM, fetch: github({ tags: { v1: release("v1", LINUX_ASSETS) } }).fetch });
+  assert.deepEqual(byTag.detection.amd, { status: "unsupported", gfxTargets: ["gfx942", "gfx1100"], reason: "no-manifest" });
 });

--- a/packages/lilbee/test/releases.test.mjs
+++ b/packages/lilbee/test/releases.test.mjs
@@ -187,3 +187,15 @@ test("the repo is configurable", async () => {
   await listReleases({ host: LINUX, fetch: gh.fetch, repo: "acme/fork" });
   assert.match(gh.calls[0].url, /\/repos\/acme\/fork\/releases\?per_page=100&page=1$/);
 });
+
+import { LauncherError } from "../lib/errors.mjs";
+
+test("release query failures carry LauncherError codes: rate-limited, http, no-release", async () => {
+  const limited = github({ status: 403 });
+  await assert.rejects(listReleases({ host: LINUX, fetch: limited.fetch }), (err) => err instanceof LauncherError && err.code === "rate-limited" && err.status === 403);
+  const broken = github({ status: 500 });
+  await assert.rejects(listReleases({ host: LINUX, fetch: broken.fetch }), (err) => err instanceof LauncherError && err.code === "http" && err.status === 500);
+  const empty = github({ pages: [[]] });
+  await assert.rejects(latestRelease({ host: LINUX, fetch: empty.fetch }), (err) => err instanceof LauncherError && err.code === "no-release");
+  await assert.rejects(releaseByTag("v404", { host: LINUX, fetch: empty.fetch }), (err) => err instanceof LauncherError && err.code === "no-release" && err.status === 404);
+});

--- a/packages/lilbee/test/releases.test.mjs
+++ b/packages/lilbee/test/releases.test.mjs
@@ -1,0 +1,189 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isDevBuild, latestRelease, listReleases, releaseByTag } from "../lib/releases.mjs";
+
+const LINUX = { platform: "linux", arch: "x64", variant: "default", amdGfxTargets: [] };
+const CUDA = { ...LINUX, variant: "cu125" };
+const ROCM = { ...LINUX, variant: "rocm", amdGfxTargets: ["gfx942", "gfx1100"] };
+
+const asset = (name, extra = {}) => ({
+  name,
+  size: 100,
+  digest: `sha256:${name}`,
+  browser_download_url: `https://dl/${name}`,
+  ...extra,
+});
+
+const release = (tag, assets, extra = {}) => ({ tag_name: tag, assets: assets.map((a) => (typeof a === "string" ? asset(a) : a)), ...extra });
+
+const LINUX_ASSETS = ["lilbee-linux-x86_64", "lilbee-linux-x86_64-cu125", "lilbee-linux-x86_64-rocm", "lilbee-macos-arm64"];
+
+/**
+ * A GitHub stand-in: `pages` are the release list pages, `tags` the per-tag
+ * lookups, `manifests` the gfx.txt bodies by asset name. Records every request.
+ */
+function github({ pages = [], tags = {}, manifests = {}, status = null } = {}) {
+  const calls = [];
+  const fetch = async (url, init = {}) => {
+    calls.push({ url, headers: init.headers ?? {} });
+    const respond = (code, json, text = "") => ({
+      ok: code < 400,
+      status: code,
+      headers: { get: () => null },
+      body: null,
+      json: async () => json,
+      text: async () => text,
+    });
+    if (status) return respond(status, {});
+    const page = /\/releases\?per_page=(\d+)&page=(\d+)$/.exec(url);
+    if (page) return respond(200, pages[Number(page[2]) - 1] ?? []);
+    const tag = /\/releases\/tags\/([^/]+)$/.exec(url);
+    if (tag) return tags[tag[1]] ? respond(200, tags[tag[1]]) : respond(404, { message: "Not Found" });
+    const manifest = /\/dl\/(.+\.gfx\.txt)$/.exec(url);
+    if (manifest) return manifest[1] in manifests ? respond(200, null, manifests[manifest[1]]) : respond(404, null);
+    throw new Error(`unexpected request ${url}`);
+  };
+  return { fetch, calls };
+}
+
+test("isDevBuild recognises the .dev suffix", () => {
+  assert.equal(isDevBuild("v0.6.90b420.dev711"), true);
+  assert.equal(isDevBuild("v0.6.90b420"), false);
+});
+
+test("stable and dev builds fill separate quotas, so a run of dev builds cannot hide stable ones", async () => {
+  const devs = Array.from({ length: 100 }, (_, i) => release(`v0.6.90b430.dev${900 - i}`, LINUX_ASSETS));
+  const stables = [release("v0.6.90b430", LINUX_ASSETS), release("v0.6.90b429", LINUX_ASSETS), release("v0.6.90b428", LINUX_ASSETS)];
+  const gh = github({ pages: [devs, stables] });
+
+  const stable = await listReleases({ host: LINUX, fetch: gh.fetch, limit: 2 });
+  assert.deepEqual(stable.map((r) => r.tag), ["v0.6.90b430", "v0.6.90b429"]);
+  assert.ok(stable.every((r) => r.dev === false));
+
+  const both = await listReleases({ host: LINUX, fetch: gh.fetch, limit: 2, includeDev: true });
+  assert.deepEqual(both.map((r) => r.tag), ["v0.6.90b430.dev900", "v0.6.90b430.dev899", "v0.6.90b430", "v0.6.90b429"]);
+  assert.deepEqual(both.map((r) => r.dev), [true, true, false, false]);
+});
+
+test("paging stops at a short page and never reads past the page budget", async () => {
+  const gh = github({ pages: [[release("v1", LINUX_ASSETS)]] });
+  assert.equal((await listReleases({ host: LINUX, fetch: gh.fetch, limit: 5 })).length, 1);
+  assert.equal(gh.calls.length, 1);
+
+  const full = Array.from({ length: 100 }, (_, i) => release(`v0.1.${999 - i}`, ["lilbee-macos-arm64"]));
+  const busy = github({ pages: [full, full, full, full] });
+  assert.deepEqual(await listReleases({ host: LINUX, fetch: busy.fetch, limit: 5 }), []);
+  assert.equal(busy.calls.length, 3);
+});
+
+test("drafts, prereleases, and releases without the host's baseline build are left out", async () => {
+  const gh = github({
+    pages: [[
+      release("v5", LINUX_ASSETS, { draft: true }),
+      release("v4", LINUX_ASSETS, { prerelease: true }),
+      release("v3", ["lilbee-macos-arm64", "lilbee-linux-x86_64-cu125"]),
+      release("v2", LINUX_ASSETS),
+    ]],
+  });
+  assert.deepEqual((await listReleases({ host: CUDA, fetch: gh.fetch })).map((r) => r.tag), ["v2"]);
+});
+
+test("a CUDA host takes the matching CUDA build and falls back to the default build", async () => {
+  const gh = github({ pages: [[release("v2", LINUX_ASSETS), release("v1", ["lilbee-linux-x86_64"])]] });
+  const [v2, v1] = await listReleases({ host: CUDA, fetch: gh.fetch });
+  assert.deepEqual(v2, {
+    tag: "v2",
+    dev: false,
+    assetName: "lilbee-linux-x86_64-cu125",
+    variant: "cu125",
+    size: 100,
+    digest: "lilbee-linux-x86_64-cu125",
+    url: "https://dl/lilbee-linux-x86_64-cu125",
+  });
+  assert.equal(v1.variant, "default");
+  assert.equal(v1.assetName, "lilbee-linux-x86_64");
+});
+
+test("the ROCm build needs a gfx manifest that covers every host GPU, not just one", async () => {
+  const manifest = "lilbee-linux-x86_64-rocm.gfx.txt";
+  const withManifest = [...LINUX_ASSETS, manifest];
+  const covering = { [manifest]: "gfx942\ngfx1100\ngfx1201\n" };
+  const partial = { [manifest]: "gfx942\n" };
+
+  const all = await listReleases({ host: ROCM, fetch: github({ pages: [[release("v3", withManifest)]], manifests: covering }).fetch });
+  assert.equal(all[0].variant, "rocm");
+  assert.equal(all[0].assetName, "lilbee-linux-x86_64-rocm");
+
+  const some = await listReleases({ host: ROCM, fetch: github({ pages: [[release("v3", withManifest)]], manifests: partial }).fetch });
+  assert.equal(some[0].variant, "default");
+
+  const none = await listReleases({ host: ROCM, fetch: github({ pages: [[release("v1", LINUX_ASSETS)]] }).fetch });
+  assert.equal(none[0].variant, "default");
+
+  const empty = await listReleases({ host: ROCM, fetch: github({ pages: [[release("v3", withManifest)]], manifests: { [manifest]: "\n" } }).fetch });
+  assert.equal(empty[0].variant, "default");
+});
+
+test("a ROCm host with no readable gfx targets takes the rocm build the release ships", async () => {
+  const blind = { ...ROCM, amdGfxTargets: [] };
+  const gh = github({ pages: [[release("v1", LINUX_ASSETS)]] });
+  assert.equal((await listReleases({ host: blind, fetch: gh.fetch }))[0].variant, "rocm");
+});
+
+test("compat hosts use the compat build as their baseline and compose the GPU flavor the same way", async () => {
+  const compatAssets = ["lilbee-linux-x86_64", "lilbee-compat-linux-x86_64", "lilbee-compat-linux-x86_64-rocm", "lilbee-compat-linux-x86_64-rocm.gfx.txt"];
+  const manifests = { "lilbee-compat-linux-x86_64-rocm.gfx.txt": "gfx942\ngfx1100\n" };
+  const gh = github({ pages: [[release("v2", compatAssets), release("v1", ["lilbee-linux-x86_64"])]], manifests });
+
+  const compatRocm = await listReleases({ host: { ...ROCM, variant: "compat-rocm" }, fetch: gh.fetch });
+  assert.deepEqual(compatRocm.map((r) => [r.tag, r.assetName]), [["v2", "lilbee-compat-linux-x86_64-rocm"]]);
+
+  const compatCuda = await listReleases({ host: { ...LINUX, variant: "compat-cu124" }, fetch: gh.fetch });
+  assert.deepEqual(compatCuda.map((r) => [r.tag, r.assetName, r.variant]), [["v2", "lilbee-compat-linux-x86_64", "compat"]]);
+});
+
+test("a host lilbee publishes no build for sees no releases", async () => {
+  const gh = github({ pages: [[release("v1", LINUX_ASSETS)]] });
+  assert.deepEqual(await listReleases({ host: { ...LINUX, arch: "arm64" }, fetch: gh.fetch }), []);
+});
+
+test("GitHub's rate limit surfaces as one plain message", async () => {
+  for (const status of [403, 429]) {
+    await assert.rejects(listReleases({ host: LINUX, fetch: github({ status }).fetch }), /rate limit was reached; release checks reset within the hour/);
+  }
+  await assert.rejects(listReleases({ host: LINUX, fetch: github({ status: 500 }).fetch }), /HTTP 500/);
+});
+
+test("a GitHub token from the environment rides along as a bearer header; none is sent otherwise", async () => {
+  const gh = github({ pages: [[release("v1", LINUX_ASSETS)]] });
+  await listReleases({ host: LINUX, fetch: gh.fetch, env: { GITHUB_TOKEN: "ghp_x" } });
+  assert.equal(gh.calls[0].headers.authorization, "Bearer ghp_x");
+  await listReleases({ host: LINUX, fetch: gh.fetch, env: { GH_TOKEN: "gho_y" } });
+  assert.equal(gh.calls[1].headers.authorization, "Bearer gho_y");
+  await listReleases({ host: LINUX, fetch: gh.fetch, env: {} });
+  assert.equal("authorization" in gh.calls[2].headers, false);
+  assert.match(gh.calls[2].headers["user-agent"], /lilbee/);
+});
+
+test("latestRelease is the newest entry on the channel and fails plainly when there is none", async () => {
+  const gh = github({ pages: [[release("v2.dev5", LINUX_ASSETS), release("v2", LINUX_ASSETS), release("v1", LINUX_ASSETS)]] });
+  assert.equal((await latestRelease({ host: LINUX, fetch: gh.fetch })).tag, "v2");
+  assert.equal((await latestRelease({ host: LINUX, fetch: gh.fetch, includeDev: true })).tag, "v2.dev5");
+  await assert.rejects(latestRelease({ host: LINUX, fetch: github({ pages: [[]] }).fetch }), /No installable lilbee release/);
+});
+
+test("releaseByTag resolves one release the same way and names a missing tag or build", async () => {
+  const gh = github({ tags: { "v0.6.90b432": release("v0.6.90b432", LINUX_ASSETS), "v0.6.90b432.dev3": release("v0.6.90b432.dev3", ["lilbee-macos-arm64"]) } });
+  const r = await releaseByTag("v0.6.90b432", { host: CUDA, fetch: gh.fetch });
+  assert.equal(r.assetName, "lilbee-linux-x86_64-cu125");
+  assert.equal(r.dev, false);
+  assert.match(gh.calls[0].url, /\/repos\/tobocop2\/lilbee\/releases\/tags\/v0\.6\.90b432$/);
+  await assert.rejects(releaseByTag("v0.0.0", { host: CUDA, fetch: gh.fetch }), /Release v0\.0\.0 was not found/);
+  await assert.rejects(releaseByTag("v0.6.90b432.dev3", { host: CUDA, fetch: gh.fetch }), /no build for linux\/x64/);
+});
+
+test("the repo is configurable", async () => {
+  const gh = github({ pages: [[release("v1", LINUX_ASSETS)]] });
+  await listReleases({ host: LINUX, fetch: gh.fetch, repo: "acme/fork" });
+  assert.match(gh.calls[0].url, /\/repos\/acme\/fork\/releases\?per_page=100&page=1$/);
+});

--- a/packages/lilbee/test/resolve.test.mjs
+++ b/packages/lilbee/test/resolve.test.mjs
@@ -5,7 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { resolveBinary } from "../lib/resolve.mjs";
 
-const HOST = { platform: "darwin", arch: "arm64", variant: "default", amdGfxTargets: [] };
+const DETECTION = { nvidia: { status: "skipped" }, amd: { status: "skipped" }, cpu: { status: "skipped" }, detectedAt: "2026-09-04T12:00:00.000Z" };
+const HOST = { platform: "darwin", arch: "arm64", variant: "default", amdGfxTargets: [], detection: DETECTION };
 const ASSET = "lilbee-macos-arm64";
 
 const tmpCache = () => fs.mkdtempSync(path.join(os.tmpdir(), "lilbee-resolve-"));

--- a/packages/lilbee/test/resolve.test.mjs
+++ b/packages/lilbee/test/resolve.test.mjs
@@ -75,7 +75,7 @@ test("when the latest lookup fails, the pinned release is the fallback", async (
   const r = await resolve(cache, flaky, { pinned: "v0.6.90b423", log: (m) => logs.push(m) });
   assert.equal(r.release, "v0.6.90b423");
   assert.equal(r.source, "download");
-  assert.match(logs.join("\n"), /network down.*tested v0\.6\.90b423/);
+  assert.ok(logs.includes("lilbee: could not look up the latest release; using the tested v0.6.90b423."));
   fs.rmSync(cache, { recursive: true, force: true });
 });
 

--- a/packages/lilbee/test/resolve.test.mjs
+++ b/packages/lilbee/test/resolve.test.mjs
@@ -1,143 +1,117 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { cacheDir, cachedBinaryPath, compareReleaseTags, resolveBinary } from "../lib/resolve.mjs";
+import { resolveBinary } from "../lib/resolve.mjs";
 
-const ENV = { LILBEE_MCP_CACHE: "/cache" };
+const HOST = { platform: "darwin", arch: "arm64", variant: "default", amdGfxTargets: [] };
 const ASSET = "lilbee-macos-arm64";
-const at = (release) => cachedBinaryPath(ENV, release, ASSET);
 
-/** deps with a cache holding `releases` and a network reporting `latest`. */
-function deps({ releases = [], latest = null, downloads = [], removed = [] } = {}) {
-  return {
-    existsSync: (p) => releases.some((r) => p === at(r)),
-    readdirSync: (p) => {
-      if (p !== "/cache") throw new Error("no dir");
-      return [...releases];
-    },
-    rmSync: (p) => removed.push(p),
-    latestTag: async () => {
-      if (!latest) throw new Error("network down");
-      return latest;
-    },
-    download: async (o) => downloads.push(o),
+const tmpCache = () => fs.mkdtempSync(path.join(os.tmpdir(), "lilbee-resolve-"));
+const seed = (cache, release) => {
+  fs.mkdirSync(path.join(cache, release), { recursive: true });
+  fs.writeFileSync(path.join(cache, release, ASSET), "");
+};
+
+/** GitHub with the given tags (newest first); `down` makes every call fail. */
+function github(tags, { down = false } = {}) {
+  const calls = [];
+  const releases = tags.map((tag) => ({
+    tag_name: tag,
+    assets: [{ name: ASSET, size: 1, digest: null, browser_download_url: `https://dl/${tag}` }],
+  }));
+  const fetch = async (url) => {
+    calls.push(url);
+    if (down) throw new Error("network down");
+    const respond = (status, json) => ({ ok: status < 400, status, headers: { get: () => null }, body: null, json: async () => json, text: async () => "" });
+    if (/\/releases\?/.test(url)) return respond(200, releases);
+    const tag = /\/releases\/tags\/(.+)$/.exec(url)?.[1];
+    const found = releases.find((r) => r.tag_name === tag);
+    return found ? respond(200, found) : respond(404, {});
   };
+  return { fetch, calls };
 }
 
-test("cacheDir honors LILBEE_MCP_CACHE and platform conventions", () => {
-  assert.equal(cacheDir({ LILBEE_MCP_CACHE: "/tmp/c" }), "/tmp/c");
-  assert.ok(cacheDir({}, "darwin").endsWith(path.join("Library", "Caches", "lilbee-npm")));
-  assert.ok(cacheDir({ XDG_CACHE_HOME: "/xdg" }, "linux").startsWith("/xdg"));
-  assert.ok(cacheDir({ LOCALAPPDATA: "C:\\LA" }, "win32").includes("lilbee-npm"));
-});
-
-test("release tags order numerically, newest first", () => {
-  const tags = ["v0.6.90b423", "v0.6.90b425", "v0.7.0", "v0.6.91"];
-  assert.deepEqual(tags.sort(compareReleaseTags), ["v0.7.0", "v0.6.91", "v0.6.90b425", "v0.6.90b423"]);
-});
+const resolve = (cache, gh, extra = {}) =>
+  resolveBinary({ env: {}, cacheDir: cache, host: HOST, pinned: "vPin", fetch: gh.fetch, ...extra });
 
 test("LILBEE_BIN wins, and a missing LILBEE_BIN is an error not a fallthrough", async () => {
-  const found = await resolveBinary({
-    env: { LILBEE_BIN: "/custom/lilbee" },
-    release: "vPin",
-    assetName: ASSET,
-    deps: { ...deps(), existsSync: (p) => p === "/custom/lilbee" },
-  });
-  assert.deepEqual(found, { path: "/custom/lilbee", source: "env", release: null });
-
-  await assert.rejects(
-    resolveBinary({ env: { LILBEE_BIN: "/gone" }, release: "vPin", assetName: ASSET, deps: deps() }),
-    /nothing is there/
-  );
+  const cache = tmpCache();
+  const bin = path.join(cache, "custom-lilbee");
+  fs.writeFileSync(bin, "");
+  const found = await resolve(cache, github(["v1"]), { env: { LILBEE_BIN: bin } });
+  assert.deepEqual(found, { path: bin, source: "env", release: null, download: null });
+  await assert.rejects(resolve(cache, github(["v1"]), { env: { LILBEE_BIN: "/gone" } }), /nothing is there/);
+  fs.rmSync(cache, { recursive: true, force: true });
 });
 
 test("a run with any cached release uses the newest one, no network", async () => {
-  const d = deps({ releases: ["v0.6.90b423", "v0.6.90b425"] });
-  d.latestTag = async () => {
-    throw new Error("must not touch the network");
-  };
-  const r = await resolveBinary({ env: ENV, release: "vPin", assetName: ASSET, deps: d });
-  assert.deepEqual(r, { path: at("v0.6.90b425"), source: "cache", release: "v0.6.90b425" });
+  const cache = tmpCache();
+  seed(cache, "v0.6.90b423");
+  seed(cache, "v0.6.90b425");
+  const gh = github(["v0.6.90b426"]);
+  const r = await resolve(cache, gh);
+  assert.deepEqual(r, { path: path.join(cache, "v0.6.90b425", ASSET), source: "cache", release: "v0.6.90b425", download: null });
+  assert.equal(gh.calls.length, 0);
+  fs.rmSync(cache, { recursive: true, force: true });
 });
 
-test("a fresh install downloads the latest release", async () => {
-  const downloads = [];
-  const r = await resolveBinary({
-    env: ENV,
-    release: "v0.6.90b423",
-    assetName: ASSET,
-    deps: deps({ latest: "v0.6.90b425", downloads }),
-  });
+test("a fresh install plans a download of the latest release", async () => {
+  const cache = tmpCache();
+  const r = await resolve(cache, github(["v0.6.90b425", "v0.6.90b423"]));
   assert.equal(r.source, "download");
   assert.equal(r.release, "v0.6.90b425");
-  assert.deepEqual(downloads.map((o) => o.release), ["v0.6.90b425"]);
+  assert.equal(r.path, path.join(cache, "v0.6.90b425", ASSET));
+  assert.equal(r.download.url, "https://dl/v0.6.90b425");
+  fs.rmSync(cache, { recursive: true, force: true });
 });
 
 test("when the latest lookup fails, the pinned release is the fallback", async () => {
-  const downloads = [];
+  const cache = tmpCache();
   const logs = [];
-  const d = { ...deps({ downloads }), log: (m) => logs.push(m) };
-  const r = await resolveBinary({ env: ENV, release: "v0.6.90b423", assetName: ASSET, deps: d });
+  const gh = github(["v0.6.90b423"]);
+  const flaky = { fetch: (url, init) => (/\/releases\?/.test(url) ? Promise.reject(new Error("network down")) : gh.fetch(url, init)) };
+  const r = await resolve(cache, flaky, { pinned: "v0.6.90b423", log: (m) => logs.push(m) });
   assert.equal(r.release, "v0.6.90b423");
   assert.equal(r.source, "download");
-  assert.match(logs.join("\n"), /tested v0\.6\.90b423/);
+  assert.match(logs.join("\n"), /network down.*tested v0\.6\.90b423/);
+  fs.rmSync(cache, { recursive: true, force: true });
 });
 
 test("refresh re-resolves latest past a cached binary, and cache satisfies it without a download", async () => {
-  const downloads = [];
-  const cachedLatest = deps({ releases: ["v0.6.90b425"], latest: "v0.6.90b425", downloads });
-  const same = await resolveBinary({
-    env: ENV,
-    release: "vPin",
-    assetName: ASSET,
-    refresh: true,
-    deps: cachedLatest,
-  });
-  assert.deepEqual(same, { path: at("v0.6.90b425"), source: "cache", release: "v0.6.90b425" });
-  assert.equal(downloads.length, 0);
+  const cache = tmpCache();
+  seed(cache, "v0.6.90b425");
+  const same = await resolve(cache, github(["v0.6.90b425"]), { refresh: true });
+  assert.deepEqual(same, { path: path.join(cache, "v0.6.90b425", ASSET), source: "cache", release: "v0.6.90b425", download: null });
 
-  const stale = deps({ releases: ["v0.6.90b423"], latest: "v0.6.90b425", downloads });
-  const upgraded = await resolveBinary({
-    env: ENV,
-    release: "vPin",
-    assetName: ASSET,
-    refresh: true,
-    deps: stale,
-  });
+  const upgraded = await resolve(cache, github(["v0.6.90b426", "v0.6.90b425"]), { refresh: true });
   assert.equal(upgraded.source, "download");
-  assert.equal(upgraded.release, "v0.6.90b425");
+  assert.equal(upgraded.release, "v0.6.90b426");
+  fs.rmSync(cache, { recursive: true, force: true });
 });
 
-test("LILBEE_RELEASE overrides latest entirely", async () => {
-  const downloads = [];
-  const d = deps({ releases: ["v0.6.90b425"], latest: "v0.6.90b426", downloads });
-  const r = await resolveBinary({
-    env: { ...ENV, LILBEE_RELEASE: "v0.6.90b410" },
-    release: "vPin",
-    assetName: ASSET,
-    deps: d,
-  });
-  assert.equal(r.release, "v0.6.90b410");
-  assert.equal(r.source, "download");
+test("LILBEE_RELEASE and the prepare tag pin one release; the tag wins over the variable", async () => {
+  const cache = tmpCache();
+  seed(cache, "v0.6.90b425");
+  const gh = github(["v0.6.90b426", "v0.6.90b425", "v0.6.90b410", "v0.6.90b400"]);
+  const fromEnv = await resolve(cache, gh, { env: { LILBEE_RELEASE: "v0.6.90b410" } });
+  assert.equal(fromEnv.release, "v0.6.90b410");
+  assert.equal(fromEnv.source, "download");
+  assert.match(gh.calls.at(-1), /releases\/tags\/v0\.6\.90b410$/);
+
+  const fromArg = await resolve(cache, gh, { env: { LILBEE_RELEASE: "v0.6.90b410" }, tag: "v0.6.90b400" });
+  assert.equal(fromArg.release, "v0.6.90b400");
+
+  const cached = await resolve(cache, gh, { tag: "v0.6.90b425" });
+  assert.equal(cached.source, "cache");
+  fs.rmSync(cache, { recursive: true, force: true });
 });
 
-test("a finished download prunes the older cached releases", async () => {
-  const removed = [];
-  const d = deps({ releases: ["v0.6.90b423"], latest: "v0.6.90b425", removed });
-  await resolveBinary({ env: ENV, release: "vPin", assetName: ASSET, refresh: true, deps: d });
-  assert.deepEqual(removed, ["/cache/v0.6.90b423"]);
-});
-
-test("lilbee installs from other package managers are ignored: the launcher's own download wins", async () => {
-  // existsSync says yes to everything EXCEPT the launcher's cache, simulating
-  // a machine covered in brew/flatpak/pip lilbees.
-  const downloads = [];
-  const d = {
-    ...deps({ latest: "vX", downloads }),
-    existsSync: (p) => !p.startsWith("/cache"),
-    readdirSync: () => [],
-  };
-  const r = await resolveBinary({ env: ENV, release: "vPin", assetName: ASSET, deps: d });
-  assert.equal(r.source, "download");
-  assert.deepEqual(downloads.map((o) => o.dest), [at("vX")]);
+test("the dev channel makes the newest dev build the latest", async () => {
+  const cache = tmpCache();
+  const gh = github(["v0.6.90b426.dev3", "v0.6.90b425"]);
+  assert.equal((await resolve(cache, gh)).release, "v0.6.90b425");
+  assert.equal((await resolve(cache, gh, { includeDev: true })).release, "v0.6.90b426.dev3");
+  fs.rmSync(cache, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Problem

The Obsidian plugin carries its own copy of what this launcher does: GitHub release paging, NVIDIA and AMD detection, build selection, a streaming download with sha256 verification. Two copies drift (the launcher keeps a hard-coded gfx list, the plugin reads each release's gfx manifest), and the plugin cannot reuse the launcher because it exposes only a CLI: progress goes to stderr, there is no cancel, no release listing, and the renderer's global fetch cannot reach GitHub's asset redirect.

## Solution

The launcher gains a programmatic API (`lib/api.mjs`, typed by `lib/api.d.ts`, the package entry point) that the plugin bundles. It exposes host detection, release listing on a stable or dev channel with the plugin's paging quotas, cached-binary lookup, and `ensureBinary` with a progress callback, an `AbortSignal`, and an injectable `fetch`. The CLI is rebuilt on the same primitives so there is one download path.

## CLI additions

`lilbee prepare <tag>` installs an exact release, the same as `LILBEE_RELEASE`. `LILBEE_DEV_BUILDS=1` lets "latest" include `.dev` builds.

## Behaviour changes

"Latest" now skips `.dev` tags unless asked; the `releases/latest` endpoint returned them whenever one was newest. ROCm selection reads the release's gfx manifest and requires every host GPU to be covered. Downloads check free space, give up after a 60 s stall (with the existing single retry), and remove other builds of the same release after a build switch.

## Nothing changes for CLI users

Every line the launcher printed in 0.6.96 prints unchanged: the detection notes, the download banner, the progress bar and the non-TTY progress lines, the retry and fallback notes, and the help table. A differential test pins the strings, and the progress renderer was diffed frame by frame against 0.6.96. An end-to-end run against the published 0.6.96 covers prepare, cached runs offline, exact release tags, variant overrides, `LILBEE_BIN`, debug output, unprepare, and the MCP route.

## Embedders

Failures carry a `LauncherError` with a stable `code`, so an embedder can word its own messages while the CLI keeps its text. `requireDigest` refuses an asset without a published sha256. The first progress event reports zero bytes when the transfer opens.

## Verified against the released plugin

The Obsidian plugin that consumes this API was run side by side with the released 0.6.91 across every download surface (install, update, downgrade, reinstall with cancel, automatic update, first run). The captured-state comparison is in tobocop2/obsidian-lilbee#249.

## Publishing

The Obsidian plugin (tobocop2/obsidian-lilbee#249) depends on `lilbee@^0.6.97`, so this needs a version bump and an npm publish after it merges.


