### PR TITLE
Give every list-typed setting the list editor and validate OCR language codes

### DIFF
--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -28,7 +28,6 @@ class RenderStyle(StrEnum):
 
     COMPACT = "compact"
     FULL = "full"
-    LIST_COLLAPSED = "list_collapsed"
     MULTILINE = "multiline"
 
 
@@ -778,7 +777,6 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         list,
         nullable=False,
         group=SettingGroup.CRAWLING,
-        render=RenderStyle.LIST_COLLAPSED,
         help_text=(
             "Browser mode: extra Chromium launch flags, one per line. "
             "Defaults trim shared-memory and GPU use."
@@ -862,7 +860,6 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         list,
         nullable=False,
         group=SettingGroup.CRAWLING,
-        render=RenderStyle.LIST_COLLAPSED,
         validate_regex=True,
         help_text=(
             "Regex patterns that skip URLs at link-discovery time during "

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -405,7 +405,7 @@ class SettingsScreen(Screen[None]):
 
     @on(Button.Pressed, ".setting-list-restore")
     def _on_list_restore(self, event: Button.Pressed) -> None:
-        """Restore defaults for a LIST_COLLAPSED setting."""
+        """Restore defaults for a list setting."""
         btn_id = event.button.id
         if btn_id is None or not btn_id.startswith(LIST_RESTORE_PREFIX):
             return

--- a/src/lilbee/cli/tui/screens/settings_widgets.py
+++ b/src/lilbee/cli/tui/screens/settings_widgets.py
@@ -107,8 +107,6 @@ def effective_value(key: str) -> str:
     """Return the effective value for a setting, including model defaults."""
     user_value = getattr(cfg, key, None)
     if user_value is not None:
-        if isinstance(user_value, list):
-            return f"{len(user_value)} lines"
         return str(user_value)
     defaults = cfg.model_defaults
     if defaults is None:
@@ -213,7 +211,7 @@ def group_settings() -> dict[SettingGroup, list[tuple[str, SettingDef]]]:
 
 def make_editor(key: str, defn: SettingDef) -> Widget:
     """Create the appropriate editor widget for a setting."""
-    # A list never reaches an Input: effective_value summarises it as "N lines".
+    # A list never reaches an Input: str(list) would be saved back as the value.
     if defn.type is list:
         return make_list_editor(key)
     value = effective_value(key)

--- a/src/lilbee/cli/tui/screens/settings_widgets.py
+++ b/src/lilbee/cli/tui/screens/settings_widgets.py
@@ -213,7 +213,8 @@ def group_settings() -> dict[SettingGroup, list[tuple[str, SettingDef]]]:
 
 def make_editor(key: str, defn: SettingDef) -> Widget:
     """Create the appropriate editor widget for a setting."""
-    if defn.render is RenderStyle.LIST_COLLAPSED:
+    # A list never reaches an Input: effective_value summarises it as "N lines".
+    if defn.type is list:
         return make_list_editor(key)
     value = effective_value(key)
     if defn.choices:

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -8,6 +8,7 @@ to the same instance defined at module bottom.
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -45,6 +46,10 @@ log = logging.getLogger(__name__)
 # instance equal to this, so the model_validator can distinguish "user passed
 # the default" from "user explicitly set a value".
 _UNSET_PATH = Path()
+
+# A Tesseract language code: ISO 639 letters plus script or orientation suffixes
+# (eng, en, chi_sim, jpn_vert). xberg rejects anything else before extracting.
+_TESSERACT_LANGUAGE_CODE = re.compile(r"[a-z]{2,3}(?:_[a-z]+)*")
 
 # Snowball stemmer languages LanceDB's FTS accepts (lancedb.index.lang_mapping);
 # hardcoded so config validation does not import lancedb.
@@ -1127,6 +1132,12 @@ class Config(BaseSettings):
             v = v.replace("+", ",").replace("\n", ",").split(",")
         items = v or []
         langs = [s.strip() for s in items if isinstance(s, str) and s.strip()]
+        for lang in langs:
+            if not _TESSERACT_LANGUAGE_CODE.fullmatch(lang):
+                raise ValueError(
+                    f"ocr_language: {lang!r} is not a Tesseract language code "
+                    "(examples: eng, deu, chi_sim, jpn_vert)"
+                )
         return langs or ["eng"]
 
     @field_validator("flash_attention", mode="before")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -262,6 +262,16 @@ class TestOcrLanguage:
     def test_blank_entries_are_dropped(self):
         assert Config(ocr_language=["", "eng", "  "]).ocr_language == ["eng"]
 
+    @pytest.mark.parametrize("code", ["en", "eng", "chi_sim", "jpn_vert", "aze_cyrl"])
+    def test_accepts_tesseract_language_codes(self, code):
+        assert Config(ocr_language=[code]).ocr_language == [code]
+
+    @pytest.mark.parametrize("value", ["1 lines", "eng+1 lines", ["eng", "English"], "e"])
+    def test_rejects_values_that_are_not_language_codes(self, value):
+        """A settings-screen summary once landed here; xberg then refused every ingest."""
+        with pytest.raises(ValueError, match="language code"):
+            Config(ocr_language=value)
+
     def test_chat_mode_defaults_to_search_when_none_or_empty(self):
         """The validator coerces None / "" to 'search' so old configs round-trip."""
         from lilbee.core.config.model import Config as ConfigCls

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1340,6 +1340,50 @@ async def test_settings_list_editor_persists_through_toml_round_trip(tmp_path):
     assert parsed == ["pat-a", "pat-b"]
 
 
+async def test_settings_every_list_setting_gets_the_list_editor():
+    """A list-typed setting never lands in a plain Input.
+
+    The Input path is seeded from ``effective_value``, which summarises a list
+    as "N lines"; saving the form then wrote that summary back as the value.
+    """
+    from textual.widgets import Collapsible
+
+    from lilbee.app.settings_map import SETTINGS_MAP
+    from lilbee.cli.tui.screens.settings_widgets import group_settings
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+
+    list_keys = [
+        key
+        for group in group_settings().values()
+        for key, defn in group
+        if SETTINGS_MAP[key].type is list
+    ]
+    assert "ocr_language" in list_keys
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 60)):
+        for key in list_keys:
+            app.screen.query_one(f"#collapsible-{key}", Collapsible)
+            assert isinstance(app.screen.query_one(f"#ed-{key}"), ListTextArea), key
+
+
+async def test_settings_ocr_language_round_trips_through_the_list_editor(tmp_path):
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+    from lilbee.core import settings
+
+    cfg.data_root = tmp_path
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        ta = app.screen.query_one("#ed-ocr_language", ListTextArea)
+        ta.focus()
+        await pilot.pause()
+        ta.load_text("eng\ndeu")
+        ta.blur()
+        landed = await pump_until(pilot, lambda: "ocr_language" in settings.load(tmp_path))
+        assert landed, "the blur never reached the settings store"
+    assert cfg.ocr_language == ["eng", "deu"]
+    assert settings.load(tmp_path)["ocr_language"] == "eng\ndeu"
+
+
 async def test_list_text_area_posts_blurred():
     """ListTextArea posts its Blurred message when focus moves away."""
     from textual.widgets import Input

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1448,23 +1448,6 @@ async def test_settings_effective_value_shows_model_default():
         object.__setattr__(cfg, "_model_defaults", old_defaults)
 
 
-def test_settings_effective_value_summarizes_list():
-    """List values are shown as a line count, not Python repr, on the help line."""
-    from lilbee.cli.tui.screens.settings_widgets import effective_value
-
-    cfg.crawl_exclude_patterns = ["a", "b", "c"]
-    result = effective_value("crawl_exclude_patterns")
-    assert result == "3 lines"
-    # Specifically guards against the "current: ['a', 'b', 'c']" regression.
-    assert "[" not in result
-    assert "'" not in result
-
-    # Empty list must still be rendered as a count, not fall through to
-    # "None" or model defaults. Guards off-by-one refactors of len().
-    cfg.crawl_exclude_patterns = []
-    assert effective_value("crawl_exclude_patterns") == "0 lines"
-
-
 async def test_settings_effective_value_user_overrides_default():
     """When user has set a value, it takes precedence over model default."""
     from dataclasses import dataclass


### PR DESCRIPTION
## Problem

Saving the Settings screen could turn the OCR language into the literal text `1 lines`. The screen picked the list editor by a render marker, and `ocr_language` had none, so its editor was a plain text field seeded with the list's "N lines" summary. Saving any setting wrote that summary back. xberg checks the OCR language before it extracts anything, so from then on every add failed, native-text PDFs included.

## Solution

The editor is chosen by the setting's type: a list always gets the list editor, and the render marker that used to carry that choice is removed. The `ocr_language` validator now accepts only Tesseract language codes (`eng`, `en`, `chi_sim`, `jpn_vert`), so a bad value is refused when it is written, with a toast in the TUI, instead of surfacing as a failed ingest later. A config file that already holds a bad value falls back to defaults at startup through the existing stale-config path and reports the error.

Tests cover the validator both ways, assert that every list-typed setting on the Settings screen is a list editor, and round-trip `ocr_language` through the editor into config.toml.
