### PR TITLE
Null the browse catalog total

### DIFF
--- a/src/lilbee/catalog/models.py
+++ b/src/lilbee/catalog/models.py
@@ -164,7 +164,7 @@ class CatalogModel:
 class CatalogResult:
     """Paginated catalog result."""
 
-    total: int
+    total: int | None
     limit: int
     offset: int
     models: list[CatalogModel]

--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -68,7 +68,9 @@ def get_catalog(
 ) -> CatalogResult:
     """One catalog page: the picks lead and the HuggingFace rows fill the rest of the window.
 
-    A window that ends inside the picks makes no HuggingFace request.
+    A window that ends inside the picks makes no HuggingFace request. The
+    browse total is unknown because HuggingFace exposes no count, so it is
+    None and clients page on has_more.
     """
     picks = get_picks()
     installed_filter = _installed_filter(installed, model_manager)
@@ -101,7 +103,7 @@ def get_catalog(
         has_more = hf_page.has_more
 
     return CatalogResult(
-        total=len(leading) + len(hf_models),
+        total=len(leading) if featured else None,
         limit=limit,
         offset=offset,
         models=page,

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -483,7 +483,7 @@ async def models_catalog(
     ]
 
     return ModelsCatalogResponse(
-        total=len(hosted) + result.total,
+        total=None if result.total is None else len(hosted) + result.total,
         limit=limit,
         offset=offset,
         has_more=result.has_more,

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -403,7 +403,7 @@ class CatalogEntryResponse(BaseModel):
 class ModelsCatalogResponse(BaseModel):
     """Response for GET /api/models/catalog."""
 
-    total: int
+    total: int | None
     limit: int
     offset: int
     models: list[CatalogEntryResponse]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -567,7 +567,7 @@ class TestGetCatalog:
     def test_returns_featured_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(get_services().hf_client, "fetch_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog()
-        assert result.total == len(SAMPLE_PICKS)
+        assert result.total is None
         assert all(m.featured for m in result.models)
 
     def test_pagination(self) -> None:
@@ -617,8 +617,17 @@ class TestGetCatalog:
         result = get_catalog(task=ModelTask.CHAT, limit=10, offset=10)
         assert not [m for m in result.models if m.featured]
         assert [(c["offset"], c["limit"]) for c in calls] == [(10 - len(PICKS_CHAT), 10)]
-        assert result.total == len(PICKS_CHAT) + len(upstream)
+        assert result.total is None
         assert result.has_more is True
+
+    def test_browse_total_is_none_on_every_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The browse total is unknown, so both pages report none and agree."""
+        upstream = [make_test_catalog_model(name=f"Hf{i}") for i in range(10)]
+        self._record_hf_pages(monkeypatch, upstream)
+        first = get_catalog(task=ModelTask.CHAT, limit=10, offset=0)
+        second = get_catalog(task=ModelTask.CHAT, limit=10, offset=10)
+        assert first.total is None
+        assert second.total is None
 
     def test_page_inside_the_picks_fetches_no_hf_rows(
         self, monkeypatch: pytest.MonkeyPatch
@@ -650,11 +659,11 @@ class TestGetCatalog:
         assert last.has_more is False
 
     def test_zero_width_window_returns_no_rows(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A page of no rows reports the picks total and leaves the HF rows to the next page."""
+        """A page of no rows reports no total and leaves the HF rows to the next page."""
         calls = self._record_hf_pages(monkeypatch, [])
         result = get_catalog(task=ModelTask.CHAT, limit=0, offset=0)
         assert result.models == []
-        assert result.total == len(PICKS_CHAT)
+        assert result.total is None
         assert calls == []
         assert result.has_more is True
 
@@ -666,13 +675,13 @@ class TestGetCatalog:
         monkeypatch.setattr(get_services().hf_client, "fetch_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(task=ModelTask.EMBEDDING)
         assert all(m.task == "embedding" for m in result.models)
-        assert result.total == len(PICKS_EMBEDDING)
+        assert result.total is None
 
     def test_filter_by_task_vision(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(get_services().hf_client, "fetch_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(task=ModelTask.VISION)
         assert all(m.task == "vision" for m in result.models)
-        assert result.total == len(PICKS_VISION)
+        assert result.total is None
 
     def test_search_by_name(self) -> None:
         result = get_catalog(search="Qwen3")
@@ -686,11 +695,13 @@ class TestGetCatalog:
 
     def test_search_case_insensitive(self) -> None:
         result = get_catalog(search="QWEN3")
-        assert result.total > 0
+        assert result.models
+        assert result.total is None
 
     def test_search_no_results(self) -> None:
         result = get_catalog(search="nonexistent_model_xyz")
-        assert result.total == 0
+        assert result.models == []
+        assert result.total is None
 
     def test_filter_size_small(self) -> None:
         result = get_catalog(size=CatalogSize.SMALL)
@@ -718,7 +729,9 @@ class TestGetCatalog:
 
     def test_filter_size_unknown_bucket_matches_nothing(self) -> None:
         """An unrecognized bucket filters everything out rather than raising."""
-        assert get_catalog(size="gigantic").total == 0  # type: ignore[arg-type]
+        result = get_catalog(size="gigantic")  # type: ignore[arg-type]
+        assert result.models == []
+        assert result.total is None
 
     def test_largest_first_page_is_all_rows_the_host_cannot_load(self) -> None:
         """The control for the fit filter: this is the page a client has to fix itself."""
@@ -774,14 +787,14 @@ class TestGetCatalog:
             fit_filter=make_fit_filter(FitLevel.FITS, 8 * 1024**3),
         )
         assert [m.hf_repo for m in result.models] == ["test/Small0", "test/Small1"]
-        assert result.total == 2
+        assert result.total is None
         assert result.has_more is True
 
-    def test_fit_filter_totals_every_row_it_keeps(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """An untruncated page and its total are the same set, fail-open rows included.
+    def test_fit_filter_browse_page_reports_no_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A filtered browse page reports no total, fail-open rows included.
 
         A row with no measurable size is kept because the host cannot prove it
-        won't run, so it has to be counted too.
+        won't run, and the client pages on has_more.
         """
         upstream = [
             make_test_catalog_model(name="Small", size_gb=2.0),
@@ -800,7 +813,7 @@ class TestGetCatalog:
             fit_filter=make_fit_filter(FitLevel.FITS, 8 * 1024**3),
         )
         assert sorted(m.hf_repo for m in result.models) == ["test/Small", "test/Unmeasured"]
-        assert result.total == len(result.models)
+        assert result.total is None
         assert result.has_more is False
 
     def test_filter_featured_true(self) -> None:
@@ -810,7 +823,7 @@ class TestGetCatalog:
     def test_filter_featured_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(get_services().hf_client, "fetch_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(featured=False)
-        assert result.total == 0
+        assert result.total is None
 
     def test_sort_featured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(get_services().hf_client, "fetch_models", lambda **kw: _EMPTY_HF_PAGE)
@@ -864,7 +877,7 @@ class TestGetCatalog:
                 raise RuntimeError("no manager")
 
         result = get_catalog(installed=True, model_manager=BadManager())
-        assert result.total == 0
+        assert result.total is None
 
     def test_combines_featured_and_hf(self, monkeypatch: pytest.MonkeyPatch) -> None:
         hf_models = [

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2707,7 +2707,7 @@ class TestModelsCatalog:
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_get_catalog.return_value = CatalogResult(total=None, limit=20, offset=0, models=[])
         mock_svc.registry.list_installed.return_value = []
         h._hosted_cache.clear()
         monkeypatch.setattr(
@@ -2729,15 +2729,15 @@ class TestModelsCatalog:
         frontier = [m for m in resp.models if m.source == ModelSource.FRONTIER]
         assert frontier and frontier[0].display_name == "gemini-2.0-flash"
         assert frontier[0].key_status == "ready"
-        # An untruncated page and its total are the same set.
-        assert resp.total == len(resp.models) == 1
+        # The browse total is unknown; clients page on has_more.
+        assert resp.total is None
         assert resp.has_more is False
 
     @patch("lilbee.server.handlers.models.get_catalog")
-    async def test_untruncated_page_and_total_are_the_same_set(
+    async def test_mixed_page_of_native_and_hosted_rows_reports_no_total(
         self, mock_get_catalog, mock_svc, monkeypatch
     ):
-        """A mixed page of native and hosted rows totals every row it returns."""
+        """A mixed page of native and hosted rows reports no total on browse."""
         from conftest import make_test_catalog_model
         from lilbee.catalog import CatalogResult
 
@@ -2746,14 +2746,30 @@ class TestModelsCatalog:
             make_test_catalog_model(name="Unmeasured", size_gb=0.0),
         ]
         mock_get_catalog.return_value = CatalogResult(
-            total=len(natives), limit=20, offset=0, models=natives, has_more=False
+            total=None, limit=20, offset=0, models=natives, has_more=False
         )
         mock_svc.registry.list_installed.return_value = []
         self._stub_frontier(monkeypatch, "gemini-2.0-flash", "gemini-2.0-pro")
         resp = await handlers.models_catalog(task="chat", max_fit="fits")
         assert len(resp.models) == 4
-        assert resp.total == len(resp.models)
+        assert resp.total is None
         assert resp.has_more is False
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_browse_total_is_none_on_every_page(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        """The browse total is unknown, so both pages report none and agree."""
+        from lilbee.catalog import CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=None, limit=20, offset=0, models=[], has_more=True
+        )
+        mock_svc.registry.list_installed.return_value = []
+        first = await handlers.models_catalog(task="chat", limit=20, offset=0)
+        second = await handlers.models_catalog(task="chat", limit=20, offset=20)
+        assert first.total is None
+        assert second.total is None
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_hosted_skipped_when_featured_filter(
@@ -2787,7 +2803,7 @@ class TestModelsCatalog:
         assert resp.total == 0
 
     @patch("lilbee.server.handlers.models.get_catalog")
-    async def test_later_page_omits_hosted_rows_but_total_counts_them(
+    async def test_later_page_omits_hosted_rows_and_reports_no_total(
         self, mock_get_catalog, mock_svc, monkeypatch
     ):
         import lilbee.server.handlers.models as h
@@ -2795,7 +2811,7 @@ class TestModelsCatalog:
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=20, models=[])
+        mock_get_catalog.return_value = CatalogResult(total=None, limit=20, offset=20, models=[])
         mock_svc.registry.list_installed.return_value = []
         h._hosted_cache.clear()
         monkeypatch.setattr(
@@ -2815,8 +2831,8 @@ class TestModelsCatalog:
         )
         resp = await handlers.models_catalog(task="chat", offset=20)
         assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
-        # The row rides page one only, but the total counts it on every page.
-        assert resp.total == 1
+        # The browse total is unknown on every page; clients page on has_more.
+        assert resp.total is None
         assert resp.offset == 20
 
     @staticmethod
@@ -2852,7 +2868,7 @@ class TestModelsCatalog:
         from lilbee.catalog import CatalogResult
 
         mock_get_catalog.return_value = CatalogResult(
-            total=0, limit=0, offset=0, models=[], has_more=True
+            total=None, limit=0, offset=0, models=[], has_more=True
         )
         mock_svc.registry.list_installed.return_value = []
         self._stub_frontier(monkeypatch, "g1", "g2", "g3")
@@ -2862,7 +2878,7 @@ class TestModelsCatalog:
         assert mock_get_catalog.call_args.kwargs["offset"] == 0
         assert resp.limit == 2
         assert resp.offset == 0
-        assert resp.total == 3
+        assert resp.total is None
         assert resp.has_more is True
 
     @patch("lilbee.server.handlers.models.get_catalog")
@@ -2875,7 +2891,7 @@ class TestModelsCatalog:
 
         natives = [make_test_catalog_model(name=f"N{i}") for i in range(17)]
         mock_get_catalog.return_value = CatalogResult(
-            total=17, limit=17, offset=0, models=natives, has_more=True
+            total=None, limit=17, offset=0, models=natives, has_more=True
         )
         mock_svc.registry.list_installed.return_value = []
         self._stub_frontier(monkeypatch, "g1", "g2", "g3")
@@ -2885,7 +2901,7 @@ class TestModelsCatalog:
         assert [m.display_name for m in first.models[:3]] == ["g1", "g2", "g3"]
         assert mock_get_catalog.call_args.kwargs["limit"] == 17
         assert mock_get_catalog.call_args.kwargs["offset"] == 0
-        assert first.total == 20
+        assert first.total is None
 
         second = await handlers.models_catalog(task="chat", limit=20, offset=20)
         assert not [m for m in second.models if m.provider]
@@ -2901,7 +2917,7 @@ class TestModelsCatalog:
         from lilbee.catalog import CatalogResult
 
         mock_get_catalog.return_value = CatalogResult(
-            total=0, limit=1, offset=0, models=[], has_more=False
+            total=None, limit=1, offset=0, models=[], has_more=False
         )
         mock_svc.registry.list_installed.return_value = []
         self._stub_frontier(monkeypatch, "g1", "g2", "g3")
@@ -2919,7 +2935,7 @@ class TestModelsCatalog:
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_get_catalog.return_value = CatalogResult(total=None, limit=20, offset=0, models=[])
         mock_svc.registry.list_installed.return_value = []
         h._hosted_cache.clear()
         monkeypatch.setattr(
@@ -2939,14 +2955,14 @@ class TestModelsCatalog:
         )
         resp = await handlers.models_catalog(task="chat", installed=False)
         assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
-        assert resp.total == 0
+        assert resp.total is None
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_returns_catalog_response(self, mock_get_catalog, mock_svc):
         from lilbee.catalog import CatalogModel, CatalogResult
 
         mock_get_catalog.return_value = CatalogResult(
-            total=1,
+            total=None,
             limit=20,
             offset=0,
             models=[
@@ -2967,7 +2983,7 @@ class TestModelsCatalog:
         ]
         result = await handlers.models_catalog()
 
-        assert result.total == 1
+        assert result.total is None
         assert result.has_more is False
         assert len(result.models) == 1
         m = result.models[0]


### PR DESCRIPTION
## Problem
The browse listing adds the picks to one HuggingFace page, so the total drifts between pages of one listing. HuggingFace exposes no count for the rest.

## Solution
The browse response now reports a null total, and clients page on has_more instead. The route is GET /api/models/catalog and the response field is total: null on browse listings, exact on featured ones. The plugin change that reads has_more ships separately.