### PR TITLE
Fail the Discover rail open on an unknown fit

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -2073,8 +2073,9 @@ class CatalogScreen(Screen[None]):
         """Push three curated row slices into the Discover landing.
 
         - For You: one runnable pick per role, in role order. Only rows the
-          engine can load and the machine can hold, so every card is a
-          one-click install rather than a coin flip.
+          engine can load and the host cannot prove will not run, measured
+          rows first, so every card is a one-click install rather than a
+          coin flip.
         - Your Collection: every installed local row + every activated
           cloud API. Mirrors the Library tab's spirit but capped to a
           single rail-friendly slice.

--- a/src/lilbee/cli/tui/screens/catalog_grouping.py
+++ b/src/lilbee/cli/tui/screens/catalog_grouping.py
@@ -42,33 +42,29 @@ def row_cache_signature(row: CatalogRow) -> tuple[str, bool]:
 
 
 def _is_runnable_pick(row: LocalCatalogRow) -> bool:
-    """Whether the engine supports the row and the machine can hold it.
-
-    Rows with no fit chip are excluded: an unknown size cannot be promised.
-    """
-    return (
-        row.compat is ModelCompat.SUPPORTED
-        and row.fit is not None
-        and row.fit.level is not FitLevel.WONT_RUN
+    """Whether the engine supports the row and the host cannot prove it will not run."""
+    return row.compat is ModelCompat.SUPPORTED and (
+        row.fit is None or row.fit.level is not FitLevel.WONT_RUN
     )
 
 
-def _backfill_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
-    """Rank a backfilled Discover pick: most downloaded first, then alphabetical.
+def _unknown_fit_rank(row: LocalCatalogRow) -> int:
+    """0 for a row with a fit chip, 1 for a row without one, so measured rows lead."""
+    return 0 if row.fit is not None else 1
 
-    Every candidate already runs here, so popularity separates them rather
-    than fit.
-    """
-    return (-row.sort_downloads, row.name.lower())
+
+def _backfill_sort_key(row: LocalCatalogRow) -> tuple[int, int, str]:
+    """Rank a backfilled Discover pick: known fit first, most downloaded, then alphabetical."""
+    return (_unknown_fit_rank(row), -row.sort_downloads, row.name.lower())
 
 
 def for_you_by_role(rows: list[LocalCatalogRow]) -> list[LocalCatalogRow]:
     """Runnable picks grouped by role: chat, embedding, vision, rerank.
 
-    Featured rows lead, best fit first. A role whose featured rows cannot run
-    backfills with the most downloaded row that does, so a card that does not
-    fit is replaced rather than dropped. A role with nothing runnable yields
-    no pick.
+    Featured rows lead, known fit first. A role whose featured rows cannot run
+    backfills with the most downloaded row the host cannot rule out, so a card
+    that does not fit is replaced rather than dropped. A role with nothing
+    runnable yields no pick.
     """
     runnable = [r for r in rows if _is_runnable_pick(r)]
     out: list[LocalCatalogRow] = []
@@ -82,14 +78,10 @@ def for_you_by_role(rows: list[LocalCatalogRow]) -> list[LocalCatalogRow]:
     return out
 
 
-def for_you_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
-    """Rank Discover 'For You' rows: best fit first, unknown fit last, then alphabetical.
-
-    Curation is applied before the sort, so featured isn't in the key.
-    """
-    unknown_fit_rank = len(FIT_RANK)
-    rank = unknown_fit_rank if row.fit is None else FIT_RANK[row.fit.level]
-    return (rank, row.name.lower())
+def for_you_sort_key(row: LocalCatalogRow) -> tuple[int, int, str]:
+    """Rank Discover 'For You' rows: known fit first, best fit next, then alphabetical."""
+    level_rank = 0 if row.fit is None else FIT_RANK[row.fit.level]
+    return (_unknown_fit_rank(row), level_rank, row.name.lower())
 
 
 def group_frontier_rows(

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -10,15 +10,20 @@ from textual.app import ComposeResult
 from textual.events import Key
 from textual.widgets import Input, TabbedContent
 
-from lilbee.catalog.models import CatalogResult
-from lilbee.catalog.types import ModelTask
+from lilbee.catalog.models import CatalogResult, ModelFamily, ModelVariant
+from lilbee.catalog.types import ModelCompat, ModelTask
 from lilbee.cli.tui.screens.catalog import CatalogScreen
-from lilbee.cli.tui.screens.catalog_grouping import for_you_sort_key, row_cache_signature
+from lilbee.cli.tui.screens.catalog_grouping import (
+    for_you_by_role,
+    for_you_sort_key,
+    row_cache_signature,
+)
 from lilbee.cli.tui.screens.catalog_utils import (
     FrontierCatalogRow,
     KeyStatus,
     LocalCatalogRow,
 )
+from lilbee.cli.tui.widgets.model_grid import ModelGrid
 from lilbee.runtime.hardware import FitChip, FitLevel
 from tests._lilbee_app_test_host import LilbeeAppHost
 
@@ -450,6 +455,30 @@ def test_stamp_fit_no_op_without_probe() -> None:
     # Should not raise; row.fit stays None.
     screen._stamp_fit(rows)
     assert rows[0].fit is None
+
+
+async def test_discover_rail_fills_when_the_probe_failed() -> None:
+    """A failed memory probe leaves every fit None; the For You rail still shows a pick."""
+    variant = ModelVariant(
+        hf_repo="a/Llama-GGUF",
+        filename="llama.gguf",
+        param_count="8B",
+        quant="Q4_K_M",
+        size_mb=4600,
+        compat=ModelCompat.SUPPORTED,
+    )
+    family = ModelFamily(
+        slug="llama", name="Llama", task=ModelTask.CHAT, description="x", variants=(variant,)
+    )
+    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = pilot.app.query_one(CatalogScreen)
+        screen._available_memory_bytes = None
+        screen._families = [family]
+        screen._family_rows_cache = None
+        screen._populate_discover_rails()
+        grid = screen.query_one("#discover-grid-for-you", ModelGrid)
+        assert [r.name for r in grid.rows] == ["Llama 8B"]
 
 
 async def test_action_select_tab_idempotent_when_already_active() -> None:
@@ -1307,13 +1336,77 @@ class TestForYouByRole:
 
         assert "ChatHuge" not in [r.name for r in for_you_by_role(self._rows())]
 
-    def test_a_row_with_no_fit_chip_is_skipped(self) -> None:
-        """An unknown size cannot be promised to fit."""
-        from lilbee.catalog.types import ModelCompat
-        from lilbee.cli.tui.screens.catalog_grouping import for_you_by_role
+    def test_a_row_with_no_fit_chip_is_kept_behind_a_measured_row(self) -> None:
+        """The host cannot prove an unmeasured row will not run, so it stays a candidate."""
+        rows = [
+            self._row("Alpha", "chat", compat=ModelCompat.SUPPORTED, fit_level=None),
+            self._row("Zeta", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.FITS),
+        ]
+        assert [r.name for r in for_you_by_role(rows)] == ["Zeta"]
+        assert [r.name for r in for_you_by_role(rows[:1])] == ["Alpha"]
 
-        rows = [self._row("NoSize", "chat", compat=ModelCompat.SUPPORTED, fit_level=None)]
+    def test_a_failed_probe_still_yields_one_pick_per_role(self) -> None:
+        """Every row keeps a null fit when the probe fails; the rail still fills."""
+        rows = [
+            self._row(name, task, compat=ModelCompat.SUPPORTED, fit_level=None)
+            for name, task in (
+                ("Rerank", "rerank"),
+                ("Chat", "chat"),
+                ("Embed", "embedding"),
+                ("Vision", "vision"),
+            )
+        ]
+        assert [r.task for r in for_you_by_role(rows)] == [
+            "chat",
+            "embedding",
+            "vision",
+            "rerank",
+        ]
+
+    def test_a_row_the_machine_cannot_hold_is_excluded_when_others_are_unmeasured(
+        self,
+    ) -> None:
+        """A measured misfit is still dropped; only an unknown fit is forgiven."""
+        rows = [
+            self._row(
+                "ChatHuge", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.WONT_RUN
+            ),
+            self._row("ChatUnknown", "chat", compat=ModelCompat.SUPPORTED, fit_level=None),
+        ]
+        assert [r.name for r in for_you_by_role(rows)] == ["ChatUnknown"]
+
+    def test_an_unsupported_architecture_is_excluded_even_with_no_fit_chip(self) -> None:
+        """A null fit does not forgive an engine that cannot load the row."""
+        rows = [self._row("ChatBad", "chat", compat=ModelCompat.UNSUPPORTED, fit_level=None)]
         assert for_you_by_role(rows) == []
+
+    def test_the_backfill_prefers_a_measured_row_over_a_more_popular_unmeasured_one(
+        self,
+    ) -> None:
+        """Fit is known before popularity in the backfill order."""
+        rows = [
+            self._row(
+                "ChatHuge", "chat", compat=ModelCompat.SUPPORTED, fit_level=FitLevel.WONT_RUN
+            ),
+            self._row(
+                "Popular",
+                "chat",
+                compat=ModelCompat.SUPPORTED,
+                fit_level=None,
+                featured=False,
+                downloads=900,
+            ),
+            self._row(
+                "Measured",
+                "chat",
+                compat=ModelCompat.SUPPORTED,
+                fit_level=FitLevel.TIGHT,
+                featured=False,
+                downloads=10,
+            ),
+        ]
+        (pick,) = for_you_by_role(rows)
+        assert pick.name == "Measured"
 
     def test_a_role_whose_featured_rows_cannot_run_backfills(self) -> None:
         """A misfit is replaced by a model that runs, not dropped."""


### PR DESCRIPTION
## Problem

When the host memory probe fails, every catalog row is left without a fit chip. The TUI's Discover For You rail dropped any row whose fit it could not read, so the rail came up empty on the machine that most needs a recommendation. A row whose size the HuggingFace listing does not publish was dropped the same way, even when the probe worked.

## Solution

The rail keeps a row whose fit is unknown, the same rule the catalog's fit filter already applies: the host cannot prove such a row will not run. A row with a known fit ranks ahead of an unmeasured one in both the featured selection and the backfill, so an unmeasured row never takes a slot from one the host has measured. Rows that will not run, and architectures the engine cannot load, are still excluded.

## Notes

The Obsidian plugin's own Discover rail carries the same exclusion and is not changed here.
