### PR TITLE
Cache the GPU memory probe in available_memory_for_fit

### DIFF
--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -22,7 +22,7 @@ _FITS_HEADROOM_BYTES = 1 * _BYTES_PER_GB
 # one probe. The TTL bounds how long a live change (a model loaded or unloaded
 # by another process) takes to reach the fit chip.
 _AVAILABLE_MEMORY_TTL_S = 60.0
-_AVAILABLE_MEMORY_CACHE: dict[str, object] = {}  # fraction -> (monotonic_at, budget)
+_AVAILABLE_MEMORY_CACHE: dict[str, tuple[float, int]] = {}
 
 
 class FitLevel(StrEnum):

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -21,25 +21,8 @@ _FITS_HEADROOM_BYTES = 1 * _BYTES_PER_GB
 # the budget keyed on gpu_memory_fraction so repeated catalog requests share
 # one probe. The TTL bounds how long a live change (a model loaded or unloaded
 # by another process) takes to reach the fit chip.
-class _AvailableMemoryCache:
-    """TTL cache for the GPU-memory probe, keyed on gpu_memory_fraction."""
-
-    _TTL_S = 60.0
-    _entry: tuple[float, float, int] | None = None  # (fraction, monotonic_at, budget)
-
-    @classmethod
-    def get(cls, fraction: float) -> int | None:
-        entry = cls._entry
-        if entry is None:
-            return None
-        cached_fraction, cached_at, budget = entry
-        if cached_fraction != fraction or time.monotonic() - cached_at >= cls._TTL_S:
-            return None
-        return budget
-
-    @classmethod
-    def set(cls, fraction: float, budget: int) -> None:
-        cls._entry = (fraction, time.monotonic(), budget)
+_AVAILABLE_MEMORY_TTL_S = 60.0
+_AVAILABLE_MEMORY_CACHE: dict[str, object] = {}  # fraction -> (monotonic_at, budget)
 
 
 class FitLevel(StrEnum):
@@ -127,13 +110,16 @@ def available_memory_for_fit() -> int | None:
         from lilbee.providers.model_cache import get_available_memory
 
         fraction = cfg.gpu_memory_fraction
-        cached = _AvailableMemoryCache.get(fraction)
+        now = time.monotonic()
+        cached = _AVAILABLE_MEMORY_CACHE.get(str(fraction))
         if cached is not None:
-            return cached
+            cached_at, budget = cached
+            if now - cached_at < _AVAILABLE_MEMORY_TTL_S:
+                return budget
         budget = get_available_memory(fraction, total=True)
     except Exception:
         return None
-    _AvailableMemoryCache.set(fraction, budget)
+    _AVAILABLE_MEMORY_CACHE[str(fraction)] = (now, budget)
     return budget + _expert_offload_headroom()
 
 

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 
+from cachetools import TTLCache
 from pydantic import BaseModel
 
 from lilbee.catalog.models import CatalogModel, ModelFamily
@@ -21,8 +21,7 @@ _FITS_HEADROOM_BYTES = 1 * _BYTES_PER_GB
 # the budget keyed on gpu_memory_fraction so repeated catalog requests share
 # one probe. The TTL bounds how long a live change (a model loaded or unloaded
 # by another process) takes to reach the fit chip.
-_AVAILABLE_MEMORY_TTL_S = 60.0
-_AVAILABLE_MEMORY_CACHE: dict[str, tuple[float, int]] = {}
+_available_memory_cache = TTLCache(maxsize=8, ttl=60.0)
 
 
 class FitLevel(StrEnum):
@@ -110,16 +109,13 @@ def available_memory_for_fit() -> int | None:
         from lilbee.providers.model_cache import get_available_memory
 
         fraction = cfg.gpu_memory_fraction
-        now = time.monotonic()
-        cached = _AVAILABLE_MEMORY_CACHE.get(str(fraction))
+        cached = _available_memory_cache.get(fraction)
         if cached is not None:
-            cached_at, budget = cached
-            if now - cached_at < _AVAILABLE_MEMORY_TTL_S:
-                return budget
+            return cached
         budget = get_available_memory(fraction, total=True)
     except Exception:
         return None
-    _AVAILABLE_MEMORY_CACHE[str(fraction)] = (now, budget)
+    _available_memory_cache[fraction] = budget
     return budget + _expert_offload_headroom()
 
 

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -13,6 +14,32 @@ from lilbee.core.config import cfg
 
 _BYTES_PER_GB = 1024**3
 _FITS_HEADROOM_BYTES = 1 * _BYTES_PER_GB
+
+
+# GPU memory is hardware; the probe is expensive (nvidia-smi subprocess up to
+# 5s without pynvml), and the catalog stamps a fit chip on every page. Cache
+# the budget keyed on gpu_memory_fraction so repeated catalog requests share
+# one probe. The TTL bounds how long a live change (a model loaded or unloaded
+# by another process) takes to reach the fit chip.
+class _AvailableMemoryCache:
+    """TTL cache for the GPU-memory probe, keyed on gpu_memory_fraction."""
+
+    _TTL_S = 60.0
+    _entry: tuple[float, float, int] | None = None  # (fraction, monotonic_at, budget)
+
+    @classmethod
+    def get(cls, fraction: float) -> int | None:
+        entry = cls._entry
+        if entry is None:
+            return None
+        cached_fraction, cached_at, budget = entry
+        if cached_fraction != fraction or time.monotonic() - cached_at >= cls._TTL_S:
+            return None
+        return budget
+
+    @classmethod
+    def set(cls, fraction: float, budget: int) -> None:
+        cls._entry = (fraction, time.monotonic(), budget)
 
 
 class FitLevel(StrEnum):
@@ -90,13 +117,23 @@ def available_memory_for_fit() -> int | None:
     Single entry point so the TUI and the HTTP catalog handler classify fit
     against the same number; otherwise the same model would chip differently in
     each surface.
+
+    Result is cached briefly keyed on gpu_memory_fraction: the underlying probe
+    is expensive (an nvidia-smi subprocess with a 5s timeout when pynvml is
+    absent) and the catalog stamps a fit chip on every page, so an uncached
+    probe repeats that cost per request.
     """
     try:
         from lilbee.providers.model_cache import get_available_memory
 
-        budget = get_available_memory(cfg.gpu_memory_fraction, total=True)
+        fraction = cfg.gpu_memory_fraction
+        cached = _AvailableMemoryCache.get(fraction)
+        if cached is not None:
+            return cached
+        budget = get_available_memory(fraction, total=True)
     except Exception:
         return None
+    _AvailableMemoryCache.set(fraction, budget)
     return budget + _expert_offload_headroom()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,21 @@ def _playwright_browsers_root(tmp_path_factory):
 
 
 @pytest.fixture(autouse=True)
+def _clear_gpu_memory_cache():
+    """Clear the GPU memory probe cache so each test starts uncached.
+
+    The cache is module-global and keyed on gpu_memory_fraction; without this,
+    a test that mocks the probe can hit a stale entry from a previous test and
+    never exercise the mock.
+    """
+    from lilbee.runtime import hardware
+
+    hardware._AvailableMemoryCache._entry = None
+    yield
+    hardware._AvailableMemoryCache._entry = None
+
+
+@pytest.fixture(autouse=True)
 def _isolate_playwright_browsers_path(_playwright_browsers_root, monkeypatch):
     """Keep the browser cache out of the developer's real Playwright directory.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,9 +332,9 @@ def _clear_gpu_memory_cache():
     """
     from lilbee.runtime import hardware
 
-    hardware._AVAILABLE_MEMORY_CACHE.clear()
+    hardware._available_memory_cache.clear()
     yield
-    hardware._AVAILABLE_MEMORY_CACHE.clear()
+    hardware._available_memory_cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,9 +332,9 @@ def _clear_gpu_memory_cache():
     """
     from lilbee.runtime import hardware
 
-    hardware._AvailableMemoryCache._entry = None
+    hardware._AVAILABLE_MEMORY_CACHE.clear()
     yield
-    hardware._AvailableMemoryCache._entry = None
+    hardware._AVAILABLE_MEMORY_CACHE.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_runtime_hardware.py
+++ b/tests/test_runtime_hardware.py
@@ -203,7 +203,7 @@ def test_available_memory_for_fit_caches_within_ttl(monkeypatch) -> None:
     from lilbee.runtime import hardware
 
     cfg.gpu_memory_fraction = 0.5
-    hardware._AvailableMemoryCache._entry = None
+    hardware._AVAILABLE_MEMORY_CACHE.clear()
     calls = {"n": 0}
 
     def fake(fraction: float, *, total: bool = False) -> int:
@@ -224,7 +224,7 @@ def test_available_memory_for_fit_invalidates_on_fraction_change(monkeypatch) ->
     from lilbee.runtime import hardware
 
     cfg.gpu_memory_fraction = 0.5
-    hardware._AvailableMemoryCache._entry = None
+    hardware._AVAILABLE_MEMORY_CACHE.clear()
     calls = {"n": 0}
 
     def fake(fraction: float, *, total: bool = False) -> int:

--- a/tests/test_runtime_hardware.py
+++ b/tests/test_runtime_hardware.py
@@ -194,3 +194,45 @@ def test_expert_offload_headroom_is_capacity_not_free_right_now(monkeypatch) -> 
     monkeypatch.setattr(model_cache, "free_system_memory", lambda: 1 * 10**9)
 
     assert hardware._expert_offload_headroom() == 32 * 10**9
+
+
+def test_available_memory_for_fit_caches_within_ttl(monkeypatch) -> None:
+    """Repeated calls within the TTL share one probe instead of re-running it."""
+    import lilbee.providers.model_cache as mc
+    from lilbee.core.config import cfg
+    from lilbee.runtime import hardware
+
+    cfg.gpu_memory_fraction = 0.5
+    hardware._AvailableMemoryCache._entry = None
+    calls = {"n": 0}
+
+    def fake(fraction: float, *, total: bool = False) -> int:
+        calls["n"] += 1
+        return int(64 * _GB * fraction)
+
+    monkeypatch.setattr(mc, "get_available_memory", fake)
+    first = available_memory_for_fit()
+    second = available_memory_for_fit()
+    assert first == second
+    assert calls["n"] == 1
+
+
+def test_available_memory_for_fit_invalidates_on_fraction_change(monkeypatch) -> None:
+    """A config change invalidates the cache and re-probes."""
+    import lilbee.providers.model_cache as mc
+    from lilbee.core.config import cfg
+    from lilbee.runtime import hardware
+
+    cfg.gpu_memory_fraction = 0.5
+    hardware._AvailableMemoryCache._entry = None
+    calls = {"n": 0}
+
+    def fake(fraction: float, *, total: bool = False) -> int:
+        calls["n"] += 1
+        return int(64 * _GB * fraction)
+
+    monkeypatch.setattr(mc, "get_available_memory", fake)
+    available_memory_for_fit()
+    cfg.gpu_memory_fraction = 0.8
+    available_memory_for_fit()
+    assert calls["n"] == 2

--- a/tests/test_runtime_hardware.py
+++ b/tests/test_runtime_hardware.py
@@ -203,7 +203,7 @@ def test_available_memory_for_fit_caches_within_ttl(monkeypatch) -> None:
     from lilbee.runtime import hardware
 
     cfg.gpu_memory_fraction = 0.5
-    hardware._AVAILABLE_MEMORY_CACHE.clear()
+    hardware._available_memory_cache.clear()
     calls = {"n": 0}
 
     def fake(fraction: float, *, total: bool = False) -> int:
@@ -224,7 +224,7 @@ def test_available_memory_for_fit_invalidates_on_fraction_change(monkeypatch) ->
     from lilbee.runtime import hardware
 
     cfg.gpu_memory_fraction = 0.5
-    hardware._AVAILABLE_MEMORY_CACHE.clear()
+    hardware._available_memory_cache.clear()
     calls = {"n": 0}
 
     def fake(fraction: float, *, total: bool = False) -> int:


### PR DESCRIPTION
## Problem

The GPU probe is expensive (an nvidia-smi subprocess with a 5s timeout
when pynvml is absent) and the catalog handler stamps a fit chip on
every page. Without caching, every page a client scrolls re-runs the
probe.

## Solution

Cache the budget keyed on gpu_memory_fraction with a 60s TTL. Repeated
catalog requests within the TTL share one probe; a config change
invalidates and re-probes.

## Notes

The probe is the single uncached call in the catalog path; memory does
not change between pages, so a short TTL is correct. Two tests cover the
cache-hit and invalidation paths.