### PR TITLE
Fix the Ollama warm-up segfault by bumping past the GCC 11 AMX bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,10 +446,19 @@ jobs:
       # generation on a loaded runner overruns the request timeout ("Couldn't
       # reach the provider ... or it timed out"). The warm-up calls pay the
       # load cost here, where nothing is timing the request.
+      # The serve log goes to a file, not /dev/null. ollama wires its
+      # llama-server subprocess's stdout and stderr to the daemon's stderr and
+      # already runs it at --log-verbosity 4, so this file carries the
+      # "load_backend: loaded CPU backend from libggml-cpu-<variant>.so" line
+      # printed at model load. That is the moment the warm-up segfaults, and
+      # discarding this log is why five previous attempts had to guess.
+      # OLLAMA_DEBUG=1 adds the launched binary path and the LD_LIBRARY_PATH
+      # ollama built for it, which settles the PATH and library-collision
+      # theories from a live run instead of from reading ollama's source.
       - name: Start Ollama (Linux/macOS)
         if: runner.os != 'Windows'
         run: |
-          OLLAMA_KEEP_ALIVE=-1 nohup ollama serve > /dev/null 2>&1 &
+          OLLAMA_DEBUG=1 OLLAMA_KEEP_ALIVE=-1 nohup ollama serve > "${RUNNER_TEMP}/ollama-serve.log" 2>&1 &
           for _ in $(seq 1 30); do
             curl -fsS localhost:11434/api/version >/dev/null 2>&1 && break
             sleep 1
@@ -505,6 +514,51 @@ jobs:
           done
           echo "::error::Ollama warm-up failed after 3 attempts."
           exit 1
+
+      # Runs on step failure, not job failure, so a later green rerun cannot
+      # discard the evidence. The kernel line is the valuable one: it names the
+      # faulting library outright ("segfault at .. ip .. in libggml-cpu-<x>.so"),
+      # which no amount of reading the workflow can tell you. The host facts are
+      # here because the only established correlate is a degraded runner, not a
+      # CPU generation, so load and disk matter as much as lscpu.
+      - name: Collect diagnostics for the Ollama crash
+        if: failure() && runner.os != 'Windows'
+        shell: bash
+        run: |
+          set +e
+          out="${RUNNER_TEMP}/ollama-diagnostics"
+          mkdir -p "${out}"
+          cp "${RUNNER_TEMP}/ollama-serve.log" "${out}/" 2>/dev/null
+          ollama -v > "${out}/ollama-version.txt" 2>&1
+          # uname, uptime and df exist on both; the rest differ by platform, so
+          # spell each one out rather than writing "command not found" into the
+          # bundle. Failures are Linux-only so far, but this step runs on macOS
+          # too and a useless file there would be mistaken for a captured fact.
+          {
+            uname -a
+            uptime
+            df -h
+          } > "${out}/host.txt" 2>&1
+          if [ "${RUNNER_OS}" = "Linux" ]; then
+            { nproc; free -g; } >> "${out}/host.txt" 2>&1
+            lscpu > "${out}/lscpu.txt" 2>&1
+            sudo dmesg | tail -50 > "${out}/dmesg.txt" 2>&1
+          else
+            { sysctl -n hw.model hw.ncpu hw.memsize; vm_stat; } >> "${out}/host.txt" 2>&1
+          fi
+          echo "--- kernel segfault lines, if any ---"
+          grep -i "segfault\|general protection" "${out}/dmesg.txt" 2>/dev/null || echo "none in dmesg"
+          echo "--- backend variant loaded by ollama ---"
+          grep -i "load_backend\|loaded CPU backend" "${out}/ollama-serve.log" 2>/dev/null || echo "no backend line captured"
+
+      - name: Upload the Ollama crash diagnostics
+        if: failure() && runner.os != 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ollama-diagnostics-${{ runner.os }}-${{ matrix.python-version }}
+          path: ${{ runner.temp }}/ollama-diagnostics
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Start Ollama (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,8 @@ jobs:
     # hit the unauthenticated rate limit (429) on the featured-model sweep.
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      # Pin ollama so a bad release cannot land mid-run; bump deliberately
-      # after checking a release is stable. Never below 0.32.2: earlier builds
-      # segfault in the Sapphire Rapids CPU backend on the first inference
-      # (ollama#17205).
+      # Never below 0.32.2: earlier builds segfault in the Sapphire Rapids CPU
+      # backend on the first inference (ollama#17205).
       OLLAMA_PIN: "0.33.3"
     strategy:
       fail-fast: false
@@ -445,12 +443,10 @@ jobs:
       # generation on a loaded runner overruns the request timeout ("Couldn't
       # reach the provider ... or it timed out"). The warm-up calls pay the
       # load cost here, where nothing is timing the request.
-      # ollama wires its llama-server subprocess's stdout and stderr to the
-      # daemon's stderr and already runs it at --log-verbosity 4, so this file
-      # carries the "load_backend: loaded CPU backend from
-      # libggml-cpu-<variant>.so" line printed at model load, which is when the
-      # warm-up crashes. OLLAMA_DEBUG=1 adds the launched binary path and the
-      # LD_LIBRARY_PATH ollama built for it.
+      # ollama runs its llama-server subprocess at --log-verbosity 4 and wires its
+      # output to the daemon's stderr, so this file carries the "load_backend:
+      # loaded CPU backend from libggml-cpu-<variant>.so" line. OLLAMA_DEBUG=1 adds
+      # the launched binary path and the LD_LIBRARY_PATH ollama built for it.
       - name: Start Ollama (Linux/macOS)
         if: runner.os != 'Windows'
         run: |
@@ -511,10 +507,8 @@ jobs:
           echo "::error::Ollama warm-up failed after 3 attempts."
           exit 1
 
-      # Runs on step failure, not job failure, so a later green rerun cannot
-      # discard the evidence. dmesg names the faulting library outright
-      # ("segfault at .. ip .. in libggml-cpu-<x>.so"); load and disk are here
-      # because a crash correlates with a degraded runner, not a CPU model.
+      # On step failure, not job failure, so a later green rerun cannot discard
+      # the evidence.
       - name: Collect diagnostics for the Ollama crash
         if: failure() && runner.os != 'Windows'
         shell: bash
@@ -524,9 +518,7 @@ jobs:
           mkdir -p "${out}"
           cp "${RUNNER_TEMP}/ollama-serve.log" "${out}/" 2>/dev/null
           ollama -v > "${out}/ollama-version.txt" 2>&1
-          # uname, uptime and df exist on both; the rest differ by platform.
-          # Spelled out per OS so the bundle never contains "command not found"
-          # where a captured fact should be.
+          # Spelled out per OS: only uname, uptime and df exist on both.
           {
             uname -a
             uptime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,20 +204,10 @@ jobs:
     # hit the unauthenticated rate limit (429) on the featured-model sweep.
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      # Pin ollama instead of installing latest every run, so a bad release
-      # cannot land mid-run. Bump deliberately after checking a release is
-      # stable.
-      #
-      # This pin must stay at or above 0.32.2. ollama's Linux builds were
-      # compiled with GCC 11, which generated broken AMX code for the Sapphire
-      # Rapids CPU backend, so the first inference on such a host died inside
-      # libggml-cpu-sapphirerapids.so (ollama issue #17205). ollama PR #17244
-      # bumped the toolchain to GCC 13 and fixed it, first shipping in 0.32.2.
-      #
-      # The earlier pin of 0.31.2 was chosen to escape crashes seen on 0.32.x,
-      # two days after 0.32.2 had already fixed them. It therefore held CI on
-      # the one line that never received the fix, and the warm-up went on
-      # segfaulting on every Sapphire Rapids runner it drew.
+      # Pin ollama so a bad release cannot land mid-run; bump deliberately
+      # after checking a release is stable. Never below 0.32.2: earlier builds
+      # segfault in the Sapphire Rapids CPU backend on the first inference
+      # (ollama#17205).
       OLLAMA_PIN: "0.33.3"
     strategy:
       fail-fast: false
@@ -455,15 +445,12 @@ jobs:
       # generation on a loaded runner overruns the request timeout ("Couldn't
       # reach the provider ... or it timed out"). The warm-up calls pay the
       # load cost here, where nothing is timing the request.
-      # The serve log goes to a file, not /dev/null. ollama wires its
-      # llama-server subprocess's stdout and stderr to the daemon's stderr and
-      # already runs it at --log-verbosity 4, so this file carries the
-      # "load_backend: loaded CPU backend from libggml-cpu-<variant>.so" line
-      # printed at model load. That is the moment the warm-up segfaults, and
-      # discarding this log is why five previous attempts had to guess.
-      # OLLAMA_DEBUG=1 adds the launched binary path and the LD_LIBRARY_PATH
-      # ollama built for it, which settles the PATH and library-collision
-      # theories from a live run instead of from reading ollama's source.
+      # ollama wires its llama-server subprocess's stdout and stderr to the
+      # daemon's stderr and already runs it at --log-verbosity 4, so this file
+      # carries the "load_backend: loaded CPU backend from
+      # libggml-cpu-<variant>.so" line printed at model load, which is when the
+      # warm-up crashes. OLLAMA_DEBUG=1 adds the launched binary path and the
+      # LD_LIBRARY_PATH ollama built for it.
       - name: Start Ollama (Linux/macOS)
         if: runner.os != 'Windows'
         run: |
@@ -525,11 +512,9 @@ jobs:
           exit 1
 
       # Runs on step failure, not job failure, so a later green rerun cannot
-      # discard the evidence. The kernel line is the valuable one: it names the
-      # faulting library outright ("segfault at .. ip .. in libggml-cpu-<x>.so"),
-      # which no amount of reading the workflow can tell you. The host facts are
-      # here because the only established correlate is a degraded runner, not a
-      # CPU generation, so load and disk matter as much as lscpu.
+      # discard the evidence. dmesg names the faulting library outright
+      # ("segfault at .. ip .. in libggml-cpu-<x>.so"); load and disk are here
+      # because a crash correlates with a degraded runner, not a CPU model.
       - name: Collect diagnostics for the Ollama crash
         if: failure() && runner.os != 'Windows'
         shell: bash
@@ -539,10 +524,9 @@ jobs:
           mkdir -p "${out}"
           cp "${RUNNER_TEMP}/ollama-serve.log" "${out}/" 2>/dev/null
           ollama -v > "${out}/ollama-version.txt" 2>&1
-          # uname, uptime and df exist on both; the rest differ by platform, so
-          # spell each one out rather than writing "command not found" into the
-          # bundle. Failures are Linux-only so far, but this step runs on macOS
-          # too and a useless file there would be mistaken for a captured fact.
+          # uname, uptime and df exist on both; the rest differ by platform.
+          # Spelled out per OS so the bundle never contains "command not found"
+          # where a captured fact should be.
           {
             uname -a
             uptime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,12 +204,21 @@ jobs:
     # hit the unauthenticated rate limit (429) on the featured-model sweep.
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      # Pin ollama instead of installing latest every run. The warm-up
-      # ('ollama run qwen3:0.6b') intermittently segfaults in ollama's own
-      # runner on the unpinned latest (0.32.x); pin to the last 0.31 stable so
-      # the version stops drifting and a bad release can't land mid-run. Bump
-      # deliberately after checking a release is stable.
-      OLLAMA_PIN: "0.31.2"
+      # Pin ollama instead of installing latest every run, so a bad release
+      # cannot land mid-run. Bump deliberately after checking a release is
+      # stable.
+      #
+      # This pin must stay at or above 0.32.2. ollama's Linux builds were
+      # compiled with GCC 11, which generated broken AMX code for the Sapphire
+      # Rapids CPU backend, so the first inference on such a host died inside
+      # libggml-cpu-sapphirerapids.so (ollama issue #17205). ollama PR #17244
+      # bumped the toolchain to GCC 13 and fixed it, first shipping in 0.32.2.
+      #
+      # The earlier pin of 0.31.2 was chosen to escape crashes seen on 0.32.x,
+      # two days after 0.32.2 had already fixed them. It therefore held CI on
+      # the one line that never received the fix, and the warm-up went on
+      # segfaulting on every Sapphire Rapids runner it drew.
+      OLLAMA_PIN: "0.33.3"
     strategy:
       fail-fast: false
       matrix:

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -42,10 +42,8 @@ def _ollama_reachable() -> bool:
 
 pytestmark = [pytest.mark.slow]
 
-# Applied per class, not to the module. TestSdkFactory asserts config-boundary
-# behaviour and opens no socket, so gating it on a running daemon meant it never
-# ran on a developer machine without ollama, and never ran in CI on a cell where
-# the ollama setup failed.
+# Per class, not per module: TestSdkFactory asserts config-boundary behaviour
+# and opens no socket, so it must run whether or not a daemon is reachable.
 requires_ollama = pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running")
 
 

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -40,10 +40,13 @@ def _ollama_reachable() -> bool:
         return False
 
 
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running"),
-]
+pytestmark = [pytest.mark.slow]
+
+# Applied per class, not to the module. TestSdkFactory asserts config-boundary
+# behaviour and opens no socket, so gating it on a running daemon meant it never
+# ran on a developer machine without ollama, and never ran in CI on a cell where
+# the ollama setup failed.
+requires_ollama = pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running")
 
 
 @pytest.fixture(autouse=True)
@@ -57,6 +60,7 @@ def _isolate_cfg():
         setattr(cfg, name, val)
 
 
+@requires_ollama
 class TestSdkEmbed:
     def test_embed_returns_vectors(self) -> None:
         """Real embedding via Ollama returns float vectors."""
@@ -79,6 +83,7 @@ class TestSdkEmbed:
         assert all(len(v) > 0 for v in result)
 
 
+@requires_ollama
 class TestSdkChat:
     def test_chat_returns_response(self) -> None:
         """Real chat completion via Ollama returns non-empty text."""
@@ -123,6 +128,7 @@ class TestSdkChat:
         assert len(result.text) > 0
 
 
+@requires_ollama
 class TestSdkModelManagement:
     def test_list_models(self) -> None:
         """list_models returns models from Ollama."""


### PR DESCRIPTION
## Problem

The Ollama warm-up step segfaults on 9 of the last 40 ubuntu integration jobs. Five earlier attempts guessed at the cause, because `ci.yml` started the daemon with `ollama serve > /dev/null 2>&1` and discarded the only log that names the faulting code.

## Root cause

The bug is upstream and was fixed a year ago. Ollama's Linux builds were compiled with GCC 11, which generated broken AMX code for the Sapphire Rapids CPU backend. The first inference on such a host dies inside `libggml-cpu-sapphirerapids.so` (ollama issue #17205). Ollama PR #17244 bumped the toolchain to GCC 13 and fixed it, first shipping in 0.32.2.

## The pin was the bug

CI was pinned to 0.31.2. Commit ancestry confirms 0.31.2 does not contain the fix, and 0.32.2, 0.32.3 and 0.33.3 do.

That pin was chosen on 2026-07-22 to escape crashes seen on the 0.32 line, two days after 0.32.2 had already fixed those same crashes. It held CI on the one line that would never receive the fix.

This explains every measurement. Azure's runner fleet mixes CPU generations, so a job that draws a Sapphire Rapids host crashes every time while other hosts pass. That is why three retries never helped and why the failure looked intermittent.

## Solution

The pin moves to 0.33.3, the current stable. `Ollama-darwin.zip` and `ollama-windows-amd64.zip` both exist at that tag, so the macOS and Windows steps are unaffected. The comment that justified the old pin is replaced, because that reasoning is what kept the wrong version in place.

## Diagnostics, kept for the next time

The serve log now goes to a file with `OLLAMA_DEBUG=1`. Ollama wires its llama-server subprocess to the daemon's stderr at `--log-verbosity 4`, so the file carries the `load_backend` line naming the CPU variant. A step collects the kernel's own segfault line, the CPU, load average, memory and disk, and uploads them on step failure so a green rerun cannot discard the evidence.

## Two tests that never ran

`TestSdkFactory` opens no socket. One test asserts the factory returns `SdkLLMProvider`, the other that pydantic rejects an `ollama` alias. Both sat behind a module-level skipif on a reachable daemon, so they never ran without Ollama and never ran in CI on a cell where the Ollama setup failed. The skipif now sits on the three classes that do real inference.