### PR TITLE
Rebuild FTS index when optimize() prunes its files

### DIFF
--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -694,6 +694,13 @@ class Store:
                     # One optimize folds new rows into every index on the table.
                     table.optimize()
                     log.debug("FTS index optimized on '%s'", CHUNKS_TABLE)
+                    if self._fts_index_dangling(table):
+                        # optimize() prunes versioned index files; a legacy FTS
+                        # index can lose its directory while its manifest
+                        # registration survives. Rebuild in the same step so the
+                        # registration and the files never diverge.
+                        self._rebuild_fts(table, "optimize() pruned its files")
+                        return
                 except Exception as exc:
                     if _is_fts_position_overflow(exc):
                         # Positional indexes overflow on optimize(); rebuild

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -695,10 +695,7 @@ class Store:
                     table.optimize()
                     log.debug("FTS index optimized on '%s'", CHUNKS_TABLE)
                     if self._fts_index_dangling(table):
-                        # optimize() prunes versioned index files; a legacy FTS
-                        # index can lose its directory while its manifest
-                        # registration survives. Rebuild in the same step so the
-                        # registration and the files never diverge.
+                        # optimize() can prune a legacy FTS index's files; rebuild to match.
                         self._rebuild_fts(table, "optimize() pruned its files")
                         return
                 except Exception as exc:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -445,6 +445,33 @@ class TestEnsureFtsIndex:
         create_spy.assert_not_called()
         optimize_spy.assert_called_once()
 
+    def test_optimize_rebuilds_fts_when_pruned(self, store, test_config):
+        """optimize() can prune a legacy FTS index's files while its
+        registration survives; rebuild in the same step."""
+        import shutil
+
+        from lilbee.core.config import CHUNKS_TABLE
+
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        table = store.open_table("chunks")
+        assert table is not None
+
+        indices_dir = test_config.lancedb_dir / f"{CHUNKS_TABLE}.lance" / "_indices"
+
+        def _optimize_then_prune():
+            # Simulate what a real optimize() prune does: drop the index dirs.
+            for d in indices_dir.iterdir():
+                shutil.rmtree(d)
+
+        with (
+            mock.patch.object(type(table), "optimize", side_effect=_optimize_then_prune),
+            mock.patch.object(type(store), "_rebuild_fts") as rebuild_spy,
+        ):
+            store.ensure_fts_index()
+
+        rebuild_spy.assert_called_once()
+
     def test_hybrid_failure_is_reported_as_a_health_warning(self, store):
         """A corpus-wide FTS breakage drops every query to vector-only recall.
         The log line alone never reached the user, so the store reports it."""


### PR DESCRIPTION
## Problem

optimize() runs LanceDB's version pruning, which can delete a legacy FTS
index's directory while its manifest registration survives. The registration
and files diverge until the next ensure_fts_index call detects the dangling
state, leaving keyword search broken in between.

## Solution

After table.optimize(), check _fts_index_dangling() and rebuild immediately
in the same step. A new helper-level test mocks optimize to prune the index
directories and asserts _rebuild_fts fires.

## Notes

The new test exercises the exact path: optimize() runs, index dirs are
removed, and the dangling check triggers a rebuild. Mutation-proven: removing
the post-optimize dangling check makes the test red.