### PR TITLE
Build the engine index from the last successful release candidate

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -97,9 +97,12 @@ jobs:
             # builds run as reusable calls inside it, so that run holds the
             # full wheel-* set whether or not a downstream leg (e.g. QA)
             # succeeded.
+            # success, not completed: completed includes cancelled runs, and a
+            # cancelled candidate's partial wheel set replaces every backend
+            # index with wheels whose release assets no longer exist.
             run_id=$(gh run list \
               --workflow=release-candidate.yml \
-              --status=completed \
+              --status=success \
               --limit=1 \
               --json databaseId \
               -q '.[0].databaseId // ""')


### PR DESCRIPTION
## Problem

The pages workflow pulls the engine wheel artifacts from the most recent completed release-candidate run, and "completed" includes cancelled runs. After the cancelled 0.6.90b434 candidate, a main push rebuilt the index from its partial wheel set, and every backend index at lilbee.sh pointed at release assets that no longer existed. `pip install lilbee[engine]` failed with 404 on all backends until a manual redeploy against the b433 run.

## Solution

The lookup asks for successful runs only, so a cancelled or failed candidate never becomes the index source. The manual `rc_run_id` override and the `workflow_run` trigger, which already skips cancelled candidates, are unchanged.
