### PR TITLE
Let ingest set its own per-file extraction timeout

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -141,6 +141,7 @@ There is no general `lilbee set` command. From a shell, set the environment vari
 | `chunk_size` | `LILBEE_CHUNK_SIZE` | `int` | `512` | yes | yes | yes | no | Document chunk size in tokens (changes invalidate the index). **Reindex** with `lilbee rebuild` after changing. |
 | `enable_ocr` | `LILBEE_ENABLE_OCR` | `bool|null` | *(none)* | yes | yes | yes | no | Vision OCR for scanned PDFs (empty = auto-detect from vision_model). |
 | `entity_extraction` | `LILBEE_ENTITY_EXTRACTION` | `bool` | `false` | yes | yes | yes | no | Extract typed entities automatically at sync (schema induced on first run). |
+| `extraction_timeout` | `LILBEE_EXTRACTION_TIMEOUT` | `int` | `0` | yes | yes | yes | no | Wall-clock seconds one file gets to extract before ingest gives up on it (0 = no limit). |
 | `ingest_processes` | `LILBEE_INGEST_PROCESSES` | `int` | `0` | yes | yes | yes | no | Ingest worker processes, one GPU each (0 = auto, one per card). Used once the corpus is big enough to pay for them; 1 keeps ingest in this process. |
 | `ingest_workers` | `LILBEE_INGEST_WORKERS` | `int` | `0` | yes | yes | yes | no | Workers for discovering and hashing files (0 = auto, all available cores). |
 | `layout_detection` | `LILBEE_LAYOUT_DETECTION` | `bool` | `false` | yes | yes | yes | no | Layout-aware PDF extraction: reading order plus header/footer stripping (changes invalidate the index). **Reindex** with `lilbee rebuild` after changing. |

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -142,6 +142,15 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group=SettingGroup.INGEST,
         help_text="Pages OCR'd concurrently per vision server; each slot adds KV cache memory",
     ),
+    "extraction_timeout": SettingDef(
+        int,
+        nullable=False,
+        group=SettingGroup.INGEST,
+        help_text=(
+            "Wall-clock seconds one file gets to extract before ingest gives up"
+            " on it (0 = no limit)"
+        ),
+    ),
     "ingest_workers": SettingDef(
         int,
         nullable=False,

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -286,6 +286,11 @@ class Config(BaseSettings):
     table_model: TableModel = ConfigField(
         default=TableModel.SLANET_AUTO, writable=True, reindex=True
     )
+    # Wall-clock cap per file for one xberg extraction, seconds. 0 = no cap.
+    # xberg's own default is 600s and applies on its batch path, so leaving this
+    # unset drops a slow file at ten minutes with no lilbee knob to raise it.
+    # Zero matches the uncapped single-file path, and ingest is background work.
+    extraction_timeout: int = ConfigField(default=0, ge=0, writable=True)
     # Coalesce concurrent extractions into one xberg extract_batch call.
     batch_extraction: bool = ConfigField(default=False, writable=True)
     batch_extraction_size: int = ConfigField(default=8, ge=1, writable=True)

--- a/src/lilbee/data/extract/document.py
+++ b/src/lilbee/data/extract/document.py
@@ -175,6 +175,16 @@ def _effective_enable_ocr() -> bool | None:
     return active_config().enable_ocr if override is None else override
 
 
+def _extraction_timeout_secs() -> int | None:
+    """``cfg.extraction_timeout`` as xberg's per-file cap; None when uncapped.
+
+    xberg defaults this to 600s. Passing lilbee's own value on every call keeps
+    the cap something a user can see and raise instead of an inherited default.
+    """
+    timeout = active_config().extraction_timeout
+    return timeout if timeout > 0 else None
+
+
 def _effective_ocr_timeout() -> float:
     """``cfg.ocr_timeout`` unless a per-request OCR timeout override is active."""
     override = _ocr_timeout_override.get()
@@ -301,6 +311,7 @@ def extraction_config(mode: ExtractMode, *, ocr_token: str | None = None) -> Ext
             ocr=ocr,
             force_ocr=force_ocr,
             pdf_options=_pdf_options(),
+            extraction_timeout_secs=_extraction_timeout_secs(),
         )
         # The layout fields keep xberg's defaults when layout detection is off.
         layout = _layout_config()
@@ -312,6 +323,7 @@ def extraction_config(mode: ExtractMode, *, ocr_token: str | None = None) -> Ext
         output_format=MARKDOWN_OUTPUT,
         ocr=ocr,
         force_ocr=force_ocr,
+        extraction_timeout_secs=_extraction_timeout_secs(),
     )
 
 

--- a/src/lilbee/data/extract/xberg.py
+++ b/src/lilbee/data/extract/xberg.py
@@ -42,11 +42,16 @@ def _input(data: bytes, mime_type: str | None, filename: str | None) -> ExtractI
 
 
 def _first(result: ExtractionResult) -> ExtractedDocument:
-    """Return the single extracted document, or raise on an extraction error."""
+    """Return the single extracted document, or raise on an extraction error.
+
+    The error item carries the reason in ``message``; it has no ``__str__``, so
+    formatting the item itself would hand the caller an object repr instead of
+    the timeout or unsupported-format it is reporting.
+    """
     if result.results:
         return result.results[0]
     if result.errors:
-        raise RuntimeError(str(result.errors[0]))
+        raise RuntimeError(result.errors[0].message)
     raise RuntimeError("xberg extraction returned no document")
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3387,6 +3387,39 @@ class TestExtractionConfig:
         # set an explicit default to preserve 4.x behavior (regression guard).
         assert config.ocr.language == ["eng"]
 
+    def test_extraction_is_uncapped_by_default(self):
+        """Shipped defaults leave no per-file cap on extraction.
+
+        Unset, xberg applies its own 600s limit, and a long file dies at ten
+        minutes with no lilbee setting able to raise it.
+        """
+        from lilbee.data.ingest import ExtractMode, extraction_config
+
+        for mode in (ExtractMode.PAGINATED, ExtractMode.MARKDOWN):
+            assert extraction_config(mode).extraction_timeout_secs is None
+
+    def test_extraction_timeout_from_config(self, monkeypatch):
+        """cfg.extraction_timeout sets xberg's per-file extraction cap.
+
+        Left unset, xberg applies its own 600s default and no lilbee surface can
+        reach it, so a long file dies at ten minutes with nothing to tune.
+        """
+        from lilbee.core.config import cfg
+        from lilbee.data.ingest import ExtractMode, extraction_config
+
+        monkeypatch.setattr(cfg, "extraction_timeout", 45)
+        for mode in (ExtractMode.PAGINATED, ExtractMode.MARKDOWN):
+            assert extraction_config(mode).extraction_timeout_secs == 45
+
+    def test_extraction_timeout_zero_lifts_the_cap(self, monkeypatch):
+        """0 means no cap, matching ocr_timeout and tesseract_timeout."""
+        from lilbee.core.config import cfg
+        from lilbee.data.ingest import ExtractMode, extraction_config
+
+        monkeypatch.setattr(cfg, "extraction_timeout", 0)
+        for mode in (ExtractMode.PAGINATED, ExtractMode.MARKDOWN):
+            assert extraction_config(mode).extraction_timeout_secs is None
+
     def test_tesseract_ocr_language_from_config(self, monkeypatch):
         from lilbee.core.config import cfg
         from lilbee.data.ingest import ExtractMode, extraction_config

--- a/tests/test_xberg_extract.py
+++ b/tests/test_xberg_extract.py
@@ -15,14 +15,27 @@ class _FakeResult:
         self.errors = list(errors)
 
 
+class _FakeError:
+    def __init__(self, index, message):
+        self.index = index
+        self.message = message
+
+
 def test_first_returns_single_document():
     doc = object()
     assert xberg_extract._first(_FakeResult([doc])) is doc
 
 
-def test_first_raises_on_extraction_error():
-    with pytest.raises(RuntimeError, match="boom"):
-        xberg_extract._first(_FakeResult([], errors=["boom"]))
+def test_first_raises_with_the_error_message():
+    """The failure reason reaches the caller, not the error object's repr.
+
+    xberg's ExtractionErrorItem has no ``__str__``, so formatting the item
+    itself yields ``<builtins.ExtractionErrorItem object at 0x...>`` and the
+    real reason (a timeout, an unsupported format) never reaches the user.
+    """
+    err = _FakeError(0, "Extraction timed out after 601000ms (limit: 600000ms)")
+    with pytest.raises(RuntimeError, match="timed out after 601000ms"):
+        xberg_extract._first(_FakeResult([], errors=[err]))
 
 
 def test_first_raises_when_no_document():
@@ -42,12 +55,6 @@ async def test_extract_document_offloads_when_a_loop_is_running():
     with mock.patch("xberg.extract", fake_extract):
         out = xberg_extract.extract_document(b"data", "text/plain", config=mock.MagicMock())
     assert out is doc
-
-
-class _FakeError:
-    def __init__(self, index, message):
-        self.index = index
-        self.message = message
 
 
 def _items(n):


### PR DESCRIPTION
## Problem

`extraction_config()` never set `ExtractionConfig.extraction_timeout_secs`, so every extraction shipped xberg's 600s default. Nothing in lilbee could reach it: no setting, no environment variable, no flag. `ocr_timeout` is a per-page OCR knob and has no bearing on it, so a file that needed more than ten minutes failed with nothing to tune.

## Solution

`cfg.extraction_timeout` (`LILBEE_EXTRACTION_TIMEOUT`, seconds) carries the value on both `extraction_config()` branches. Zero means no cap, matching `ocr_timeout` and `tesseract_timeout`, and is the default.

## Why zero

The cap is enforced on the `extract_batch` path, where it also covers a file's wait behind its batch siblings, and not on the single-file path. Zero makes the two agree, and ingest is background work.

## Readable extraction errors

`_first()` raised `RuntimeError(str(errors[0]))`. xberg's `ExtractionErrorItem` has no `__str__`, so a failure on the single-file path reached the caller as `<builtins.ExtractionErrorItem object at 0x...>` instead of its reason. It now reads the item's message, as the batch path already did.

## Regression guard

Three tests: the shipped default leaves both modes uncapped, a set value reaches both modes, and a failed extraction surfaces its message. Measured on xberg 1.1.2, a 1s cap on a 1.9s file returns `Extraction timed out after 1886ms (limit: 1000ms)` through the batch path.

## Not covered

A ten-minute ingest failure on stock defaults, where `batch_extraction` is off and this cap never fires. The remaining 600s constant on that path is the cold-load floor behind llama-swap's health-check timeout and the embed busy-retry deadline.