### PR TITLE
Fix six broken links across the docs and QA tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <a href="https://github.com/tobocop2/lilbee#install"><img src="https://img.shields.io/badge/Nix-flake-c4a7e7?logo=nixos&logoColor=c4a7e7&style=flat-square&labelColor=191724" alt="Nix flake"></a>
   <a href="https://github.com/tobocop2/lilbee#install"><img src="https://img.shields.io/badge/Scoop-bucket-908caa?logo=windows&logoColor=908caa&style=flat-square&labelColor=191724" alt="Scoop bucket"></a>
   <a href="https://github.com/tobocop2/lilbee/pkgs/container/lilbee"><img src="https://img.shields.io/badge/Docker-ghcr.io-9ccfd8?logo=docker&logoColor=9ccfd8&style=flat-square&labelColor=191724" alt="Docker image on GHCR"></a>
-  <a href="https://tobocop2.github.io/flatpak-lilbee/"><img src="https://img.shields.io/badge/Flatpak-repo-9ccfd8?logo=flatpak&logoColor=9ccfd8&style=flat-square&labelColor=191724" alt="Flatpak repo"></a>
+  <a href="https://github.com/tobocop2/flatpak-lilbee"><img src="https://img.shields.io/badge/Flatpak-repo-9ccfd8?logo=flatpak&logoColor=9ccfd8&style=flat-square&labelColor=191724" alt="Flatpak repo"></a>
   <a href="https://github.com/tobocop2/lilbee/releases/latest"><img src="https://img.shields.io/badge/Snap-sideload-f6c177?logo=snapcraft&logoColor=f6c177&style=flat-square&labelColor=191724" alt="Snap package"></a>
   <a href="https://pypi.org/project/lilbee/"><img src="https://img.shields.io/badge/PyPI-pip%20%7C%20uv-9ccfd8?logo=pypi&logoColor=9ccfd8&style=flat-square&labelColor=191724" alt="Install from PyPI"></a>
   <a href="https://www.npmjs.com/package/lilbee"><img src="https://img.shields.io/npm/v/lilbee?label=npm&logo=npm&logoColor=ebbcba&style=flat-square&labelColor=191724&color=ebbcba" alt="lilbee on npm"></a>
@@ -619,7 +619,7 @@ https://github.com/user-attachments/assets/a578dfd1-61a5-4008-b9bf-e94539003b6e
 
 https://github.com/user-attachments/assets/702975d8-5c1f-4fa7-92a6-bf594ef9d2e3
 
-Every reel on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) with long-form captions. Tape sources are in [`demos/`](demos). For commands and settings, see the [usage guide](docs/usage.md).
+Every reel on this page (plus the extras that don't fit here) is at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial) with long-form captions. Tape sources are in [`demos-src/`](https://github.com/tobocop2/lilbee/tree/gh-pages/demos-src) on the `gh-pages` branch. For commands and settings, see the [usage guide](docs/usage.md).
 
 ## HTTP Server
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1064,7 +1064,7 @@ Two query-time effects:
   - Top 3 results: 70% fusion / 30% rerank (these were already ranked high by fusion for good reason)
   - Positions 4-10: 50% / 50% (equal influence)
   - Positions 11+: 30% fusion / 70% rerank (reranker has more opportunity to rescue misranked items)
-- **Blending rationale**: derived from learning-to-rank literature (Burges et al. 2005, "[Learning to Rank using Gradient Descent](https://icml.cc/imls/conferences/2005/proceedings/papers/012_Learning_BurgesEtAl.pdf)"). Top positions already have strong signal, so the reranker provides diminishing returns there.
+- **Blending rationale**: derived from learning-to-rank literature (Burges et al. 2005, "[Learning to Rank using Gradient Descent](https://dl.acm.org/doi/10.1145/1102351.1102363)"). Top positions already have strong signal, so the reranker provides diminishing returns there.
 - **BM25 protection**: if the rank-1 result has a BM25 score above the expansion skip threshold, it is protected from demotion. This prevents the neural reranker from pushing down obvious exact keyword matches.
 - **Context selection**: reranked results carry their blended score (`rerank_score`) and the reranked order decides which chunks become LLM context, taking the top `max_context_sources` directly instead of the set-cover pass below.
 - **Cost**: depends on model and candidate count. ~200-500ms for 20 candidates with a small cross-encoder.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -456,7 +456,7 @@ lilbee is also the retrieval backend for AI coding agents. Wire it into any
 agent that speaks MCP (Claude Code, opencode, Cursor, anything else) and the
 agent calls `lilbee_search` / `lilbee_add` and gets back cited snippets it can
 quote back. Your files, the embeddings, and the index stay on your computer.
-See the [`lilbee-mcp` skill](agent-skills/lilbee-mcp/SKILL.md) for the full MCP
+See the [`lilbee-mcp` skill](../src/lilbee/skills/lilbee_mcp/SKILL.md) for the full MCP
 tool list and workflows. Non-MCP agents can use the [JSON CLI
 fallback](#json-cli-fallback) below.
 

--- a/tools/qa/cloud-rerun.sh
+++ b/tools/qa/cloud-rerun.sh
@@ -8,7 +8,7 @@
 
 set -euxo pipefail
 
-BRANCH="${LILBEE_BRANCH:-feat/local-model-api}"
+BRANCH="${LILBEE_BRANCH:-main}"
 FAMILIES="${1:-}"
 WORK_DIR="${HOME}/lilbee"
 

--- a/tools/qa/cloud-setup.sh
+++ b/tools/qa/cloud-setup.sh
@@ -4,19 +4,19 @@
 # Fresh SSH session -> running QA matrix in one command.
 #
 # Usage on the cloud box:
-#   bash <(curl -fsSL https://raw.githubusercontent.com/tobocop2/lilbee/feat/local-model-api/tools/qa/cloud-setup.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/tobocop2/lilbee/main/tools/qa/cloud-setup.sh)
 #
 # Or if you've already cloned the repo:
 #   cd lilbee && bash tools/qa/cloud-setup.sh
 #
 # Optional env:
-#   LILBEE_BRANCH=feat/local-model-api  (default)
+#   LILBEE_BRANCH=main  (default)
 #   LLAMA_CUDA=cu124                    (cu121..cu125 - engine build backend; match the box's nvidia-smi CUDA version)
 #   HF_TOKEN=hf_xxx                     (only if pulling gated repos; the default matrix cells are all public)
 
 set -euxo pipefail
 
-BRANCH="${LILBEE_BRANCH:-feat/local-model-api}"
+BRANCH="${LILBEE_BRANCH:-main}"
 CUDA="${LLAMA_CUDA:-cu124}"
 REPO_URL="https://github.com/tobocop2/lilbee.git"
 WORK_DIR="${HOME}/lilbee"

--- a/tools/qa/opencode/pod_bootstrap.sh
+++ b/tools/qa/opencode/pod_bootstrap.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 BACKEND="${BACKEND:-cu124}"
 WORKSPACE="${WORKSPACE:-/workspace}"
 REPO_DIR="${REPO_DIR:-$WORKSPACE/lilbee}"
-BRANCH="${BRANCH:-feat/local-model-api}"
+BRANCH="${BRANCH:-main}"
 ENGINE_CACHE="$WORKSPACE/engine-cache/$BACKEND"
 export UV_PROJECT_ENVIRONMENT="${UV_PROJECT_ENVIRONMENT:-/root/lilbee_venv}"
 export UV_CACHE_DIR="${UV_CACHE_DIR:-/root/uvcache}"


### PR DESCRIPTION
## Problem

A link audit of every external URL and relative markdown link in the tree found six that return 404. All predate this change.

## Solution

**Flatpak badge.** It pointed at the Pages directory index, which has no `index.html` and returns 404. The repository page is a better landing spot. The install command in the table already uses the `.flatpakrepo` file, which resolves.

**README demo sources.** `demos/` moved off `main` in #263. The tape sources live in `demos-src/` on the `gh-pages` branch.

**Usage guide skill link.** It pointed at `agent-skills/lilbee-mcp/SKILL.md`. The skill lives at `src/lilbee/skills/lilbee_mcp/SKILL.md`.

**RankNet citation.** The `icml.cc` path no longer exists. It now uses the ACM DOI, matching the other citations in `architecture.md`.

**QA scripts.** Three defaulted their branch to `feat/local-model-api`, which GitHub deleted when it merged #267.

## Not changed

`repo.charm.sh/apt/` returns 404 on its directory index, but `apt/gpg.key` returns 200, so the install works. GitHub's `user-attachments` URLs return 404 to a script by design: GitHub rewrites them into signed URLs at render time and the README videos play. Both were false positives in the first audit pass.