### PR TITLE
Resolve the release-candidate run by tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ on:
       tag:
         description: "Existing tag to publish (e.g. v0.6.66b469)."
         required: true
+      rc_run_id:
+        description: "Release-candidate run id to publish from. Only needed when neither the tag nor the commit finds the right run."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -63,17 +67,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ inputs.tag }}
+          RC_RUN_ID: ${{ inputs.rc_run_id }}
         run: |
           set -euo pipefail
           SHA=$(git rev-parse HEAD)
           echo "${TAG} -> ${SHA}"
-          # Most recent push-triggered RC run for this commit -- any status; we
-          # only need its default wheels + sdist, which land well before the
-          # executables / CUDA matrix / QA finish.
-          RC_ID=$(gh api "repos/${REPO}/actions/workflows/release-candidate.yml/runs?head_sha=${SHA}&event=push&per_page=50" \
-            --jq '.workflow_runs | sort_by(.run_started_at) | last | .id // empty')
+          # Resolve by tag, which is what the run was triggered on and stays
+          # correct even if the tag is later moved to another commit. head_sha
+          # is the fallback, and an explicit run id overrides both. Any status
+          # will do: we need the default wheels + sdist, which land well before
+          # the executables / CUDA matrix / QA finish.
+          runs_for () {
+            gh api "repos/${REPO}/actions/workflows/release-candidate.yml/runs?$1&event=push&per_page=50" \
+              --jq '.workflow_runs | sort_by(.run_started_at) | last | .id // empty'
+          }
+          RC_ID="${RC_RUN_ID}"
+          [ -n "${RC_ID}" ] || RC_ID=$(runs_for "branch=${TAG}")
+          [ -n "${RC_ID}" ] || RC_ID=$(runs_for "head_sha=${SHA}")
           if [ -z "${RC_ID}" ]; then
-            echo "no 'Release candidate' run for ${SHA}; push the tag first" >&2
+            echo "no 'Release candidate' run for tag ${TAG} or commit ${SHA}; push the tag first, or pass rc_run_id" >&2
             exit 1
           fi
           echo "release-candidate run = ${RC_ID}"


### PR DESCRIPTION
## Problem

`publish.yml` finds the run that built a release by checking out the tag, reading `git rev-parse HEAD`, and matching that commit against the run's `head_sha`.

That lookup returns nothing whenever the tag has moved since the run started, and the publish fails with `no 'Release candidate' run for <sha>`.

## Solution

The tag is the stable identity here: it is what triggered the run, and it keeps pointing at the release even when the commit underneath it changes. Resolution now tries the tag first, falls back to `head_sha`, and takes an explicit `rc_run_id` over both.

## Why now

The history consolidation moved every tag to a new commit. The in-flight release candidate for `v0.6.90b435` (run `34187069809`) builds and attaches correctly, because its jobs resolve the tag by name and the tree behind that name is byte-identical. Its `dispatch-publish` would hand `publish.yml` a tag whose SHA no longer matches the run, so the PyPI upload alone would fail.

Nothing else is affected: `dispatch-fanout` and `dispatch-cuda` depend only on `[resolve, attach-prerelease]`, so Docker, Homebrew, AUR, Nix, Scoop, Flatpak and the CUDA packages fan out normally.

## Verified against the live run

```
head_sha=<current tag commit>   ->  0 runs      (the break)
branch=v0.6.90b435              ->  34187069809 (the in-flight run)
artifacts on that run           ->  wheel-default, sdist
```

`workflow_dispatch` runs the workflow file from the default branch, so this has to be on `main` before `dispatch-publish` fires. That job waits on `attach-prerelease`, which waits on the eight builds still running.