### PR TITLE
fix(test): stop the catalog viewport tests flaking on Windows CI

### DIFF
--- a/tests/test_catalog_search_fills_viewport.py
+++ b/tests/test_catalog_search_fills_viewport.py
@@ -199,8 +199,7 @@ async def test_search_matches_fill_the_viewport(_mock_resolve):
             container = screen._grid_container
             # The filter pass replaces the grouped sections with one flat grid
             # through the same deferred mount chain. Counting before it lands
-            # sums two grids' partial regions, which is why the observed count
-            # was 7: not a multiple of columns_per_row, so not one settled grid.
+            # sums two grids' partial regions instead of one settled grid.
             assert await pump_until(
                 pilot,
                 lambda: (
@@ -242,8 +241,8 @@ async def test_search_after_scrolling_starts_at_the_top(_mock_resolve):
             # scroll_to clamps against max_scroll_y at call time and never
             # re-applies the target when the content later grows, so scrolling
             # before the sections are tall enough parks the viewport at 0 for
-            # good. Asserting the precondition here also moves the failure off
-            # scroll_y, one step downstream of the state that was wrong.
+            # good. Asserting it here also fails on the wrong quantity rather
+            # than on scroll_y downstream.
             assert await pump_until(pilot, lambda: container.max_scroll_y > 0), (
                 "the unfiltered grid never grew taller than the viewport "
                 f"(max_scroll_y={container.max_scroll_y})"

--- a/tests/test_catalog_search_fills_viewport.py
+++ b/tests/test_catalog_search_fills_viewport.py
@@ -135,11 +135,10 @@ async def _open_catalog_chat_grid(app, pilot):
     screen._active_tab_id_cache = "chat"
     screen._activation_settled = True
     await pilot.pause()
-    # _remount_grid_sections mounts only the first section and defers the rest
-    # through call_after_refresh. Pilot.pause waits only on widgets that existed
-    # when it was called, so it never covers those; a bare pause here returns
-    # while the grid is still empty. region.height is the cheap proof that both
-    # the mount chain and the layout pass ran, since an unlaid-out grid is 0.
+    # _remount_grid_sections mounts the first section and defers the rest through
+    # call_after_refresh. Pilot.pause waits only on widgets that existed when it
+    # was called, so a bare pause returns while the grid is still empty.
+    # region.height is 0 until the layout pass runs.
     assert await pump_until(
         pilot, lambda: any(g.region.height for g in screen._grid_container.query(ModelGrid))
     ), "the deferred grid sections never mounted and laid out"
@@ -240,9 +239,7 @@ async def test_search_after_scrolling_starts_at_the_top(_mock_resolve):
             container = screen._grid_container
             # scroll_to clamps against max_scroll_y at call time and never
             # re-applies the target when the content later grows, so scrolling
-            # before the sections are tall enough parks the viewport at 0 for
-            # good. Asserting it here also fails on the wrong quantity rather
-            # than on scroll_y downstream.
+            # before the sections are tall enough parks the viewport at 0 for good.
             assert await pump_until(pilot, lambda: container.max_scroll_y > 0), (
                 "the unfiltered grid never grew taller than the viewport "
                 f"(max_scroll_y={container.max_scroll_y})"

--- a/tests/test_catalog_search_fills_viewport.py
+++ b/tests/test_catalog_search_fills_viewport.py
@@ -13,8 +13,9 @@ import pytest
 
 from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.widgets.model_grid import ModelGrid
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import await_chat
+from tests._lilbee_app_test_host import await_chat, pump_until
 
 # Terminal the assertions are calibrated against: 40 rows total, of which the
 # catalog body gets 32 after the top and bottom bars.
@@ -134,6 +135,14 @@ async def _open_catalog_chat_grid(app, pilot):
     screen._active_tab_id_cache = "chat"
     screen._activation_settled = True
     await pilot.pause()
+    # _remount_grid_sections mounts only the first section and defers the rest
+    # through call_after_refresh. Pilot.pause waits only on widgets that existed
+    # when it was called, so it never covers those; a bare pause here returns
+    # while the grid is still empty. region.height is the cheap proof that both
+    # the mount chain and the layout pass ran, since an unlaid-out grid is 0.
+    assert await pump_until(
+        pilot, lambda: any(g.region.height for g in screen._grid_container.query(ModelGrid))
+    ), "the deferred grid sections never mounted and laid out"
     return screen
 
 
@@ -172,7 +181,6 @@ async def test_search_matches_fill_the_viewport(_mock_resolve):
     """
     from lilbee.catalog.types import ModelTask
     from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.widgets.model_grid import ModelGrid
 
     with _mock_catalog_deps(_featured_families(3)), _mock_remote_models():
         app = LilbeeApp()
@@ -189,6 +197,20 @@ async def test_search_matches_fill_the_viewport(_mock_resolve):
             await _type_search(pilot, "searchme")
 
             container = screen._grid_container
+            # The filter pass replaces the grouped sections with one flat grid
+            # through the same deferred mount chain. Counting before it lands
+            # sums two grids' partial regions, which is why the observed count
+            # was 7: not a multiple of columns_per_row, so not one settled grid.
+            assert await pump_until(
+                pilot,
+                lambda: (
+                    len(container.query(ModelGrid)) == 1
+                    and all(g.region.height for g in container.query(ModelGrid))
+                ),
+            ), (
+                "the flat result set never replaced the pre-search sections "
+                f"(grids={len(container.query(ModelGrid))})"
+            )
             grids = list(container.query(ModelGrid))
             headings = list(container.query(".section-heading"))
             # One heading is the only chrome the matches pay for, so every card
@@ -217,6 +239,15 @@ async def test_search_after_scrolling_starts_at_the_top(_mock_resolve):
         async with app.run_test(size=_TERMINAL_SIZE) as pilot:
             screen = await _open_catalog_chat_grid(app, pilot)
             container = screen._grid_container
+            # scroll_to clamps against max_scroll_y at call time and never
+            # re-applies the target when the content later grows, so scrolling
+            # before the sections are tall enough parks the viewport at 0 for
+            # good. Asserting the precondition here also moves the failure off
+            # scroll_y, one step downstream of the state that was wrong.
+            assert await pump_until(pilot, lambda: container.max_scroll_y > 0), (
+                "the unfiltered grid never grew taller than the viewport "
+                f"(max_scroll_y={container.max_scroll_y})"
+            )
             container.scroll_to(y=100, animate=False)
             await pilot.pause()
             assert container.scroll_y > 0


### PR DESCRIPTION
## Problem

Two tests in `tests/test_catalog_search_fills_viewport.py` fail intermittently on Windows CI: three failures across 14 `test (windows-latest, 3.12)` jobs, and zero across 14 jobs on Windows 3.13, both macOS lanes and all three Ubuntu lanes.

    assert 0.0 > 0      container.scroll_y
    assert 7 >= 12      cards laid out in the viewport

Both read catalog state before Textual's deferred mount cascade settles. `_remount_grid_sections` mounts only the first section and defers the rest through `call_after_refresh`. `_mount_grid_section` already records why one pause does not cover that: "Pilot.pause only waits on the widgets that were present when it was called, so it never covers these." Each test gave one bare pause.

## The scroll failure is in the setup

`scroll_to` clamps against `max_scroll_y` at call time and never re-applies the target when the content later grows. A scroll issued before the sections are tall enough parks the viewport at 0 permanently, so the search under test never runs. Waiting on `max_scroll_y > 0` as a named precondition also moves the failure off `scroll_y`, one step downstream of the state that was wrong.

## The viewport count is the same defect, one step later

Seven is not a multiple of `columns_per_row`, so the count summed two grids' partial regions: the flatten remount had not finished replacing the grouped sections. Waiting for one laid-out grid is enough.

The expectation stays computed from live geometry rather than pinned to a literal. "Matches fill whatever the viewport holds after heading chrome" is the property the test exists to prove, and a literal would discard it.

## Uses the house helper

`pump_until` from PR #562 is wall-clock bounded, so a slow runner gets more attempts rather than the same fixed few. It returns a bool and deliberately does not assert, so every call carries its own message naming the state actually observed.

## Verification

The local run is green, which shows no regression. It cannot show the fix: these reproduce only on contended Windows runners, where four xdist workers share four cores. Confidence rests on the mechanism, which the product code documents next to the deferred mount.

## Not covered

`test_tui.py::TestCatalogScreenAsync::test_escape_from_filter_in_list_view_focuses_list` fails the same way, reading a multi-hop focus cascade one hop early. It needs a wait on focus rather than on grid geometry, so it is filed separately.