### PR TITLE
Bump xberg to 1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # shard-adoption path, which that hardware cannot reach.
     "lancedb[pylance] ; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "lancedb ; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "xberg>=1.1.0",
+    "xberg>=1.1.2",
     # The engine user-lock protocol leans on release(), is_singleton reentrancy
     # and the SoftFileLock fallback; the ceiling is the line verified against it.
     "filelock<3.33",

--- a/src/lilbee/data/extract/document.py
+++ b/src/lilbee/data/extract/document.py
@@ -21,7 +21,6 @@ from lilbee.data.types import (
     IMAGE_CONTENT_TYPE,
     MARKDOWN_OUTPUT,
     PDF_CONTENT_TYPE,
-    PLAIN_OUTPUT,
     ChunkRecord,
     ExtractMode,
     MemberRecords,
@@ -224,11 +223,9 @@ def _ocr_config(ocr_token: str | None) -> OcrConfig:
         )
     # xberg requires a non-empty language list (4.x defaulted to English;
     # xberg 1.0 errors on an empty one). cfg.ocr_language is validated non-empty.
-    # Plain page text: Tesseract's markdown renderer turns column gaps into tables.
     return OcrConfig(
         backend=OcrBackendName.TESSERACT,
         language=list(config.ocr_language),
-        output_format=PLAIN_OUTPUT,
     )
 
 

--- a/src/lilbee/data/types.py
+++ b/src/lilbee/data/types.py
@@ -26,7 +26,6 @@ from lilbee.data.store import (
 PDF_CONTENT_TYPE = "pdf"
 IMAGE_CONTENT_TYPE = "image"
 MARKDOWN_OUTPUT = "markdown"
-PLAIN_OUTPUT = "plain"
 MARKDOWN_MIME = "text/markdown"
 
 

--- a/tests/integration/test_pdf_integration.py
+++ b/tests/integration/test_pdf_integration.py
@@ -152,6 +152,41 @@ class TestTesseractOcrFallback:
         not shutil.which("tesseract"),
         reason="Tesseract not installed",
     )
+    async def test_tesseract_reads_the_numbered_list_as_a_list(self, monkeypatch):
+        """The scanned list stays a list, and its text appears once.
+
+        xberg 1.1.0 read the numbered list on this page as a three-column table
+        and put the page text in the document twice. Both are fixed in 1.1.2,
+        so lilbee's shipped OCR config carries no output_format workaround.
+        """
+        from lilbee.data.extract.xberg import aextract_document
+        from lilbee.data.ingest import ExtractMode, extraction_config
+        from lilbee.data.types import OcrBackendName
+
+        # The Tesseract branch is the subject: a configured vision model would
+        # route this page to lilbee's own backend instead.
+        monkeypatch.setattr(cfg, "vision_model", "")
+        config = extraction_config(ExtractMode.PAGINATED)
+        assert config.ocr.backend == OcrBackendName.TESSERACT
+
+        doc = await aextract_document(
+            SCANNED_PDF.read_bytes(),
+            mime_type="application/pdf",
+            filename=SCANNED_PDF.name,
+            config=config,
+        )
+        page = doc.pages[0].content
+        assert "| --- |" not in page, f"Page read as a markdown table: {page}"
+        assert not doc.tables, f"List page reported {len(doc.tables)} tables"
+        repeated = [
+            line for line in page.split("\n") if line.strip() and doc.content.count(line) > 1
+        ]
+        assert not repeated, f"Page lines repeated in document content: {repeated}"
+
+    @pytest.mark.skipif(
+        not shutil.which("tesseract"),
+        reason="Tesseract not installed",
+    )
     async def test_tesseract_extracts_known_phrases(self):
         """Tesseract OCR captures key phrases from the scanned document."""
         from xberg import ExtractionConfig, OcrConfig

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3387,13 +3387,6 @@ class TestExtractionConfig:
         # set an explicit default to preserve 4.x behavior (regression guard).
         assert config.ocr.language == ["eng"]
 
-    def test_tesseract_ocr_emits_plain_page_text(self):
-        from lilbee.data.ingest import ExtractMode, extraction_config
-
-        config = extraction_config(ExtractMode.PAGINATED)
-        # Tesseract's markdown renderer guesses tables from column gaps.
-        assert config.ocr.output_format == "plain"
-
     def test_tesseract_ocr_language_from_config(self, monkeypatch):
         from lilbee.core.config import cfg
         from lilbee.data.ingest import ExtractMode, extraction_config

--- a/uv.lock
+++ b/uv.lock
@@ -1971,7 +1971,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "uvicorn", specifier = ">=0.30" },
-    { name = "xberg", specifier = ">=1.1.0" },
+    { name = "xberg", specifier = ">=1.1.2" },
 ]
 provides-extras = ["engine", "litellm", "graph", "crawler", "cuda12", "release"]
 
@@ -5001,17 +5001,17 @@ wheels = [
 
 [[package]]
 name = "xberg"
-version = "1.1.0"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/02/138ae8149ee425a51c51647dc02f4c91b3faf277c9e384088aeadd96fa90/xberg-1.1.0.tar.gz", hash = "sha256:7bc147cfc592b367d1c456e5ffa0dd63772f5270695e5695ce68c2ccd5db0f7c", size = 384695, upload-time = "2026-09-06T19:56:26.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ce/3ef572ebba4a6fc31576b4aec10f980ec3ab165929813d6009d3bc537e21/xberg-1.1.2.tar.gz", hash = "sha256:374ad881a41ef05bf9cced389a12569fc697a1a40ba9dc7311afbf7158b50203", size = 383829, upload-time = "2026-09-07T22:37:48.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1b/8371a3fe0310614845af4d353ce5a34d25ca6557d8fe306dcd43b4401245/xberg-1.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:62e0213c14e287f92f2c5ab52ecb29e25ddb427b6aa34a1f2f2455049a7a11af", size = 43536919, upload-time = "2026-09-06T19:56:03.262Z" },
-    { url = "https://files.pythonhosted.org/packages/24/d9/1b7e34286d81fc9c246543b52e2a00ec2b0a81fad62262521b9cc744f5b7/xberg-1.1.0-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:a6513d67dd48503c9daf3c7df8f7f9972fb5a4c3a517a07a4c722d69c698cbf3", size = 35773432, upload-time = "2026-09-06T19:56:06.107Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e8/d607aab16d35a612f569b218f9ec6cab024e7fea8f01d15aaf7ecf154d59/xberg-1.1.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:94ae5d18810be5fe6d5ecbf130ef3d70b5078212434564fbd6c20e2d9d7f975f", size = 56772402, upload-time = "2026-09-06T19:56:09.454Z" },
-    { url = "https://files.pythonhosted.org/packages/59/f6/555ec01f81c99cfa6d45373d2f3978275ca2b445ed5dbdb3324cd0e13263/xberg-1.1.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1af8acdc78302145f0984292935fb13c8f2aea218a12a99c44d906ac01b0b50c", size = 63411526, upload-time = "2026-09-06T19:56:13.122Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/79/55d2c5f1f87e5d4485f0a36f60929c799fd5bde18571dfbfa2b480de6513/xberg-1.1.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b75f8bdc22a4b3cb773f66d5dbb47d45be79e339dc30145a6f3b3607810185ac", size = 57331447, upload-time = "2026-09-06T19:56:16.573Z" },
-    { url = "https://files.pythonhosted.org/packages/57/3f/4a32a4507ab208649e7c224547cbdf6318c8aab23583ea397055f806992e/xberg-1.1.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c1561e72f405ea752c1e31429e35188d32b5bd2d44ec0ecaa71061c9acdace30", size = 63331998, upload-time = "2026-09-06T19:56:20.206Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5f/f6a7721f7b7124340d7278a5c40c70b16495b99fb3b0c40f0ab2d4e0db29/xberg-1.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:d28843e0482c8b9f2dd005329fc8dfc4d69fe9b06765961356304a873f34496e", size = 46971840, upload-time = "2026-09-06T19:56:24.867Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/aff6e4a2e630db3690955644bdf2dfd9f78dfa39c3f133d3e50957889653/xberg-1.1.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3065b43d19e0ee00c658c75f89f0e2e26f6d581c848830f411fe46ea036713fa", size = 43549421, upload-time = "2026-09-07T22:37:13.976Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4b/2ac5baeb35983bb80a12b3885bb3b6ab0750c6e4aa06f3d2fb3a459d8576/xberg-1.1.2-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:31c7b9039199209f9d92c06d83f081d351737eb2bc24c6693e737bda28876bd9", size = 35783254, upload-time = "2026-09-07T22:37:18.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/46/0003728488ea10db99d67a8b4fd9e7a7bc4bc96d0cac543f9aff1b134e7a/xberg-1.1.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:105f4ae96a27cdd8639239f0a1d7c96c3c9642a36d18e5a8a502febffa0f160d", size = 56788898, upload-time = "2026-09-07T22:37:23.658Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/6fe27f97438fe964b3f66804dd579f67616a5d446529b2bdbfeee0bfcf79/xberg-1.1.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a1ef56ff0dcc3426a1d2b1334acaecca9746acaff2f47ad9d4aa6370be449ee", size = 63436866, upload-time = "2026-09-07T22:37:29.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/05b2e42caf544cb3587673e78a004f576a033742a6d832889693799b8aa8/xberg-1.1.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a330690f7e3403f0ec5b8feff974af3a9f349527ecda1ba04bee2688631be035", size = 57341587, upload-time = "2026-09-07T22:37:35.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/55/11d6000d93f69c716960c2b1b753f26f6313e8fbcb727e0ca8d3a298c357/xberg-1.1.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e50670addc4313ce516b2601c1f03a3acb999975d6c1f8d884c99c7a51c9a01", size = 63359708, upload-time = "2026-09-07T22:37:41.057Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/df/10fcfd2c39c85f495e086ef7e4a9037db23b706b67d4ba2edf5005f95359/xberg-1.1.2-cp310-abi3-win_amd64.whl", hash = "sha256:83be30982401f28134f1bc8760c2525ac854ce877e817ab2b27c201bc85c35f9", size = 46979971, upload-time = "2026-09-07T22:37:45.899Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

xberg 1.1.0 read the numbered list on a scanned page as a three-column table and returned the page text twice in the document content. lilbee asked Tesseract for plain page text, which brought the list back but left the duplicated content and the false table entry in place.

## Solution

Pin xberg 1.1.2, which rejects a candidate region whose first column is list markers and stops a detected table repeating its text as paragraphs. The `output_format` workaround comes out: on the scanned fixture 1.1.2 returns the same 173 characters and no tables with or without it.

## Reach of the other fixes

lilbee never builds a `TesseractConfig` and never sets an `ImageExtractionConfig`, so the language-precedence, PSM-sentinel, render-DPI and page-OCR fixes change nothing here. Neither breaking change reaches lilbee either: it asks for markdown or the default renderer, so the `structured` to `doctags` rename and the now-optional `psm` field have no call site. The registry is unchanged, so the README formats table still holds at 126 extensions.

## Regression guard

An integration test runs lilbee's shipped paginated config over the scanned fixture and asserts no table markup on the page, no tables on the document, and no page line repeated in the content. It fails on 1.1.0.

## Not covered

Where Tesseract wrongly reads an image as a table, 1.1.2 keeps only the table reading where 1.1.0 also kept the paragraph text; `output_format` has no reach over that, measured on both versions. Layout mode still sets its own 5% header and footer bands, which xberg no longer applies by default.
