### PR TITLE
Reset stale warm tracker on request-triggered model loads

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -68,7 +68,12 @@ from lilbee.providers.fleet.swap_manager import (
 from lilbee.providers.fleet.windowing import window_messages
 from lilbee.providers.model_ref import parse_model_ref
 from lilbee.providers.roles import MODEL_FIELD_TO_ROLE, WorkerRole, configured_model_message
-from lilbee.providers.warm_progress import WarmPhase, WarmProgress, WarmProgressTracker
+from lilbee.providers.warm_progress import (
+    ACTIVE_WARM_PHASES,
+    WarmPhase,
+    WarmProgress,
+    WarmProgressTracker,
+)
 from lilbee.runtime.engine_lock import (
     ENGINE_DIR_ENV,
     UserLockHold,
@@ -938,6 +943,9 @@ class FleetProvider:
         # warm thread is dispatched until it finishes, so a second warm_up_pool
         # never starts a second swap and double-allocates GPU memory.
         self._warming = False
+        # Request-triggered lazy-warm single-flight: one request begins the warm
+        # cycle, concurrent siblings share it instead of each resetting.
+        self._lazy_warming = False
         # Single-flight guard for the off-thread reload: a second reload_role
         # while one is in flight sets the pending flag instead of dispatching,
         # and the in-flight thread re-runs the plan loop once per pending flag.
@@ -1677,6 +1685,7 @@ class FleetProvider:
         from lilbee.providers.engine_params import chat_options_to_kwargs
 
         self._require_configured_model(model, str(cfg.chat_model), WorkerRole.CHAT)
+        self._reset_warm_if_stale()
         self._require_clients(WorkerRole.CHAT)
         messages = self._fit_chat_context(messages, tools, options, model or str(cfg.chat_model))
         # Translate options exactly as the in-process path did (validate via
@@ -1688,19 +1697,23 @@ class FleetProvider:
             # The first frame is pulled eagerly so a dead proxy fails inside
             # _with_rediscover; a failure past the first frame surfaces to the
             # caller as a retry error, and rediscovery covers the next call.
-            return self._with_rediscover(
-                lambda: _primed_stream(
-                    _least_in_flight(self._require_clients(WorkerRole.CHAT)).chat_stream_items(
-                        messages, tools=tools, tool_choice=tool_choice, options=server_options
-                    )
+            return self._finalize_lazy_warm_after(
+                lambda: self._with_rediscover(
+                    lambda: _primed_stream(
+                        _least_in_flight(self._require_clients(WorkerRole.CHAT)).chat_stream_items(
+                            messages, tools=tools, tool_choice=tool_choice, options=server_options
+                        )
+                    ),
+                    role=WorkerRole.CHAT,
+                )
+            )
+        return self._finalize_lazy_warm_after(
+            lambda: self._with_rediscover(
+                lambda: _least_in_flight(self._require_clients(WorkerRole.CHAT)).chat_result(
+                    messages, tools=tools, tool_choice=tool_choice, options=server_options
                 ),
                 role=WorkerRole.CHAT,
             )
-        return self._with_rediscover(
-            lambda: _least_in_flight(self._require_clients(WorkerRole.CHAT)).chat_result(
-                messages, tools=tools, tool_choice=tool_choice, options=server_options
-            ),
-            role=WorkerRole.CHAT,
         )
 
     def chat_with_tools(
@@ -1716,14 +1729,17 @@ class FleetProvider:
         from lilbee.providers.engine_params import chat_options_to_kwargs
 
         self._require_configured_model(model, str(cfg.chat_model), WorkerRole.CHAT)
+        self._reset_warm_if_stale()
         self._require_clients(WorkerRole.CHAT)
         messages = self._fit_chat_context(messages, tools, options, model or str(cfg.chat_model))
         server_options = chat_options_to_kwargs(options) or None
-        return self._with_rediscover(
-            lambda: _least_in_flight(self._require_clients(WorkerRole.CHAT)).chat_tools(
-                messages, tools=tools, tool_choice=tool_choice, options=server_options
-            ),
-            role=WorkerRole.CHAT,
+        return self._finalize_lazy_warm_after(
+            lambda: self._with_rediscover(
+                lambda: _least_in_flight(self._require_clients(WorkerRole.CHAT)).chat_tools(
+                    messages, tools=tools, tool_choice=tool_choice, options=server_options
+                ),
+                role=WorkerRole.CHAT,
+            )
         )
 
     def _fit_chat_context(
@@ -2169,6 +2185,49 @@ class FleetProvider:
                 self._warm_tracker.ready()
             else:
                 self._warm_tracker.fail(self._chat_load_failure())
+
+    def _reset_warm_if_stale(self) -> None:
+        """Start a fresh warm cycle when the chat role was evicted.
+
+        The tracker keeps its terminal READY/ERROR snapshot after llama-swap
+        idle-unloads the model, so a request that finds the role cold must begin
+        a fresh warm; otherwise health reads ``not_started`` and the warm stream
+        answers at once with the stale terminal phase. Only the first of several
+        concurrent requests resets; siblings see the warm already in flight and
+        skip. A snapshot that is terminal or absent means no load is in flight.
+        """
+        if self.role_ready(WorkerRole.CHAT):
+            return
+        if self.warm_pending() or self._lazy_warming:
+            return
+        snapshot = self._warm_tracker.snapshot()
+        if snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES:
+            return
+        with self._lock:
+            if self._lazy_warming:
+                return
+            self._lazy_warming = True
+        self._warm_tracker.begin(str(cfg.chat_model))
+
+    def _finalize_lazy_warm(self, error: str | None = None) -> None:
+        """Mark a request-triggered lazy warm ready or failed and clear the flag."""
+        if not self._lazy_warming:
+            return
+        if error:
+            self._warm_tracker.fail(error)
+        else:
+            self._warm_tracker.ready()
+        self._lazy_warming = False
+
+    def _finalize_lazy_warm_after(self, call: Callable[[], _T]) -> _T:
+        """Run *call* and finalize a request-triggered lazy warm around it."""
+        try:
+            result = call()
+        except Exception as exc:
+            self._finalize_lazy_warm(str(exc))
+            raise
+        self._finalize_lazy_warm()
+        return result
 
     def _chat_load_failure(self) -> str:
         """The engine's own reason the chat model did not load, when it gave one."""

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -177,7 +177,12 @@ async def warm_stream() -> AsyncGenerator[str, None]:
             yield sse_event(SseEvent.WARM, WarmProgress(phase=WarmPhase.STARTING).model_dump())
         else:
             yield sse_event(SseEvent.WARM, snapshot.model_dump())
-            if snapshot.phase in (WarmPhase.READY, WarmPhase.ERROR):
+            # A READY snapshot only ends the stream if the role is actually
+            # loaded; a stale READY after eviction must not short-circuit while
+            # the model is gone (the next request begins a fresh warm).
+            if snapshot.phase is WarmPhase.READY and provider.role_ready(WorkerRole.CHAT):
+                break
+            if snapshot.phase is WarmPhase.ERROR:
                 break
         await asyncio.sleep(_WARM_POLL_INTERVAL_S)
     yield sse_done({})

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -224,6 +224,169 @@ def test_least_in_flight_picks_minimum() -> None:
     assert _least_in_flight([busy, idle]) is idle
 
 
+def test_chat_resets_stale_tracker_after_eviction(monkeypatch) -> None:
+    """bb-v53z2: after idle eviction, a chat request must reset the stale
+    READY snapshot to STARTING, then mark READY once the response arrives."""
+    from lilbee.providers.base import ChatResult, FinishReason
+    from lilbee.providers.warm_progress import WarmPhase
+
+    client = _fake_client()
+    client.chat_result.return_value = ChatResult(
+        text="ok", tool_calls=(), finish_reason=FinishReason.STOP
+    )
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    # Simulate eviction: tracker holds a terminal READY for a different model,
+    # role reports not loaded.
+    p._warm_tracker.begin("stale-model")
+    p._warm_tracker.ready()
+    assert p._warm_tracker.snapshot().model_ref == "stale-model"
+    # The fake swap reports the role as not ready (no `ready` set).
+    assert not p.role_ready(WorkerRole.CHAT)
+
+    # Spy on begin() so the test observes the reset directly: a stale snapshot
+    # that _reset_warm_if_stale clears by beginning a fresh warm. Without the
+    # reset, begin() is not called again after the initial stale one.
+    begins: list[str] = []
+    real_begin = p._warm_tracker.begin
+
+    def _record_begin(model_ref, *args, **kw):
+        begins.append(model_ref)
+        return real_begin(model_ref, *args, **kw)
+
+    monkeypatch.setattr(p._warm_tracker, "begin", _record_begin)
+
+    p.chat([{"role": "user", "content": "hi"}])
+
+    snap = p._warm_tracker.snapshot()
+    assert snap is not None
+    assert snap.phase is WarmPhase.READY
+    # The reset fired: a fresh begin() ran with the configured model ref, not
+    # the stale one. Without _reset_warm_if_stale, begins stays empty.
+    assert begins == [str(cfg.chat_model)]
+    assert snap.model_ref == cfg.chat_model
+    assert not p._lazy_warming
+
+
+def test_reset_warm_begins_fresh_warm_when_evicted() -> None:
+    """bb-v53z2: _reset_warm_if_stale calls begin() when the role is unloaded."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    client = _fake_client()
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    # Simulate eviction: terminal READY snapshot, role reports not loaded.
+    p._warm_tracker.begin("stale-model")
+    p._warm_tracker.ready()
+    assert not p.role_ready(WorkerRole.CHAT)
+
+    p._reset_warm_if_stale()
+
+    snap = p._warm_tracker.snapshot()
+    assert snap is not None
+    assert snap.phase is WarmPhase.STARTING
+    assert p._lazy_warming
+
+
+def test_reset_warm_skips_via_early_guard_when_flag_set() -> None:
+    """bb-v53z2: the pre-lock guard returns when a sibling already began."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    client = _fake_client()
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    p._warm_tracker.begin("stale-model")
+    p._warm_tracker.ready()
+    p._lazy_warming = True  # sibling already began
+
+    p._reset_warm_if_stale()
+
+    assert p._warm_tracker.snapshot().phase is WarmPhase.READY
+    assert p._warm_tracker.snapshot().model_ref == "stale-model"
+
+
+def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
+    """bb-v53z2: the under-lock check returns if a sibling set the flag after
+    the pre-lock guard passed but before the lock was acquired."""
+    client = _fake_client()
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    p._warm_tracker.begin("stale-model")
+    p._warm_tracker.ready()
+
+    # The pre-lock guard reads _lazy_warming as False. Then snapshot() is
+    # called; we use it as the injection point to flip the flag, simulating a
+    # sibling that began the warm in the gap between the guard and the lock.
+    # The inner check under the lock must then see True and bail.
+    real_snapshot = p._warm_tracker.snapshot
+
+    def _snapshot_then_set_flag():
+        p._lazy_warming = True
+        return real_snapshot()
+
+    monkeypatch.setattr(p._warm_tracker, "snapshot", _snapshot_then_set_flag)
+
+    p._reset_warm_if_stale()
+
+    # begin() must NOT have been called: the inner check bailed.
+    assert p._warm_tracker.snapshot().model_ref == "stale-model"
+
+
+def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
+    """bb-v53z2: a failed lazy warm reports the reason via the tracker."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    client = _fake_client()
+    client.chat_result.side_effect = RuntimeError("engine exploded")
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    p._warm_tracker.begin("old-model")
+    p._warm_tracker.ready()
+
+    with pytest.raises(RuntimeError, match="engine exploded"):
+        p.chat([{"role": "user", "content": "hi"}])
+
+    snap = p._warm_tracker.snapshot()
+    assert snap is not None
+    assert snap.phase is WarmPhase.ERROR
+    assert snap.error == "engine exploded"
+    assert not p._lazy_warming
+
+
+def test_reset_warm_is_noop_when_role_ready() -> None:
+    """bb-v53z2: no reset when the chat role is already loaded."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    p = FleetProvider()
+    group = SwapGroup(WorkerRole.CHAT.value)
+    p._role_group = {WorkerRole.CHAT: group}
+    swap = _FakeSwap()
+    swap.ready.add(WorkerRole.CHAT)  # role_ready returns True
+    p._swaps = {group: swap}
+    p._clients = {WorkerRole.CHAT: [_fake_client()]}
+    p._warm_tracker.begin("m")
+    p._warm_tracker.ready()
+
+    p._reset_warm_if_stale()
+
+    assert p._warm_tracker.snapshot().phase is WarmPhase.READY
+    assert not p._lazy_warming
+
+
+def test_reset_warm_is_noop_when_warm_in_flight() -> None:
+    """bb-v53z2: no reset when a warm is already active (boot/reload warm)."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    p = FleetProvider()
+    group = SwapGroup(WorkerRole.CHAT.value)
+    p._role_group = {WorkerRole.CHAT: group}
+    p._swaps = {group: _FakeSwap()}  # role_ready False (empty ready set)
+    p._clients = {WorkerRole.CHAT: [_fake_client()]}
+    p._warm_tracker.begin("m")
+    p._warm_tracker.loading_engine()
+
+    p._reset_warm_if_stale()
+
+    # Tracker unchanged: still mid-warm, no second begin().
+    assert p._warm_tracker.snapshot().phase is WarmPhase.LOADING_ENGINE
+    assert not p._lazy_warming
+
+
 def test_chat_routes_to_chat_server() -> None:
     from lilbee.providers.base import ChatResult, FinishReason
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -316,6 +316,32 @@ class TestWarmStream:
         assert all(e["phase"] == WarmPhase.STARTING for e in events)
         assert "event: done" in chunks[-1]
 
+    async def test_stale_ready_does_not_short_circuit_stream(self, mock_svc):
+        """bb-v53z2: a stale READY snapshot after eviction must not end the
+        warm stream at once while the role is unloaded."""
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        # Before the fix, a single READY snapshot ended the stream on the
+        # first poll; the done event followed immediately. After the fix the
+        # stream keeps polling because the role is not actually loaded.
+        mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.READY)
+        mock_svc.provider.role_ready.return_value = False
+        calls = {"n": 0}
+
+        def _fake_monotonic() -> float:
+            calls["n"] += 1
+            return 0.0 if calls["n"] <= 4 else 99.0
+
+        with (
+            patch("lilbee.server.handlers._WARM_POLL_INTERVAL_S", 0),
+            patch("lilbee.server.handlers._WARM_STREAM_TIMEOUT_S", 5.0),
+            patch("lilbee.server.handlers.time.monotonic", _fake_monotonic),
+        ):
+            chunks = [chunk async for chunk in handlers.warm_stream()]
+        events = _parse_warm_events(chunks)
+        warm_count = sum(1 for e in events if e["phase"] == WarmPhase.READY)
+        assert warm_count > 1, "stale READY must not end the stream at once"
+
 
 class TestStatus:
     async def test_returns_config_and_sources(self):


### PR DESCRIPTION
## Problem

After llama-swap idle-unloads a chat model, the warm tracker keeps its terminal READY snapshot. A request that finds the role cold went straight to llama-swap without touching the tracker, so health read "not_started" and the warm stream answered at once with the stale READY phase. No client could paint a loading phase for a request-triggered load.

## Solution

The request path resets the tracker and begins a fresh warm when the chat role is unloaded and no warm is in flight. The result path marks the tracker ready on success or failed on error. The warm stream no longer breaks on a READY snapshot unless the role is actually loaded. A per-request single-flight flag prevents concurrent requests from each resetting the tracker.

## Notes

The warm stream is still polled by a launcher before the first request; it will now keep polling through a stale READY until the request begins a fresh warm cycle.

Real-server run: started `lilbee serve -p 7801` with a throwaway data dir on head — the server boots and `GET /api/warm/stream` (200 with bearer token) streams `starting` snapshots and keeps polling, as the fix intends. A full stale-READY reproduction needs a model that loads then idle-unloads, which this machine has no `.gguf` for, so that branch is not exercised here. The unit-test evidence stands in: `test_chat_resets_stale_tracker_after_eviction` spies on `_warm_tracker.begin` and asserts a fresh `begin()` fires after `chat()` on an evicted provider. Mutating `_reset_warm_if_stale` to a no-op makes the test red (`begins == []`), proving the assertion guards the reset.