### PR TITLE
Route MCP status through gather_status

### DIFF
--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -290,42 +290,9 @@ def search(
 @_tool
 def status() -> dict[str, Any]:
     """Show indexed documents, configuration, and chunk counts."""
-    sources = get_services().store.get_sources()
-    return {
-        "config": {
-            "documents_dir": str(cfg.documents_dir),
-            "data_dir": str(cfg.data_dir),
-            "chat_model": cfg.chat_model,
-            "embedding_model": cfg.embedding_model,
-            "vision_model": cfg.vision_model,
-            "reranker_model": cfg.reranker_model,
-            "enable_ocr": cfg.enable_ocr,
-            "num_ctx": cfg.num_ctx,
-            "num_ctx_max": cfg.num_ctx_max,
-            "chat_n_ctx_target": cfg.chat_n_ctx_target,
-            "flash_attention": cfg.flash_attention,
-            "kv_cache_type": cfg.kv_cache_type.value,
-            "n_gpu_layers": cfg.n_gpu_layers,
-            "cpu_moe": cfg.cpu_moe,
-            "n_cpu_moe": cfg.n_cpu_moe,
-            "main_gpu": cfg.main_gpu,
-            "gpu_devices": cfg.gpu_devices,
-        },
-        "sources": [
-            {"filename": s["filename"], "chunk_count": s["chunk_count"]}
-            for s in sorted(sources, key=lambda x: x["filename"])
-        ],
-        "total_chunks": sum(s["chunk_count"] for s in sources),
-        "entities": _entity_status_dict(),
-    }
+    from lilbee.app.status import gather_status
 
-
-def _entity_status_dict() -> dict[str, Any] | None:
-    """Entity types + extracted rows, mirroring the HTTP status section."""
-    from lilbee.app.status import entity_status
-
-    section = entity_status()
-    return section.model_dump() if section is not None else None
+    return gather_status().model_dump()
 
 
 @contextmanager

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -295,6 +295,22 @@ class TestStatus:
         cfg.entity_extraction = False
         assert status()["entities"] is None
 
+    def test_status_includes_the_index_section(self, mock_svc):
+        """MCP status carries the persisted-index identity the HTTP route carries."""
+        mock_svc.store.get_meta.return_value = {
+            "embedding_model": "org/embed-GGUF/embed.Q4_K_M.gguf",
+            "embedding_dim": 768,
+        }
+        result = status()
+        assert result["index"] == {
+            "embedding_model": "org/embed-GGUF/embed.Q4_K_M.gguf",
+            "embedding_dim": 768,
+        }
+
+    def test_status_index_is_none_before_any_sync(self, mock_svc):
+        mock_svc.store.get_meta.return_value = None
+        assert status()["index"] is None
+
     def test_status_exposes_all_four_model_roles(self):
         """MCP status must expose vision + reranker slots so plugin clients see them."""
         result = status()
@@ -302,21 +318,6 @@ class TestStatus:
         assert "embedding_model" in result["config"]
         assert "vision_model" in result["config"]
         assert "reranker_model" in result["config"]
-
-    def test_status_exposes_memory_tuning_settings(self):
-        """MCP status reports the dynamic-ctx tuning knobs so clients can read them."""
-        result = status()
-        for key in (
-            "num_ctx",
-            "num_ctx_max",
-            "chat_n_ctx_target",
-            "flash_attention",
-            "kv_cache_type",
-            "n_gpu_layers",
-        ):
-            assert key in result["config"], f"missing {key} in MCP status"
-        # Enum value is stringified (kv_cache_type is a StrEnum, not raw text)
-        assert isinstance(result["config"]["kv_cache_type"], str)
 
 
 class TestSync:


### PR DESCRIPTION
## Problem

The MCP status tool builds its own dict and omits the index section (persisted embedding_model and embedding_dim) that the HTTP route and CLI carry. A client that holds the index identity from the HTTP surface cannot read it from MCP.

## Solution

Call gather_status() and serialize it, so the MCP surface matches the HTTP route and CLI. This drops the MCP-only memory-tuning fields that were not part of the shared StatusConfig; MCP now matches the other two surfaces exactly.

## Notes

The new index section appears in MCP status as {"embedding_model": ..., "embedding_dim": ...}, matching GET /api/status. No other consumer of the status dict changes.