### PR TITLE
Filter the model catalog by what the host can run

### DIFF
--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -60,6 +60,7 @@ def get_catalog(
     size: CatalogSize | None = None,
     installed: bool | None = None,
     featured: bool | None = None,
+    fit_filter: Callable[[CatalogModel], bool] | None = None,
     sort: CatalogSort = CatalogSort.FEATURED,
     limit: int = 20,
     offset: int = 0,
@@ -81,6 +82,7 @@ def get_catalog(
             search=search,
             size=size,
             installed_filter=installed_filter,
+            fit_filter=fit_filter,
             featured=featured,
         )
 
@@ -139,6 +141,7 @@ def _filter_models(
     search: str,
     size: CatalogSize | None,
     installed_filter: Callable[[CatalogModel], bool] | None,
+    fit_filter: Callable[[CatalogModel], bool] | None,
     featured: bool | None,
 ) -> list[CatalogModel]:
     """The rows of *models* that pass every requested filter."""
@@ -151,6 +154,8 @@ def _filter_models(
         models = [m for m in models if size_bucket(m.params) == size]
     if installed_filter is not None:
         models = [m for m in models if installed_filter(m)]
+    if fit_filter is not None:
+        models = [m for m in models if fit_filter(m)]
     if featured is not None:
         models = [m for m in models if m.featured == featured]
     return models

--- a/src/lilbee/cli/tui/screens/catalog_grouping.py
+++ b/src/lilbee/cli/tui/screens/catalog_grouping.py
@@ -14,7 +14,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
     LocalCatalogRow,
 )
 from lilbee.cli.tui.widgets.model_list import ModelListSection
-from lilbee.runtime.hardware import FitLevel
+from lilbee.runtime.hardware import FIT_RANK, FitLevel
 
 
 @dataclass
@@ -87,8 +87,6 @@ def for_you_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
 
     Curation is applied before the sort, so featured isn't in the key.
     """
-    from lilbee.runtime.hardware import FIT_RANK
-
     unknown_fit_rank = len(FIT_RANK)
     rank = unknown_fit_rank if row.fit is None else FIT_RANK[row.fit.level]
     return (rank, row.name.lower())

--- a/src/lilbee/cli/tui/screens/catalog_grouping.py
+++ b/src/lilbee/cli/tui/screens/catalog_grouping.py
@@ -83,19 +83,14 @@ def for_you_by_role(rows: list[LocalCatalogRow]) -> list[LocalCatalogRow]:
 
 
 def for_you_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
-    """Rank Discover 'For You' rows: best fit first, then alphabetical.
+    """Rank Discover 'For You' rows: best fit first, unknown fit last, then alphabetical.
 
-    Fit rank: FITS=0, TIGHT=1, WONT_RUN=2, no chip=3. Curation is applied
-    before the sort, so featured isn't in the key.
+    Curation is applied before the sort, so featured isn't in the key.
     """
-    if row.fit is None:
-        rank = 3
-    elif row.fit.level is FitLevel.FITS:
-        rank = 0
-    elif row.fit.level is FitLevel.TIGHT:
-        rank = 1
-    else:
-        rank = 2
+    from lilbee.runtime.hardware import FIT_RANK
+
+    unknown_fit_rank = len(FIT_RANK)
+    rank = unknown_fit_rank if row.fit is None else FIT_RANK[row.fit.level]
     return (rank, row.name.lower())
 
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -1116,22 +1116,28 @@ def catalog_browse(
     size: str = "",
     installed: bool | None = None,
     featured: bool | None = None,
+    max_fit: str = "",
     sort: str = "featured",
     limit: int = 20,
     offset: int = 0,
 ) -> dict[str, Any]:
-    """Browse the lilbee model catalog. ``task``: chat/embedding/vision/rerank.
+    """Browse the model catalog. ``task``: chat/embedding/vision/rerank.
     ``size``: small/medium/large/huge, by parameter count.
+    ``max_fit``: fits/tight/wont_run, worst fit to keep.
     ``sort``: featured/downloads/name/size_asc/size_desc."""
     from lilbee.catalog.query import get_catalog
     from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
+    from lilbee.runtime.hardware import FitLevel, available_memory_for_fit, make_fit_filter
 
     try:
         parsed_task = ModelTask(task) if task else None
         parsed_size = CatalogSize(size) if size else None
         parsed_sort = CatalogSort(sort)
+        parsed_max_fit = FitLevel(max_fit) if max_fit else None
     except ValueError as exc:
         return _error(str(exc))
+    # The host probe costs a GPU query, so only run it when a fit was asked for.
+    available_bytes = available_memory_for_fit() if parsed_max_fit is not None else None
     try:
         result = get_catalog(
             task=parsed_task,
@@ -1139,6 +1145,7 @@ def catalog_browse(
             size=parsed_size,
             installed=installed,
             featured=featured,
+            fit_filter=make_fit_filter(parsed_max_fit, available_bytes),
             sort=parsed_sort,
             limit=limit,
             offset=offset,

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 
 from pydantic import BaseModel
 
-from lilbee.catalog.models import ModelFamily
+from lilbee.catalog.models import CatalogModel, ModelFamily
 from lilbee.core.config import cfg
 
 _BYTES_PER_GB = 1024**3
@@ -18,6 +19,15 @@ class FitLevel(StrEnum):
     FITS = "fits"
     TIGHT = "tight"
     WONT_RUN = "wont_run"
+
+
+# Fit is an ordered notion, best first. Callers rank against it instead of
+# spelling the order out again.
+FIT_RANK: dict[FitLevel, int] = {
+    FitLevel.FITS: 0,
+    FitLevel.TIGHT: 1,
+    FitLevel.WONT_RUN: 2,
+}
 
 
 @dataclass(frozen=True)
@@ -43,6 +53,32 @@ def compute_fit(model_size_bytes: int, available_bytes: int) -> FitChip:
     else:
         level = FitLevel.WONT_RUN
     return FitChip(level=level, headroom_gb=headroom_gb)
+
+
+def fit_for_size(size_gb: float, available_bytes: int | None) -> FitLevel | None:
+    """Fit level for a *size_gb* footprint, or None when it cannot be measured."""
+    if available_bytes is None or size_gb <= 0:
+        return None
+    return compute_fit(int(size_gb * _BYTES_PER_GB), available_bytes).level
+
+
+def make_fit_filter(
+    worst: FitLevel | None, available_bytes: int | None
+) -> Callable[[CatalogModel], bool] | None:
+    """Row predicate for a *worst* acceptable fit, or None when no fit was asked for.
+
+    A row whose fit cannot be measured is kept: the host cannot prove it will
+    not run.
+    """
+    if worst is None:
+        return None
+    worst_rank = FIT_RANK[worst]
+
+    def keep(model: CatalogModel) -> bool:
+        level = fit_for_size(model.size_gb, available_bytes)
+        return level is None or FIT_RANK[level] <= worst_rank
+
+    return keep
 
 
 def available_memory_for_fit() -> int | None:

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -21,8 +21,7 @@ class FitLevel(StrEnum):
     WONT_RUN = "wont_run"
 
 
-# Fit is an ordered notion, best first. Callers rank against it instead of
-# spelling the order out again.
+# Fit levels in rank order, best first.
 FIT_RANK: dict[FitLevel, int] = {
     FitLevel.FITS: 0,
     FitLevel.TIGHT: 1,

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -35,8 +35,9 @@ from lilbee.runtime.hardware import (
     FitLevel,
     SizeVariantInfo,
     available_memory_for_fit,
-    compute_fit,
     family_size_variants,
+    fit_for_size,
+    make_fit_filter,
 )
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.sse import SseStream, sse_error, sse_event
@@ -296,18 +297,11 @@ def _parse_source(source: str) -> ModelSource:
     return ModelSource(source)
 
 
-_BYTES_PER_GB = 1024**3
-
-
 def _row_fit(enriched: EnrichedModel, available_bytes: int | None) -> FitLevel | None:
     """Fit level for *enriched*, or None when host memory or row size can't be measured."""
-    if available_bytes is None:
-        return None
     if enriched.source != ModelSource.NATIVE.value:
         return None
-    if enriched.size_gb <= 0:
-        return None
-    return compute_fit(int(enriched.size_gb * _BYTES_PER_GB), available_bytes).level
+    return fit_for_size(enriched.size_gb, available_bytes)
 
 
 def _families_by_repo() -> dict[str, ModelFamily]:
@@ -441,6 +435,7 @@ async def models_catalog(
     size: str | None = None,
     installed: bool | None = None,
     featured: bool | None = None,
+    max_fit: str | None = None,
     sort: str = "featured",
     limit: int = 20,
     offset: int = 0,
@@ -451,6 +446,7 @@ async def models_catalog(
     parsed_task = ModelTask(task) if task else None
     parsed_size = CatalogSize(size) if size else None
     parsed_sort = CatalogSort(sort)
+    parsed_max_fit = FitLevel(max_fit) if max_fit else None
 
     # Hosted rows (frontier + ollama) lead the listing; none for featured-only
     # or installed=False.
@@ -459,6 +455,7 @@ async def models_catalog(
         hosted = await _collect_hosted_entries(task=parsed_task, search=search)
     window = page_window(len(hosted), offset, limit)
 
+    available_bytes = available_memory_for_fit()
     # get_catalog resolves the picks, which is HTTP on the first call.
     result = await asyncio.to_thread(
         get_catalog,
@@ -467,6 +464,7 @@ async def models_catalog(
         size=parsed_size,
         installed=installed,
         featured=featured,
+        fit_filter=make_fit_filter(parsed_max_fit, available_bytes),
         sort=parsed_sort,
         limit=window.rest_limit,
         offset=window.rest_offset,
@@ -477,7 +475,6 @@ async def models_catalog(
     installed_refs = {m.ref for m in registry.list_installed()}
     enriched = enrich_catalog(result, installed_refs)
 
-    available_bytes = available_memory_for_fit()
     families_by_repo = _families_by_repo()
 
     native_rows = [

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -100,11 +100,16 @@ async def models_catalog_route(
     size: FromQuery[str | None] = None,
     installed: FromQuery[bool | None] = None,
     featured: FromQuery[bool | None] = None,
+    max_fit: FromQuery[str | None] = None,
     sort: FromQuery[str] = "featured",
     limit: Annotated[int, QueryParameter(ge=1, le=1000)] = 20,
     offset: Annotated[int, QueryParameter(ge=0)] = 0,
 ) -> ModelsCatalogResponse:
-    """Browse the model catalog with optional filters."""
+    """Browse the model catalog with optional filters.
+
+    ``max_fit`` is the worst hardware fit to return: ``fits``, ``tight``, or
+    ``wont_run``.
+    """
     try:
         return await handlers.models_catalog(
             task=task,
@@ -112,6 +117,7 @@ async def models_catalog_route(
             size=size,
             installed=installed,
             featured=featured,
+            max_fit=max_fit,
             sort=sort,
             limit=limit,
             offset=offset,

--- a/src/lilbee/skills/lilbee_mcp/SKILL.md
+++ b/src/lilbee/skills/lilbee_mcp/SKILL.md
@@ -82,7 +82,7 @@ wait ~10s, re-check `lilbee_status`, retry. Don't switch tools.
 | `lilbee_model_list(source, task)` | Locally-installed models, optionally filtered. |
 | `lilbee_model_show(model)` | Catalog + installed metadata for one model ref. |
 | `lilbee_model_rm(model, source)` | Delete an installed model from disk. |
-| `lilbee_catalog_browse(task, search, size, installed, featured, sort, limit, offset)` | Browse the model picks + Hugging Face. Use before `lilbee_model_pull` to pick what to install. Each returned entry includes the model's `architecture` and a `compat` field (`supported` / `unsupported` / `unknown`); check `compat` before pulling. |
+| `lilbee_catalog_browse(task, search, size, installed, featured, max_fit, sort, limit, offset)` | Browse the model picks + Hugging Face. Use before `lilbee_model_pull` to pick what to install. `max_fit` is the worst hardware fit to return (`fits` / `tight` / `wont_run`). Each returned entry includes the model's `architecture` and a `compat` field (`supported` / `unsupported` / `unknown`); check `compat` before pulling. |
 | `lilbee_settings_list(group)` | Every writable setting with value, default, type, help text, choices, `reindex_required`. Groups: `Models`, `Retrieval`, `Generation`, `Ingest`, `Wiki`, `Memory`, `Crawling`, `Local-Servers`, `API-Keys`, `Display`, `System`, `General`. |
 | `lilbee_settings_get(key)` | One setting's current value + metadata. |
 | `lilbee_settings_set(updates)` | Atomically update writable settings. Persists to `config.toml`, invalidates in-process model and provider caches. |

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -65,6 +65,7 @@ from lilbee.catalog.refs import (
 )
 from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 from lilbee.core.config import cfg
+from lilbee.runtime.hardware import FitLevel, fit_for_size, make_fit_filter
 
 _EMPTY_HF_PAGE = HfPage(models=[], has_more=False)
 
@@ -718,6 +719,89 @@ class TestGetCatalog:
     def test_filter_size_unknown_bucket_matches_nothing(self) -> None:
         """An unrecognized bucket filters everything out rather than raising."""
         assert get_catalog(size="gigantic").total == 0  # type: ignore[arg-type]
+
+    def test_largest_first_page_is_all_rows_the_host_cannot_load(self) -> None:
+        """The control for the fit filter: this is the page a client has to fix itself."""
+        result = get_catalog(
+            task=ModelTask.CHAT, featured=True, sort=CatalogSort.SIZE_DESC, limit=3
+        )
+        assert [m.size_gb for m in result.models] == [68.6, 40.0, 19.4]
+        assert all(fit_for_size(m.size_gb, 8 * 1024**3) is FitLevel.WONT_RUN for m in result.models)
+
+    def test_fit_filter_applies_before_the_page_window(self) -> None:
+        """A limited request comes back full, not short by the rows the filter dropped."""
+        result = get_catalog(
+            task=ModelTask.CHAT,
+            featured=True,
+            sort=CatalogSort.SIZE_DESC,
+            limit=3,
+            fit_filter=make_fit_filter(FitLevel.FITS, 8 * 1024**3),
+        )
+        assert [m.size_gb for m in result.models] == [4.6, 1.8, 0.6]
+
+    def test_fit_filter_totals_only_the_matching_rows(self) -> None:
+        """A page smaller than the match count still reports how many rows match."""
+        result = get_catalog(
+            task=ModelTask.CHAT,
+            featured=True,
+            sort=CatalogSort.SIZE_DESC,
+            limit=2,
+            fit_filter=make_fit_filter(FitLevel.FITS, 8 * 1024**3),
+        )
+        assert [m.size_gb for m in result.models] == [4.6, 1.8]
+        assert result.total == 3
+
+    def test_fit_filter_narrows_a_browse_page_without_ending_paging(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Browse pages are narrowed, not truncated.
+
+        Every fitting row of the upstream page survives, and ``has_more`` still
+        tells the client to ask for the next one.
+        """
+        upstream = [make_test_catalog_model(name=f"Big{i}", size_gb=80.0) for i in range(3)] + [
+            make_test_catalog_model(name=f"Small{i}", size_gb=2.0) for i in range(2)
+        ]
+        monkeypatch.setattr(
+            get_services().hf_client,
+            "fetch_models",
+            lambda **kw: HfPage(models=upstream, has_more=True),
+        )
+        result = get_catalog(
+            task=ModelTask.CHAT,
+            featured=False,
+            limit=5,
+            fit_filter=make_fit_filter(FitLevel.FITS, 8 * 1024**3),
+        )
+        assert [m.hf_repo for m in result.models] == ["test/Small0", "test/Small1"]
+        assert result.total == 2
+        assert result.has_more is True
+
+    def test_fit_filter_totals_every_row_it_keeps(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An untruncated page and its total are the same set, fail-open rows included.
+
+        A row with no measurable size is kept because the host cannot prove it
+        won't run, so it has to be counted too.
+        """
+        upstream = [
+            make_test_catalog_model(name="Small", size_gb=2.0),
+            make_test_catalog_model(name="Big", size_gb=80.0),
+            make_test_catalog_model(name="Unmeasured", size_gb=0.0),
+        ]
+        monkeypatch.setattr(
+            get_services().hf_client,
+            "fetch_models",
+            lambda **kw: HfPage(models=upstream, has_more=False),
+        )
+        result = get_catalog(
+            task=ModelTask.CHAT,
+            featured=False,
+            limit=50,
+            fit_filter=make_fit_filter(FitLevel.FITS, 8 * 1024**3),
+        )
+        assert sorted(m.hf_repo for m in result.models) == ["test/Small", "test/Unmeasured"]
+        assert result.total == len(result.models)
+        assert result.has_more is False
 
     def test_filter_featured_true(self) -> None:
         result = get_catalog(featured=True)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2135,6 +2135,22 @@ class TestCatalogBrowseMcp:
         result = catalog_browse(sort="random", featured=True)
         assert "error" in result
 
+    def test_browse_rejects_invalid_max_fit(self, isolated_env, mock_svc):
+        """An unknown fit level returns the uniform error envelope."""
+        result = catalog_browse(max_fit="roomy", featured=True)
+        assert "error" in result
+
+    def test_browse_max_fit_pages_only_rows_that_run_here(self, isolated_env, mock_svc):
+        """The agent surface filters by host fit before the page window, like the route."""
+        with mock.patch(
+            "lilbee.runtime.hardware.available_memory_for_fit", return_value=8 * 1024**3
+        ):
+            result = catalog_browse(
+                task="chat", featured=True, sort="size_desc", max_fit="fits", limit=3
+            )
+        assert [m["size_gb"] for m in result["models"]] == [4.6, 1.8, 0.6]
+        assert result["total"] == 3
+
     def test_browse_omits_chat_model_when_filtered_to_chat_only_role(self, isolated_env, mock_svc):
         """task=rerank never returns chat models even with no other filters."""
         result = catalog_browse(task="rerank", featured=True)

--- a/tests/test_runtime_hardware.py
+++ b/tests/test_runtime_hardware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from conftest import make_test_catalog_model
 from lilbee.catalog.models import ModelFamily, ModelVariant
 from lilbee.runtime.hardware import (
     FitLevel,
@@ -9,6 +10,8 @@ from lilbee.runtime.hardware import (
     available_memory_for_fit,
     compute_fit,
     family_size_variants,
+    fit_for_size,
+    make_fit_filter,
 )
 
 _GB = 1024**3
@@ -53,6 +56,51 @@ def test_chip_is_immutable() -> None:
     except dataclasses.FrozenInstanceError:
         return
     raise AssertionError("FitChip should be frozen")
+
+
+def test_fit_for_size_classifies_a_footprint_against_the_budget() -> None:
+    assert fit_for_size(4.0, 8 * _GB) is FitLevel.FITS
+    assert fit_for_size(7.5, 8 * _GB) is FitLevel.TIGHT
+    assert fit_for_size(10.0, 8 * _GB) is FitLevel.WONT_RUN
+
+
+def test_fit_for_size_is_unknown_without_a_budget() -> None:
+    assert fit_for_size(4.0, None) is None
+
+
+def test_fit_for_size_is_unknown_without_a_size() -> None:
+    assert fit_for_size(0.0, 8 * _GB) is None
+
+
+def test_make_fit_filter_returns_no_predicate_without_a_threshold() -> None:
+    assert make_fit_filter(None, 8 * _GB) is None
+
+
+def test_fit_filter_keeps_rows_no_worse_than_the_threshold() -> None:
+    keep = make_fit_filter(FitLevel.TIGHT, 8 * _GB)
+    assert keep is not None
+    assert keep(make_test_catalog_model(size_gb=4.0)) is True
+    assert keep(make_test_catalog_model(size_gb=7.5)) is True
+    assert keep(make_test_catalog_model(size_gb=10.0)) is False
+
+
+def test_fit_filter_at_fits_drops_a_tight_row() -> None:
+    keep = make_fit_filter(FitLevel.FITS, 8 * _GB)
+    assert keep is not None
+    assert keep(make_test_catalog_model(size_gb=7.5)) is False
+
+
+def test_fit_filter_keeps_a_row_whose_size_is_unknown() -> None:
+    """An unmeasurable row is kept: the host cannot prove it will not run."""
+    keep = make_fit_filter(FitLevel.FITS, 8 * _GB)
+    assert keep is not None
+    assert keep(make_test_catalog_model(size_gb=0.0)) is True
+
+
+def test_fit_filter_keeps_every_row_when_the_memory_probe_failed() -> None:
+    keep = make_fit_filter(FitLevel.FITS, None)
+    assert keep is not None
+    assert keep(make_test_catalog_model(size_gb=500.0)) is True
 
 
 def test_available_memory_for_fit_sums_whole_fleet(monkeypatch) -> None:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2684,6 +2684,47 @@ class TestModelsCatalog:
         assert resp.has_more is False
 
     @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_untruncated_page_and_total_are_the_same_set(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        """A mixed page of native and hosted rows totals every row it returns."""
+        import lilbee.server.handlers.models as h
+        from conftest import make_test_catalog_model
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        natives = [
+            make_test_catalog_model(name="Small", size_gb=2.0),
+            make_test_catalog_model(name="Unmeasured", size_gb=0.0),
+        ]
+        mock_get_catalog.return_value = CatalogResult(
+            total=len(natives), limit=20, offset=0, models=natives, has_more=False
+        )
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache.clear()
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name=name,
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                    for name in ("gemini-2.0-flash", "gemini-2.0-pro")
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", max_fit="fits")
+        assert len(resp.models) == 4
+        assert resp.total == len(resp.models)
+        assert resp.has_more is False
+
+    @patch("lilbee.server.handlers.models.get_catalog")
     async def test_hosted_skipped_when_featured_filter(
         self, mock_get_catalog, mock_svc, monkeypatch
     ):
@@ -2929,6 +2970,7 @@ class TestModelsCatalog:
             size=CatalogSize.SMALL,
             installed=True,
             featured=True,
+            fit_filter=None,
             sort=CatalogSort.DOWNLOADS,
             limit=10,
             offset=5,
@@ -3126,6 +3168,32 @@ class TestModelsCatalog:
         mock_svc.registry.list_installed.return_value = []
         result = await handlers.models_catalog()
         assert result.models[0].fit is None
+
+    @patch("lilbee.server.handlers.models.available_memory_for_fit", return_value=8 * 1024**3)
+    async def test_max_fit_returns_a_full_page_of_rows_that_run_here(self, _mock_mem, mock_svc):
+        """The filter runs before the page window, so a limited request is not short."""
+        from lilbee.runtime.hardware import FitLevel
+
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog(
+            task="chat", featured=True, sort="size_desc", max_fit="fits", limit=3
+        )
+        assert [m.size_gb for m in result.models] == [4.6, 1.8, 0.6]
+        assert result.total == 3
+        assert all(m.fit is FitLevel.FITS for m in result.models)
+
+    @patch("lilbee.server.handlers.models.available_memory_for_fit", return_value=8 * 1024**3)
+    async def test_max_fit_tight_keeps_the_rows_that_only_just_fit(self, _mock_mem, mock_svc):
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog(
+            task="chat", featured=True, sort="size_desc", max_fit="tight", limit=4
+        )
+        assert [m.size_gb for m in result.models] == [7.4, 4.6, 1.8, 0.6]
+        assert result.total == 4
+
+    async def test_unknown_max_fit_is_rejected(self, mock_svc):
+        with pytest.raises(ValueError):
+            await handlers.models_catalog(max_fit="roomy")
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_fit_none_when_size_unknown(self, mock_get_catalog, mock_svc):

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -982,6 +982,22 @@ class TestModelsCatalogRoute:
         resp = client.get("/api/models/catalog?task=bogus&featured=true")
         assert resp.status_code == 422
 
+    def test_invalid_max_fit_returns_422(self, client):
+        """An unknown fit level must surface as 422, not 500."""
+        resp = client.get("/api/models/catalog?max_fit=roomy&featured=true")
+        assert resp.status_code == 422
+
+    def test_max_fit_reaches_the_handler(self, client):
+        """The route forwards the fit threshold instead of dropping it."""
+        with mock.patch(
+            "lilbee.server.handlers.models_catalog",
+            new_callable=AsyncMock,
+            return_value={"total": 0, "limit": 20, "offset": 0, "models": []},
+        ) as mock_cat:
+            resp = client.get("/api/models/catalog?max_fit=fits&featured=true")
+        assert resp.status_code == 200
+        assert mock_cat.call_args.kwargs["max_fit"] == "fits"
+
 
 class TestModelsInstalledRoute:
     @mock.patch(


### PR DESCRIPTION
## Problem

The catalog computes hardware fit for every row and returns it, but no client can ask for only the rows that fit. `size` does not substitute: it buckets by parameter count, not by what this machine can load.

So each client fetches a page and drops the rows it cannot run. That cannot page. A request for 40 comes back with fewer usable rows and there is no way to ask for more, and every client reinvents the rule.

Measured against a server on this machine: the featured chat list returns 8 models, of which two are 101 GB and will not run here. The Obsidian plugin currently filters those out itself.

## Solution

`GET /api/models/catalog` and the `catalog_browse` MCP tool take `max_fit`: the worst fit to return, one of `fits`, `tight`, `wont_run`. It is a threshold rather than an equality test because a picker wants fits or tight, and fit is already ordered. An unknown value is rejected at the boundary like `sort` is.

The filter runs in the shared row filter beside `installed` and `featured`, before the sort and the page window, on the picks and on the HuggingFace rows alike, so a limited request comes back full and `total` counts only matching rows.

A row whose footprint or host memory cannot be measured is kept. The server cannot prove it will not run, and a failed probe should not empty a picker.

## Notes

The parameter is opt-in and defaults to off, so browse and search are unchanged: they still return every row, with a fit chip on the ones that will not run. Only a surface that makes a recommendation should narrow, and picking is the caller's decision, not the catalog's.

No TUI caller passes it. The only TUI change here is that the Discover rail's own copy of the fit ordering is replaced by the shared one; the rail's existing filter is untouched.

Hosted rows are never narrowed by it. They lead the listing inside the page window, so a filtered request still returns them and still counts them.

The catalog layer may not import the runtime layer, so the predicate is injected as a typed callable.

`featured` unset uses the upstream-backed path, which fetches a page and then filters, so it can still return a short page, and a page whose upstream rows all fail the filter is empty with `has_more` still true. A client must advance its offset by the limit, not by the rows it received. That is pre-existing and equally true of `size` and `search`.

Verified on a 3 GB Linux VM, where 133 of 197 chat rows report `wont_run`: `fits`, `tight`, `wont_run` and an invalid value behave as described, an absent parameter equals `wont_run`, search is unchanged by it, and every page walk that advances by the limit covers the unpaged listing with no gap and no duplicate.
