### PR TITLE
Retry a failed publish workflow so no release channel stays unpublished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ on:
       - 'tools/wheel-build/**'
       - 'packaging/tools/**'
       - 'scripts/qa/**'
-      - '.github/workflows/ci.yml'
-      - '.github/actions/restore-ci-models/**'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - 'scripts/*.sh'
   pull_request:
     paths: *ci-paths
   workflow_call:
@@ -61,6 +62,37 @@ jobs:
 
       - name: Check imports resolve
         run: make imports-check
+
+  # Shell is a first-class part of the release path: scripts/release_watch.sh
+  # heals the publish fan-out, and actionlint runs shellcheck over every inline
+  # `run:` block in .github as well.
+  shell:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Install actionlint and bats
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          BATS_VERSION: "1.14.0"
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin actionlint
+          npm install -g "bats@${BATS_VERSION}"
+
+      # make lint-shell skips a missing tool so it stays usable on a laptop.
+      # Assert them here so a runner image that drops one fails loudly instead.
+      - name: Every tool the shell gate needs is present
+        run: shellcheck --version && actionlint --version && bats --version
+
+      - run: make lint-shell
+      - run: make test-shell
 
   npm-launcher:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
       - name: Install actionlint and bats
         env:
           ACTIONLINT_VERSION: "1.7.12"
-          BATS_VERSION: "1.14.0"
+          # npm's `bats` package trails the GitHub releases; 1.13.0 is the
+          # newest there. Every helper used in tests/shell predates it.
+          BATS_VERSION: "1.13.0"
         run: |
           set -euo pipefail
           curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Check imports resolve
         run: make imports-check
 
-  # Shell is a first-class part of the release path: scripts/release_watch.sh
-  # heals the publish fan-out, and actionlint runs shellcheck over every inline
-  # `run:` block in .github as well.
   shell:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -79,8 +76,7 @@ jobs:
       - name: Install actionlint and bats
         env:
           ACTIONLINT_VERSION: "1.7.12"
-          # npm's `bats` package trails the GitHub releases; 1.13.0 is the
-          # newest there. Every helper used in tests/shell predates it.
+          # npm's `bats` package trails the GitHub releases; this is the newest npm has.
           BATS_VERSION: "1.13.0"
         run: |
           set -euo pipefail
@@ -88,8 +84,8 @@ jobs:
             | sudo tar xz -C /usr/local/bin actionlint
           npm install -g "bats@${BATS_VERSION}"
 
-      # make lint-shell skips a missing tool so it stays usable on a laptop.
-      # Assert them here so a runner image that drops one fails loudly instead.
+      # make lint-shell skips a missing tool. Assert them here so a runner image
+      # that drops one fails loudly.
       - name: Every tool the shell gate needs is present
         run: shellcheck --version && actionlint --version && bats --version
 

--- a/.github/workflows/publish-compat-packages.yml
+++ b/.github/workflows/publish-compat-packages.yml
@@ -1,4 +1,5 @@
 name: Publish compat packages
+run-name: Publish compat packages ${{ inputs.tag }}
 
 # Pins a tag's pre-Haswell Linux binary into the lilbee-compat channels: the
 # Homebrew lilbee-compat formula, the AUR lilbee-compat PKGBUILD, the Nix flake

--- a/.github/workflows/publish-cuda-packages.yml
+++ b/.github/workflows/publish-cuda-packages.yml
@@ -1,4 +1,5 @@
 name: Publish CUDA Packages
+run-name: Publish CUDA Packages ${{ inputs.tag }}
 
 # Updates the Homebrew lilbee-cuda formula, AUR lilbee-cuda PKGBUILD, and the
 # Nix flake CUDA entry to pin a tag's GH-release CUDA Linux binary. Runs

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,4 +1,5 @@
 name: Publish Docker Image
+run-name: Publish Docker Image ${{ inputs.tag }}
 
 # Dispatched by the publish & emergency-publish workflows (and by hand) once
 # the tag's binaries are attached to its GH release.

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,4 +1,5 @@
 name: Publish Packages
+run-name: Publish Packages ${{ inputs.tag }}
 
 # Updates the Homebrew formula, AUR PKGBUILD, and Nix flake to pin a tag's
 # GH-release binaries, and publishes the npm launcher packages. Dispatched by

--- a/.github/workflows/publish-rocm-packages.yml
+++ b/.github/workflows/publish-rocm-packages.yml
@@ -1,4 +1,5 @@
 name: Publish ROCm Packages
+run-name: Publish ROCm Packages ${{ inputs.tag }}
 
 # Updates the Homebrew lilbee-rocm formula, AUR lilbee-rocm PKGBUILD, and the Nix
 # flake ROCm entry to pin a tag's GH-release ROCm Linux binary, and builds the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish to PyPI
+run-name: Publish to PyPI ${{ inputs.tag }}
 
 # Pure PyPI publish: finds the release-candidate.yml run for this tag, downloads
 # its default wheels + sdist, uploads them to PyPI. Auto-dispatched by

--- a/.github/workflows/release-selfheal.yml
+++ b/.github/workflows/release-selfheal.yml
@@ -94,7 +94,7 @@ jobs:
           {
             echo "Failed cells:"
             echo
-            echo "${failed}" | sed 's/^/- /'
+            echo "${failed}" | awk '{ print "- " $0 }'
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/release-selfheal.yml
+++ b/.github/workflows/release-selfheal.yml
@@ -7,9 +7,6 @@ run-name: Self-heal ${{ github.event.workflow_run.head_branch || inputs.run_id }
 # strands the release short of promotion until a human notices. This reruns the
 # cells that failed, so the candidate corrects itself.
 #
-# The mechanism, and why the retry is blind, are documented in
-# scripts/release_selfheal.sh.
-
 on:
   workflow_run:
     workflows: ["Release candidate"]
@@ -40,9 +37,8 @@ jobs:
        startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     steps:
-      # The default branch, never the tag: heal the candidate with the newest
-      # logic, and a bare checkout resolves against the run's pinned sha, which
-      # hard-fails once a tag is force-moved.
+      # The default branch, never the tag: a bare checkout resolves the run's
+      # pinned sha, which hard-fails once a tag is force-moved.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release-selfheal.yml
+++ b/.github/workflows/release-selfheal.yml
@@ -7,28 +7,8 @@ run-name: Self-heal ${{ github.event.workflow_run.head_branch || inputs.run_id }
 # strands the release short of promotion until a human notices. This reruns the
 # cells that failed, so the candidate corrects itself.
 #
-# `gh run rerun --failed` is the whole mechanism. It reruns the failed jobs plus
-# the jobs skipped behind them and leaves the successful cells alone, which is
-# what both failure modes need:
-#
-#   - A soft cell (every cell in build-gpu-executables.yml is
-#     continue-on-error) carries conclusion=failure while the run stays green.
-#     Nothing is skipped, so only that cell reruns; its own release_tag step
-#     attaches the missing asset, and verify-release re-fires when the run
-#     completes again.
-#   - A hard cell takes the run red, which skips attach-prerelease and all five
-#     dispatch jobs. Rerunning the cell alone would leave them skipped forever,
-#     because a per-job rerun does not re-queue dependents. `--failed` picks the
-#     stranded cascade up with the cell.
-#
-# Every dispatch job on a tag build shares one `if` (push + refs/tags/v), so a
-# skipped job there always means "stranded", never "skipped by design". That is
-# what makes --failed safe to point at this workflow.
-#
-# The retry is blind: it does not read logs to guess whether a failure was a
-# flake or a defect. Signature matching against GitHub's error text is a list
-# that goes stale, and a defect just fails again and stops at the attempt bound
-# below, which costs one cell rebuild.
+# The mechanism, and why the retry is blind, are documented in
+# scripts/release_selfheal.sh.
 
 on:
   workflow_run:
@@ -41,17 +21,12 @@ on:
         required: true
 
 permissions:
-  actions: write
+  contents: read   # check out the script
+  actions: write  # rerun the failed cells
 
 concurrency:
   group: release-selfheal-${{ github.event.workflow_run.id || inputs.run_id }}
   cancel-in-progress: false
-
-env:
-  # One retry. A second flake on the same cell is rare enough to be worth a
-  # human look, and this is the only thing standing between a real defect and
-  # an unbounded rebuild loop.
-  MAX_ATTEMPTS: 2
 
 jobs:
   heal:
@@ -65,47 +40,17 @@ jobs:
        startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     steps:
+      # The default branch, never the tag: heal the candidate with the newest
+      # logic, and a bare checkout resolves against the run's pinned sha, which
+      # hard-fails once a tag is force-moved.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Rerun the cells that failed
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
-        run: |
-          set -euo pipefail
-
-          attempt=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .run_attempt)
-          conclusion=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .conclusion)
-
-          failed=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-            --paginate -q '.jobs[] | select(.conclusion == "failure") | .name')
-
-          {
-            echo "## Release self-heal"
-            echo
-            echo "Run [${RUN_ID}](https://github.com/${REPO}/actions/runs/${RUN_ID}), attempt ${attempt}, concluded ${conclusion}."
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ -z "${failed}" ]; then
-            echo "no failed cells; nothing to heal" | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          {
-            echo "Failed cells:"
-            echo
-            echo "${failed}" | awk '{ print "- " $0 }'
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
-            echo "attempt ${attempt} reached the bound of ${MAX_ATTEMPTS}; not retrying again" \
-              | tee -a "$GITHUB_STEP_SUMMARY"
-            echo "These cells failed twice. Read the logs before rerunning: a second failure is a defect until proven otherwise." \
-              >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          echo "rerunning the failed cells and anything stranded behind them"
-          gh run rerun "${RUN_ID}" --repo "${REPO}" --failed
-          echo "Retried as attempt $((attempt + 1))." >> "$GITHUB_STEP_SUMMARY"
+        run: bash scripts/release_selfheal.sh

--- a/.github/workflows/release-watch.yml
+++ b/.github/workflows/release-watch.yml
@@ -2,12 +2,7 @@ name: Release watch
 
 run-name: Watch ${{ github.event.workflow_run.head_branch || inputs.tag }}
 
-# Every dispatched publish leg gets watched and healed. The logic is
-# scripts/release_watch.sh so it can be read, shellchecked, tested with bats and
-# run by hand; this file only supplies the trigger and the environment.
-#
-# There is no alerting by design: green is silence, and a red run here is the
-# signal, delivered by GitHub's own failed-workflow notification.
+# No alerting: a red run here is the signal, via GitHub's failed-workflow notification.
 
 on:
   workflow_run:
@@ -27,19 +22,17 @@ permissions:
   contents: read   # check out the script; read the release to confirm it promoted
   actions: write   # rerun a failed leg, re-issue a lost dispatch
 
-# Keyed on the tag and cancelling, unlike every other release workflow here.
-# release-selfheal reruns the candidate, which emits a second completion and
-# would start a second watcher. Two watchers racing the same legs spend the
-# two-attempt budget in one pass, so the newest view of the release wins.
+# Cancelling, unlike the other release workflows: release-selfheal's rerun emits
+# a second candidate completion, and two watchers racing the same legs would
+# spend the two-attempt budget in one pass.
 concurrency:
   group: release-watch-${{ github.event.workflow_run.head_branch || inputs.tag }}
   cancel-in-progress: true
 
 jobs:
   watch:
-    # Only a tag push. A workflow_dispatch candidate skips create-prerelease and
-    # the whole dispatch cascade by design, so there would be no legs to watch
-    # and this would go red on a build that was correct.
+    # Only a tag push: a workflow_dispatch candidate skips create-prerelease and
+    # the whole dispatch cascade, so there are no legs to watch.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.event == 'push' &&
@@ -50,9 +43,8 @@ jobs:
     # both. Stays under the 360-minute job ceiling.
     timeout-minutes: 300
     steps:
-      # The default branch, never the tag. The watcher should always run the
-      # newest logic, and a bare checkout resolves against the run's pinned sha,
-      # which hard-fails once a tag is force-moved.
+      # The default branch, never the tag: a bare checkout resolves the run's
+      # pinned sha, which hard-fails once a tag is force-moved.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release-watch.yml
+++ b/.github/workflows/release-watch.yml
@@ -1,0 +1,68 @@
+name: Release watch
+
+run-name: Watch ${{ github.event.workflow_run.head_branch || inputs.tag }}
+
+# Every dispatched publish leg gets watched and healed. The logic is
+# scripts/release_watch.sh so it can be read, shellchecked, tested with bats and
+# run by hand; this file only supplies the trigger and the environment.
+#
+# There is no alerting by design: green is silence, and a red run here is the
+# signal, delivered by GitHub's own failed-workflow notification.
+
+on:
+  workflow_run:
+    workflows: ["Release candidate"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to watch (e.g. v0.6.90b434)."
+        required: true
+      dry_run:
+        description: "Report what would be rerun or re-dispatched, and change nothing."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read   # check out the script; read the release to confirm it promoted
+  actions: write   # rerun a failed leg, re-issue a lost dispatch
+
+# Keyed on the tag and cancelling, unlike every other release workflow here.
+# release-selfheal reruns the candidate, which emits a second completion and
+# would start a second watcher. Two watchers racing the same legs spend the
+# two-attempt budget in one pass, so the newest view of the release wins.
+concurrency:
+  group: release-watch-${{ github.event.workflow_run.head_branch || inputs.tag }}
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    # Only a tag push. A workflow_dispatch candidate skips create-prerelease and
+    # the whole dispatch cascade by design, so there would be no legs to watch
+    # and this would go red on a build that was correct.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    # verify-release waits up to 180 minutes for the channel artifacts and
+    # publish-flatpak up to 90 for the variant binaries, so the watch spans
+    # both. Stays under the 360-minute job ceiling.
+    timeout-minutes: 300
+    steps:
+      # The default branch, never the tag. The watcher should always run the
+      # newest logic, and a bare checkout resolves against the run's pinned sha,
+      # which hard-fails once a tag is force-moved.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Watch every dispatched leg to a conclusion
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.workflow_run.head_branch || inputs.tag }}
+          RC_RUN_ID: ${{ github.event.workflow_run.id }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: bash scripts/release_watch.sh

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ scripts/*
 !scripts/release_notes.sh
 !scripts/promote_release.sh
 !scripts/release_watch.sh
+!scripts/release_selfheal.sh
 !scripts/qa/
 scripts/qa/*
 !scripts/qa/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ scripts/*
 !scripts/release.sh
 !scripts/release_notes.sh
 !scripts/promote_release.sh
+!scripts/release_watch.sh
 !scripts/qa/
 scripts/qa/*
 !scripts/qa/*.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,8 +469,10 @@ closure. These rules exist because each one shipped a broken artifact once.
   The retry is deliberately blind: matching GitHub's error text to tell a flake
   from a defect is a list that goes stale, and a defect costs one rebuild.
 - **A failed publish leg is retried once too.** `release-watch.yml` runs
-  `scripts/release_watch.sh` after every Release candidate, waits for the eight
-  dispatched legs, reruns a failed one, and re-issues a dispatch that never landed.
+  `scripts/release_watch.sh` after every Release candidate, waits for the seven
+  dispatched legs plus `verify-release` (which fires on the candidate's
+  completion, so it is watched but never re-dispatched), reruns a failed one,
+  and re-issues a dispatch that never landed.
   It defers while the candidate still has failed cells: `release-selfheal` reruns a
   dropped build cell, and retrying `verify-release` before the healed asset is
   attached would spend both its attempts on the same missing file.
@@ -478,6 +480,14 @@ closure. These rules exist because each one shipped a broken artifact once.
   `run:` blocks cannot be run, linted or tested off a runner. `make lint-shell`
   shellchecks the scripts and runs actionlint over every workflow; `make test-shell`
   runs the bats suite in `tests/shell/` against a stubbed `gh`.
+- **The release attempt bound is two, in one place per script.** A cell or a
+  publish leg gets one retry; a second failure on the same thing is a defect
+  until proven otherwise, and the bound is all that separates a real defect from
+  an unbounded rerun loop. `scripts/release_selfheal.sh` applies it to candidate
+  cells and `scripts/release_watch.sh` to publish legs.
+- **`gh api --paginate` runs the `-q` filter once per page.** That is correct
+  when the filter emits one line per item and wrong when it emits a count: two
+  pages return `0\n0`, and a numeric test on it errors instead of comparing.
 - **A skipped job on a tag build means stranded, never "skipped by design".**
   Every dispatch job in `release-candidate.yml` shares one `if` (push +
   `refs/tags/v`), which is what makes `--failed` safe to point at the run. A new

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,16 +455,29 @@ closure. These rules exist because each one shipped a broken artifact once.
   every cell, not just CUDA: cmake caches an unknown `-D` instead of failing, which is
   how the published rocm wheel shipped as a CPU build. A new flavor needs its library
   name added there or the gate asserts nothing for it.
-- **A new publish workflow needs both ends wired.** A `publish-*.yml` is invoked by a
-  dispatch job in `release-candidate.yml`, and its assets belong in
-  `verify-release.yml`. Adding the gate without the dispatcher makes every release
-  unpromotable: the wait loop burns its full timeout, then promotion refuses.
+- **A new publish workflow needs three ends wired.** A `publish-*.yml` is invoked by a
+  dispatch job in `release-candidate.yml`, its assets belong in
+  `verify-release.yml`, and it belongs in the `LEGS` table in
+  `scripts/release_watch.sh` so a flake in it gets retried. Adding the gate without
+  the dispatcher makes every release unpromotable: the wait loop burns its full
+  timeout, then promotion refuses. It also needs a `run-name` carrying
+  `${{ inputs.tag }}`, which is how the watcher tells this tag's run from an older one.
 - **A failed build cell is retried once, not forever.** `release-selfheal.yml`
   watches every Release candidate run and reruns the failed cells with
   `gh run rerun --failed`, which also picks up whatever was skipped behind them.
   It gives up at `run_attempt` 2, so a real defect surfaces instead of looping.
   The retry is deliberately blind: matching GitHub's error text to tell a flake
   from a defect is a list that goes stale, and a defect costs one rebuild.
+- **A failed publish leg is retried once too.** `release-watch.yml` runs
+  `scripts/release_watch.sh` after every Release candidate, waits for the eight
+  dispatched legs, reruns a failed one, and re-issues a dispatch that never landed.
+  It defers while the candidate still has failed cells: `release-selfheal` reruns a
+  dropped build cell, and retrying `verify-release` before the healed asset is
+  attached would spend both its attempts on the same missing file.
+- **Release shell lives in `scripts/*.sh`, not inline in a workflow.** Inline
+  `run:` blocks cannot be run, linted or tested off a runner. `make lint-shell`
+  shellchecks the scripts and runs actionlint over every workflow; `make test-shell`
+  runs the bats suite in `tests/shell/` against a stubbed `gh`.
 - **A skipped job on a tag build means stranded, never "skipped by design".**
   Every dispatch job in `release-candidate.yml` shares one `if` (push +
   `refs/tags/v`), which is what makes `--failed` safe to point at the run. A new

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ lint-shell:  ## shellcheck the release scripts and actionlint every workflow
 	@if command -v shellcheck >/dev/null; then \
 	  shellcheck -s bash scripts/*.sh tests/shell/stubs/*; \
 	else echo "lint-shell: shellcheck is not installed, skipping"; fi
-	# actionlint also runs shellcheck over every inline `run:` block, which is
-	# where most of the shell in .github still lives.
+	# actionlint also shellchecks every inline `run:` block.
 	@if command -v actionlint >/dev/null; then actionlint; \
 	else echo "lint-shell: actionlint is not installed, skipping"; fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: lint format format-check typecheck test test-ci test-ci-serial test-ci-forked test-integration imports-check fuzz-smoke engine-archs docs-settings docs-formats check clean install demo demo-prep demo-publish build publish release promote release-promote docs docs-api docs-site site site-serve site-tar dns-setup qa-pod-volume qa-pod-up qa-pod-logs qa-pod-down
+.PHONY: lint lint-shell test-shell format format-check typecheck test test-ci test-ci-serial test-ci-forked test-integration imports-check fuzz-smoke engine-archs docs-settings docs-formats check clean install demo demo-prep demo-publish build publish release promote release-promote docs docs-api docs-site site site-serve site-tar dns-setup qa-pod-volume qa-pod-up qa-pod-logs qa-pod-down
 
-lint:
+lint: lint-shell
 	uv run ruff check src/ tests/ tools/qa/ scripts/qa/ tools/readme_media.py tools/gen_settings_reference.py tools/gen_formats_table.py hatch_build.py
 	uv run python scripts/check_style_rules.py
 	# docs/settings.md is generated from the Config fields; a new setting must
@@ -9,6 +9,19 @@ lint:
 	# The README formats table is generated from discovery's format map, so an
 	# xberg or tree-sitter bump that changes the set lands in the table.
 	uv run python tools/gen_formats_table.py --check
+
+lint-shell:  ## shellcheck the release scripts and actionlint every workflow
+	@if command -v shellcheck >/dev/null; then \
+	  shellcheck -s bash scripts/*.sh tests/shell/stubs/*; \
+	else echo "lint-shell: shellcheck is not installed, skipping"; fi
+	# actionlint also runs shellcheck over every inline `run:` block, which is
+	# where most of the shell in .github still lives.
+	@if command -v actionlint >/dev/null; then actionlint; \
+	else echo "lint-shell: actionlint is not installed, skipping"; fi
+
+test-shell:  ## Run the bats tests for the release scripts
+	@command -v bats >/dev/null || { echo "test-shell: bats-core is missing (brew install bats-core)"; exit 1; }
+	bats tests/shell/
 
 format:
 	uv run ruff format src/ tests/ tools/qa/ scripts/qa/ tools/readme_media.py tools/gen_settings_reference.py tools/gen_formats_table.py hatch_build.py
@@ -47,7 +60,7 @@ test-integration:
 fuzz-smoke:  ## Seeded adversarial TUI fuzz, fixed seeds (deterministic, CI-sized)
 	uv run python scripts/qa/tui_fuzz.py smoke
 
-check: lint format-check typecheck test  ## Run all checks (same as CI)
+check: lint format-check typecheck test test-shell  ## Run all checks (same as CI)
 
 install:
 	uv tool install ".[crawler]" --force --reinstall --compile-bytecode

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,9 +18,12 @@ git fetch -q origin main
   || { echo "release: main is not in sync with origin/main" >&2; exit 1; }
 
 cur=$(awk -F'"' '/^version *= */ { print $2; exit }' pyproject.toml)
+# The counter must END the version, not merely appear in it: 0.7.0b1.post1
+# would pass a "contains bN" test and then abort inside the arithmetic below
+# with a raw bash error, after the branch and sync checks have already run.
 case "$cur" in
-  *b[0-9]*) ;;
-  *) echo "release: version '$cur' has no beta (bNNN) segment to bump" >&2; exit 1;;
+  *.dev[0-9]|*.dev[0-9][0-9]*|*b[0-9]|*b[0-9][0-9]*) ;;
+  *) echo "release: version '$cur' does not end in a bNNN or .devNNN counter to bump" >&2; exit 1;;
 esac
 # Bump the last numeric segment: the dev counter when the version carries one
 # (0.6.90b420.dev710 -> .dev711), otherwise the beta counter (0.6.66b507 -> b508).
@@ -37,8 +40,9 @@ perl -pi -e 's/^version = "\Q'"$cur"'\E"$/version = "'"$next"'"/' pyproject.toml
 git add pyproject.toml uv.lock
 git commit -q -m "Release ${next}"
 git tag "$tag"
-git push origin main
-git push origin "$tag"
+# One push: a rejected main (someone landed between the fetch above and here)
+# must not leave the tag published against a commit that never reached main.
+git push --atomic origin main "$tag"
 
 echo "release: pushed ${tag}. The pipeline takes it from here: it builds, publishes"
 echo "release: every channel, retries a leg that flakes, and promotes the tag itself."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Cut a beta release: bump the trailing counter (the .devNNN when the version has
 # one, else the bNNN), commit, tag, and push from main.
-# release-candidate.yml builds the artifacts, publishes to PyPI, and creates the
-# pre-release with generated notes. Once that pipeline is green run
-# `make release-promote` to rewrite the notes as headings and mark it latest.
+# Everything after the push is automatic. release-candidate.yml builds the
+# artifacts, publishes to PyPI and fans out to every channel; release-selfheal.yml
+# retries a failed build cell; release-watch.yml retries a failed publish leg; and
+# verify-release.yml promotes the tag once the assets pass a real-inference smoke.
+# `make release-promote` stays as the manual path for rewriting notes by hand.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -38,5 +40,6 @@ git tag "$tag"
 git push origin main
 git push origin "$tag"
 
-echo "release: pushed ${tag}; release-candidate.yml is building."
-echo "release: when the PyPI publish is green, run 'make release-promote'."
+echo "release: pushed ${tag}. The pipeline takes it from here: it builds, publishes"
+echo "release: every channel, retries a leg that flakes, and promotes the tag itself."
+echo "release: a red 'Watch ${tag}' run is the only thing that wants your attention."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 # Cut a beta release: bump the trailing counter (the .devNNN when the version has
 # one, else the bNNN), commit, tag, and push from main.
-# Everything after the push is automatic. release-candidate.yml builds the
-# artifacts, publishes to PyPI and fans out to every channel; release-selfheal.yml
-# retries a failed build cell; release-watch.yml retries a failed publish leg; and
-# verify-release.yml promotes the tag once the assets pass a real-inference smoke.
-# `make release-promote` stays as the manual path for rewriting notes by hand.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -18,9 +13,8 @@ git fetch -q origin main
   || { echo "release: main is not in sync with origin/main" >&2; exit 1; }
 
 cur=$(awk -F'"' '/^version *= */ { print $2; exit }' pyproject.toml)
-# The counter must END the version, not merely appear in it: 0.7.0b1.post1
-# would pass a "contains bN" test and then abort inside the arithmetic below
-# with a raw bash error, after the branch and sync checks have already run.
+# The counter must END the version: 0.7.0b1.post1 passes a "contains bN" test
+# and then fails inside the arithmetic below, after the branch and sync checks.
 case "$cur" in
   *.dev[0-9]|*.dev[0-9][0-9]*|*b[0-9]|*b[0-9][0-9]*) ;;
   *) echo "release: version '$cur' does not end in a bNNN or .devNNN counter to bump" >&2; exit 1;;

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -33,9 +33,8 @@ gh api "repos/${repo}/releases/generate-notes" "${args[@]}" --jq .body | awk '
 if [ -n "$prev" ]; then
   old_archs=$(mktemp)
   new_archs=$(mktemp)
-  # The body is already on stdout by now. If the table generator exits non-zero,
-  # set -e ends the script here, so the cleanup has to be a trap rather than the
-  # rm below, or the caller gets a complete-looking body and two leaked files.
+  # set -e can end the script inside the table generator, after the body is
+  # already on stdout. Cleanup must be a trap.
   trap 'rm -f "$old_archs" "$new_archs"' EXIT
   archs_path="src/lilbee/_generated/engine_archs.py"
   root=$(cd "$(dirname "$0")/.." && pwd)

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -5,8 +5,8 @@
 # Usage: release_notes.sh <owner/repo> <tag> [previous_tag]
 set -euo pipefail
 
-repo=$1
-tag=$2
+repo=${1:?usage: release_notes.sh <owner/repo> <tag> [previous_tag]}
+tag=${2:?usage: release_notes.sh <owner/repo> <tag> [previous_tag]}
 prev=${3:-}
 
 args=(-f tag_name="$tag")
@@ -33,6 +33,10 @@ gh api "repos/${repo}/releases/generate-notes" "${args[@]}" --jq .body | awk '
 if [ -n "$prev" ]; then
   old_archs=$(mktemp)
   new_archs=$(mktemp)
+  # The body is already on stdout by now. If the table generator exits non-zero,
+  # set -e ends the script here, so the cleanup has to be a trap rather than the
+  # rm below, or the caller gets a complete-looking body and two leaked files.
+  trap 'rm -f "$old_archs" "$new_archs"' EXIT
   archs_path="src/lilbee/_generated/engine_archs.py"
   root=$(cd "$(dirname "$0")/.." && pwd)
   if git -C "$root" show "${prev}:${archs_path}" > "$old_archs" 2>/dev/null \
@@ -43,5 +47,4 @@ if [ -n "$prev" ]; then
       printf '\n%s\n' "$table"
     fi
   fi
-  rm -f "$old_archs" "$new_archs"
 fi

--- a/scripts/release_selfheal.sh
+++ b/scripts/release_selfheal.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Rerun the release-candidate cells that failed, so the candidate corrects itself.
+#
+# A candidate builds for hours across ~30 cells, and a cell that dies from an
+# infra flake (runner lost communication, no space left on device) strands the
+# release short of promotion until a person notices.
+#
+# `gh run rerun --failed` is the whole mechanism. It reruns the failed jobs plus
+# the jobs skipped behind them and leaves the successful cells alone, which is
+# what both failure modes need:
+#
+#   - A soft cell (every cell in build-gpu-executables.yml is continue-on-error)
+#     carries conclusion=failure while the run stays green. Nothing is skipped,
+#     so only that cell reruns; its own release_tag step attaches the missing
+#     asset, and verify-release re-fires when the run completes again.
+#   - A hard cell takes the run red, which skips attach-prerelease and every
+#     dispatch job. Rerunning the cell alone would leave them skipped forever,
+#     because a per-job rerun does not re-queue dependents. `--failed` picks the
+#     stranded cascade up with the cell.
+#
+# Every dispatch job on a tag build shares one `if` (push + refs/tags/v), so a
+# skipped job there always means "stranded", never "skipped by design". That is
+# what makes --failed safe to point at this workflow.
+#
+# The retry is blind: it does not read logs to guess whether a failure was a
+# flake or a defect. Signature matching against GitHub's error text is a list
+# that goes stale, and a defect just fails again and stops at the attempt bound.
+#
+# Run it by hand against a finished candidate:
+#   RUN_ID=1234567 bash scripts/release_selfheal.sh
+#
+# Environment:
+#   RUN_ID        release-candidate run to heal (required)
+#   REPO          owner/name (default: tobocop2/lilbee)
+#   MAX_ATTEMPTS  attempts before a failure is called a defect (default 2)
+
+set -euo pipefail
+
+RUN_ID="${RUN_ID:?RUN_ID is required}"
+REPO="${REPO:-tobocop2/lilbee}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-2}"   # see AGENTS.md on the release attempt bound
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+attempt=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .run_attempt)
+conclusion=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .conclusion)
+
+# --paginate is correct here: the filter emits one name per line, so pages
+# concatenate. It would be wrong with a jq count, which runs per page.
+failed=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+  --paginate -q '.jobs[] | select(.conclusion == "failure") | .name')
+
+{
+  echo "## Release self-heal"
+  echo
+  echo "Run [${RUN_ID}](https://github.com/${REPO}/actions/runs/${RUN_ID}), attempt ${attempt}, concluded ${conclusion}."
+  echo
+} >> "${SUMMARY}"
+
+if [ -z "${failed}" ]; then
+  echo "no failed cells; nothing to heal" | tee -a "${SUMMARY}"
+  exit 0
+fi
+
+{
+  echo "Failed cells:"
+  echo
+  echo "${failed}" | awk '{ print "- " $0 }'
+  echo
+} >> "${SUMMARY}"
+
+if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+  echo "attempt ${attempt} reached the bound of ${MAX_ATTEMPTS}; not retrying again" | tee -a "${SUMMARY}"
+  echo "These cells failed twice. Read the logs before rerunning: a second failure is a defect until proven otherwise." >> "${SUMMARY}"
+  exit 1
+fi
+
+echo "rerunning the failed cells and anything stranded behind them"
+gh run rerun "${RUN_ID}" --repo "${REPO}" --failed
+echo "Retried as attempt $((attempt + 1))." >> "${SUMMARY}"

--- a/scripts/release_selfheal.sh
+++ b/scripts/release_selfheal.sh
@@ -1,30 +1,10 @@
 #!/usr/bin/env bash
 # Rerun the release-candidate cells that failed, so the candidate corrects itself.
 #
-# A candidate builds for hours across ~30 cells, and a cell that dies from an
-# infra flake (runner lost communication, no space left on device) strands the
-# release short of promotion until a person notices.
-#
-# `gh run rerun --failed` is the whole mechanism. It reruns the failed jobs plus
-# the jobs skipped behind them and leaves the successful cells alone, which is
-# what both failure modes need:
-#
-#   - A soft cell (every cell in build-gpu-executables.yml is continue-on-error)
-#     carries conclusion=failure while the run stays green. Nothing is skipped,
-#     so only that cell reruns; its own release_tag step attaches the missing
-#     asset, and verify-release re-fires when the run completes again.
-#   - A hard cell takes the run red, which skips attach-prerelease and every
-#     dispatch job. Rerunning the cell alone would leave them skipped forever,
-#     because a per-job rerun does not re-queue dependents. `--failed` picks the
-#     stranded cascade up with the cell.
-#
-# Every dispatch job on a tag build shares one `if` (push + refs/tags/v), so a
-# skipped job there always means "stranded", never "skipped by design". That is
-# what makes --failed safe to point at this workflow.
-#
-# The retry is blind: it does not read logs to guess whether a failure was a
-# flake or a defect. Signature matching against GitHub's error text is a list
-# that goes stale, and a defect just fails again and stops at the attempt bound.
+# `gh run rerun --failed` reruns the failed jobs plus the jobs skipped behind
+# them. A soft cell (build-gpu-executables.yml is all continue-on-error) reruns
+# alone and re-attaches its asset; a hard cell takes the run red and strands the
+# dispatch cascade, which a per-job rerun would leave skipped forever.
 #
 # Run it by hand against a finished candidate:
 #   RUN_ID=1234567 bash scripts/release_selfheal.sh
@@ -44,8 +24,7 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 attempt=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .run_attempt)
 conclusion=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" -q .conclusion)
 
-# --paginate is correct here: the filter emits one name per line, so pages
-# concatenate. It would be wrong with a jq count, which runs per page.
+# --paginate is safe here: the filter emits one name per line, not a count.
 failed=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
   --paginate -q '.jobs[] | select(.conclusion == "failure") | .name')
 

--- a/scripts/release_watch.sh
+++ b/scripts/release_watch.sh
@@ -2,12 +2,13 @@
 # Watch the workflows a release candidate dispatches, and heal the ones that flake.
 #
 # release-selfheal.yml reruns the candidate's own build cells. Nothing watched
-# the eight workflows the candidate dispatches, so a flake in a publish leg (an
+# the seven workflows the candidate dispatches, nor verify-release which fires
+# on its completion, so a flake in a publish leg (an
 # apt 403 on a runner image, an AUR maintenance window, a nix job racing a push
 # to main) left that channel unpublished until a person noticed and pressed
 # rerun. This script is that person.
 #
-# It waits for every dispatched leg, reruns a failed one under the same attempt
+# It waits for all eight legs, reruns a failed one under the same attempt
 # bound release-selfheal uses, re-issues a dispatch that never landed, and exits
 # non-zero when a leg burns both attempts.
 #
@@ -56,9 +57,6 @@ publish-docker.yml|Publish Docker Image|yes
 publish-flatpak.yml|Publish Flatpak|yes
 verify-release.yml|Verify release|no'
 
-# Shared by watch_legs and handle_missing_leg: a lost dispatch pushes it out.
-appear_deadline=0
-
 state_dir="$(mktemp -d "${TMPDIR:-/tmp}/release-watch.XXXXXX")"
 trap 'rm -rf "${state_dir}"' EXIT
 
@@ -84,12 +82,24 @@ defer_to_selfheal() {
   [ -n "${RC_RUN_ID}" ] || return 1
 
   local rc rc_attempt rc_conclusion rc_failed
+  # An unreadable candidate is not evidence that it is healing. Deferring on an
+  # API error would end the watch having watched nothing, and self-heal only
+  # fires on a candidate that actually failed, so nothing would follow.
   rc=$(gh api "repos/${REPO}/actions/runs/${RC_RUN_ID}" \
-         -q '"\(.run_attempt) \(.conclusion)"' 2>/dev/null) || rc="1 unknown"
+         -q '"\(.run_attempt) \(.conclusion)"') || {
+    note "could not read candidate ${RC_RUN_ID}; watching the legs rather than assuming a heal"
+    return 1
+  }
   rc_attempt="${rc%% *}"
   rc_conclusion="${rc#* }"
+  # No --paginate: the jq runs per page, so a second page makes this "0\n0" and
+  # the numeric test below errors instead of comparing. per_page=100 covers the
+  # candidate's job count, and release-selfheal.yml queries the same way.
   rc_failed=$(gh api "repos/${REPO}/actions/runs/${RC_RUN_ID}/jobs?per_page=100" \
-                --paginate -q '[.jobs[] | select(.conclusion == "failure")] | length' 2>/dev/null) || rc_failed=0
+                -q '[.jobs[] | select(.conclusion == "failure")] | length') || {
+    note "could not read candidate ${RC_RUN_ID} jobs; watching the legs"
+    return 1
+  }
 
   if [ "${rc_conclusion}" = "success" ] && [ "${rc_failed:-0}" -eq 0 ]; then
     return 1
@@ -109,9 +119,12 @@ defer_to_selfheal() {
 }
 
 find_run() {  # workflow-file  run-title -> the newest matching run as JSON, or empty
+  # Exit status matters: an API error must not read as "this leg never ran",
+  # because that path issues a real dispatch and would publish a duplicate.
+  # --arg rather than string interpolation so the title cannot alter the filter.
   gh run list --workflow="$1" --repo "${REPO}" --limit 30 \
     --json databaseId,status,conclusion,displayTitle \
-    --jq "[.[] | select(.displayTitle == \"$2\")] | first" 2>/dev/null
+    | jq -c --arg title "$2" '[.[] | select(.displayTitle == $title)] | first'
 }
 
 # publish.yml's guard refuses when the version is already live on PyPI, which is
@@ -121,10 +134,14 @@ version_is_on_pypi() {
   curl -fsS -o /dev/null "https://pypi.org/pypi/${PACKAGE}/${TAG#v}/json"
 }
 
-handle_missing_leg() {  # file  title  redispatchable; extends the shared appear_deadline
-  local file="$1" title="$2" redispatchable="$3"
+handle_missing_leg() {  # file  title  redispatchable
+  local file="$1" title="$2" redispatchable="$3" deadline_file="${state_dir}/$1.deadline"
 
-  [ "$(now)" -lt "${appear_deadline}" ] && return 0
+  # Per leg, not shared. A shared deadline meant one re-dispatch pushed every
+  # other missing leg out by another APPEAR_MINUTES, so healing seven lost
+  # dispatches took seven times the wait, in series, for no reason.
+  [ -f "${deadline_file}" ] || echo "$(( $(now) + APPEAR_MINUTES * 60 ))" > "${deadline_file}"
+  [ "$(now)" -lt "$(cat "${deadline_file}")" ] && return 0
 
   if [ "${redispatchable}" != "yes" ] || [ -f "${state_dir}/${file}.redispatched" ]; then
     settle "${file}" red "never appeared"
@@ -139,7 +156,7 @@ handle_missing_leg() {  # file  title  redispatchable; extends the shared appear
   fi
   note "${file}: no run titled '${title}' after ${APPEAR_MINUTES}m; the dispatch was lost, issuing it again"
   gh workflow run "${file}" --repo "${REPO}" -f tag="${TAG}" || true
-  appear_deadline=$(( $(now) + APPEAR_MINUTES * 60 ))
+  echo "$(( $(now) + APPEAR_MINUTES * 60 ))" > "${deadline_file}"
 }
 
 handle_completed_leg() {  # file  run-json
@@ -173,10 +190,14 @@ handle_completed_leg() {  # file  run-json
   gh run rerun "${run_id}" --repo "${REPO}" --failed || true
 }
 
+# `gh run watch <id> --exit-status` owns "block on one run, exit non-zero if it
+# failed", and if this ever waited on a single known run it should call that.
+# It cannot own this: a leg that never appeared has no run id to watch, and the
+# fan-in needs one deadline and one attempt bound across all eight rather than
+# eight blocking calls and a wait.
 watch_legs() {
   local watch_deadline pending file label redispatchable title run status
   watch_deadline=$(( $(now) + WATCH_MINUTES * 60 ))
-  appear_deadline=$(( $(now) + APPEAR_MINUTES * 60 ))
 
   while true; do
     pending=0
@@ -186,7 +207,10 @@ watch_legs() {
       pending=1
       title="${label} ${TAG}"
 
-      run=$(find_run "${file}" "${title}")
+      if ! run=$(find_run "${file}" "${title}"); then
+        note "${file}: could not list runs; leaving it pending rather than re-dispatching"
+        continue
+      fi
       if [ -z "${run}" ] || [ "${run}" = "null" ]; then
         handle_missing_leg "${file}" "${title}" "${redispatchable}"
         continue

--- a/scripts/release_watch.sh
+++ b/scripts/release_watch.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Watch the workflows a release candidate dispatches, and heal the ones that flake.
+#
+# release-selfheal.yml reruns the candidate's own build cells. Nothing watched
+# the eight workflows the candidate dispatches, so a flake in a publish leg (an
+# apt 403 on a runner image, an AUR maintenance window, a nix job racing a push
+# to main) left that channel unpublished until a person noticed and pressed
+# rerun. This script is that person.
+#
+# It waits for every dispatched leg, reruns a failed one under the same attempt
+# bound release-selfheal uses, re-issues a dispatch that never landed, and exits
+# non-zero when a leg burns both attempts.
+#
+# Run it by hand against a finished release:
+#   TAG=v0.6.90b434 DRY_RUN=true bash scripts/release_watch.sh
+#
+# Environment:
+#   TAG             release tag to watch (required)
+#   REPO            owner/name (default: tobocop2/lilbee)
+#   RC_RUN_ID       release-candidate run that dispatched the legs (optional;
+#                   when set, the script defers while that run is still healing)
+#   DRY_RUN         true reports what it would do and changes nothing
+#   MAX_ATTEMPTS    attempts per leg before it is called a defect (default 2)
+#   APPEAR_MINUTES  how long a leg may take to show up before its dispatch is
+#                   assumed lost and issued again (default 20)
+#   WATCH_MINUTES   total watch budget (default 290)
+#   PACKAGE         PyPI project name for the already-published check (default lilbee)
+
+set -uo pipefail
+
+TAG="${TAG:?TAG is required, e.g. TAG=v0.6.90b434}"
+REPO="${REPO:-tobocop2/lilbee}"
+RC_RUN_ID="${RC_RUN_ID:-}"
+DRY_RUN="${DRY_RUN:-false}"
+# One retry, matching release-selfheal.yml. A second failure on the same leg is
+# a defect until proven otherwise, and the bound is the only thing between a
+# real defect and an unbounded rerun loop.
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-2}"
+APPEAR_MINUTES="${APPEAR_MINUTES:-20}"
+WATCH_MINUTES="${WATCH_MINUTES:-290}"
+POLL_SECONDS="${POLL_SECONDS:-60}"
+PACKAGE="${PACKAGE:-lilbee}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# file | run-name prefix | may this leg be re-dispatched?
+#
+# verify-release must not be: its promote job is gated on
+# github.event_name == 'workflow_run', so a dispatched copy verifies the tag but
+# never marks it latest.
+LEGS='publish.yml|Publish to PyPI|yes
+publish-packages.yml|Publish Packages|yes
+publish-cuda-packages.yml|Publish CUDA Packages|yes
+publish-rocm-packages.yml|Publish ROCm Packages|yes
+publish-compat-packages.yml|Publish compat packages|yes
+publish-docker.yml|Publish Docker Image|yes
+publish-flatpak.yml|Publish Flatpak|yes
+verify-release.yml|Verify release|no'
+
+# Shared by watch_legs and handle_missing_leg: a lost dispatch pushes it out.
+appear_deadline=0
+
+state_dir="$(mktemp -d "${TMPDIR:-/tmp}/release-watch.XXXXXX")"
+trap 'rm -rf "${state_dir}"' EXIT
+
+note() { echo "$*"; }
+now() { date +%s; }
+
+settle() {  # leg-file  state  reason
+  echo "$2" > "${state_dir}/$1.state"
+  echo "$3" > "${state_dir}/$1.reason"
+  note "${1}: ${2} (${3})"
+}
+
+# Defer to release-selfheal while the candidate is still healing.
+#
+# A soft build cell that drops its artifact leaves the candidate GREEN with an
+# asset missing. verify-release fires on the same completion and fails on the
+# gap, while release-selfheal reruns the dropped cell. Rerunning verify-release
+# now would fail it again on the same missing asset and spend both its attempts
+# before the healed cell re-attaches anything. Self-heal's rerun emits a fresh
+# candidate completion, which starts a fresh watch, so nothing is lost by
+# leaving.
+defer_to_selfheal() {
+  [ -n "${RC_RUN_ID}" ] || return 1
+
+  local rc rc_attempt rc_conclusion rc_failed
+  rc=$(gh api "repos/${REPO}/actions/runs/${RC_RUN_ID}" \
+         -q '"\(.run_attempt) \(.conclusion)"' 2>/dev/null) || rc="1 unknown"
+  rc_attempt="${rc%% *}"
+  rc_conclusion="${rc#* }"
+  rc_failed=$(gh api "repos/${REPO}/actions/runs/${RC_RUN_ID}/jobs?per_page=100" \
+                --paginate -q '[.jobs[] | select(.conclusion == "failure")] | length' 2>/dev/null) || rc_failed=0
+
+  if [ "${rc_conclusion}" = "success" ] && [ "${rc_failed:-0}" -eq 0 ]; then
+    return 1
+  fi
+  if [ "${rc_attempt:-1}" -lt "${MAX_ATTEMPTS}" ]; then
+    note "candidate ${RC_RUN_ID} concluded ${rc_conclusion} with ${rc_failed} failed cell(s) on attempt ${rc_attempt}."
+    note "release-selfheal owns this; its rerun starts a fresh watch. Nothing to do."
+    {
+      echo "## Release watch ${TAG}"
+      echo
+      echo "release-selfheal owns this candidate: it concluded ${rc_conclusion} with ${rc_failed} failed cell(s) on attempt ${rc_attempt}."
+    } >> "${SUMMARY}"
+    return 0
+  fi
+  note "candidate ${RC_RUN_ID} still has ${rc_failed} failed cell(s) at attempt ${rc_attempt}; watching the legs that did dispatch."
+  return 1
+}
+
+find_run() {  # workflow-file  run-title -> the newest matching run as JSON, or empty
+  gh run list --workflow="$1" --repo "${REPO}" --limit 30 \
+    --json databaseId,status,conclusion,displayTitle \
+    --jq "[.[] | select(.displayTitle == \"$2\")] | first" 2>/dev/null
+}
+
+# publish.yml's guard refuses when the version is already live on PyPI, which is
+# the documented benign failure. The goal is the wheel being on PyPI, not the run
+# being green, so check the goal before spending a retry on it.
+version_is_on_pypi() {
+  curl -fsS -o /dev/null "https://pypi.org/pypi/${PACKAGE}/${TAG#v}/json"
+}
+
+handle_missing_leg() {  # file  title  redispatchable; extends the shared appear_deadline
+  local file="$1" title="$2" redispatchable="$3"
+
+  [ "$(now)" -lt "${appear_deadline}" ] && return 0
+
+  if [ "${redispatchable}" != "yes" ] || [ -f "${state_dir}/${file}.redispatched" ]; then
+    settle "${file}" red "never appeared"
+    return 0
+  fi
+
+  touch "${state_dir}/${file}.redispatched"
+  if [ "${DRY_RUN}" = "true" ]; then
+    note "${file}: would re-dispatch (no run titled '${title}' after ${APPEAR_MINUTES}m)"
+    settle "${file}" red "dry run: never appeared"
+    return 0
+  fi
+  note "${file}: no run titled '${title}' after ${APPEAR_MINUTES}m; the dispatch was lost, issuing it again"
+  gh workflow run "${file}" --repo "${REPO}" -f tag="${TAG}" || true
+  appear_deadline=$(( $(now) + APPEAR_MINUTES * 60 ))
+}
+
+handle_completed_leg() {  # file  run-json
+  local file="$1" run="$2" conclusion run_id attempt
+  conclusion=$(echo "${run}" | jq -r .conclusion)
+  run_id=$(echo "${run}" | jq -r .databaseId)
+
+  if [ "${conclusion}" = "success" ]; then
+    settle "${file}" green "run ${run_id}"
+    return 0
+  fi
+  if [ "${file}" = "publish.yml" ] && version_is_on_pypi; then
+    settle "${file}" green "${PACKAGE} ${TAG#v} is live on PyPI"
+    return 0
+  fi
+  if [ "${conclusion}" != "failure" ]; then
+    settle "${file}" red "run ${run_id} concluded ${conclusion}"
+    return 0
+  fi
+
+  attempt=$(gh api "repos/${REPO}/actions/runs/${run_id}" -q .run_attempt 2>/dev/null) || attempt="${MAX_ATTEMPTS}"
+  if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+    settle "${file}" red "run ${run_id} failed on attempt ${attempt}"
+    return 0
+  fi
+  if [ "${DRY_RUN}" = "true" ]; then
+    settle "${file}" red "dry run: would rerun ${run_id} (attempt ${attempt})"
+    return 0
+  fi
+  note "${file}: run ${run_id} failed on attempt ${attempt}; rerunning its failed jobs"
+  gh run rerun "${run_id}" --repo "${REPO}" --failed || true
+}
+
+watch_legs() {
+  local watch_deadline pending file label redispatchable title run status
+  watch_deadline=$(( $(now) + WATCH_MINUTES * 60 ))
+  appear_deadline=$(( $(now) + APPEAR_MINUTES * 60 ))
+
+  while true; do
+    pending=0
+    while IFS='|' read -r file label redispatchable; do
+      [ -n "${file}" ] || continue
+      [ -f "${state_dir}/${file}.state" ] && continue
+      pending=1
+      title="${label} ${TAG}"
+
+      run=$(find_run "${file}" "${title}")
+      if [ -z "${run}" ] || [ "${run}" = "null" ]; then
+        handle_missing_leg "${file}" "${title}" "${redispatchable}"
+        continue
+      fi
+
+      status=$(echo "${run}" | jq -r .status)
+      [ "${status}" = "completed" ] || continue
+      handle_completed_leg "${file}" "${run}"
+    done <<< "${LEGS}"
+
+    [ "${pending}" -eq 0 ] && return 0
+    if [ "$(now)" -ge "${watch_deadline}" ]; then
+      note "watch budget of ${WATCH_MINUTES}m is spent; the legs below are still unsettled"
+      return 0
+    fi
+    sleep "${POLL_SECONDS}"
+  done
+}
+
+report() {  # -> 0 when everything shipped
+  local failed=0 file label redispatchable state reason prerelease
+  {
+    echo "## Release watch ${TAG}"
+    echo
+    echo "| Leg | State | Detail |"
+    echo "| --- | --- | --- |"
+  } >> "${SUMMARY}"
+
+  while IFS='|' read -r file label redispatchable; do
+    [ -n "${file}" ] || continue
+    if [ -f "${state_dir}/${file}.state" ]; then
+      state=$(cat "${state_dir}/${file}.state")
+      reason=$(cat "${state_dir}/${file}.reason")
+    else
+      state="unsettled"
+      reason="still running when the watch budget ran out"
+    fi
+    [ "${state}" = "green" ] || failed=1
+    echo "| ${file} | ${state} | ${reason} |" >> "${SUMMARY}"
+  done <<< "${LEGS}"
+
+  # verify-release going green means its promote job marked the release latest.
+  # Asserting it directly costs one call and states the actual definition of a
+  # shipped release rather than inferring it.
+  prerelease=$(gh release view "${TAG}" --repo "${REPO}" --json isPrerelease -q .isPrerelease 2>/dev/null) || prerelease="unknown"
+  if [ "${prerelease}" = "false" ]; then
+    echo "| (release) | green | ${TAG} is promoted to latest |" >> "${SUMMARY}"
+  else
+    failed=1
+    echo "| (release) | red | ${TAG} is not promoted (isPrerelease=${prerelease}) |" >> "${SUMMARY}"
+  fi
+
+  echo >> "${SUMMARY}"
+  if [ "${failed}" -eq 0 ]; then
+    echo "Every channel published and ${TAG} is latest. Nothing was left for a person." >> "${SUMMARY}"
+    return 0
+  fi
+  echo "A leg above did not reach green. Each failing leg was retried once; read its logs before rerunning, because a second failure is a defect until proven otherwise." >> "${SUMMARY}"
+  return 1
+}
+
+main() {
+  if defer_to_selfheal; then
+    return 0
+  fi
+  watch_legs
+  report
+}
+
+main "$@"

--- a/scripts/release_watch.sh
+++ b/scripts/release_watch.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 # Watch the workflows a release candidate dispatches, and heal the ones that flake.
 #
-# release-selfheal.yml reruns the candidate's own build cells. Nothing watched
-# the seven workflows the candidate dispatches, nor verify-release which fires
-# on its completion, so a flake in a publish leg (an
-# apt 403 on a runner image, an AUR maintenance window, a nix job racing a push
-# to main) left that channel unpublished until a person noticed and pressed
-# rerun. This script is that person.
+# release-selfheal.yml owns the candidate's own build cells. This owns the seven
+# workflows the candidate dispatches, plus verify-release, which fires on its
+# completion. Without it, a flake in a publish leg (an apt 403 on a runner
+# image, an AUR maintenance window, a nix job racing a push to main) leaves that
+# channel unpublished until a person presses rerun.
 #
 # It waits for all eight legs, reruns a failed one under the same attempt
 # bound release-selfheal uses, re-issues a dispatch that never landed, and exits
@@ -137,9 +136,7 @@ version_is_on_pypi() {
 handle_missing_leg() {  # file  title  redispatchable
   local file="$1" title="$2" redispatchable="$3" deadline_file="${state_dir}/$1.deadline"
 
-  # Per leg, not shared. A shared deadline meant one re-dispatch pushed every
-  # other missing leg out by another APPEAR_MINUTES, so healing seven lost
-  # dispatches took seven times the wait, in series, for no reason.
+  # Per leg: one leg's re-dispatch must not extend another leg's wait.
   [ -f "${deadline_file}" ] || echo "$(( $(now) + APPEAR_MINUTES * 60 ))" > "${deadline_file}"
   [ "$(now)" -lt "$(cat "${deadline_file}")" ] && return 0
 

--- a/scripts/release_watch.sh
+++ b/scripts/release_watch.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
 # Watch the workflows a release candidate dispatches, and heal the ones that flake.
 #
-# release-selfheal.yml owns the candidate's own build cells. This owns the seven
-# workflows the candidate dispatches, plus verify-release, which fires on its
-# completion. Without it, a flake in a publish leg (an apt 403 on a runner
-# image, an AUR maintenance window, a nix job racing a push to main) leaves that
-# channel unpublished until a person presses rerun.
-#
-# It waits for all eight legs, reruns a failed one under the same attempt
-# bound release-selfheal uses, re-issues a dispatch that never landed, and exits
-# non-zero when a leg burns both attempts.
+# release-selfheal.yml owns the candidate's build cells; this owns the workflows
+# it dispatches, plus verify-release.
 #
 # Run it by hand against a finished release:
 #   TAG=v0.6.90b434 DRY_RUN=true bash scripts/release_watch.sh
@@ -32,9 +25,7 @@ TAG="${TAG:?TAG is required, e.g. TAG=v0.6.90b434}"
 REPO="${REPO:-tobocop2/lilbee}"
 RC_RUN_ID="${RC_RUN_ID:-}"
 DRY_RUN="${DRY_RUN:-false}"
-# One retry, matching release-selfheal.yml. A second failure on the same leg is
-# a defect until proven otherwise, and the bound is the only thing between a
-# real defect and an unbounded rerun loop.
+# One retry, matching release_selfheal.sh.
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-2}"
 APPEAR_MINUTES="${APPEAR_MINUTES:-20}"
 WATCH_MINUTES="${WATCH_MINUTES:-290}"
@@ -44,9 +35,8 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 
 # file | run-name prefix | may this leg be re-dispatched?
 #
-# verify-release must not be: its promote job is gated on
-# github.event_name == 'workflow_run', so a dispatched copy verifies the tag but
-# never marks it latest.
+# verify-release must not be re-dispatched: its promote job is gated on
+# github.event_name == 'workflow_run', so a dispatched copy never marks latest.
 LEGS='publish.yml|Publish to PyPI|yes
 publish-packages.yml|Publish Packages|yes
 publish-cuda-packages.yml|Publish CUDA Packages|yes
@@ -68,22 +58,14 @@ settle() {  # leg-file  state  reason
   note "${1}: ${2} (${3})"
 }
 
-# Defer to release-selfheal while the candidate is still healing.
-#
-# A soft build cell that drops its artifact leaves the candidate GREEN with an
-# asset missing. verify-release fires on the same completion and fails on the
-# gap, while release-selfheal reruns the dropped cell. Rerunning verify-release
-# now would fail it again on the same missing asset and spend both its attempts
-# before the healed cell re-attaches anything. Self-heal's rerun emits a fresh
-# candidate completion, which starts a fresh watch, so nothing is lost by
-# leaving.
+# Defer to release-selfheal while the candidate is still healing: a dropped
+# build cell leaves the candidate green with an asset missing, and retrying
+# verify-release now spends both its attempts before the cell re-attaches it.
+# Self-heal's rerun starts a fresh watch, so nothing is lost by leaving.
 defer_to_selfheal() {
   [ -n "${RC_RUN_ID}" ] || return 1
 
   local rc rc_attempt rc_conclusion rc_failed
-  # An unreadable candidate is not evidence that it is healing. Deferring on an
-  # API error would end the watch having watched nothing, and self-heal only
-  # fires on a candidate that actually failed, so nothing would follow.
   rc=$(gh api "repos/${REPO}/actions/runs/${RC_RUN_ID}" \
          -q '"\(.run_attempt) \(.conclusion)"') || {
     note "could not read candidate ${RC_RUN_ID}; watching the legs rather than assuming a heal"
@@ -91,9 +73,8 @@ defer_to_selfheal() {
   }
   rc_attempt="${rc%% *}"
   rc_conclusion="${rc#* }"
-  # No --paginate: the jq runs per page, so a second page makes this "0\n0" and
-  # the numeric test below errors instead of comparing. per_page=100 covers the
-  # candidate's job count, and release-selfheal.yml queries the same way.
+  # No --paginate: the -q count runs per page and returns "0\n0". per_page=100
+  # covers the candidate's job count.
   rc_failed=$(gh api "repos/${REPO}/actions/runs/${RC_RUN_ID}/jobs?per_page=100" \
                 -q '[.jobs[] | select(.conclusion == "failure")] | length') || {
     note "could not read candidate ${RC_RUN_ID} jobs; watching the legs"
@@ -118,17 +99,15 @@ defer_to_selfheal() {
 }
 
 find_run() {  # workflow-file  run-title -> the newest matching run as JSON, or empty
-  # Exit status matters: an API error must not read as "this leg never ran",
-  # because that path issues a real dispatch and would publish a duplicate.
-  # --arg rather than string interpolation so the title cannot alter the filter.
+  # An API error must not read as "this leg never ran": that path issues a real
+  # dispatch and would publish a duplicate. --arg, so the title cannot alter the filter.
   gh run list --workflow="$1" --repo "${REPO}" --limit 30 \
     --json databaseId,status,conclusion,displayTitle \
     | jq -c --arg title "$2" '[.[] | select(.displayTitle == $title)] | first'
 }
 
-# publish.yml's guard refuses when the version is already live on PyPI, which is
-# the documented benign failure. The goal is the wheel being on PyPI, not the run
-# being green, so check the goal before spending a retry on it.
+# publish.yml refuses when the version is already live on PyPI. That is the goal
+# met, not a flake, so it must not spend a retry.
 version_is_on_pypi() {
   curl -fsS -o /dev/null "https://pypi.org/pypi/${PACKAGE}/${TAG#v}/json"
 }
@@ -187,11 +166,8 @@ handle_completed_leg() {  # file  run-json
   gh run rerun "${run_id}" --repo "${REPO}" --failed || true
 }
 
-# `gh run watch <id> --exit-status` owns "block on one run, exit non-zero if it
-# failed", and if this ever waited on a single known run it should call that.
-# It cannot own this: a leg that never appeared has no run id to watch, and the
-# fan-in needs one deadline and one attempt bound across all eight rather than
-# eight blocking calls and a wait.
+# Not `gh run watch <id> --exit-status`: a leg that never appeared has no run id,
+# and the fan-in needs one deadline and one attempt bound across all eight.
 watch_legs() {
   local watch_deadline pending file label redispatchable title run status
   watch_deadline=$(( $(now) + WATCH_MINUTES * 60 ))
@@ -249,9 +225,8 @@ report() {  # -> 0 when everything shipped
     echo "| ${file} | ${state} | ${reason} |" >> "${SUMMARY}"
   done <<< "${LEGS}"
 
-  # verify-release going green means its promote job marked the release latest.
-  # Asserting it directly costs one call and states the actual definition of a
-  # shipped release rather than inferring it.
+  # isPrerelease=false is the definition of a shipped release. verify-release
+  # going green only implies it.
   prerelease=$(gh release view "${TAG}" --repo "${REPO}" --json isPrerelease -q .isPrerelease 2>/dev/null) || prerelease="unknown"
   if [ "${prerelease}" = "false" ]; then
     echo "| (release) | green | ${TAG} is promoted to latest |" >> "${SUMMARY}"

--- a/tests/shell/release_selfheal.bats
+++ b/tests/shell/release_selfheal.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# scripts/release_selfheal.sh against the same stubbed gh the watcher uses.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/release_selfheal.sh"
+  FIXTURE="${BATS_TEST_TMPDIR}/fx"
+  mkdir -p "${FIXTURE}/runs" "${FIXTURE}/attempts" "${FIXTURE}/conclusions" "${FIXTURE}/bin"
+  : > "${FIXTURE}/actions.log"
+  echo "[]" > "${FIXTURE}/empty.json"
+  echo false > "${FIXTURE}/prerelease"
+  echo 1 > "${FIXTURE}/attempts/900"
+  echo success > "${FIXTURE}/conclusions/900"
+  : > "${FIXTURE}/rc_failed"          # job-name lines, not a count
+  cp "${BATS_TEST_DIRNAME}/stubs/gh" "${FIXTURE}/bin/gh"
+  chmod +x "${FIXTURE}/bin/gh"
+}
+
+heal() {
+  FIXTURE="${FIXTURE}" GITHUB_STEP_SUMMARY="${FIXTURE}/summary.md" \
+  GH_TOKEN=stub REPO=tobocop2/lilbee RUN_ID=900 MAX_ATTEMPTS=2 \
+  PATH="${FIXTURE}/bin:${PATH}" bash "${SCRIPT}"
+}
+
+@test "a candidate with no failed cells is left alone" {
+  run heal
+  [ "$status" -eq 0 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  [[ "$output" == *"nothing to heal"* ]]
+}
+
+@test "a failed cell on the first attempt is rerun" {
+  printf 'build-binaries (ubuntu)\n' > "${FIXTURE}/rc_failed"
+  run heal
+  [ "$status" -eq 0 ]
+  [[ "$(cat "${FIXTURE}/actions.log")" == *"rerun 900"* ]]
+}
+
+@test "a candidate already at the attempt bound is not rerun again" {
+  printf 'build-binaries (ubuntu)\n' > "${FIXTURE}/rc_failed"
+  echo 2 > "${FIXTURE}/attempts/900"
+  run heal
+  [ "$status" -eq 1 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  [[ "$output" == *"reached the bound"* ]]
+}

--- a/tests/shell/release_watch.bats
+++ b/tests/shell/release_watch.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# scripts/release_watch.sh against a stubbed gh CLI. Every leg is a fixture file
+# under $FIXTURE/runs, so a scenario is one jq edit away.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/release_watch.sh"
+  TAG="v0.6.90b999"
+  FIXTURE="${BATS_TEST_TMPDIR}/fx"
+  mkdir -p "${FIXTURE}/runs" "${FIXTURE}/attempts" "${FIXTURE}/conclusions" "${FIXTURE}/bin"
+
+  : > "${FIXTURE}/actions.log"
+  echo "[]" > "${FIXTURE}/empty.json"
+  echo false > "${FIXTURE}/prerelease"
+
+  # The release candidate that dispatched the legs: green, nothing to heal.
+  echo 1 > "${FIXTURE}/attempts/900"
+  echo success > "${FIXTURE}/conclusions/900"
+  echo 0 > "${FIXTURE}/rc_failed"
+
+  cp "${BATS_TEST_DIRNAME}/stubs/gh" "${FIXTURE}/bin/gh"
+  chmod +x "${FIXTURE}/bin/gh"
+  stub_curl 22   # the version is not on PyPI unless a test says otherwise
+
+  # A virtual clock. `date +%s` reads it and `sleep` advances it, so a poll loop
+  # runs its passes instantly and deterministically instead of against wall time.
+  echo 1000000 > "${FIXTURE}/clock"
+  cat > "${FIXTURE}/bin/date" <<'CLOCK'
+#!/usr/bin/env bash
+[ "${1:-}" = "+%s" ] && { cat "${FIXTURE}/clock"; exit 0; }
+exec /bin/date "$@"
+CLOCK
+  cat > "${FIXTURE}/bin/sleep" <<'CLOCK'
+#!/usr/bin/env bash
+echo $(( $(cat "${FIXTURE}/clock") + ${1:-0} )) > "${FIXTURE}/clock"
+CLOCK
+  chmod +x "${FIXTURE}/bin/date" "${FIXTURE}/bin/sleep"
+
+  local i=1
+  while IFS='|' read -r file label; do
+    make_leg "${file}" "${label}" "$((100 + i))" success
+    i=$((i + 1))
+  done <<'LEGS'
+publish.yml|Publish to PyPI
+publish-packages.yml|Publish Packages
+publish-cuda-packages.yml|Publish CUDA Packages
+publish-rocm-packages.yml|Publish ROCm Packages
+publish-compat-packages.yml|Publish compat packages
+publish-docker.yml|Publish Docker Image
+publish-flatpak.yml|Publish Flatpak
+verify-release.yml|Verify release
+LEGS
+}
+
+make_leg() {  # file  label  run-id  conclusion
+  printf '[{"databaseId":%d,"status":"completed","conclusion":"%s","displayTitle":"%s %s"}]\n' \
+    "$3" "$4" "$2" "${TAG}" > "${FIXTURE}/runs/$1.json"
+  echo 1 > "${FIXTURE}/attempts/$3"
+}
+
+set_conclusion() {  # file  conclusion
+  jq -c --arg c "$2" 'map(.conclusion = $c)' "${FIXTURE}/runs/$1.json" > "${FIXTURE}/t"
+  mv "${FIXTURE}/t" "${FIXTURE}/runs/$1.json"
+}
+
+stub_curl() {  # exit-code
+  printf '#!/usr/bin/env bash\nexit %s\n' "$1" > "${FIXTURE}/bin/curl"
+  chmod +x "${FIXTURE}/bin/curl"
+}
+
+watch() {
+  FIXTURE="${FIXTURE}" \
+  GITHUB_STEP_SUMMARY="${FIXTURE}/summary.md" \
+  GH_TOKEN=stub REPO=tobocop2/lilbee TAG="${TAG}" RC_RUN_ID=900 \
+  DRY_RUN="${DRY_RUN:-false}" MAX_ATTEMPTS=2 APPEAR_MINUTES=0 WATCH_MINUTES=5 POLL_SECONDS=60 \
+  PATH="${FIXTURE}/bin:${PATH}" \
+    bash "${SCRIPT}"
+}
+
+dispatch_log() { cat "${FIXTURE}/actions.log"; }
+summary() { cat "${FIXTURE}/summary.md"; }
+
+@test "every leg green and the release promoted: exits 0 and touches nothing" {
+  run watch
+  [ "$status" -eq 0 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"Every channel published"* ]]
+}
+
+@test "a leg that failed on its first attempt is rerun and heals" {
+  set_conclusion publish-packages.yml failure
+  run watch
+  [ "$status" -eq 0 ]
+  run dispatch_log
+  [[ "$output" == *"rerun 102"* ]]
+}
+
+@test "a leg already at the attempt bound is called a defect, not rerun again" {
+  set_conclusion publish-flatpak.yml failure
+  echo 2 > "${FIXTURE}/attempts/107"
+  run watch
+  [ "$status" -eq 1 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"failed on attempt 2"* ]]
+}
+
+@test "a rerun that fails again stops at the bound" {
+  set_conclusion publish-docker.yml failure
+  touch "${FIXTURE}/no_heal_106"
+  run watch
+  [ "$status" -eq 1 ]
+  [ "$(grep -c 'rerun 106' "${FIXTURE}/actions.log")" -eq 1 ]
+}
+
+@test "a leg whose dispatch was lost is dispatched again exactly once" {
+  rm "${FIXTURE}/runs/publish-docker.yml.json"
+  run watch
+  [ "$status" -eq 1 ]
+  [ "$(grep -c 'dispatch publish-docker.yml' "${FIXTURE}/actions.log")" -eq 1 ]
+}
+
+@test "a re-dispatched leg that lands is green" {
+  cp "${FIXTURE}/runs/publish-docker.yml.json" "${FIXTURE}/appear_on_dispatch"
+  rm "${FIXTURE}/runs/publish-docker.yml.json"
+  run watch
+  [ "$status" -eq 0 ]
+}
+
+@test "verify-release is never re-dispatched, because a dispatched copy cannot promote" {
+  rm "${FIXTURE}/runs/verify-release.yml.json"
+  run watch
+  [ "$status" -eq 1 ]
+  run dispatch_log
+  [[ "$output" != *"verify-release.yml"* ]]
+}
+
+@test "while the candidate is still healing the watcher defers and changes nothing" {
+  echo 3 > "${FIXTURE}/rc_failed"
+  set_conclusion publish-packages.yml failure
+  run watch
+  [ "$status" -eq 0 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"release-selfheal owns this"* ]]
+}
+
+@test "a candidate already at the attempt bound is watched rather than deferred to" {
+  echo 2 > "${FIXTURE}/attempts/900"
+  echo 1 > "${FIXTURE}/rc_failed"
+  run watch
+  [ "$status" -eq 0 ]
+}
+
+@test "a red publish.yml whose version is live on PyPI spends no retry" {
+  set_conclusion publish.yml failure
+  stub_curl 0
+  run watch
+  [ "$status" -eq 0 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"is live on PyPI"* ]]
+}
+
+@test "every leg green but an unpromoted release is still a failure" {
+  echo true > "${FIXTURE}/prerelease"
+  run watch
+  [ "$status" -eq 1 ]
+  run summary
+  [[ "$output" == *"is not promoted"* ]]
+}
+
+@test "a cancelled leg is reported, not rerun" {
+  set_conclusion publish-cuda-packages.yml cancelled
+  run watch
+  [ "$status" -eq 1 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"concluded cancelled"* ]]
+}
+
+@test "a leg still running when the budget runs out is reported unsettled" {
+  jq -c 'map(.status = "in_progress")' "${FIXTURE}/runs/publish-packages.yml.json" > "${FIXTURE}/t"
+  mv "${FIXTURE}/t" "${FIXTURE}/runs/publish-packages.yml.json"
+  run watch
+  [ "$status" -eq 1 ]
+  run summary
+  [[ "$output" == *"unsettled"* ]]
+}
+
+@test "dry run reports what it would do and issues nothing" {
+  set_conclusion publish-packages.yml failure
+  DRY_RUN=true run watch
+  [ "$status" -eq 1 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"would rerun"* ]]
+}

--- a/tests/shell/release_watch.bats
+++ b/tests/shell/release_watch.bats
@@ -16,7 +16,7 @@ setup() {
   # The release candidate that dispatched the legs: green, nothing to heal.
   echo 1 > "${FIXTURE}/attempts/900"
   echo success > "${FIXTURE}/conclusions/900"
-  echo 0 > "${FIXTURE}/rc_failed"
+  : > "${FIXTURE}/rc_failed"          # job-name lines; empty means no failed cells
 
   cp "${BATS_TEST_DIRNAME}/stubs/gh" "${FIXTURE}/bin/gh"
   chmod +x "${FIXTURE}/bin/gh"
@@ -72,7 +72,8 @@ watch() {
   FIXTURE="${FIXTURE}" \
   GITHUB_STEP_SUMMARY="${FIXTURE}/summary.md" \
   GH_TOKEN=stub REPO=tobocop2/lilbee TAG="${TAG}" RC_RUN_ID=900 \
-  DRY_RUN="${DRY_RUN:-false}" MAX_ATTEMPTS=2 APPEAR_MINUTES=0 WATCH_MINUTES=5 POLL_SECONDS=60 \
+  DRY_RUN="${DRY_RUN:-false}" MAX_ATTEMPTS=2 POLL_SECONDS=60 \
+  APPEAR_MINUTES="${APPEAR_MINUTES:-0}" WATCH_MINUTES="${WATCH_MINUTES:-5}" \
   PATH="${FIXTURE}/bin:${PATH}" \
     bash "${SCRIPT}"
 }
@@ -137,7 +138,7 @@ summary() { cat "${FIXTURE}/summary.md"; }
 }
 
 @test "while the candidate is still healing the watcher defers and changes nothing" {
-  echo 3 > "${FIXTURE}/rc_failed"
+  printf 'cell-a\ncell-b\ncell-c\n' > "${FIXTURE}/rc_failed"
   set_conclusion publish-packages.yml failure
   run watch
   [ "$status" -eq 0 ]
@@ -148,7 +149,7 @@ summary() { cat "${FIXTURE}/summary.md"; }
 
 @test "a candidate already at the attempt bound is watched rather than deferred to" {
   echo 2 > "${FIXTURE}/attempts/900"
-  echo 1 > "${FIXTURE}/rc_failed"
+  printf 'cell-a\n' > "${FIXTURE}/rc_failed"
   run watch
   [ "$status" -eq 0 ]
 }
@@ -196,4 +197,39 @@ summary() { cat "${FIXTURE}/summary.md"; }
   [ ! -s "${FIXTURE}/actions.log" ]
   run summary
   [[ "$output" == *"would rerun"* ]]
+}
+
+@test "two legs whose dispatch was lost are re-dispatched in the same pass" {
+  # A shared appear deadline made one re-dispatch push every other missing leg
+  # out by another APPEAR_MINUTES, so seven lost dispatches healed in series.
+  rm "${FIXTURE}/runs/publish-docker.yml.json" "${FIXTURE}/runs/publish-cuda-packages.yml.json"
+  APPEAR_MINUTES=20 WATCH_MINUTES=60 run watch
+  [ "$status" -eq 1 ]
+  [ "$(grep -c 'dispatch publish-docker.yml' "${FIXTURE}/actions.log")" -eq 1 ]
+  [ "$(grep -c 'dispatch publish-cuda-packages.yml' "${FIXTURE}/actions.log")" -eq 1 ]
+}
+
+@test "a failing run list leaves the leg pending and dispatches nothing" {
+  # An API error must not read as "this leg never ran": that path issues a real
+  # dispatch and would publish a duplicate.
+  rm "${FIXTURE}/runs/publish-docker.yml.json"
+  touch "${FIXTURE}/fail_run_list"
+  run watch
+  [ "$status" -eq 1 ]
+  [ ! -s "${FIXTURE}/actions.log" ]
+  run summary
+  [[ "$output" == *"unsettled"* ]]
+}
+
+@test "an unreadable candidate is watched, not mistaken for one that is healing" {
+  # Deferring on an API error would end the watch having watched nothing, and
+  # self-heal only fires on a candidate that actually failed, so nothing would
+  # follow. Every leg here is green, so watching correctly ends green too.
+  touch "${FIXTURE}/fail_api"
+  run watch
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not read candidate"* ]]
+  run summary
+  [[ "$output" != *"release-selfheal owns this"* ]]
+  [[ "$output" == *"Every channel published"* ]]
 }

--- a/tests/shell/release_watch.bats
+++ b/tests/shell/release_watch.bats
@@ -200,8 +200,6 @@ summary() { cat "${FIXTURE}/summary.md"; }
 }
 
 @test "two legs whose dispatch was lost are re-dispatched in the same pass" {
-  # A shared appear deadline made one re-dispatch push every other missing leg
-  # out by another APPEAR_MINUTES, so seven lost dispatches healed in series.
   rm "${FIXTURE}/runs/publish-docker.yml.json" "${FIXTURE}/runs/publish-cuda-packages.yml.json"
   APPEAR_MINUTES=20 WATCH_MINUTES=60 run watch
   [ "$status" -eq 1 ]
@@ -210,8 +208,6 @@ summary() { cat "${FIXTURE}/summary.md"; }
 }
 
 @test "a failing run list leaves the leg pending and dispatches nothing" {
-  # An API error must not read as "this leg never ran": that path issues a real
-  # dispatch and would publish a duplicate.
   rm "${FIXTURE}/runs/publish-docker.yml.json"
   touch "${FIXTURE}/fail_run_list"
   run watch
@@ -222,9 +218,6 @@ summary() { cat "${FIXTURE}/summary.md"; }
 }
 
 @test "an unreadable candidate is watched, not mistaken for one that is healing" {
-  # Deferring on an API error would end the watch having watched nothing, and
-  # self-heal only fires on a candidate that actually failed, so nothing would
-  # follow. Every leg here is green, so watching correctly ends green too.
   touch "${FIXTURE}/fail_api"
   run watch
   [ "$status" -eq 0 ]

--- a/tests/shell/stubs/gh
+++ b/tests/shell/stubs/gh
@@ -13,9 +13,6 @@ case "${sub}" in
     [ -f "${FIXTURE}/fail_api" ] && { echo "stub gh: simulated API failure" >&2; exit 1; }
     # --paginate applies the -q filter per page, so a count comes back as
     # "0\n0" and the caller's numeric test errors. Fail loudly if it returns.
-    # --paginate applies the -q filter per page. That is correct when the
-    # filter emits one line per job and wrong when it emits a count, so gate on
-    # the filter rather than banning the flag.
     paginate=no
     for arg in "$@"; do
       [ "${arg}" = "--paginate" ] && paginate=yes
@@ -62,9 +59,8 @@ case "${sub}" in
         done
         f="${FIXTURE}/runs/${wf}.json"
         [ -f "${f}" ] || f="${FIXTURE}/empty.json"
-        # Real gh emits the whole JSON array when --jq is absent; the caller
-        # pipes it into jq itself. Modelling that matters: the script relies on
-        # gh's exit status to tell an API error from an empty result.
+        # Real gh emits the whole array when --jq is absent. The script relies on
+        # its exit status to tell an API error from an empty result.
         if [ -n "${jqexpr}" ]; then jq -c "${jqexpr}" < "${f}"; else cat "${f}"; fi
         ;;
       rerun)
@@ -74,7 +70,6 @@ case "${sub}" in
         # A rerun heals the run unless the fixture says this failure is a defect.
         if [ ! -f "${FIXTURE}/no_heal_${run_id}" ]; then
           # An unmatched glob stays literal, so guard on the file existing.
-          # release_selfheal.bats has no per-leg run fixtures at all.
           for f in "${FIXTURE}"/runs/*.json; do
             [ -f "${f}" ] || continue
             jq -c --argjson id "${run_id}" \

--- a/tests/shell/stubs/gh
+++ b/tests/shell/stubs/gh
@@ -10,6 +10,16 @@ sub="$1"; shift
 
 case "${sub}" in
   api)
+    [ -f "${FIXTURE}/fail_api" ] && { echo "stub gh: simulated API failure" >&2; exit 1; }
+    # --paginate applies the -q filter per page, so a count comes back as
+    # "0\n0" and the caller's numeric test errors. Fail loudly if it returns.
+    # --paginate applies the -q filter per page. That is correct when the
+    # filter emits one line per job and wrong when it emits a count, so gate on
+    # the filter rather than banning the flag.
+    paginate=no
+    for arg in "$@"; do
+      [ "${arg}" = "--paginate" ] && paginate=yes
+    done
     target="$1"; shift
     jqexpr=""
     while [ $# -gt 0 ]; do
@@ -17,7 +27,13 @@ case "${sub}" in
     done
     case "${target}" in
       */jobs*)
-        cat "${FIXTURE}/rc_failed"
+        case "${jqexpr}" in
+          *length*)
+            [ "${paginate}" = "yes" ] && { echo "stub gh: --paginate with a jq count returns one line per page" >&2; exit 1; }
+            grep -c . < "${FIXTURE}/rc_failed" || true
+            ;;
+          *) cat "${FIXTURE}/rc_failed" ;;
+        esac
         ;;
       */actions/runs/*)
         run_id="${target##*/}"
@@ -37,6 +53,7 @@ case "${sub}" in
   run)
     case "$1" in
       list)
+        [ -f "${FIXTURE}/fail_run_list" ] && { echo "stub gh: simulated list failure" >&2; exit 1; }
         wf=""; jqexpr=""; prev=""
         for arg in "$@"; do
           case "${arg}" in --workflow=*) wf="${arg#--workflow=}" ;; esac
@@ -45,7 +62,10 @@ case "${sub}" in
         done
         f="${FIXTURE}/runs/${wf}.json"
         [ -f "${f}" ] || f="${FIXTURE}/empty.json"
-        jq -c "${jqexpr}" < "${f}"
+        # Real gh emits the whole JSON array when --jq is absent; the caller
+        # pipes it into jq itself. Modelling that matters: the script relies on
+        # gh's exit status to tell an API error from an empty result.
+        if [ -n "${jqexpr}" ]; then jq -c "${jqexpr}" < "${f}"; else cat "${f}"; fi
         ;;
       rerun)
         run_id="$2"

--- a/tests/shell/stubs/gh
+++ b/tests/shell/stubs/gh
@@ -73,12 +73,16 @@ case "${sub}" in
         echo "$(( $(cat "${FIXTURE}/attempts/${run_id}") + 1 ))" > "${FIXTURE}/attempts/${run_id}"
         # A rerun heals the run unless the fixture says this failure is a defect.
         if [ ! -f "${FIXTURE}/no_heal_${run_id}" ]; then
+          # An unmatched glob stays literal, so guard on the file existing.
+          # release_selfheal.bats has no per-leg run fixtures at all.
           for f in "${FIXTURE}"/runs/*.json; do
+            [ -f "${f}" ] || continue
             jq -c --argjson id "${run_id}" \
               'map(if .databaseId == $id then .conclusion = "success" else . end)' \
               "${f}" > "${f}.tmp" && mv "${f}.tmp" "${f}"
           done
         fi
+        exit 0
         ;;
       *) echo "stub gh: unhandled run $1" >&2; exit 1 ;;
     esac

--- a/tests/shell/stubs/gh
+++ b/tests/shell/stubs/gh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Stand-in for the gh CLI, driven by files under $FIXTURE. Only the calls
+# scripts/release_watch.sh makes are implemented; anything else is a loud
+# failure so a new call site cannot pass a test silently.
+set -uo pipefail
+
+log() { echo "$*" >> "${FIXTURE}/actions.log"; }
+
+sub="$1"; shift
+
+case "${sub}" in
+  api)
+    target="$1"; shift
+    jqexpr=""
+    while [ $# -gt 0 ]; do
+      case "$1" in -q|--jq) jqexpr="$2"; shift 2 ;; *) shift ;; esac
+    done
+    case "${target}" in
+      */jobs*)
+        cat "${FIXTURE}/rc_failed"
+        ;;
+      */actions/runs/*)
+        run_id="${target##*/}"
+        case "${jqexpr}" in
+          *run_attempt*conclusion*)
+            echo "$(cat "${FIXTURE}/attempts/${run_id}") $(cat "${FIXTURE}/conclusions/${run_id}")"
+            ;;
+          *)
+            cat "${FIXTURE}/attempts/${run_id}"
+            ;;
+        esac
+        ;;
+      *) echo "stub gh: unhandled api ${target}" >&2; exit 1 ;;
+    esac
+    ;;
+
+  run)
+    case "$1" in
+      list)
+        wf=""; jqexpr=""; prev=""
+        for arg in "$@"; do
+          case "${arg}" in --workflow=*) wf="${arg#--workflow=}" ;; esac
+          [ "${prev}" = "--jq" ] && jqexpr="${arg}"
+          prev="${arg}"
+        done
+        f="${FIXTURE}/runs/${wf}.json"
+        [ -f "${f}" ] || f="${FIXTURE}/empty.json"
+        jq -c "${jqexpr}" < "${f}"
+        ;;
+      rerun)
+        run_id="$2"
+        log "rerun ${run_id}"
+        echo "$(( $(cat "${FIXTURE}/attempts/${run_id}") + 1 ))" > "${FIXTURE}/attempts/${run_id}"
+        # A rerun heals the run unless the fixture says this failure is a defect.
+        if [ ! -f "${FIXTURE}/no_heal_${run_id}" ]; then
+          for f in "${FIXTURE}"/runs/*.json; do
+            jq -c --argjson id "${run_id}" \
+              'map(if .databaseId == $id then .conclusion = "success" else . end)' \
+              "${f}" > "${f}.tmp" && mv "${f}.tmp" "${f}"
+          done
+        fi
+        ;;
+      *) echo "stub gh: unhandled run $1" >&2; exit 1 ;;
+    esac
+    ;;
+
+  workflow)
+    # gh workflow run <file> --repo R -f tag=T
+    log "dispatch $2"
+    [ -f "${FIXTURE}/appear_on_dispatch" ] && cp "${FIXTURE}/appear_on_dispatch" "${FIXTURE}/runs/$2.json"
+    ;;
+
+  release)
+    cat "${FIXTURE}/prerelease"
+    ;;
+
+  *) echo "stub gh: unhandled ${sub}" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
## Problem

A release candidate dispatches eight publish workflows. Nothing watches them. `release-selfheal.yml` watches the candidate only. If a publish workflow fails, that channel stays unpublished until a person reruns it by hand. This happened on v0.6.90b431, when the Publish Flatpak (cuda) run died on an apt 403 error.

Promotion does not catch this. `verify-release.yml` checks the snap and flatpakref files on the release. It never checks that Homebrew, AUR, Nix, Scoop, npm or Docker published anything.

## Solution

`scripts/release_watch.sh` waits for the eight workflows. It reruns a failed one, and it dispatches again a workflow that never started. The limit is 2 attempts, the same limit `release-selfheal.yml` uses. The script reports an error if a workflow fails twice.

## The script waits while the candidate heals

A dropped build cell leaves an asset missing, and `release-selfheal.yml` reruns that cell. An early retry of `verify-release.yml` spends both attempts on the same missing asset. The script exits instead, and the self-heal rerun starts a new watch.

## Six workflows get a run name

The run name carries the tag, so the script can find this tag's run. `verify-release.yml` keeps its current run name, because `make release-promote` matches that name exactly.

## You can run this one yourself

The logic is a script, not an inline `run:` block:

    TAG=v0.6.90b434 DRY_RUN=true bash scripts/release_watch.sh

`make test-shell` runs 14 bats tests against a stubbed `gh`. `make lint-shell` runs shellcheck on `scripts/*.sh` and actionlint on every workflow. Actionlint also applies shellcheck to the 1884 lines of inline shell elsewhere in `.github`. A new `shell` job in CI runs both targets.

## Not covered

The watcher proves the publish workflows pass. It does not prove the Homebrew, AUR or Scoop content is correct. It does not repair a defect: a defect fails twice, and the watcher reports it.