### PR TITLE
Pick a CUDA build only when nvidia-smi names the CUDA version

### DIFF
--- a/packages/lilbee/README.md
+++ b/packages/lilbee/README.md
@@ -48,7 +48,7 @@ The [usage guide](https://github.com/tobocop2/lilbee/blob/main/docs/usage.md) co
 
 ## How the package works
 
-The package is a small launcher with zero runtime dependencies. On first use it detects your hardware and downloads the matching standalone binary of the **latest lilbee release** — CUDA on NVIDIA, ROCm on AMD, Metal on Apple silicon, and an AVX-baseline build on older x86-64 CPUs — sha256-verified against the release manifest and cached. Every later run execs the cached binary directly, with no network.
+The package is a small launcher with zero runtime dependencies. On first use it detects your hardware and downloads the matching standalone binary of the **latest lilbee release** — CUDA on NVIDIA, ROCm on AMD, Metal on Apple silicon, and an AVX-baseline build on older x86-64 CPUs — sha256-verified against the release manifest and cached. A CUDA build is chosen only when `nvidia-smi` reports the driver's CUDA version; on any other NVIDIA host the default build's Vulkan engine drives the card. Every later run execs the cached binary directly, with no network.
 
 The first download is large (about 370MB on macOS, more for CUDA builds). Run `lilbee prepare` once to do it ahead of time; run it again any time to upgrade to the newest release (the old binary is removed). `lilbee prepare <tag>` installs one exact release instead. If the latest-release lookup is unreachable, the launcher falls back to the release pinned in `package.json`, the one this launcher version was tested against.
 

--- a/packages/lilbee/lib/detect.mjs
+++ b/packages/lilbee/lib/detect.mjs
@@ -190,18 +190,23 @@ function skippedDetection() {
   return { nvidia: { status: "skipped" }, amd: { status: "skipped" }, cpu: { status: "skipped" }, detectedAt: new Date().toISOString() };
 }
 
-/** The CUDA build the NVIDIA probe calls for, or null; logs the CLI's line for the choice. */
+/**
+ * The CUDA build the NVIDIA probe calls for, or null; logs the CLI's line for the choice.
+ * Only a driver that names its CUDA version gets a CUDA build: without one the default
+ * build's Vulkan engine still uses the card, where a CUDA runtime that fails to
+ * initialise would fall back to the CPU.
+ */
 function cudaBuild(nvidia, platform, exists, log) {
-  if (nvidia.status === "detected" || nvidia.status === "unreadable") {
-    const ceiling = nvidia.status === "detected" ? nvidia.cudaCeiling : null;
-    const cuda = ceiling === null ? "cu121" : cudaVariantForCeiling(ceiling);
-    const label = ceiling === null ? "unknown" : `${Math.floor(ceiling / 100)}.${ceiling % 100}`;
+  if (nvidia.status === "detected") {
+    const cuda = cudaVariantForCeiling(nvidia.cudaCeiling);
+    const label = `${Math.floor(nvidia.cudaCeiling / 100)}.${nvidia.cudaCeiling % 100}`;
     if (cuda) log(`lilbee: detected NVIDIA driver (CUDA ${label}) — using the ${cuda} build (override with LILBEE_VARIANT).`);
     return cuda;
   }
-  if (platform === "linux" && (exists(NVIDIA_DEVICE) || exists(NVIDIA_DRIVER_VERSION))) {
-    log("lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT).");
-    return "cu121";
+  if (nvidia.status === "unreadable") {
+    log("lilbee: nvidia-smi names no CUDA version — using the default build (override with LILBEE_VARIANT).");
+  } else if (platform === "linux" && (exists(NVIDIA_DEVICE) || exists(NVIDIA_DRIVER_VERSION))) {
+    log("lilbee: NVIDIA device present but nvidia-smi is not runnable — using the default build (override with LILBEE_VARIANT).");
   }
   return null;
 }

--- a/packages/lilbee/package-lock.json
+++ b/packages/lilbee/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lilbee",
-  "version": "0.6.98",
+  "version": "0.6.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lilbee",
-      "version": "0.6.98",
+      "version": "0.6.99",
       "license": "MIT",
       "bin": {
         "lilbee": "bin/lilbee.mjs",

--- a/packages/lilbee/package.json
+++ b/packages/lilbee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lilbee",
-  "version": "0.6.98",
+  "version": "0.6.99",
   "description": "The whole local AI stack in one executable: run and manage local models across every GPU you have, and search your files, notes, code, and crawled sites with answers that cite the source. Terminal app, CLI, MCP server, and REST API. Auto-detects your hardware (CUDA, ROCm, Metal) and fetches the matching standalone binary on first use.",
   "license": "MIT",
   "homepage": "https://lilbee.sh",

--- a/packages/lilbee/test/detect.test.mjs
+++ b/packages/lilbee/test/detect.test.mjs
@@ -66,8 +66,14 @@ test("linux NVIDIA hosts get the matching CUDA build", async () => {
   assert.equal(await variant("linux", "x64", { smi: "CUDA Version: 12.4" }), "cu124");
 });
 
-test("visible NVIDIA device without runnable nvidia-smi falls back to cu121", async () => {
-  assert.equal(await variant("linux", "x64", { files: ["/dev/nvidia0"] }), "cu121");
+test("visible NVIDIA device without runnable nvidia-smi keeps the default build", async () => {
+  assert.equal(await variant("linux", "x64", { files: ["/dev/nvidia0"] }), "default");
+  assert.equal(await variant("linux", "x64", { files: ["/proc/driver/nvidia/version"] }), "default");
+});
+
+test("nvidia-smi output without a CUDA version keeps the default build", async () => {
+  assert.equal(await variant("linux", "x64", { smi: "no version here" }), "default");
+  assert.equal(await variant("win32", "x64", { smi: "no version here" }), "default");
 });
 
 test("gfx_target_version maps to gfx names", () => {
@@ -178,7 +184,7 @@ test("a failing nvidia-smi is missing, not sandboxed, and its first error is one
 test("a timed-out nvidia-smi records the timeout", async () => {
   const hung = Object.assign(new Error("spawn nvidia-smi ETIMEDOUT"), { killed: true, signal: "SIGTERM" });
   assert.deepEqual((await report("linux", "x64", { smi: hung })).nvidia, { status: "missing", error: "nvidia-smi did not answer within 10 s" });
-  assert.equal(await variant("linux", "x64", { smi: hung, files: ["/dev/nvidia0"] }), "cu121");
+  assert.equal(await variant("linux", "x64", { smi: hung, files: ["/dev/nvidia0"] }), "default");
 });
 
 test("Windows looks for nvidia-smi on PATH, then in System32, then in the NVSMI directory", async () => {
@@ -296,8 +302,8 @@ test("the log lines the CLI prints are unchanged by the report", async () => {
     "lilbee: detected NVIDIA driver (CUDA 12.6) — using the cu125 build (override with LILBEE_VARIANT).",
     "lilbee: this CPU has no AVX2 — using the -compat build family (override with LILBEE_VARIANT).",
   ]);
-  assert.deepEqual(await lines("linux", { smi: "no version here" }), ["lilbee: detected NVIDIA driver (CUDA unknown) — using the cu121 build (override with LILBEE_VARIANT)."]);
-  assert.deepEqual(await lines("linux", { files: [NVIDIA_MODULE] }), ["lilbee: NVIDIA device present but nvidia-smi is not runnable — using the cu121 build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("linux", { smi: "no version here" }), ["lilbee: nvidia-smi names no CUDA version — using the default build (override with LILBEE_VARIANT)."]);
+  assert.deepEqual(await lines("linux", { files: [NVIDIA_MODULE] }), ["lilbee: NVIDIA device present but nvidia-smi is not runnable — using the default build (override with LILBEE_VARIANT)."]);
   assert.deepEqual(await lines("linux", { files: KFD, kfdNodes: { 1: 90402 } }), ["lilbee: detected an AMD GPU (gfx942) — using the rocm build (override with LILBEE_VARIANT)."]);
   assert.deepEqual(await lines("linux", { files: [...KFD, "/opt/rocm"] }), ["lilbee: detected a ROCm userland — using the rocm build (override with LILBEE_VARIANT)."]);
   assert.deepEqual(await lines("linux", {}), []);


### PR DESCRIPTION
## Problem

On Linux, an NVIDIA device with no runnable `nvidia-smi` (a sandbox, a partial driver install) got the cu121 build, and `nvidia-smi` output with no CUDA version got cu121 too. cu121 is pinned to an old llama.cpp because CUDA 12.1's compiler cannot build the newer kernels, and on exactly these hosts the CUDA user-space libraries are the most likely thing missing, which leaves the server on the CPU.

## Solution

Only a driver that names its CUDA version gets a CUDA build. Every other NVIDIA host gets the default build, whose Vulkan engine drives the card with the current llama.cpp. The two log lines now say "using the default build"; `LILBEE_VARIANT` still overrides. This matches what the Obsidian plugin did before it moved onto the launcher.

## Version

0.6.99.
