### PR TITLE
Fix false greens and contract gaps in three merged PRs

### DIFF
--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -1165,12 +1165,13 @@ class Store:
         """
         if not self._fts_ready:
             self.ensure_fts_index(blocking=False)
-            # A dangling scalar index fails the prefilter alongside a missing
-            # FTS index; rebuild both before the query runs.
-            self.ensure_scalar_indexes(blocking=False)
-            # The maintenance pass may have created or replaced the index; the
-            # caller's handle still resolves the registration it opened with.
-            table.checkout_latest()
+        # A dangling scalar index fails the prefilter alongside a missing
+        # FTS index; rebuild it before the query runs regardless of FTS state,
+        # since scalar indexes can be evicted independently of FTS.
+        self.ensure_scalar_indexes(blocking=False)
+        # The maintenance pass may have created or replaced an index; the
+        # caller's handle still resolves the registration it opened with.
+        table.checkout_latest()
         if self._config.title_search and not self._title_fts_ready:
             self.ensure_title_fts_index(blocking=False)
         if not self._fts_ready:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -287,19 +287,36 @@ def test_reset_warm_begins_fresh_warm_when_evicted() -> None:
 
 
 def test_reset_warm_skips_via_early_guard_when_flag_set() -> None:
-    """bb-v53z2: the pre-lock guard returns when a sibling already began."""
+    """bb-v53z2: the pre-lock guard returns when a warm is already in flight.
+
+    The early guard checks warm_pending() (boot/reload warm) OR _lazy_warming.
+    The lock double-check only covers _lazy_warming, so this test exercises
+    the warm_pending() branch that the double-check cannot reach."""
     from lilbee.providers.warm_progress import WarmPhase
 
     client = _fake_client()
     p = _provider_with_clients({WorkerRole.CHAT: [client]})
     p._warm_tracker.begin("stale-model")
     p._warm_tracker.ready()
-    p._lazy_warming = True  # sibling already began
+    # A boot/reload warm is in flight: warm_pending() returns True. The early
+    # guard must bail before reading the snapshot or acquiring the lock.
+    p._warming = True
+
+    # Spy on begin() so the test verifies the guard bails before calling it.
+    begins: list[str] = []
+    real_begin = p._warm_tracker.begin
+
+    def _record_begin(model_ref, *args, **kw):
+        begins.append(model_ref)
+        return real_begin(model_ref, *args, **kw)
+
+    p._warm_tracker.begin = _record_begin  # type: ignore[method-assign]
 
     p._reset_warm_if_stale()
 
     assert p._warm_tracker.snapshot().phase is WarmPhase.READY
     assert p._warm_tracker.snapshot().model_ref == "stale-model"
+    assert begins == [], "early guard must bail before begin()"
 
 
 def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
@@ -322,10 +339,22 @@ def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
 
     monkeypatch.setattr(p._warm_tracker, "snapshot", _snapshot_then_set_flag)
 
+    # Spy on begin() so the test verifies the inner check bails before calling
+    # it, not just that the tracker state is unchanged (which holds for a no-op).
+    begins: list[str] = []
+    real_begin = p._warm_tracker.begin
+
+    def _record_begin(model_ref, *args, **kw):
+        begins.append(model_ref)
+        return real_begin(model_ref, *args, **kw)
+
+    p._warm_tracker.begin = _record_begin  # type: ignore[method-assign]
+
     p._reset_warm_if_stale()
 
     # begin() must NOT have been called: the inner check bailed.
     assert p._warm_tracker.snapshot().model_ref == "stale-model"
+    assert begins == [], "lock double-check must bail before begin()"
 
 
 def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
@@ -345,6 +374,42 @@ def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
     assert snap is not None
     assert snap.phase is WarmPhase.ERROR
     assert snap.error == "engine exploded"
+    assert not p._lazy_warming
+
+
+def test_chat_with_tools_resets_stale_tracker_after_eviction() -> None:
+    """bb-v53z2: chat_with_tools also resets the stale tracker on eviction."""
+    from lilbee.providers.base import ChatToolResult
+    from lilbee.providers.warm_progress import WarmPhase
+
+    client = _fake_client()
+    client.chat_tools.return_value = ChatToolResult(content="ok", tool_calls=())
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    p._warm_tracker.begin("stale-model")
+    p._warm_tracker.ready()
+    assert not p.role_ready(WorkerRole.CHAT)
+
+    begins: list[str] = []
+    real_begin = p._warm_tracker.begin
+
+    def _record_begin(model_ref, *args, **kw):
+        begins.append(model_ref)
+        return real_begin(model_ref, *args, **kw)
+
+    p._warm_tracker.begin = _record_begin  # type: ignore[method-assign]
+
+    from lilbee.providers.base import ChatMessage
+
+    result = p.chat_with_tools(
+        [ChatMessage(role="user", content="hi")],
+        tools=[{"type": "function", "function": {"name": "calc"}}],
+    )
+
+    assert result.content == "ok"
+    snap = p._warm_tracker.snapshot()
+    assert snap is not None
+    assert snap.phase is WarmPhase.READY
+    assert begins == [str(cfg.chat_model)]
     assert not p._lazy_warming
 
 

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -225,7 +225,7 @@ def test_least_in_flight_picks_minimum() -> None:
 
 
 def test_chat_resets_stale_tracker_after_eviction(monkeypatch) -> None:
-    """bb-v53z2: after idle eviction, a chat request must reset the stale
+    """after idle eviction, a chat request must reset the stale
     READY snapshot to STARTING, then mark READY once the response arrives."""
     from lilbee.providers.base import ChatResult, FinishReason
     from lilbee.providers.warm_progress import WarmPhase
@@ -268,7 +268,7 @@ def test_chat_resets_stale_tracker_after_eviction(monkeypatch) -> None:
 
 
 def test_reset_warm_begins_fresh_warm_when_evicted() -> None:
-    """bb-v53z2: _reset_warm_if_stale calls begin() when the role is unloaded."""
+    """_reset_warm_if_stale calls begin() when the role is unloaded."""
     from lilbee.providers.warm_progress import WarmPhase
 
     client = _fake_client()
@@ -287,7 +287,7 @@ def test_reset_warm_begins_fresh_warm_when_evicted() -> None:
 
 
 def test_reset_warm_skips_via_early_guard_when_flag_set() -> None:
-    """bb-v53z2: the pre-lock guard returns when a warm is already in flight.
+    """the pre-lock guard returns when a warm is already in flight.
 
     The early guard checks warm_pending() (boot/reload warm) OR _lazy_warming.
     The lock double-check only covers _lazy_warming, so this test exercises
@@ -320,7 +320,7 @@ def test_reset_warm_skips_via_early_guard_when_flag_set() -> None:
 
 
 def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
-    """bb-v53z2: the under-lock check returns if a sibling set the flag after
+    """the under-lock check returns if a sibling set the flag after
     the pre-lock guard passed but before the lock was acquired."""
     client = _fake_client()
     p = _provider_with_clients({WorkerRole.CHAT: [client]})
@@ -358,7 +358,7 @@ def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
 
 
 def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
-    """bb-v53z2: a failed lazy warm reports the reason via the tracker."""
+    """a failed lazy warm reports the reason via the tracker."""
     from lilbee.providers.warm_progress import WarmPhase
 
     client = _fake_client()
@@ -378,7 +378,7 @@ def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
 
 
 def test_chat_with_tools_resets_stale_tracker_after_eviction() -> None:
-    """bb-v53z2: chat_with_tools also resets the stale tracker on eviction."""
+    """chat_with_tools also resets the stale tracker on eviction."""
     from lilbee.providers.base import ChatToolResult
     from lilbee.providers.warm_progress import WarmPhase
 
@@ -414,7 +414,7 @@ def test_chat_with_tools_resets_stale_tracker_after_eviction() -> None:
 
 
 def test_reset_warm_is_noop_when_role_ready() -> None:
-    """bb-v53z2: no reset when the chat role is already loaded."""
+    """no reset when the chat role is already loaded."""
     from lilbee.providers.warm_progress import WarmPhase
 
     p = FleetProvider()
@@ -434,7 +434,7 @@ def test_reset_warm_is_noop_when_role_ready() -> None:
 
 
 def test_reset_warm_is_noop_when_warm_in_flight() -> None:
-    """bb-v53z2: no reset when a warm is already active (boot/reload warm)."""
+    """no reset when a warm is already active (boot/reload warm)."""
     from lilbee.providers.warm_progress import WarmPhase
 
     p = FleetProvider()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -317,7 +317,7 @@ class TestWarmStream:
         assert "event: done" in chunks[-1]
 
     async def test_stale_ready_does_not_short_circuit_stream(self, mock_svc):
-        """bb-v53z2: a stale READY snapshot after eviction must not end the
+        """a stale READY snapshot after eviction must not end the
         warm stream at once while the role is unloaded."""
         from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1149,6 +1149,21 @@ class TestScalarIndexDangling:
         from lilbee.data.store.lance_helpers import _scalar_index_dangling
 
         table = fresh.open_table(CHUNKS_TABLE)
+        # The rebuild must have recreated the scalar index files. Verify at the
+        # filesystem level: the scalar index directories must exist. This is
+        # independent of _scalar_index_dangling (which would trivially pass if
+        # that helper were gutted to return []).
+        indices_dir = test_config.lancedb_dir / f"{CHUNKS_TABLE}.lance" / "_indices"
+        scalar_uuids = {
+            idx.index_uuid
+            for idx in table.list_indices()
+            if idx.index_type.lower() in ("bitmap", "btree")
+        }
+        assert scalar_uuids, "scalar indexes must be registered"
+        for uuid in scalar_uuids:
+            assert (indices_dir / uuid).is_dir(), (
+                f"scalar index dir {uuid} must exist after rebuild"
+            )
         assert _scalar_index_dangling(table, test_config.lancedb_dir) == []
 
     def test_dangling_probe_returns_empty_on_list_indices_error(self, store, test_config):
@@ -1160,6 +1175,29 @@ class TestScalarIndexDangling:
         assert table is not None
         with mock.patch.object(type(table), "list_indices", side_effect=RuntimeError("boom")):
             assert _scalar_index_dangling(table, test_config.lancedb_dir) == []
+
+    def test_search_rebuilds_dangling_scalar_when_fts_is_ready(self, store, test_config):
+        """A dangling scalar index must be rebuilt even when FTS is ready."""
+        from lilbee.core.config import CHUNKS_TABLE
+
+        store.add_chunks(_make_records())
+        store.ensure_scalar_indexes()
+        store.ensure_fts_index()
+
+        self._remove_scalar_index_files(test_config)
+        fresh = Store(test_config)
+        # Both readiness flags are True: the scalar indexes are dangling but
+        # FTS is fine. The keyword path must still rebuild the scalar indexes.
+        fresh._scalar_ready = True
+        fresh._fts_ready = True
+
+        hits = fresh.search([0.5] * cfg.embedding_dim, top_k=1, query_text="chunk number 1")
+
+        assert hits
+        from lilbee.data.store.lance_helpers import _scalar_index_dangling
+
+        table = fresh.open_table(CHUNKS_TABLE)
+        assert _scalar_index_dangling(table, test_config.lancedb_dir) == []
 
 
 class TestEnsureVectorIndex:


### PR DESCRIPTION
## Problem

Three merged PRs left false-green tests and a partial contract fix:

**Warm tracker reset (provider.py)** — Two guard tests assert end state instead of guard behavior. Both stay green when the reset helper is gutted to a no-op. The early-guard test also set `_lazy_warming=True`, a condition the lock double-check already covers, so it never exercised `warm_pending()` uniquely. `chat_with_tools` was modified to use the lazy-warm path but never tested.

**Dangling scalar index (core.py, lance_helpers.py)** — One test asserts the dangling helper returns an empty list, which trivially passes when that helper is gutted. More importantly, `_keyword_arm` only rebuilt scalar indexes when FTS was not ready, leaving a dangling scalar with ready FTS silently degrading search.

## Solution

- Reworked both warm-tracker guard tests to spy on `begin()` and verify bail-before-call. The early-guard test now sets `_warming=True` (making `warm_pending()` return True), the branch the double-check cannot reach.
- Added a test covering the modified `chat_with_tools` eviction-reset path.
- Replaced the false-green scalar assertion with a filesystem-level check: scalar index directories must exist on disk after rebuild, independent of the helper.
- Moved `ensure_scalar_indexes(blocking=False)` out of the `if not self._fts_ready` block in `_keyword_arm` so a dangling scalar is rebuilt regardless of FTS state. Added a test for the ready-FTS case.