### PR TITLE
Suppress the unfixable nltk model-artifact CVE in security scans

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -118,6 +118,12 @@ jobs:
           # - PYSEC-2026-597: second nltk path-traversal advisory for the
           #   incomplete #3504 fix (percent-encoded ..%2f; CVE-2026-12243).
           #   Same triage and tracking as GHSA-p4gq-832x-fm9v.
+          # - PYSEC-2026-3740: nltk model-artifact APIs bypass the pathsec
+          #   sandbox (CVE-2026-81726). Affects every nltk up to 3.10.3 and
+          #   upstream has published no fix. It only bites an application
+          #   that sets pathsec.ENFORCE and lets untrusted input pick a model
+          #   path. lilbee never imports nltk and crawl4ai touches none of the
+          #   affected APIs, so no model path is caller-controlled.
           ignore-vulns: |
             CVE-2025-69872
             PYSEC-2022-42969
@@ -130,6 +136,7 @@ jobs:
             PYSEC-2024-277
             GHSA-p4gq-832x-fm9v
             PYSEC-2026-597
+            PYSEC-2026-3740
 
   osv-scan:
     name: OSV-Scanner (multi-ecosystem CVEs)

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -65,3 +65,7 @@ reason = "Path traversal in nltk.data.load() via URL-encoded path separators (CV
 [[IgnoredVulns]]
 id = "PYSEC-2026-597"
 reason = "nltk path traversal, second advisory for the incomplete #3504 fix (percent-encoded ..%2f bypass of _UNSAFE_NO_PROTOCOL_RE; alias CVE-2026-12243). Same triage as GHSA-p4gq-832x-fm9v: no fixed nltk release exists (3.9.4 is latest), nltk arrives transitively via crawl4ai under the crawler extra, lilbee never imports nltk, and crawl4ai only loads hardcoded resource names while crawled text flows in as tokenizer data, never as a resource path, so the attacker-controlled-path vector is unreachable. bb-m851 tracks the bump once nltk >= 3.10 ships."
+
+[[IgnoredVulns]]
+id = "GHSA-8mgp-746c-j5xp"
+reason = "nltk model-artifact APIs bypass the pathsec sandbox (CVE-2026-81726, PYSEC-2026-3740). Every nltk release up to and including 3.10.3 is affected and upstream has published no fix. The advisory covers TransitionParser.train/parse, AveragedPerceptron.save/load, PerceptronTagger.save_to_json and save_maxent_params, and it only bites an application that sets pathsec.ENFORCE and then lets untrusted input choose a model path. nltk arrives transitively via crawl4ai under the `crawler` extra; lilbee never imports nltk, never enables pathsec, and crawl4ai touches none of the affected APIs (it uses nltk.data.find, nltk.download, sent_tokenize, word_tokenize, stopwords and WordNetLemmatizer only), so no model path is caller-controlled. Remove this entry once nltk ships a fixed release."


### PR DESCRIPTION
## Problem

Security Scan is red on main. pip-audit and osv-scanner both flag `nltk 3.10.3` for PYSEC-2026-3740 (CVE-2026-81726, GHSA-8mgp-746c-j5xp), a pathsec sandbox bypass in the nltk model-artifact save and load APIs. Every nltk release up to and including 3.10.3 is affected and upstream has published no fix, so there is nothing to bump to.

## Why it is not reachable

The advisory only bites an application that sets `pathsec.ENFORCE` and then lets untrusted input choose a model path. nltk arrives transitively through crawl4ai under the optional `crawler` extra. lilbee never imports nltk and never enables pathsec, and crawl4ai calls only `nltk.data.find`, `nltk.download`, `sent_tokenize`, `word_tokenize`, `stopwords` and `WordNetLemmatizer`. None of the affected APIs (`TransitionParser.train/parse`, `AveragedPerceptron.save/load`, `PerceptronTagger.save_to_json`, `save_maxent_params`) is called, so no model path is caller-controlled.

## Solution

Add the advisory to `osv-scanner.toml` and mirror it in the pip-audit `ignore-vulns` list, following the pattern the repo already uses for no-fix, not-reachable advisories. Each entry carries the reachability argument and the condition for removing it: nltk shipping a fixed release.