### PR TITLE
Tokenize catalog search on slash and dash

### DIFF
--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -6,6 +6,7 @@ import fnmatch
 import functools
 import logging
 import os
+import re
 import threading
 import time
 from http import HTTPStatus
@@ -116,8 +117,15 @@ def hf_headers() -> dict[str, str]:
 
 
 def _hf_search_value(search: str) -> str:
-    """Build the HF ``search=`` value: GGUF plus the user's tokens, space-joined."""
-    tokens = [_HF_GGUF_SEARCH_TERM, *search.split()]
+    """Build the HF ``search=`` value: GGUF plus the user's tokens, space-joined.
+
+    The user's query is split on whitespace, "/", and "-" as well as case, so an
+    exact owner/repo like "Qwen/Qwen3-8B-GGUF" reaches the API as the matchable
+    tokens "GGUF Qwen Qwen3 8B GGUF" instead of the single unsplit substring
+    "GGUF Qwen/Qwen3-8B-GGUF" (which the API cannot match against a repo id).
+    """
+    parts = re.split(r"[\s/\-]+", search.strip())
+    tokens = [_HF_GGUF_SEARCH_TERM, *(p for p in parts if p)]
     return " ".join(tokens)
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2190,6 +2190,14 @@ class TestHfSearchValue:
     def test_whitespace_split_collapses_into_single_string(self) -> None:
         assert _hf_client._hf_search_value("qwen3 8b  instruct") == "GGUF qwen3 8b instruct"
 
+    def test_owner_repo_splits_on_slash_and_dash(self) -> None:
+        """An exact owner/repo reaches the API as matchable tokens.
+
+        'Qwen/Qwen3-8B-GGUF' must not be sent as the single unsplit substring
+        'GGUF Qwen/Qwen3-8B-GGUF', which the HF API cannot match against a repo id.
+        """
+        assert _hf_client._hf_search_value("Qwen/Qwen3-8B-GGUF") == "GGUF Qwen Qwen3 8B GGUF"
+
 
 class TestFetchHfModelsSearchForwarding:
     pytestmark = pytest.mark.real_hf_client
@@ -2206,6 +2214,19 @@ class TestFetchHfModelsSearchForwarding:
         monkeypatch.setattr(httpx, "get", capture_get)
         get_services().hf_client.fetch_models(search="qwen3 8b")
         assert captured_params[0].get_list("search") == ["GGUF qwen3 8b"]
+
+    def test_owner_repo_is_tokenized_for_the_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An exact owner/repo must reach the API as slash/dash-split tokens."""
+        captured_params: list[httpx.QueryParams] = []
+        mock_resp = httpx.Response(200, json=[])
+
+        def capture_get(url: str, **kwargs: Any) -> httpx.Response:
+            captured_params.append(kwargs["params"])
+            return mock_resp
+
+        monkeypatch.setattr(httpx, "get", capture_get)
+        get_services().hf_client.fetch_models(search="Qwen/Qwen3-8B-GGUF")
+        assert captured_params[0].get_list("search") == ["GGUF Qwen Qwen3 8B GGUF"]
 
     def test_empty_search_still_sends_gguf_term(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured_params: list[httpx.QueryParams] = []


### PR DESCRIPTION
## Problem

Catalog search returns nothing for an exact owner/repo string. GET /api/models/catalog?task=chat&search=Qwen/Qwen3-8B-GGUF returns 0 rows, but search=Qwen3-8B returns 20 (including that model). A client holding an exact hf_repo cannot find its own model.

The cause: _hf_search_value sent the user's query to the HF API as 'GGUF Qwen/Qwen3-8B-GGUF', a single unsplit substring the API cannot match against a repo id. The local substring filter already handled the full ref; only the HF API path was broken.

## Solution

Split the user's query on whitespace, '/', and '-' before joining onto the GGUF filter, so 'Qwen/Qwen3-8B-GGUF' reaches the API as the matchable tokens 'GGUF Qwen Qwen3 8B GGUF'.

## Notes

The HF API does substring matching per token. Splitting on the repo-id separators makes each component independently matchable without changing the result set for plain queries.