### PR TITLE
Detect and report a dangling scalar index

### DIFF
--- a/src/lilbee/core/health_warnings.py
+++ b/src/lilbee/core/health_warnings.py
@@ -21,6 +21,8 @@ class WarningCode(StrEnum):
     """Queries are prefixed but stored documents are not; retrieval is degraded."""
     INDEX_EMBEDDING_MISMATCH = "index_embedding_mismatch"
     """The index was built with another embedding model; search refuses until they agree."""
+    SCALAR_INDEX_UNAVAILABLE = "scalar_index_unavailable"
+    """A scalar index is registered but its files are gone; filtered search is degraded."""
 
 
 class HealthWarning(BaseModel):

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -41,6 +41,7 @@ from .lance_helpers import (
     _has_scalar_index,
     _has_vector_index,
     _safe_delete_unlocked,
+    _scalar_index_dangling,
     _sources_search_filter,
     ensure_table,
     escape_sql_string,
@@ -552,6 +553,21 @@ class Store:
                     remedy="Run `lilbee rebuild` to rebuild the search index.",
                 )
             )
+        table = self.open_table(CHUNKS_TABLE)
+        if table is not None:
+            dangling_scalar = _scalar_index_dangling(table, self._config.lancedb_dir)
+            if dangling_scalar:
+                warnings.append(
+                    HealthWarning(
+                        code=WarningCode.SCALAR_INDEX_UNAVAILABLE,
+                        message=(
+                            "The scalar index on "
+                            + ", ".join(dangling_scalar)
+                            + " is missing its files, so filtered search is degraded."
+                        ),
+                        remedy="Run `lilbee rebuild` to rebuild the search index.",
+                    )
+                )
         if self._doc_prefix_mismatch and not self._doc_prefix_is_stale():
             # The remedy is `lilbee rebuild`, which usually runs in another
             # process, so the query path's cached verdict outlives the fix.
@@ -794,7 +810,12 @@ class Store:
                 complete = False
                 continue
             names = table.schema.names
-            if any(c in names and not _has_scalar_index(table, c) for c, _ in columns):
+            dangling = _scalar_index_dangling(table, self._config.lancedb_dir)
+            needs_build = any(
+                c in names and (not _has_scalar_index(table, c) or c in dangling)
+                for c, _ in columns
+            )
+            if needs_build:
                 pending.append((name, columns))
         if not pending:
             self._scalar_ready = complete
@@ -823,11 +844,12 @@ class Store:
             return
         names = table.schema.names
         fail_level = logging.WARNING if table.count_rows() > 0 else logging.DEBUG
+        dangling = _scalar_index_dangling(table, self._config.lancedb_dir)
         for column, index_type in columns:
-            if column not in names or _has_scalar_index(table, column):
+            if column not in names or (_has_scalar_index(table, column) and column not in dangling):
                 continue
             try:
-                table.create_scalar_index(column, index_type=index_type, replace=False)
+                table.create_scalar_index(column, index_type=index_type, replace=column in dangling)
                 log.debug("Scalar (%s) index created on '%s.%s'", index_type, table_name, column)
             except Exception:
                 log.log(
@@ -1143,6 +1165,9 @@ class Store:
         """
         if not self._fts_ready:
             self.ensure_fts_index(blocking=False)
+            # A dangling scalar index fails the prefilter alongside a missing
+            # FTS index; rebuild both before the query runs.
+            self.ensure_scalar_indexes(blocking=False)
             # The maintenance pass may have created or replaced the index; the
             # caller's handle still resolves the registration it opened with.
             table.checkout_latest()

--- a/src/lilbee/data/store/lance_helpers.py
+++ b/src/lilbee/data/store/lance_helpers.py
@@ -167,6 +167,29 @@ def _fts_index_dangling(
         return False
 
 
+def _scalar_index_dangling(table: lancedb.table.Table, lancedb_dir: Path) -> list[str]:
+    """Column names whose scalar (BITMAP/BTree) index is registered but its files are gone.
+
+    LanceDB keeps the registration in the manifest after the index directory
+    under ``_indices`` is removed, and every prefilter on the column then fails
+    on a missing file. Returns the dangling column names, empty when none.
+    """
+    indices_dir = lancedb_dir / f"{table.name}.lance" / "_indices"
+    dangling: list[str] = []
+    try:
+        for idx in table.list_indices():
+            if (
+                idx.index_type.lower() in ("bitmap", "btree")
+                and not (indices_dir / idx.index_uuid).is_dir()
+            ):
+                for column in idx.columns:
+                    if column not in dangling:
+                        dangling.append(column)
+    except Exception:
+        return []
+    return dangling
+
+
 def _has_scalar_index(table: lancedb.table.Table, column: str) -> bool:
     """Return True when a scalar index on *column* already exists.
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1100,6 +1100,68 @@ class TestEnsureScalarIndexes:
         assert store._scalar_ready is True
 
 
+class TestScalarIndexDangling:
+    """A registered scalar index whose directory is gone must be detected and
+    reported as SCALAR_INDEX_UNAVAILABLE, not misattributed to FTS."""
+
+    def _remove_scalar_index_files(self, test_config):
+        import shutil
+
+        from lilbee.core.config import CHUNKS_TABLE
+
+        indices_dir = test_config.lancedb_dir / f"{CHUNKS_TABLE}.lance" / "_indices"
+        if not indices_dir.is_dir():
+            return
+        for index_dir in indices_dir.iterdir():
+            shutil.rmtree(index_dir)
+
+    def test_dangling_scalar_reports_scalar_warning_not_fts(self, store, test_config):
+        from lilbee.core.health_warnings import WarningCode
+
+        store.add_chunks(_make_records())
+        store.ensure_scalar_indexes()
+        store.ensure_fts_index()
+
+        self._remove_scalar_index_files(test_config)
+
+        codes = [w.code for w in store.health_warnings()]
+        assert WarningCode.SCALAR_INDEX_UNAVAILABLE in codes
+        assert WarningCode.FTS_UNAVAILABLE not in codes
+
+    def test_search_rebuilds_a_dangling_scalar_index(self, store, test_config):
+        from lilbee.core.config import CHUNKS_TABLE
+
+        store.add_chunks(_make_records())
+        store.ensure_scalar_indexes()
+        store.ensure_fts_index()
+
+        self._remove_scalar_index_files(test_config)
+        fresh = Store(test_config)
+        # Force the _keyword_arm rebuild path: scalar is "ready" so search()
+        # skips its own ensure_scalar_indexes, but FTS is not ready so
+        # _keyword_arm runs and must rebuild the dangling scalar index.
+        fresh._scalar_ready = True
+        fresh._fts_ready = False
+
+        hits = fresh.search([0.5] * cfg.embedding_dim, top_k=1, query_text="chunk number 1")
+
+        assert hits
+        from lilbee.data.store.lance_helpers import _scalar_index_dangling
+
+        table = fresh.open_table(CHUNKS_TABLE)
+        assert _scalar_index_dangling(table, test_config.lancedb_dir) == []
+
+    def test_dangling_probe_returns_empty_on_list_indices_error(self, store, test_config):
+        """An unreadable manifest is not evidence of missing files."""
+        from lilbee.data.store.lance_helpers import _scalar_index_dangling
+
+        store.add_chunks(_make_records())
+        table = store.open_table("chunks")
+        assert table is not None
+        with mock.patch.object(type(table), "list_indices", side_effect=RuntimeError("boom")):
+            assert _scalar_index_dangling(table, test_config.lancedb_dir) == []
+
+
 class TestEnsureVectorIndex:
     """Small vaults stay on exact flat search; large ones get an ANN index."""
 


### PR DESCRIPTION
## Problem

A dangling scalar (Bitmap/BTree) index leaves search answering 503 and health misattributing the dead index to FTS. Reproduction: delete the scalar index directories under the chunks table's `_indices`, restart, and search. The log shows the FTS rebuild line then `LanceError(IO) object not found` for the scalar index, but health reports `fts_unavailable`. The root cause is twofold: `_probe_keyword_search` stamps `_fts_degraded` on ANY exception (so a scalar miss looks like FTS), and there is no existence-before-use check for scalar indexes to mirror `_fts_index_dangling`.

## Solution

Add `_scalar_index_dangling()` to `lance_helpers.py` returning the list of scalar-index columns whose registered directory is missing (mirrors `_fts_index_dangling`). Add `SCALAR_INDEX_UNAVAILABLE` to `WarningCode`. Report it in `health_warnings()` naming the missing column with a `lilbee rebuild` remedy. Make `ensure_scalar_indexes()` detect and rebuild dangling scalar indexes (replace=True), and call it on the search path alongside `ensure_fts_index` so a dangling scalar is rebuilt before the prefilter runs.

## Notes

The new public contract is the `scalar_index_unavailable` warning code surfaced in `GET /api/health` warnings. No other `WarningCode` dispatch sites needed updating — the enum is a StrEx with no exhaustive match arms.

Real-store reproduction after deleting the scalar index directories (`shutil.rmtree` each `_indices` subdir) on a Store with chunks and both indexes built:

```
>>> store.health_warnings()
  code='scalar_index_unavailable'
  message='The scalar index on chunk_type, source is missing its files, so filtered search is degraded.'
  remedy='Run `lilbee rebuild` to rebuild the search index.'
```

Without the fix the same call returns no warnings (the scalar miss is silently attributed to FTS).