### PR TITLE
Tokenize catalog search on slash and dash

### DIFF
--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -6,6 +6,7 @@ import fnmatch
 import functools
 import logging
 import os
+import re
 import threading
 import time
 from http import HTTPStatus
@@ -116,8 +117,9 @@ def hf_headers() -> dict[str, str]:
 
 
 def _hf_search_value(search: str) -> str:
-    """Build the HF ``search=`` value: GGUF plus the user's tokens, space-joined."""
-    tokens = [_HF_GGUF_SEARCH_TERM, *search.split()]
+    """Build the HF ``search=`` value: GGUF plus the user's slash/dash-split tokens."""
+    parts = re.split(r"[\s/\-]+", search.strip())
+    tokens = [_HF_GGUF_SEARCH_TERM, *(p for p in parts if p)]
     return " ".join(tokens)
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2190,6 +2190,10 @@ class TestHfSearchValue:
     def test_whitespace_split_collapses_into_single_string(self) -> None:
         assert _hf_client._hf_search_value("qwen3 8b  instruct") == "GGUF qwen3 8b instruct"
 
+    def test_owner_repo_splits_on_slash_and_dash(self) -> None:
+        """An exact owner/repo reaches the API as matchable tokens."""
+        assert _hf_client._hf_search_value("Qwen/Qwen3-8B-GGUF") == "GGUF Qwen Qwen3 8B GGUF"
+
 
 class TestFetchHfModelsSearchForwarding:
     pytestmark = pytest.mark.real_hf_client
@@ -2206,6 +2210,19 @@ class TestFetchHfModelsSearchForwarding:
         monkeypatch.setattr(httpx, "get", capture_get)
         get_services().hf_client.fetch_models(search="qwen3 8b")
         assert captured_params[0].get_list("search") == ["GGUF qwen3 8b"]
+
+    def test_owner_repo_is_tokenized_for_the_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An exact owner/repo must reach the API as slash/dash-split tokens."""
+        captured_params: list[httpx.QueryParams] = []
+        mock_resp = httpx.Response(200, json=[])
+
+        def capture_get(url: str, **kwargs: Any) -> httpx.Response:
+            captured_params.append(kwargs["params"])
+            return mock_resp
+
+        monkeypatch.setattr(httpx, "get", capture_get)
+        get_services().hf_client.fetch_models(search="Qwen/Qwen3-8B-GGUF")
+        assert captured_params[0].get_list("search") == ["GGUF Qwen Qwen3 8B GGUF"]
 
     def test_empty_search_still_sends_gguf_term(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured_params: list[httpx.QueryParams] = []


### PR DESCRIPTION
## Problem

An exact owner/repo search returns no rows. GET /api/models/catalog with task=chat and search=Qwen/Qwen3-8B-GGUF returns zero rows, while the short search returns the repo among its rows. The client sent the ref to the HuggingFace API as one unsplit substring, which matches no repo id.

## Solution

Split the search text on whitespace, slash and dash before joining it onto the GGUF filter, so the ref arrives as matchable tokens. The exact search now returns the repo ranked first.

## Notes

The embedding example from the report needs a separate pipeline filter fix. The canonical repo is tagged sentence-similarity, so it stays invisible under the embedding task filters for any search text.
