### PR TITLE
Fall back to a model that runs when Discover has no runnable featured pick

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog_grouping.py
+++ b/src/lilbee/cli/tui/screens/catalog_grouping.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from lilbee.catalog.types import ModelTask
+from lilbee.catalog.types import ModelCompat, ModelTask
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.screens.catalog_utils import (
     CatalogRow,
@@ -14,6 +14,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
     LocalCatalogRow,
 )
 from lilbee.cli.tui.widgets.model_list import ModelListSection
+from lilbee.runtime.hardware import FitLevel
 
 
 @dataclass
@@ -40,40 +41,53 @@ def row_cache_signature(row: CatalogRow) -> tuple[str, bool]:
     return (row.name, row.installed)
 
 
+def _is_runnable_pick(row: LocalCatalogRow) -> bool:
+    """Whether the engine supports the row and the machine can hold it.
+
+    Rows with no fit chip are excluded: an unknown size cannot be promised.
+    """
+    return (
+        row.compat is ModelCompat.SUPPORTED
+        and row.fit is not None
+        and row.fit.level is not FitLevel.WONT_RUN
+    )
+
+
+def _backfill_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
+    """Rank a backfilled Discover pick: most downloaded first, then alphabetical.
+
+    Every candidate already runs here, so popularity separates them rather
+    than fit.
+    """
+    return (-row.sort_downloads, row.name.lower())
+
+
 def for_you_by_role(rows: list[LocalCatalogRow]) -> list[LocalCatalogRow]:
     """Runnable picks grouped by role: chat, embedding, vision, rerank.
 
-    A row qualifies only when the engine supports its architecture and the
-    machine can hold it, so every card in the rail is installable as-is.
-    Rows with no fit chip are excluded: an unknown size cannot be promised.
+    Featured rows lead, best fit first. A role whose featured rows cannot run
+    backfills with the most downloaded row that does, so a card that does not
+    fit is replaced rather than dropped. A role with nothing runnable yields
+    no pick.
     """
-    from lilbee.catalog.types import ModelCompat, ModelTask
-    from lilbee.runtime.hardware import FitLevel
-
-    runnable = [
-        r
-        for r in rows
-        if r.featured
-        and r.compat is ModelCompat.SUPPORTED
-        and r.fit is not None
-        and r.fit.level is not FitLevel.WONT_RUN
-    ]
+    runnable = [r for r in rows if _is_runnable_pick(r)]
     out: list[LocalCatalogRow] = []
-    for task in (ModelTask.CHAT, ModelTask.EMBEDDING, ModelTask.VISION, ModelTask.RERANK):
-        for row in sorted((r for r in runnable if r.task == task), key=for_you_sort_key):
-            out.append(row)
-            break
+    for task in TASK_BUCKET_ORDER:
+        candidates = [r for r in runnable if r.task == task]
+        featured = [r for r in candidates if r.featured]
+        if featured:
+            out.append(min(featured, key=for_you_sort_key))
+        elif candidates:
+            out.append(min(candidates, key=_backfill_sort_key))
     return out
 
 
 def for_you_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
     """Rank Discover 'For You' rows: best fit first, then alphabetical.
 
-    Fit rank: FITS=0, TIGHT=1, WONT_RUN=2, no chip=3. Featured-only
-    callers already filtered, so featured isn't in the key.
+    Fit rank: FITS=0, TIGHT=1, WONT_RUN=2, no chip=3. Curation is applied
+    before the sort, so featured isn't in the key.
     """
-    from lilbee.runtime.hardware import FitLevel
-
     if row.fit is None:
         rank = 3
     elif row.fit.level is FitLevel.FITS:

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1250,7 +1250,7 @@ class TestForYouByRole:
     """Discover's For You rail: one runnable pick per role, in role order."""
 
     @staticmethod
-    def _row(name, task, *, compat, fit_level, featured=True):
+    def _row(name, task, *, compat, fit_level, featured=True, downloads=1_000_000):
         from lilbee.cli.tui.screens.catalog_utils import LocalCatalogRow
         from lilbee.runtime.hardware import FitChip
 
@@ -1263,7 +1263,7 @@ class TestForYouByRole:
             downloads="1M",
             featured=featured,
             installed=False,
-            sort_downloads=1_000_000,
+            sort_downloads=downloads,
             sort_size=4.6,
             ref=f"a/{name}-GGUF",
             compat=compat,
@@ -1315,19 +1315,96 @@ class TestForYouByRole:
         rows = [self._row("NoSize", "chat", compat=ModelCompat.SUPPORTED, fit_level=None)]
         assert for_you_by_role(rows) == []
 
-    def test_non_pick_rows_are_skipped(self) -> None:
+    def test_a_role_whose_featured_rows_cannot_run_backfills(self) -> None:
+        """A misfit is replaced by a model that runs, not dropped."""
         from lilbee.catalog.types import ModelCompat
         from lilbee.cli.tui.screens.catalog_grouping import for_you_by_role
         from lilbee.runtime.hardware import FitLevel
 
         rows = [
             self._row(
-                "Browse",
+                "ChatHuge", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.WONT_RUN
+            ),
+            self._row(
+                "ChatSpare",
                 "chat",
                 compat=ModelCompat.SUPPORTED,
                 fit_level=FitLevel.FITS,
                 featured=False,
+            ),
+        ]
+        (pick,) = for_you_by_role(rows)
+        assert pick.name == "ChatSpare"
+        assert pick.fit is not None
+        assert pick.fit.level is FitLevel.FITS
+
+    def test_the_backfill_takes_the_most_downloaded_row_that_runs(self) -> None:
+        """Popularity separates the substitutes.
+
+        Ordered so the expected pick is wrong under the two orders it could be
+        confused with: input order yields Middle, fit-then-name yields Aardvark.
+        """
+        from lilbee.catalog.types import ModelCompat
+        from lilbee.cli.tui.screens.catalog_grouping import for_you_by_role
+        from lilbee.runtime.hardware import FitLevel
+
+        def spare(name, fit_level, downloads):
+            return self._row(
+                name,
+                "chat",
+                compat=ModelCompat.SUPPORTED,
+                fit_level=fit_level,
+                featured=False,
+                downloads=downloads,
             )
+
+        rows = [
+            self._row(
+                "ChatHuge", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.WONT_RUN
+            ),
+            spare("Middle", FitLevel.TIGHT, 500),
+            spare("Aardvark", FitLevel.FITS, 10),
+            spare("Zebra", FitLevel.FITS, 900),
+        ]
+        (pick,) = for_you_by_role(rows)
+        assert pick.name == "Zebra"
+
+    def test_a_featured_row_that_runs_is_never_replaced(self) -> None:
+        """The rail does not reach past a featured row that already fits."""
+        from lilbee.catalog.types import ModelCompat
+        from lilbee.cli.tui.screens.catalog_grouping import for_you_by_role
+        from lilbee.runtime.hardware import FitLevel
+
+        rows = [
+            self._row("Zeta", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.FITS),
+            self._row(
+                "Alpha",
+                "chat",
+                compat=ModelCompat.SUPPORTED,
+                fit_level=FitLevel.FITS,
+                featured=False,
+            ),
+        ]
+        (pick,) = for_you_by_role(rows)
+        assert pick.name == "Zeta"
+
+    def test_a_role_with_nothing_runnable_yields_no_pick(self) -> None:
+        """An empty role is a legitimate outcome, not an error."""
+        from lilbee.catalog.types import ModelCompat
+        from lilbee.cli.tui.screens.catalog_grouping import for_you_by_role
+        from lilbee.runtime.hardware import FitLevel
+
+        rows = [
+            self._row(
+                "ChatHuge", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.WONT_RUN
+            ),
+            self._row(
+                "ChatBad",
+                "chat",
+                compat=ModelCompat.UNSUPPORTED,
+                fit_level=FitLevel.FITS,
+                featured=False,
+            ),
         ]
         assert for_you_by_role(rows) == []
 


### PR DESCRIPTION
## Problem

Discover's For You rail filters the featured rows to those the host can run, then takes one per role. A role whose only featured candidates will not run shows nothing at all, rather than falling back to a model from the wider set that does run.

Reproduced with the real shape: a featured chat list of two 101.2 GB rows against a host that cannot hold them gives a three-card rail with no chat pick, while 44 of the 56 chat rows on that host fit.

## Solution

A role that has no runnable featured candidate falls back to the most popular runnable row in the wider set, ranked by download count. A role whose featured candidate already runs is untouched, and the featured cards keep their existing fit-then-name order.

No fetch was added: the caller already passes the wider set to this function, so the change is confined to selection.

## Notes

Discover only. Browse and search still return every row with its fit chip, because a user browsing is choosing for themselves.

A search now influences the fallback. The wider set grows as the catalog worker fetches search results, so a row a user searched for can win a role when it outranks everything else that runs.

The fallback pick is not a featured row, so it can also appear in the Fresh rail. Making the two rails disjoint would change what Fresh shows, so it is left for its own change.

A role can still end up empty when nothing in the whole set runs. That is left as is.

On a host where the featured rows all run, the rail is byte-identical before and after, so this changes nothing in the common case.
