### PR TITLE
Enforce the commit-message rules with committed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: the commit-message check needs a merge base.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -62,6 +65,14 @@ jobs:
 
       - name: Check imports resolve
         run: make imports-check
+
+      - name: Check commit messages
+        if: github.event_name == 'pull_request'
+        # Check the branch's own commits. HEAD is the synthetic merge commit
+        # that GitHub builds for the event, and it is not ours to lint.
+        run: |
+          uvx --from committed committed \
+            "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
 
   shell:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # Run the same lint, format, and type checks CI enforces, before each commit.
 # Hooks call the project's existing tools so there's no second config to keep in sync.
 # Install with: uv run pre-commit install
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: local
     hooks:
@@ -20,3 +21,9 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+
+  - repo: https://github.com/crate-ci/committed
+    rev: v1.1.11
+    hooks:
+      - id: committed
+        stages: [commit-msg]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,36 @@ make format-check  # verify formatting without changing files
 
 See [`AGENTS.md`](AGENTS.md) for the complete set of rules (DRY, layering, TUI conventions, cross-cutting-change checklist, self-review checklist).
 
-## Commits and PRs
+## Commit messages
 
-- Keep commits focused and descriptive. No "Phase N" numbering, no `Co-Authored-By` lines.
+lilbee follows [the seven rules of a great commit message](https://cbea.ms/git-commit/):
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why, not how
+
+A `subsystem: summary` prefix is fine, as the Linux kernel uses. lilbee does not
+use Conventional Commits: nothing here consumes the prefixes, and they push
+subjects into lowercase.
+
+The body states what changed and the mechanism that makes it work: the flag, the
+ordering constraint, the invariant, the root cause. It does not narrate how the
+work was reached, list files, or restate the diff. Keep sentences under about 25
+words, in the active voice and the present tense.
+
+No em dashes. No `Phase N` numbering. No ticket ids in the subject. No
+`Co-Authored-By` lines for tools.
+
+[`committed`](https://github.com/crate-ci/committed) enforces the mechanical
+rules through a `commit-msg` hook and in CI. It reads `committed.toml`. The
+`uv run pre-commit install` step above installs the hook.
+
+## Pull requests
+
 - PR descriptions are short and human-readable: a `## Problem` and `## Solution` paragraph. No implementation dumps, internal names, or test-plan sections.
 - Run the full `make check` gate before every push.
 

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,11 @@
+# Commit-message rules, per CONTRIBUTING.md.
+# Check a range with: committed origin/main..HEAD
+subject_length = 50
+line_length = 72
+subject_capitalized = true
+subject_not_punctuated = true
+imperative_subject = true
+no_fixup = true
+no_wip = true
+merge_commit = false
+style = "none"

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,3 +68,10 @@ uv run pytest   # Full suite including RAG accuracy
 ## License
 
 MIT
+
+## Repository history
+
+The commit history was consolidated to keep the repository small. Commit
+guidelines are now in place to avoid the need to do this again. The original
+history up to `v0.6.90b435` (2026-09-08) lives at
+[tobocop2/lilbee-archive](https://github.com/tobocop2/lilbee-archive).


### PR DESCRIPTION
## Problem

The project had no written commit-message standard and nothing checking one. Measured across the pre-consolidation history: 55% of subjects ran past 50 characters, 16% past 72 where GitHub truncates them, and 30% of body lines past 72.

## Solution

`CONTRIBUTING.md` states the standard: [the seven rules](https://cbea.ms/git-commit/) plus the project's own constraints. No em dashes, no `Phase N`, no ticket ids in the subject, active voice, sentences under about 25 words.

[`committed`](https://github.com/crate-ci/committed) enforces the mechanical rules. A `commit-msg` hook rejects a bad message locally, and the lint job checks every commit in a pull request. Both read `committed.toml`.

## Why committed and not gitlint

It ships as a prebuilt binary, so it never enters the dependency graph. That matters here: `gitlint` pulls `gitlint-core[trusted-deps]`, which pins `click==8.1.3` and cannot resolve against this project's floor. Eight workflow steps run `uv sync --locked`, so one conflicting dev dependency breaks every job at install.

`committed` also checks imperative mood, which `gitlint` does not, and is actively maintained. `gitlint`'s last release was 0.19.1 in 2023 and its last commit was July 2024.

## Verified

`committed` passes against all 628 commits of the current history and against this PR's own commit, and correctly rejects a subject that is too long, lowercase, non-imperative or punctuated.

`docs/development.md` records where the pre-consolidation history lives.