### PR TITLE
Use Node's own HTTP client for downloads inside a browser runtime

### DIFF
--- a/packages/lilbee/README.md
+++ b/packages/lilbee/README.md
@@ -116,7 +116,7 @@ The launcher always runs its own sha256-verified download; it ignores lilbee ins
 
 ## Embedding
 
-The launcher is also a library. `import { ensureBinary, listReleases, detectHost } from "lilbee"` gives a Node program the same host detection, release selection, verified download, and cache layout the CLI uses, with progress and cancel callbacks and no console output. The [Obsidian plugin](https://obsidian.lilbee.sh/) installs its server this way. Inside an Electron renderer, pass your own `fetch` so the download goes through the transport the renderer allows. The full contract is in `lib/api.d.ts`.
+The launcher is also a library. `import { ensureBinary, listReleases, detectHost } from "lilbee"` gives a Node program the same host detection, release selection, verified download, and cache layout the CLI uses, with progress and cancel callbacks and no console output. The [Obsidian plugin](https://obsidian.lilbee.sh/) installs its server this way. Inside an Electron renderer the launcher uses Node's own HTTP client, because the renderer's `fetch` refuses GitHub's asset redirect under CORS; pass `fetch` only to substitute a transport of your own. The full contract is in `lib/api.d.ts`.
 
 ```js
 import { ensureBinary, cacheDir } from "lilbee";

--- a/packages/lilbee/lib/api.d.ts
+++ b/packages/lilbee/lib/api.d.ts
@@ -112,7 +112,10 @@ export interface ReleaseQuery {
     includeDev?: boolean;
     /** The host to resolve builds for; defaults to detectHost(). */
     host?: Host;
-    /** Transport for the GitHub API and the asset manifests; defaults to global fetch. */
+    /**
+     * Transport for the GitHub API, the asset manifests, and the download. Defaults to global
+     * fetch, or to Node's own HTTP client inside a browser runtime such as an Electron renderer.
+     */
     fetch?: FetchLike;
     /** Read for GITHUB_TOKEN / GH_TOKEN (sent as a bearer to the GitHub API). Defaults to process.env. */
     env?: NodeJS.ProcessEnv;

--- a/packages/lilbee/lib/fetch.mjs
+++ b/packages/lilbee/lib/fetch.mjs
@@ -1,12 +1,21 @@
 /** The launcher's default transport: global fetch, routed through the env proxy when one is set. */
 
+import { nodeFetch } from "./http-client.mjs";
+
 const PROXY_VARS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"];
 
+/** A browser's fetch is in scope: an Electron renderer, where CORS refuses GitHub's asset redirect. */
+export function browserRuntime(scope = globalThis) {
+  return typeof scope.window !== "undefined" && typeof scope.document !== "undefined";
+}
+
 /**
- * Global fetch, with undici's env proxy agent installed first when the
- * environment names a proxy. Node's fetch ignores HTTP(S)_PROXY on its own.
+ * Node's own client inside a browser runtime; otherwise global fetch, with
+ * undici's env proxy agent installed first when the environment names a
+ * proxy. Node's fetch ignores HTTP(S)_PROXY on its own.
  */
-export async function launcherFetch(env = process.env, log = () => {}) {
+export async function launcherFetch(env = process.env, log = () => {}, scope = globalThis) {
+  if (browserRuntime(scope)) return nodeFetch;
   if (PROXY_VARS.some((name) => env[name])) {
     try {
       const { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } = await import("undici");
@@ -15,5 +24,5 @@ export async function launcherFetch(env = process.env, log = () => {}) {
       log("lilbee: HTTPS_PROXY is set but the proxy agent is unavailable; downloading directly.");
     }
   }
-  return globalThis.fetch;
+  return scope.fetch;
 }

--- a/packages/lilbee/lib/http-client.mjs
+++ b/packages/lilbee/lib/http-client.mjs
@@ -1,0 +1,83 @@
+/**
+ * The launcher's fetch contract over Node's own http and https clients, for
+ * runtimes whose global fetch is a browser's: an Electron renderer refuses
+ * GitHub's cross-host asset redirect under CORS.
+ */
+
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+
+const MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const AUTHORIZATION_HEADER = "authorization";
+
+function abortError() {
+  return new DOMException("The request was aborted.", "AbortError");
+}
+
+/** One GET; resolves with the raw response once its headers arrive. */
+function get(url, headers, signal) {
+  return new Promise((resolve, reject) => {
+    const request = url.protocol === "https:" ? httpsRequest : httpRequest;
+    let response = null;
+    const req = request(url, { method: "GET", headers }, (res) => {
+      response = res;
+      res.on("close", () => signal?.removeEventListener("abort", onAbort));
+      resolve(res);
+    });
+    // After the headers the body is the caller's stream, so it carries the abort.
+    const onAbort = () => (response ?? req).destroy(abortError());
+    signal?.addEventListener("abort", onAbort, { once: true });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function collect(body) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    body.on("data", (chunk) => chunks.push(chunk));
+    body.on("error", reject);
+    body.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+function toResponse(res) {
+  const status = res.statusCode ?? 0;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name) => {
+        const value = res.headers[name.toLowerCase()];
+        if (value === undefined) return null;
+        return Array.isArray(value) ? value.join(", ") : value;
+      },
+    },
+    body: res,
+    text: () => collect(res),
+    json: async () => JSON.parse(await collect(res)),
+  };
+}
+
+function withoutAuthorization(headers) {
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => name.toLowerCase() !== AUTHORIZATION_HEADER));
+}
+
+/** GET `rawUrl`, following up to five redirects; the authorization header stays on its own host. */
+export async function nodeFetch(rawUrl, init = {}) {
+  const { signal } = init;
+  if (signal?.aborted) throw abortError();
+  let url = new URL(rawUrl);
+  let headers = { ...(init.headers ?? {}) };
+  for (let hop = 0; ; hop++) {
+    const res = await get(url, headers, signal);
+    const location = res.headers.location;
+    if (!REDIRECT_STATUSES.has(res.statusCode ?? 0) || !location) return toResponse(res);
+    res.resume();
+    if (hop >= MAX_REDIRECTS) throw new Error(`GET ${rawUrl}: too many redirects`);
+    const next = new URL(location, url);
+    if (next.host !== url.host) headers = withoutAuthorization(headers);
+    url = next;
+  }
+}

--- a/packages/lilbee/package-lock.json
+++ b/packages/lilbee/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lilbee",
-  "version": "0.6.99",
+  "version": "0.6.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lilbee",
-      "version": "0.6.99",
+      "version": "0.6.100",
       "license": "MIT",
       "bin": {
         "lilbee": "bin/lilbee.mjs",

--- a/packages/lilbee/package.json
+++ b/packages/lilbee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lilbee",
-  "version": "0.6.99",
+  "version": "0.6.100",
   "description": "The whole local AI stack in one executable: run and manage local models across every GPU you have, and search your files, notes, code, and crawled sites with answers that cite the source. Terminal app, CLI, MCP server, and REST API. Auto-detects your hardware (CUDA, ROCm, Metal) and fetches the matching standalone binary on first use.",
   "license": "MIT",
   "homepage": "https://lilbee.sh",

--- a/packages/lilbee/test/fetch.test.mjs
+++ b/packages/lilbee/test/fetch.test.mjs
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { browserRuntime, launcherFetch } from "../lib/fetch.mjs";
+import { nodeFetch } from "../lib/http-client.mjs";
+
+test("a scope with window and document is a browser runtime", () => {
+  assert.equal(browserRuntime({ window: {}, document: {} }), true);
+  assert.equal(browserRuntime({ window: {} }), false);
+  assert.equal(browserRuntime({}), false);
+});
+
+test("inside a browser runtime the launcher uses Node's own client", async () => {
+  const scope = { window: {}, document: {}, fetch: async () => ({}) };
+  assert.equal(await launcherFetch({}, () => {}, scope), nodeFetch);
+});
+
+test("outside a browser runtime the launcher uses the scope's fetch", async () => {
+  const fetch = async () => ({});
+  assert.equal(await launcherFetch({}, () => {}, { fetch }), fetch);
+});

--- a/packages/lilbee/test/http-client.test.mjs
+++ b/packages/lilbee/test/http-client.test.mjs
@@ -1,0 +1,158 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+import { nodeFetch } from "../lib/http-client.mjs";
+
+let server;
+let base;
+let handler;
+const requests = [];
+
+function listen(srv) {
+  return new Promise((resolve) => {
+    srv.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${srv.address().port}`));
+  });
+}
+
+async function readAll(body) {
+  let text = "";
+  for await (const chunk of body) text += chunk.toString();
+  return text;
+}
+
+beforeEach(async () => {
+  requests.length = 0;
+  handler = (_req, res) => {
+    res.writeHead(200, { "content-type": "text/plain", "content-length": "5" });
+    res.end("hello");
+  };
+  server = createServer((req, res) => {
+    requests.push({ url: req.url, headers: req.headers });
+    handler(req, res);
+  });
+  base = await listen(server);
+});
+
+afterEach(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("returns the status, the headers, and the body as a Node stream", async () => {
+  const res = await nodeFetch(`${base}/asset`, { headers: { "user-agent": "lilbee-test" } });
+  assert.equal(res.ok, true);
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("Content-Length"), "5");
+  assert.equal(res.headers.get("x-missing"), null);
+  assert.ok(res.body instanceof Readable);
+  assert.equal(await readAll(res.body), "hello");
+  assert.equal(requests[0].headers["user-agent"], "lilbee-test");
+});
+
+test("reads json and text from the body", async () => {
+  handler = (_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ tag_name: "v1" }));
+  };
+  assert.deepEqual(await (await nodeFetch(`${base}/releases`)).json(), { tag_name: "v1" });
+  assert.equal(await (await nodeFetch(`${base}/releases`)).text(), '{"tag_name":"v1"}');
+});
+
+test("reports a failing status without throwing", async () => {
+  handler = (_req, res) => {
+    res.writeHead(404);
+    res.end("missing");
+  };
+  const res = await nodeFetch(`${base}/nope`);
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 404);
+  assert.equal(await res.text(), "missing");
+});
+
+test("follows a redirect and keeps the headers on the same host", async () => {
+  handler = (req, res) => {
+    if (req.url === "/start") {
+      res.writeHead(302, { location: "/final" });
+      res.end();
+      return;
+    }
+    res.writeHead(200);
+    res.end("landed");
+  };
+  const res = await nodeFetch(`${base}/start`, { headers: { authorization: "Bearer t", "user-agent": "ua" } });
+  assert.equal(await res.text(), "landed");
+  assert.deepEqual(
+    requests.map((r) => r.url),
+    ["/start", "/final"]
+  );
+  assert.equal(requests[1].headers.authorization, "Bearer t");
+  assert.equal(requests[1].headers["user-agent"], "ua");
+});
+
+test("drops the authorization header when a redirect changes host", async () => {
+  const other = createServer((req, res) => {
+    requests.push({ url: `other${req.url}`, headers: req.headers });
+    res.writeHead(200);
+    res.end("elsewhere");
+  });
+  const otherBase = await listen(other);
+  handler = (_req, res) => {
+    res.writeHead(302, { location: `${otherBase.replace("127.0.0.1", "localhost")}/asset` });
+    res.end();
+  };
+  try {
+    const res = await nodeFetch(`${base}/start`, { headers: { authorization: "Bearer t", "user-agent": "ua" } });
+    assert.equal(await res.text(), "elsewhere");
+    assert.equal(requests[1].url, "other/asset");
+    assert.equal(requests[1].headers.authorization, undefined);
+    assert.equal(requests[1].headers["user-agent"], "ua");
+  } finally {
+    await new Promise((resolve) => other.close(resolve));
+  }
+});
+
+test("gives up after too many redirects", async () => {
+  handler = (_req, res) => {
+    res.writeHead(302, { location: "/loop" });
+    res.end();
+  };
+  await assert.rejects(nodeFetch(`${base}/loop`), /redirects/);
+});
+
+test("rejects with an AbortError when the signal aborts before the response", async () => {
+  handler = () => {};
+  const controller = new AbortController();
+  const pending = nodeFetch(`${base}/slow`, { signal: controller.signal });
+  controller.abort();
+  await assert.rejects(pending, { name: "AbortError" });
+});
+
+test("rejects at once when the signal is already aborted", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(nodeFetch(`${base}/asset`, { signal: controller.signal }), { name: "AbortError" });
+  assert.equal(requests.length, 0);
+});
+
+test("ends the body stream with an AbortError when the signal aborts mid-transfer", async () => {
+  let hold = null;
+  handler = (_req, res) => {
+    res.writeHead(200, { "content-length": "10" });
+    res.write("12345");
+    hold = res;
+  };
+  const controller = new AbortController();
+  const res = await nodeFetch(`${base}/asset`, { signal: controller.signal });
+  const ended = new Promise((resolve) => {
+    res.body.on("error", (err) => resolve(err));
+    res.body.on("close", () => resolve(null));
+  });
+  controller.abort();
+  const outcome = await ended;
+  assert.ok(outcome === null || outcome.name === "AbortError");
+  hold?.destroy();
+});
+
+test("rejects a connection failure", async () => {
+  await assert.rejects(nodeFetch("http://127.0.0.1:1/asset"));
+});


### PR DESCRIPTION
## Problem

Inside an Electron renderer the global fetch is the browser's, and it refuses GitHub's cross-host asset redirect under CORS. The Obsidian plugin worked around that by handing the launcher the node-fetch library as its transport. Obsidian's plugin review bans that library, and the workaround left a piece of the download outside the package.

## Solution

The launcher ships its own transport over Node's http and https clients and selects it whenever `window` and `document` are in scope. It follows up to five redirects, drops the authorization header when the host changes, streams the body, and turns a cancel into an AbortError. Outside a browser runtime nothing changes: global fetch, with the env proxy agent when a proxy is set. The `fetch` option stays for embedders that want a transport of their own.

Verified with a real download in a browser-like scope: the listing, a 387 MB asset with its digest checked, and the binary running.

## Version

0.6.100.
