### PR TITLE
Blast-radius fixes for three merged PRs

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -2187,15 +2187,7 @@ class FleetProvider:
                 self._warm_tracker.fail(self._chat_load_failure())
 
     def _reset_warm_if_stale(self) -> None:
-        """Start a fresh warm cycle when the chat role was evicted.
-
-        The tracker keeps its terminal READY/ERROR snapshot after llama-swap
-        idle-unloads the model, so a request that finds the role cold must begin
-        a fresh warm; otherwise health reads ``not_started`` and the warm stream
-        answers at once with the stale terminal phase. Only the first of several
-        concurrent requests resets; siblings see the warm already in flight and
-        skip. A snapshot that is terminal or absent means no load is in flight.
-        """
+        """Begin a fresh warm when the chat role was evicted and none is in flight."""
         if self.role_ready(WorkerRole.CHAT):
             return
         if self.warm_pending() or self._lazy_warming:

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -177,9 +177,7 @@ async def warm_stream() -> AsyncGenerator[str, None]:
             yield sse_event(SseEvent.WARM, WarmProgress(phase=WarmPhase.STARTING).model_dump())
         else:
             yield sse_event(SseEvent.WARM, snapshot.model_dump())
-            # A READY snapshot only ends the stream if the role is actually
-            # loaded; a stale READY after eviction must not short-circuit while
-            # the model is gone (the next request begins a fresh warm).
+            # A stale READY after eviction must not short-circuit; wait for the role.
             if snapshot.phase is WarmPhase.READY and provider.role_ready(WorkerRole.CHAT):
                 break
             if snapshot.phase is WarmPhase.ERROR:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -225,7 +225,7 @@ def test_least_in_flight_picks_minimum() -> None:
 
 
 def test_chat_resets_stale_tracker_after_eviction(monkeypatch) -> None:
-    """bb-v53z2: after idle eviction, a chat request must reset the stale
+    """after idle eviction, a chat request must reset the stale
     READY snapshot to STARTING, then mark READY once the response arrives."""
     from lilbee.providers.base import ChatResult, FinishReason
     from lilbee.providers.warm_progress import WarmPhase
@@ -268,7 +268,7 @@ def test_chat_resets_stale_tracker_after_eviction(monkeypatch) -> None:
 
 
 def test_reset_warm_begins_fresh_warm_when_evicted() -> None:
-    """bb-v53z2: _reset_warm_if_stale calls begin() when the role is unloaded."""
+    """_reset_warm_if_stale calls begin() when the role is unloaded."""
     from lilbee.providers.warm_progress import WarmPhase
 
     client = _fake_client()
@@ -287,7 +287,7 @@ def test_reset_warm_begins_fresh_warm_when_evicted() -> None:
 
 
 def test_reset_warm_skips_via_early_guard_when_flag_set() -> None:
-    """bb-v53z2: the pre-lock guard returns when a sibling already began."""
+    """the pre-lock guard returns when a sibling already began."""
     from lilbee.providers.warm_progress import WarmPhase
 
     client = _fake_client()
@@ -303,7 +303,7 @@ def test_reset_warm_skips_via_early_guard_when_flag_set() -> None:
 
 
 def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
-    """bb-v53z2: the under-lock check returns if a sibling set the flag after
+    """the under-lock check returns if a sibling set the flag after
     the pre-lock guard passed but before the lock was acquired."""
     client = _fake_client()
     p = _provider_with_clients({WorkerRole.CHAT: [client]})
@@ -329,7 +329,7 @@ def test_reset_warm_skips_via_lock_double_check(monkeypatch) -> None:
 
 
 def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
-    """bb-v53z2: a failed lazy warm reports the reason via the tracker."""
+    """a failed lazy warm reports the reason via the tracker."""
     from lilbee.providers.warm_progress import WarmPhase
 
     client = _fake_client()
@@ -349,7 +349,7 @@ def test_chat_marks_tracker_failed_on_error(monkeypatch) -> None:
 
 
 def test_reset_warm_is_noop_when_role_ready() -> None:
-    """bb-v53z2: no reset when the chat role is already loaded."""
+    """no reset when the chat role is already loaded."""
     from lilbee.providers.warm_progress import WarmPhase
 
     p = FleetProvider()
@@ -369,7 +369,7 @@ def test_reset_warm_is_noop_when_role_ready() -> None:
 
 
 def test_reset_warm_is_noop_when_warm_in_flight() -> None:
-    """bb-v53z2: no reset when a warm is already active (boot/reload warm)."""
+    """no reset when a warm is already active (boot/reload warm)."""
     from lilbee.providers.warm_progress import WarmPhase
 
     p = FleetProvider()
@@ -4800,6 +4800,35 @@ def test_chat_with_tools_transport_failure_rediscovers_once(monkeypatch, tmp_pat
     p = _chat_ladder(monkeypatch, tmp_path, _client_factory)
     assert p.chat_with_tools([{"role": "user", "content": "hi"}], tools=[]) == "tools-recovered"
     assert len(clients) == 2
+
+
+def test_chat_with_tools_resets_stale_tracker_after_eviction(monkeypatch) -> None:
+    """chat_with_tools resets the stale warm tracker after eviction, like chat()."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    client = _fake_client()
+    client.chat_tools.return_value = "tools-ok"
+    p = _provider_with_clients({WorkerRole.CHAT: [client]})
+    p._warm_tracker.begin("stale-model")
+    p._warm_tracker.ready()
+    assert not p.role_ready(WorkerRole.CHAT)
+
+    begins: list[str] = []
+    real_begin = p._warm_tracker.begin
+
+    def _record_begin(model_ref, *args, **kw):
+        begins.append(model_ref)
+        return real_begin(model_ref, *args, **kw)
+
+    monkeypatch.setattr(p._warm_tracker, "begin", _record_begin)
+
+    p.chat_with_tools([{"role": "user", "content": "hi"}], tools=[])
+
+    snap = p._warm_tracker.snapshot()
+    assert snap is not None
+    assert snap.phase is WarmPhase.READY
+    assert begins == [str(cfg.chat_model)]
+    assert not p._lazy_warming
 
 
 def test_can_build_engine_false_when_nothing_placeable() -> None:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -317,7 +317,7 @@ class TestWarmStream:
         assert "event: done" in chunks[-1]
 
     async def test_stale_ready_does_not_short_circuit_stream(self, mock_svc):
-        """bb-v53z2: a stale READY snapshot after eviction must not end the
+        """a stale READY snapshot after eviction must not end the
         warm stream at once while the role is unloaded."""
         from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 


### PR DESCRIPTION
## Problem

Rigorous blast-radius review of three PRs merged earlier found:
- Multi-sentence docstrings where AGENTS.md requires one line
- Multi-sentence comments where a single line suffices
- Missing test coverage for the chat_with_tools eviction-reset path
- Bead ids left in test docstrings

## Solution

- Condensed _reset_warm_if_stale docstring to one line
- Condensed warm_stream handler comment to one line
- Added test_chat_with_tools_resets_stale_tracker_after_eviction
- Removed bead ids from all test docstrings

## Notes

All fixes verified with the project gate (lint, format, typecheck, 1148 tests). The new chat_with_tools test was mutation-proven: removing _reset_warm_if_stale from chat_with_tools makes it red.