### PR TITLE
Report a stopped chat engine and silent retrieval failures in health

### DIFF
--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -16,7 +16,7 @@ from lilbee.providers.fleet.planning import (
     resolve_placement_plan,
 )
 from lilbee.providers.roles import WorkerRole
-from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress, is_active_warm
 
 _PLACEMENT_KEY = "placement"
 
@@ -27,9 +27,6 @@ _PLACEMENT_KEY = "placement"
 _CHAT_READY_TIMEOUT_S = 1800.0
 _CHAT_READY_POLL_S = 0.5
 _CHAT_READY_GRACE_S = 3.0
-_ACTIVE_WARM_PHASES = frozenset(
-    {WarmPhase.STARTING, WarmPhase.READING_WEIGHTS, WarmPhase.LOADING_ENGINE}
-)
 
 
 @dataclass(frozen=True)
@@ -216,11 +213,6 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
 
 
-def warm_is_reporting(snapshot: WarmProgress | None) -> bool:
-    """Whether *snapshot* is a warm that is actively loading, rather than idle or done."""
-    return snapshot is not None and snapshot.phase in _ACTIVE_WARM_PHASES
-
-
 def wait_chat_ready(
     timeout_s: float = _CHAT_READY_TIMEOUT_S,
     *,
@@ -256,7 +248,7 @@ def wait_chat_ready(
         snapshot = provider.warm_progress()
         # A requested warm counts as in flight before it stamps a phase: the fleet
         # spawns and health-checks llama-swap first, which takes seconds.
-        if warm_is_reporting(snapshot):
+        if is_active_warm(snapshot):
             if on_progress is not None and snapshot is not None:
                 on_progress(snapshot)
             grace_deadline = time.monotonic() + _CHAT_READY_GRACE_S
@@ -312,7 +304,7 @@ def active_chat_warm_progress() -> WarmProgress | None:
         return None
     provider = services.provider
     snapshot = provider.warm_progress()
-    if not warm_is_reporting(snapshot):
+    if not is_active_warm(snapshot):
         return None
     return None if provider.role_ready(WorkerRole.CHAT) else snapshot
 

--- a/src/lilbee/core/health_warnings.py
+++ b/src/lilbee/core/health_warnings.py
@@ -1,0 +1,31 @@
+"""Degradations a running server can report to a client.
+
+Each subsystem owns the state behind its own warnings and exposes them; the
+health handler aggregates. Nothing here holds state, so there is no registry to
+keep in sync with the components that produce it.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class WarningCode(StrEnum):
+    """Stable identifier for a degradation, so a client can branch on it."""
+
+    FTS_UNAVAILABLE = "fts_unavailable"
+    """Keyword search failed and queries fall back to vector-only recall."""
+    EMBEDDING_PREFIX_MISMATCH = "embedding_prefix_mismatch"
+    """Queries are prefixed but stored documents are not; retrieval is degraded."""
+
+
+class HealthWarning(BaseModel):
+    """One active degradation, with the remedy the user can act on."""
+
+    code: WarningCode
+    message: str
+    """User-facing description of what is degraded."""
+    remedy: str | None = None
+    """The action that clears it, when there is one."""

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -27,6 +27,7 @@ from lilbee.core.config import (
     WIKI_MENTIONS_TABLE,
     Config,
 )
+from lilbee.core.health_warnings import HealthWarning, WarningCode
 from lilbee.core.vectors import Vector
 from lilbee.retrieval.embedding_profiles import resolve_embedding_profile
 from lilbee.runtime.lock import LOCK_TIMEOUT, LockTimeoutError, write_lock
@@ -265,6 +266,9 @@ class Store:
         self._fts_ready: bool = False
         self._title_fts_ready: bool = False
         self._doc_prefix_warned: bool = False
+        # Degradations the health endpoint reports; set where they are detected.
+        self._fts_degraded: bool = False
+        self._doc_prefix_mismatch: bool = False
         # Scalar indexes (source/chunk_type) are built at ingest; a serve-only
         # store builds them lazily from the search path.
         self._scalar_ready: bool = False
@@ -408,6 +412,9 @@ class Store:
                 }
             ]
         )
+        # A rebuild is the remedy the prefix warning names, so the next query
+        # re-decides instead of logging a mismatch this write just resolved.
+        self._doc_prefix_warned = False
 
     def _has_chunks(self) -> bool:
         """Return True when the chunks table exists and has at least one row."""
@@ -475,25 +482,64 @@ class Store:
             current_dim=current_dim,
         )
 
+    def _doc_prefix_is_stale(self) -> bool:
+        """Whether the stored documents predate the embedding family's document prefix."""
+        meta = self.get_meta()
+        if meta is None:
+            return False
+        profile = resolve_embedding_profile(self._config.embedding_model)
+        return bool(profile.doc_prefix) and meta["schema_version"] < profile.doc_prefix_since
+
     def _warn_stale_doc_prefix(self) -> None:
         """Warn once when the embedding family's document prefix postdates this store.
 
         Queries would carry the family prefix while stored documents do not;
-        the mismatch degrades quality silently until a rebuild re-embeds.
+        the mismatch degrades quality silently until a rebuild re-embeds. The
+        check reads the metadata row, which the query path cannot pay per search.
         """
         if self._doc_prefix_warned:
             return
         self._doc_prefix_warned = True
-        meta = self.get_meta()
-        if meta is None:
+        if not self._doc_prefix_is_stale():
             return
-        profile = resolve_embedding_profile(self._config.embedding_model)
-        if profile.doc_prefix and meta["schema_version"] < profile.doc_prefix_since:
-            log.warning(
-                "This index predates '%s' document prefixes: queries are prefixed "
-                "but stored documents are not. Run `lilbee rebuild` to re-embed.",
-                self._config.embedding_model,
+        self._doc_prefix_mismatch = True
+        log.warning(
+            "This index predates '%s' document prefixes: queries are prefixed "
+            "but stored documents are not. Run `lilbee rebuild` to re-embed.",
+            self._config.embedding_model,
+        )
+
+    def health_warnings(self) -> list[HealthWarning]:
+        """Silent retrieval degradations this store has hit since it opened."""
+        warnings: list[HealthWarning] = []
+        if self._fts_degraded:
+            warnings.append(
+                HealthWarning(
+                    code=WarningCode.FTS_UNAVAILABLE,
+                    message=(
+                        "Keyword search is unavailable, so answers are drawn from "
+                        "vector similarity alone and exact terms may be missed."
+                    ),
+                    remedy="Run `lilbee rebuild` to rebuild the search index.",
+                )
             )
+        if self._doc_prefix_mismatch and not self._doc_prefix_is_stale():
+            # The remedy is `lilbee rebuild`, which usually runs in another
+            # process, so the query path's cached verdict outlives the fix.
+            self._doc_prefix_mismatch = False
+        if self._doc_prefix_mismatch:
+            warnings.append(
+                HealthWarning(
+                    code=WarningCode.EMBEDDING_PREFIX_MISMATCH,
+                    message=(
+                        f"This index predates '{self._config.embedding_model}' document "
+                        "prefixes: queries are prefixed but stored documents are not, "
+                        "so retrieval is less accurate."
+                    ),
+                    remedy="Run `lilbee rebuild` to re-embed the documents.",
+                )
+            )
+        return warnings
 
     def assert_embedding_compatible(self) -> None:
         """Run the full embedding-identity gate (legacy init, canonicalize, check).
@@ -1016,20 +1062,12 @@ class Store:
             # built; without them the source/chunk_type prefilters full-scan.
             self.ensure_scalar_indexes(blocking=False)
 
-        if query_text and not self._fts_ready:
-            self.ensure_fts_index(blocking=False)
-        if query_text and self._config.title_search and not self._title_fts_ready:
-            self.ensure_title_fts_index(blocking=False)
-
-        if query_text and self._fts_ready:
-            try:
-                return self._hybrid_search(
-                    table, query_text, query_vector, top_k, max_distance, chunk_type
-                )
-            except Exception:
-                # Falling back changes recall characteristics for the query;
-                # a corpus-wide FTS breakage must not present as silence.
-                log.warning("Hybrid search failed, falling back to vector-only", exc_info=True)
+        if query_text:
+            hits = self._keyword_arm(
+                table, query_text, query_vector, top_k, max_distance, chunk_type
+            )
+            if hits is not None:
+                return hits
 
         rows = self._vector_arm(
             table, query_vector, top_k * self._config.candidate_multiplier, chunk_type
@@ -1049,6 +1087,43 @@ class Store:
             )
             for r in results
         ]
+
+    def _keyword_arm(
+        self,
+        table: lancedb.table.Table,
+        query_text: str,
+        query_vector: Vector,
+        top_k: int,
+        max_distance: float,
+        chunk_type: ChunkType | None,
+    ) -> list[SearchChunk] | None:
+        """Hybrid results, or None when keyword search cannot serve this query and
+        the caller must fall back to vector-only.
+
+        Owns the keyword-search health the endpoint reports. An index that will
+        not build and an index that fails mid-query drop every query to vector
+        recall alike, so both stamp the flag, and a working index clears it.
+        """
+        if not self._fts_ready:
+            self.ensure_fts_index(blocking=False)
+        if self._config.title_search and not self._title_fts_ready:
+            self.ensure_title_fts_index(blocking=False)
+        if not self._fts_ready:
+            # An empty corpus has nothing to index and nothing to degrade.
+            self._fts_degraded = self._has_chunks()
+            return None
+        try:
+            hits = self._hybrid_search(
+                table, query_text, query_vector, top_k, max_distance, chunk_type
+            )
+        except Exception:
+            # Falling back changes recall characteristics for the query;
+            # a corpus-wide FTS breakage must not present as silence.
+            self._fts_degraded = True
+            log.warning("Hybrid search failed, falling back to vector-only", exc_info=True)
+            return None
+        self._fts_degraded = False
+        return hits
 
     def _vector_arm(
         self,

--- a/src/lilbee/providers/warm_progress.py
+++ b/src/lilbee/providers/warm_progress.py
@@ -44,6 +44,21 @@ class WarmProgress(BaseModel):
     elapsed_s: float = 0.0
 
 
+ACTIVE_WARM_PHASES = frozenset(
+    {WarmPhase.STARTING, WarmPhase.READING_WEIGHTS, WarmPhase.LOADING_ENGINE}
+)
+"""Phases in which a load is still in flight. READY and ERROR are terminal."""
+
+
+def is_active_warm(snapshot: WarmProgress | None) -> bool:
+    """Whether *snapshot* is a load still in flight, rather than absent or finished.
+
+    A terminal snapshot outlives the engine it describes: the tracker is not
+    cleared when a role is swapped out, so READY can survive an eviction.
+    """
+    return snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
+
+
 class WarmProgressTracker:
     """Thread-safe warm-state holder: the warm thread writes, handlers read.
 

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -22,7 +22,7 @@ from lilbee.app.status import gather_status
 from lilbee.app.version import get_version
 from lilbee.core.config import cfg
 from lilbee.providers.roles import WorkerRole
-from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress, is_active_warm
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.agent_config import agent_config, agent_config_index
 from lilbee.server.handlers.config import (
@@ -117,11 +117,11 @@ def _chat_status(
     if provider.role_ready(WorkerRole.CHAT):
         return "ready", None
     snapshot = provider.warm_progress()
-    if snapshot is None:
-        return "not_started", None
-    if snapshot.phase is WarmPhase.ERROR:
+    if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
         return "error", snapshot.error
-    return "loading", None
+    if is_active_warm(snapshot):
+        return "loading", None
+    return "not_started", None
 
 
 async def health() -> HealthResponse:

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -126,7 +126,8 @@ def _chat_status(
 
 async def health() -> HealthResponse:
     """Return service health, version, and whether the chat engine is warm."""
-    provider = get_services().provider
+    services = get_services()
+    provider = services.provider
     chat_status, chat_error = _chat_status(provider)
     prefill = provider.chat_prefill_progress()
     return HealthResponse(
@@ -139,6 +140,7 @@ async def health() -> HealthResponse:
         chat_slots=provider.served_chat_slots(),
         chat_prefill_processed=prefill[0] if prefill else None,
         chat_prefill_total=prefill[1] if prefill else None,
+        warnings=services.store.health_warnings(),
     )
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 from lilbee.app.agent_configs.document import AgentClient, AgentSurface, ConfigFormat
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.core.config.enums import CrawlRenderMode
+from lilbee.core.health_warnings import HealthWarning
 from lilbee.data.store import ChunkType, MemoryKind, scope_to_chunk_type
 from lilbee.data.types import SkippedSource
 from lilbee.providers.roles import WorkerRole
@@ -240,6 +241,11 @@ class HealthResponse(BaseModel):
     chat_prefill_total: int | None = None
     """Prompt tokens the in-flight chat prefill will process in total. None when
     no prefill is running."""
+    warnings: list[HealthWarning] = []
+    """Degradations that answer correctly but worse, so a client can say so.
+
+    Retrieval falling back to vector-only, or an index whose documents predate
+    the embedder's prefixes, both return results and look healthy."""
 
 
 class CompactionInfo(BaseModel):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -145,6 +145,24 @@ class TestHealth:
         mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.ERROR)
         assert (await handlers.health()).chat_status == "error"
 
+    async def test_health_reports_silent_retrieval_degradations(self, mock_svc):
+        """Vector-only fallback and a prefix-mismatched index both answer and look
+        healthy. Health carries them so a client can say the answers are degraded."""
+        from lilbee.core.health_warnings import HealthWarning, WarningCode
+
+        mock_svc.store.health_warnings.return_value = [
+            HealthWarning(
+                code=WarningCode.FTS_UNAVAILABLE, message="keyword search is down", remedy="rebuild"
+            )
+        ]
+        result = await handlers.health()
+        assert [w.code for w in result.warnings] == [WarningCode.FTS_UNAVAILABLE]
+        assert result.warnings[0].remedy == "rebuild"
+
+    async def test_health_reports_no_warnings_on_a_clean_store(self, mock_svc):
+        mock_svc.store.health_warnings.return_value = []
+        assert (await handlers.health()).warnings == []
+
     async def test_chat_status_is_not_started_when_a_finished_warm_is_stale(self, mock_svc):
         """An engine that loaded and was then swapped out must not read as loading.
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -145,6 +145,29 @@ class TestHealth:
         mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.ERROR)
         assert (await handlers.health()).chat_status == "error"
 
+    async def test_chat_status_is_not_started_when_a_finished_warm_is_stale(self, mock_svc):
+        """An engine that loaded and was then swapped out must not read as loading.
+
+        The tracker keeps its terminal READY snapshot after an idle eviction, so
+        classifying on 'not ERROR' reported loading forever for an engine that was
+        down and would only come back on the next request.
+        """
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        mock_svc.provider.role_ready.return_value = False
+        mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.READY)
+        result = await handlers.health()
+        assert result.chat_status == "not_started"
+        assert result.chat_error is None
+
+    async def test_chat_status_loading_covers_every_in_flight_phase(self, mock_svc):
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        mock_svc.provider.role_ready.return_value = False
+        for phase in (WarmPhase.STARTING, WarmPhase.READING_WEIGHTS, WarmPhase.LOADING_ENGINE):
+            mock_svc.provider.warm_progress.return_value = WarmProgress(phase=phase)
+            assert (await handlers.health()).chat_status == "loading"
+
     async def test_chat_error_carries_the_warm_failure_reason(self, mock_svc):
         """A failed warm (e.g. a wedged GPU probe) names its cause in health, so a
         polling client reports why instead of retrying forever (bb-0yf0)."""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -445,6 +445,63 @@ class TestEnsureFtsIndex:
         create_spy.assert_not_called()
         optimize_spy.assert_called_once()
 
+    def test_hybrid_failure_is_reported_as_a_health_warning(self, store):
+        """A corpus-wide FTS breakage drops every query to vector-only recall.
+        The log line alone never reached the user, so the store reports it."""
+        from lilbee.core.health_warnings import WarningCode
+
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        assert store.health_warnings() == []
+
+        with mock.patch.object(
+            type(store), "_hybrid_search", side_effect=RuntimeError("fts index gone")
+        ):
+            store.search([0.5] * cfg.embedding_dim, top_k=1, query_text="anything")
+
+        codes = [w.code for w in store.health_warnings()]
+        assert WarningCode.FTS_UNAVAILABLE in codes
+
+    def test_an_index_that_never_builds_is_reported(self, store):
+        """A create_index failure leaves keyword search off for every query. The
+        hybrid arm never runs, so the failure has to be reported from readiness."""
+        from lilbee.core.health_warnings import WarningCode
+
+        store.add_chunks(_make_records())
+        with mock.patch.object(type(store), "ensure_fts_index"):
+            store.search([0.5] * cfg.embedding_dim, top_k=1, query_text="anything")
+
+        codes = [w.code for w in store.health_warnings()]
+        assert WarningCode.FTS_UNAVAILABLE in codes
+
+    def test_an_emptied_corpus_reports_no_keyword_warning(self, store):
+        """A store whose chunks are all gone keeps the table and cannot index it.
+        There is nothing to degrade, so the warning must not fire."""
+        store.add_chunks(_make_records())
+        for record in _make_records():
+            store.delete_by_source(record["source"])
+        with mock.patch.object(type(store), "ensure_fts_index"):
+            store.search([0.5] * cfg.embedding_dim, top_k=1, query_text="anything")
+
+        assert store.health_warnings() == []
+
+    def test_hybrid_recovery_clears_the_health_warning(self, store):
+        """The warning names a remedy, so running it must clear the warning.
+        A latching flag would train the user to ignore the banner."""
+        from lilbee.core.health_warnings import WarningCode
+
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        with mock.patch.object(
+            type(store), "_hybrid_search", side_effect=RuntimeError("fts index gone")
+        ):
+            store.search([0.5] * cfg.embedding_dim, top_k=1, query_text="anything")
+        assert WarningCode.FTS_UNAVAILABLE in [w.code for w in store.health_warnings()]
+
+        # Index healthy again: the next query reports the current state.
+        store.search([0.5] * cfg.embedding_dim, top_k=1, query_text="anything")
+        assert store.health_warnings() == []
+
     def test_optimize_failure_keeps_hybrid_ready(self, store):
         """An optimize() crash on an already-built index (a LanceDB encoding
         bug bites large corpora) must not disable hybrid search: the index
@@ -832,6 +889,37 @@ class TestEnsureScalarIndexes:
             store.search([0.5] * test_config.embedding_dim, top_k=1)
         warned = [r for r in caplog.records if "document prefixes" in r.message]
         assert len(warned) == 1
+
+    def test_pre_prefix_store_reports_a_health_warning(self, store, test_config):
+        """The rebuild advice was log-only, so a user whose retrieval was quietly
+        degraded never saw it. The store reports it for the health endpoint."""
+        from lilbee.core.health_warnings import WarningCode
+
+        test_config.embedding_model = "nomic-ai/nomic-embed-text-v1.5-GGUF/n.gguf"
+        store.add_chunks(_make_records())
+        old_meta = {**store.get_meta(), "schema_version": 1}
+        with mock.patch.object(type(store), "get_meta", return_value=old_meta):
+            store.search([0.5] * test_config.embedding_dim, top_k=1)
+            codes = [w.code for w in store.health_warnings()]
+
+        assert WarningCode.EMBEDDING_PREFIX_MISMATCH in codes
+
+    def test_rebuild_in_another_process_clears_the_prefix_warning(self, store, test_config):
+        """`lilbee rebuild` is the remedy the warning names and it runs in its own
+        process, so the server cannot report the verdict its query path cached."""
+        from lilbee.core.health_warnings import WarningCode
+
+        test_config.embedding_model = "nomic-ai/nomic-embed-text-v1.5-GGUF/n.gguf"
+        store.add_chunks(_make_records())
+        old_meta = {**store.get_meta(), "schema_version": 1}
+        with mock.patch.object(type(store), "get_meta", return_value=old_meta):
+            store.search([0.5] * test_config.embedding_dim, top_k=1)
+            assert WarningCode.EMBEDDING_PREFIX_MISMATCH in [
+                w.code for w in store.health_warnings()
+            ]
+
+        # Meta now reads at the current schema version, as after a rebuild.
+        assert store.health_warnings() == []
 
     def test_blocking_index_builds_propagate_lock_timeouts(self, store, test_config):
         """Ingest-path callers keep the old contract: a lock timeout raises."""


### PR DESCRIPTION
## Problem

`/api/health` reports the chat engine as loading when it is not loading and will not start on its own. Any client that waits on that field waits until the process restarts. The check asks whether a warm failed, not whether one is running, and a finished warm leaves its snapshot behind. Reproduced twice, 22 minutes apart.

The Obsidian plugin gates chat on this field, so once the engine idles out it refuses to send until the user restarts the app.

Two retrieval failures are also invisible. Keyword search can break across a corpus and drop every query to vector-only recall; one session logged that 11,000 times while the UI reported nothing. An index built before the embedder changed its document format returns results from a mismatched space. Both reach only the log.

## Solution

Health reports `not_started` when nothing is warming and the engine is down. The test for "a warm is running" now has one definition, shared with the code that waits on it.

Health also carries a `warnings` list. Each entry names the degradation and its remedy and reports the current state, so running the remedy clears it, including when `lilbee rebuild` runs in another process.

## Verified

Against a live server with a search index file deleted from disk: health reports `not_started` where the released build reports `loading`, search still looks healthy, health names the broken keyword search and its remedy, and running that remedy clears the warning.

## Not covered

Nothing in this repo renders the warnings yet; the Obsidian plugin is the intended client. A downsized engine and a refused model already have fields of their own. One placement gap stays log-only and is tracked separately.
