### PR TITLE
Clean up the catalog paging round after the AGENTS.md audit

### DIFF
--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -66,11 +66,9 @@ def get_catalog(
     offset: int = 0,
     model_manager: Any = None,
 ) -> CatalogResult:
-    """Get paginated, filtered catalog of models.
+    """One catalog page: the picks lead and the HuggingFace rows fill the rest of the window.
 
-    The picks lead the listing and the HuggingFace rows follow them, so one
-    page window covers both: the HuggingFace request is shifted by the picks
-    that precede it, and a window that ends inside the picks makes no request.
+    A window that ends inside the picks makes no HuggingFace request.
     """
     picks = get_picks()
     installed_filter = _installed_filter(installed, model_manager)

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -68,6 +68,7 @@ from lilbee.data.store import (
     scope_to_chunk_type,
 )
 from lilbee.runtime.cancellation import TaskCancelledError
+from lilbee.runtime.hardware import FitLevel, available_memory_for_fit, make_fit_filter
 from lilbee.sessions import (
     AGENT_SESSIONS_DISABLED_HINT,
     MessageRole,
@@ -1127,7 +1128,6 @@ def catalog_browse(
     ``sort``: featured/downloads/name/size_asc/size_desc."""
     from lilbee.catalog.query import get_catalog
     from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
-    from lilbee.runtime.hardware import FitLevel, available_memory_for_fit, make_fit_filter
 
     try:
         parsed_task = ModelTask(task) if task else None

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -1136,7 +1136,7 @@ def catalog_browse(
         parsed_max_fit = FitLevel(max_fit) if max_fit else None
     except ValueError as exc:
         return _error(str(exc))
-    # The host probe costs a GPU query, so only run it when a fit was asked for.
+    # The rows here carry no fit chip; only the filter needs the uncached GPU probe.
     available_bytes = available_memory_for_fit() if parsed_max_fit is not None else None
     try:
         result = get_catalog(

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -66,8 +66,7 @@ def make_fit_filter(
 ) -> Callable[[CatalogModel], bool] | None:
     """Row predicate for a *worst* acceptable fit, or None when no fit was asked for.
 
-    A row whose fit cannot be measured is kept: the host cannot prove it will
-    not run.
+    A row whose fit cannot be measured is kept.
     """
     if worst is None:
         return None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2142,14 +2142,19 @@ class TestCatalogBrowseMcp:
 
     def test_browse_max_fit_pages_only_rows_that_run_here(self, isolated_env, mock_svc):
         """The agent surface filters by host fit before the page window, like the route."""
-        with mock.patch(
-            "lilbee.runtime.hardware.available_memory_for_fit", return_value=8 * 1024**3
-        ):
+        with mock.patch("lilbee.mcp_server.available_memory_for_fit", return_value=8 * 1024**3):
             result = catalog_browse(
                 task="chat", featured=True, sort="size_desc", max_fit="fits", limit=3
             )
         assert [m["size_gb"] for m in result["models"]] == [4.6, 1.8, 0.6]
         assert result["total"] == 3
+
+    def test_browse_skips_host_probe_without_max_fit(self, isolated_env, mock_svc):
+        """The agent surface reads host memory only when a fit was asked for."""
+        with mock.patch("lilbee.mcp_server.available_memory_for_fit") as probe:
+            result = catalog_browse(task="chat", featured=True)
+        probe.assert_not_called()
+        assert result["total"] > 0
 
     def test_browse_omits_chat_model_when_filtered_to_chat_only_role(self, isolated_env, mock_svc):
         """task=rerank never returns chat models even with no other filters."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2688,11 +2688,8 @@ class TestModelsCatalog:
         self, mock_get_catalog, mock_svc, monkeypatch
     ):
         """A mixed page of native and hosted rows totals every row it returns."""
-        import lilbee.server.handlers.models as h
         from conftest import make_test_catalog_model
         from lilbee.catalog import CatalogResult
-        from lilbee.catalog.types import ModelTask
-        from lilbee.modelhub.model_manager.types import RemoteModel
 
         natives = [
             make_test_catalog_model(name="Small", size_gb=2.0),
@@ -2702,23 +2699,7 @@ class TestModelsCatalog:
             total=len(natives), limit=20, offset=0, models=natives, has_more=False
         )
         mock_svc.registry.list_installed.return_value = []
-        h._hosted_cache.clear()
-        monkeypatch.setattr(
-            h,
-            "discover_api_models",
-            lambda: {
-                "Gemini": [
-                    RemoteModel(
-                        name=name,
-                        task=ModelTask.CHAT,
-                        family="",
-                        parameter_size="",
-                        provider="Gemini",
-                    )
-                    for name in ("gemini-2.0-flash", "gemini-2.0-pro")
-                ]
-            },
-        )
+        self._stub_frontier(monkeypatch, "gemini-2.0-flash", "gemini-2.0-pro")
         resp = await handlers.models_catalog(task="chat", max_fit="fits")
         assert len(resp.models) == 4
         assert resp.total == len(resp.models)
@@ -2756,7 +2737,9 @@ class TestModelsCatalog:
         assert resp.total == 0
 
     @patch("lilbee.server.handlers.models.get_catalog")
-    async def test_hosted_skipped_on_later_page(self, mock_get_catalog, mock_svc, monkeypatch):
+    async def test_later_page_omits_hosted_rows_but_total_counts_them(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
         import lilbee.server.handlers.models as h
         from lilbee.catalog import CatalogResult
         from lilbee.catalog.types import ModelSource, ModelTask


### PR DESCRIPTION
## Problem

An audit of the catalog fit and paging round against AGENTS.md found a function-local import with no permitted reason, docstrings that argue for their code instead of describing it, a comment that made the MCP catalog tool and the HTTP catalog route look like they disagree about the host memory probe, and two handler tests that copy a helper or name a mechanism the page window replaced.

## Solution

- The catalog MCP tool imports the hardware fit helpers at module top. The test that stubs the probe patches where the tool reads it, and a new test pins that no probe runs without `max_fit`.
- The fit-filter and catalog-page docstrings state their invariant in one line each.
- The probe comment states the constraint: the tool's rows carry no fit chip, so only its filter needs the uncached GPU probe. The HTTP route still probes on every request because its rows carry the chip. No response changes.
- One handler test uses the shared frontier stub, and the paging test is named for what it asserts.

## Notes

Deferred, not in this change:

- The catalog query and the catalog route handler are each about three times the function-length rule.
- `8 * 1024**3` repeats across three test files while one of them already names it.
- The function-local imports in the new tests copy their files' pattern.
- Parametrize candidates in the hardware and MCP tests.
- The `max_fit: str` parameter shape on both surfaces, the same as the sibling params.
- Two other handler tests still inline the frontier stub.
