### PR TITLE
Fit hosted rows and picks inside the catalog page

### DIFF
--- a/src/lilbee/catalog/__init__.py
+++ b/src/lilbee/catalog/__init__.py
@@ -34,6 +34,8 @@ from lilbee.catalog.models import (
     DownloadProgress,
     ModelFamily,
     ModelVariant,
+    PageWindow,
+    page_window,
 )
 from lilbee.catalog.picks import (
     find_pick,
@@ -61,6 +63,7 @@ __all__ = [
     "EnrichedModel",
     "ModelFamily",
     "ModelVariant",
+    "PageWindow",
     "ProgressCallback",
     "agent_model_id",
     "build_adhoc_entry",
@@ -78,6 +81,7 @@ __all__ = [
     "get_picks",
     "is_rerank_ref",
     "make_download_callback",
+    "page_window",
     "picks_for",
     "quant_tier",
     "reset_picks",

--- a/src/lilbee/catalog/models.py
+++ b/src/lilbee/catalog/models.py
@@ -172,6 +172,20 @@ class CatalogResult:
 
 
 @dataclass(frozen=True)
+class PageWindow:
+    """The part of a page left for the rows paged after the ones held locally."""
+
+    rest_offset: int
+    rest_limit: int
+
+
+def page_window(leading_count: int, offset: int, limit: int) -> PageWindow:
+    """The window left of ``[offset, offset + limit)`` after *leading_count* local rows."""
+    covered = min(offset + limit, leading_count) - min(offset, leading_count)
+    return PageWindow(rest_offset=max(0, offset - leading_count), rest_limit=limit - covered)
+
+
+@dataclass(frozen=True)
 class HfPage:
     """One page of HuggingFace API results."""
 

--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -1,12 +1,13 @@
 """Catalog filtering, sorting, lookup, and ad-hoc HF resolution."""
 
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from huggingface_hub.utils import HFValidationError, validate_repo_id
 
 from lilbee.app.services import get_services
-from lilbee.catalog.models import CatalogModel, CatalogResult
+from lilbee.catalog.models import CatalogModel, CatalogResult, HfPage, PageWindow, page_window
 from lilbee.catalog.picks import get_picks
 from lilbee.catalog.refs import (
     GGUF_GLOB,
@@ -64,67 +65,95 @@ def get_catalog(
     offset: int = 0,
     model_manager: Any = None,
 ) -> CatalogResult:
-    """Get paginated, filtered catalog of models."""
-    picks = get_picks()
-    # Picks only on the first page
-    all_models = list(picks) if offset == 0 else []
-    hf_has_more = False
+    """Get paginated, filtered catalog of models.
 
-    # Optionally fetch from HF API
-    if not featured:
-        hf_task, hf_library = task_to_pipeline(task)
-        hf_page = get_services().hf_client.fetch_models(
-            pipeline_tag=hf_task,
-            limit=limit,
-            offset=offset,
-            library=hf_library,
+    The picks lead the listing and the HuggingFace rows follow them, so one
+    page window covers both: the HuggingFace request is shifted by the picks
+    that precede it, and a window that ends inside the picks makes no request.
+    """
+    picks = get_picks()
+    installed_filter = _installed_filter(installed, model_manager)
+
+    def keep(models: list[CatalogModel]) -> list[CatalogModel]:
+        return _filter_models(
+            models,
+            task=task,
             search=search,
+            size=size,
+            installed_filter=installed_filter,
+            featured=featured,
         )
-        hf_has_more = hf_page.has_more
+
+    leading = _sort_models(keep(list(picks)), sort)
+    window = page_window(len(leading), offset, limit)
+    page = leading[offset : offset + limit]
+    hf_models: list[CatalogModel] = []
+    if featured:
+        has_more = offset + limit < len(leading)
+    elif window.rest_limit == 0:
+        has_more = True  # the HuggingFace rows start on the next page
+    else:
+        hf_page = _fetch_hf_page(task, search, window)
         # Deduplicate: skip HF models already shown as a pick
         pick_repos = {m.hf_repo for m in picks}
-        hf_models = [m for m in hf_page.models if m.hf_repo not in pick_repos]
-        all_models.extend(hf_models)
-
-    # Filter by task
-    if task:
-        all_models = [m for m in all_models if m.task == task]
-
-    # Filter by search. Single join+lower per model per keystroke instead
-    # of four separate lowers + substring checks; the no-match path
-    # (the common case) runs four times fewer ``str.lower()`` calls.
-    if search:
-        search_lower = search.lower()
-        all_models = [m for m in all_models if search_lower in _search_blob(m)]
-
-    # Filter by size
-    if size is not None:
-        all_models = [m for m in all_models if size_bucket(m.params) == size]
-
-    # A repo is "installed" if any of its quants has a manifest.
-    if installed is not None and model_manager is not None:
-        installed_repos = {hf_repo_from_ref(ref) for ref in _get_installed_models(model_manager)}
-        if installed:
-            all_models = [m for m in all_models if m.hf_repo in installed_repos]
-        else:
-            all_models = [m for m in all_models if m.hf_repo not in installed_repos]
-
-    # Filter by featured status
-    if featured is not None:
-        all_models = [m for m in all_models if m.featured == featured]
-
-    # Sort
-    all_models = _sort_models(all_models, sort)
-
-    total = len(all_models)
-
-    # When HF API pagination is active (offset passed to API), skip local slicing
-    # to avoid double-applying the offset. Only slice for featured-only requests.
-    paginated = all_models[offset : offset + limit] if featured else all_models[:limit]
+        hf_models = keep([m for m in hf_page.models if m.hf_repo not in pick_repos])
+        page.extend(_sort_models(hf_models, sort))
+        has_more = hf_page.has_more
 
     return CatalogResult(
-        total=total, limit=limit, offset=offset, models=paginated, has_more=hf_has_more
+        total=len(leading) + len(hf_models),
+        limit=limit,
+        offset=offset,
+        models=page,
+        has_more=has_more,
     )
+
+
+def _fetch_hf_page(task: ModelTask | None, search: str, window: PageWindow) -> HfPage:
+    """The HuggingFace rows that fill the rest of *window*."""
+    hf_task, hf_library = task_to_pipeline(task)
+    return get_services().hf_client.fetch_models(
+        pipeline_tag=hf_task,
+        limit=window.rest_limit,
+        offset=window.rest_offset,
+        library=hf_library,
+        search=search,
+    )
+
+
+def _installed_filter(
+    installed: bool | None, model_manager: Any
+) -> Callable[[CatalogModel], bool] | None:
+    """Row predicate for the installed filter, or None when it is off."""
+    if installed is None or model_manager is None:
+        return None
+    # A repo is installed if any of its quants has a manifest.
+    installed_repos = {hf_repo_from_ref(ref) for ref in _get_installed_models(model_manager)}
+    return lambda m: (m.hf_repo in installed_repos) == installed
+
+
+def _filter_models(
+    models: list[CatalogModel],
+    *,
+    task: ModelTask | None,
+    search: str,
+    size: CatalogSize | None,
+    installed_filter: Callable[[CatalogModel], bool] | None,
+    featured: bool | None,
+) -> list[CatalogModel]:
+    """The rows of *models* that pass every requested filter."""
+    if task:
+        models = [m for m in models if m.task == task]
+    if search:
+        search_lower = search.lower()
+        models = [m for m in models if search_lower in _search_blob(m)]
+    if size is not None:
+        models = [m for m in models if size_bucket(m.params) == size]
+    if installed_filter is not None:
+        models = [m for m in models if installed_filter(m)]
+    if featured is not None:
+        models = [m for m in models if m.featured == featured]
+    return models
 
 
 def task_to_pipeline(task: ModelTask | None) -> tuple[str, str | None]:

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -18,6 +18,7 @@ from lilbee.catalog import (
     get_catalog,
     get_families,
     get_picks,
+    page_window,
     picks_for,
 )
 from lilbee.catalog.refs import hf_repo_from_ref, is_bare_hf_repo
@@ -450,6 +451,14 @@ async def models_catalog(
     parsed_task = ModelTask(task) if task else None
     parsed_size = CatalogSize(size) if size else None
     parsed_sort = CatalogSort(sort)
+
+    # Hosted rows (frontier + ollama) lead the listing; none for featured-only
+    # or installed=False.
+    hosted: list[CatalogEntryResponse] = []
+    if not featured and installed is not False:
+        hosted = await _collect_hosted_entries(task=parsed_task, search=search)
+    window = page_window(len(hosted), offset, limit)
+
     # get_catalog resolves the picks, which is HTTP on the first call.
     result = await asyncio.to_thread(
         get_catalog,
@@ -459,8 +468,8 @@ async def models_catalog(
         installed=installed,
         featured=featured,
         sort=parsed_sort,
-        limit=limit,
-        offset=offset,
+        limit=window.rest_limit,
+        offset=window.rest_offset,
         model_manager=get_services().model_manager,
     )
 
@@ -475,20 +484,13 @@ async def models_catalog(
         _build_catalog_entry(e, available_bytes=available_bytes, families_by_repo=families_by_repo)
         for e in enriched
     ]
-    # Hosted rows (frontier + ollama) are selectable and download-free, shown
-    # on the first page only and skipped for featured-only / installed=False.
-    # They stay out of ``total``: as an unpaginated overlay they made page 1
-    # report a larger total than page 2 of the same listing.
-    hosted_rows: list[CatalogEntryResponse] = []
-    if offset == 0 and not featured and installed is not False:
-        hosted_rows = await _collect_hosted_entries(task=parsed_task, search=search)
 
     return ModelsCatalogResponse(
-        total=result.total,
-        limit=result.limit,
-        offset=result.offset,
+        total=len(hosted) + result.total,
+        limit=limit,
+        offset=offset,
         has_more=result.has_more,
-        models=hosted_rows + native_rows,
+        models=hosted[offset : offset + limit] + native_rows,
     )
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -13,7 +13,14 @@ import httpx
 import pytest
 from huggingface_hub.hf_api import RepoSibling
 
-from conftest import PICKS_CHAT, PICKS_EMBEDDING, PICKS_RERANK, PICKS_VISION, SAMPLE_PICKS
+from conftest import (
+    PICKS_CHAT,
+    PICKS_EMBEDDING,
+    PICKS_RERANK,
+    PICKS_VISION,
+    SAMPLE_PICKS,
+    make_test_catalog_model,
+)
 from lilbee import catalog
 from lilbee.app.services import get_services
 from lilbee.catalog import (
@@ -574,6 +581,81 @@ class TestGetCatalog:
         repos1 = {m.hf_repo for m in r1.models}
         repos2 = {m.hf_repo for m in r2.models}
         assert repos1.isdisjoint(repos2)
+
+    @staticmethod
+    def _record_hf_pages(
+        monkeypatch: pytest.MonkeyPatch, rows: list[CatalogModel], *, has_more: bool = True
+    ) -> list[dict[str, Any]]:
+        """Stub the HF page with *rows*, honoring ``limit``, and record each fetch's arguments."""
+        calls: list[dict[str, Any]] = []
+
+        def _fetch(**kwargs: Any) -> HfPage:
+            calls.append(kwargs)
+            return HfPage(models=rows[: kwargs["limit"]], has_more=has_more)
+
+        monkeypatch.setattr(get_services().hf_client, "fetch_models", _fetch)
+        return calls
+
+    def test_picks_count_against_the_page_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The first browse page holds the picks and only as many HF rows as fit after them."""
+        upstream = [make_test_catalog_model(name=f"Hf{i}") for i in range(10)]
+        calls = self._record_hf_pages(monkeypatch, upstream)
+        result = get_catalog(task=ModelTask.CHAT, limit=10, offset=0)
+        assert [m.hf_repo for m in result.models] == [m.hf_repo for m in PICKS_CHAT] + [
+            "test/Hf0",
+            "test/Hf1",
+        ]
+        assert [(c["offset"], c["limit"]) for c in calls] == [(0, 2)]
+
+    def test_second_page_starts_where_the_first_ended(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Page two asks HF for the rows after the ones page one showed, not after the limit."""
+        upstream = [make_test_catalog_model(name=f"Hf{i}") for i in range(10)]
+        calls = self._record_hf_pages(monkeypatch, upstream)
+        result = get_catalog(task=ModelTask.CHAT, limit=10, offset=10)
+        assert not [m for m in result.models if m.featured]
+        assert [(c["offset"], c["limit"]) for c in calls] == [(10 - len(PICKS_CHAT), 10)]
+        assert result.total == len(PICKS_CHAT) + len(upstream)
+        assert result.has_more is True
+
+    def test_page_inside_the_picks_fetches_no_hf_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A window that ends inside the picks needs no HF request and still has more."""
+        calls = self._record_hf_pages(monkeypatch, [])
+        result = get_catalog(task=ModelTask.CHAT, limit=3, offset=2)
+        assert [m.hf_repo for m in result.models] == [m.hf_repo for m in PICKS_CHAT[2:5]]
+        assert calls == []
+        assert result.has_more is True
+
+    def test_page_ending_at_the_last_pick_still_has_more(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The HF rows start on the next page, so the client is told to ask for it."""
+        calls = self._record_hf_pages(monkeypatch, [])
+        result = get_catalog(task=ModelTask.CHAT, limit=len(PICKS_CHAT), offset=0)
+        assert len(result.models) == len(PICKS_CHAT)
+        assert calls == []
+        assert result.has_more is True
+
+    def test_featured_listing_pages_past_the_first(self) -> None:
+        """A featured-only listing pages through the picks with an exact has_more."""
+        first = get_catalog(task=ModelTask.CHAT, featured=True, limit=3, offset=3)
+        last = get_catalog(task=ModelTask.CHAT, featured=True, limit=4, offset=4)
+        assert [m.hf_repo for m in first.models] == [m.hf_repo for m in PICKS_CHAT[3:6]]
+        assert first.has_more is True
+        assert [m.hf_repo for m in last.models] == [m.hf_repo for m in PICKS_CHAT[4:8]]
+        assert last.has_more is False
+
+    def test_zero_width_window_returns_no_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A page of no rows reports the picks total and leaves the HF rows to the next page."""
+        calls = self._record_hf_pages(monkeypatch, [])
+        result = get_catalog(task=ModelTask.CHAT, limit=0, offset=0)
+        assert result.models == []
+        assert result.total == len(PICKS_CHAT)
+        assert calls == []
+        assert result.has_more is True
 
     def test_filter_by_task_chat(self) -> None:
         result = get_catalog(task=ModelTask.CHAT)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2679,10 +2679,9 @@ class TestModelsCatalog:
         frontier = [m for m in resp.models if m.source == ModelSource.FRONTIER]
         assert frontier and frontier[0].display_name == "gemini-2.0-flash"
         assert frontier[0].key_status == "ready"
-        # total describes the paginated native listing only. Counting the
-        # first-page-only hosted overlay into it made page 1 report a larger
-        # total than page 2 of the same listing.
-        assert resp.total == 0
+        # An untruncated page and its total are the same set.
+        assert resp.total == len(resp.models) == 1
+        assert resp.has_more is False
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_hosted_skipped_when_featured_filter(
@@ -2713,6 +2712,7 @@ class TestModelsCatalog:
         )
         resp = await handlers.models_catalog(task="chat", featured=True)
         assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+        assert resp.total == 0
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_hosted_skipped_on_later_page(self, mock_get_catalog, mock_svc, monkeypatch):
@@ -2741,6 +2741,100 @@ class TestModelsCatalog:
         )
         resp = await handlers.models_catalog(task="chat", offset=20)
         assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+        # The row rides page one only, but the total counts it on every page.
+        assert resp.total == 1
+        assert resp.offset == 20
+
+    @staticmethod
+    def _stub_frontier(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+        """Discover one Gemini chat row per name in *names*."""
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache.clear()
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name=name,
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                    for name in names
+                ]
+            },
+        )
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_rows_count_against_the_page_limit(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        """A page never returns more rows than its limit, hosted rows included."""
+        from lilbee.catalog import CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=0, limit=0, offset=0, models=[], has_more=True
+        )
+        mock_svc.registry.list_installed.return_value = []
+        self._stub_frontier(monkeypatch, "g1", "g2", "g3")
+        resp = await handlers.models_catalog(task="chat", limit=2)
+        assert [m.display_name for m in resp.models] == ["g1", "g2"]
+        assert mock_get_catalog.call_args.kwargs["limit"] == 0
+        assert mock_get_catalog.call_args.kwargs["offset"] == 0
+        assert resp.limit == 2
+        assert resp.offset == 0
+        assert resp.total == 3
+        assert resp.has_more is True
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_rows_shift_the_native_window(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        """The native rows start after the hosted rows on page one and continue on page two."""
+        from conftest import make_test_catalog_model
+        from lilbee.catalog import CatalogResult
+
+        natives = [make_test_catalog_model(name=f"N{i}") for i in range(17)]
+        mock_get_catalog.return_value = CatalogResult(
+            total=17, limit=17, offset=0, models=natives, has_more=True
+        )
+        mock_svc.registry.list_installed.return_value = []
+        self._stub_frontier(monkeypatch, "g1", "g2", "g3")
+
+        first = await handlers.models_catalog(task="chat", limit=20, offset=0)
+        assert len(first.models) == 20
+        assert [m.display_name for m in first.models[:3]] == ["g1", "g2", "g3"]
+        assert mock_get_catalog.call_args.kwargs["limit"] == 17
+        assert mock_get_catalog.call_args.kwargs["offset"] == 0
+        assert first.total == 20
+
+        second = await handlers.models_catalog(task="chat", limit=20, offset=20)
+        assert not [m for m in second.models if m.provider]
+        assert mock_get_catalog.call_args.kwargs["limit"] == 20
+        assert mock_get_catalog.call_args.kwargs["offset"] == 17
+        assert second.offset == 20
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_rows_straddle_a_page_boundary(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        """A window that starts inside the hosted rows takes the rest of them first."""
+        from lilbee.catalog import CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=0, limit=1, offset=0, models=[], has_more=False
+        )
+        mock_svc.registry.list_installed.return_value = []
+        self._stub_frontier(monkeypatch, "g1", "g2", "g3")
+        resp = await handlers.models_catalog(task="chat", limit=2, offset=2)
+        assert [m.display_name for m in resp.models] == ["g3"]
+        assert mock_get_catalog.call_args.kwargs["limit"] == 1
+        assert mock_get_catalog.call_args.kwargs["offset"] == 0
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_hosted_skipped_when_installed_false(
@@ -2771,6 +2865,7 @@ class TestModelsCatalog:
         )
         resp = await handlers.models_catalog(task="chat", installed=False)
         assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+        assert resp.total == 0
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_returns_catalog_response(self, mock_get_catalog, mock_svc):


### PR DESCRIPTION
## Problem

Page one of the model catalog returns more rows than its limit. The hosted rows (frontier, Ollama, LM Studio) are added after the page window is applied, so a request for 20 rows gets 20 plus the hosted count. A client that advances its offset by the rows it received, which the Obsidian catalog modal does, then starts page two too late and never shows the native rows it stepped over. On a live server that is two models on the embedding tab and three on chat, with no error.

The picks have the same defect one layer down. They occupy the first slots of page one, but page two asks HuggingFace for an offset equal to the limit, so the HuggingFace rows the picks displaced are skipped even by a client that pages correctly. Measured on a live server: eight rows per chat listing.

## Solution

The listing is the hosted rows, then the picks, then the HuggingFace rows, and one page window covers all three. A small helper splits a window between the rows held locally and the rows paged upstream. The handler applies it to the hosted rows and the catalog query applies it to the picks, so the HuggingFace request is shifted by every row that precedes it.

A page never exceeds its limit. A window that ends inside the local rows makes no HuggingFace request and reports `has_more`, because the upstream rows start on the next page. The response echoes the requested `limit` and `offset`, and `total` counts the hosted rows and the picks on every page.

## Notes

A featured-only listing now pages past its first page with an exact `has_more`. Before, any offset above zero returned nothing.

The MCP catalog tool and the TUI call the same query. The TUI browses with the picks excluded, so its pages are unchanged. The MCP tool gets the corrected paging.

Verified on a live server by walking every page of the chat and embedding listings and comparing the union against one unpaged request.
