### PR TITLE
Surface placement divergence in health warnings

### DIFF
--- a/src/lilbee/core/health_warnings.py
+++ b/src/lilbee/core/health_warnings.py
@@ -25,6 +25,8 @@ class WarningCode(StrEnum):
     """A scalar index is registered but its files are gone; filtered search is degraded."""
     EMBED_WINDOW_BELOW_CHUNK = "embed_window_below_chunk"
     """The embedder's window is below the chunk budget; chunks are sized in its tokens."""
+    PLACEMENT_DIVERGED = "placement_diverged"
+    """The engine allocated materially more or less GPU memory than planned."""
 
 
 class HealthWarning(BaseModel):

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -1460,12 +1460,18 @@ class FleetProvider:
         return planning.planned_embed_token_cap(cfg.embedding_model)
 
     def health_warnings(self) -> list[HealthWarning]:
-        """Serving degradations: an embed window below the configured chunk budget."""
+        """Serving degradations: the embed window and any placement divergences."""
+        warnings: list[HealthWarning] = []
         cap = self.embed_token_cap()
-        if cap is None:
-            return []
-        warning = engine_params.embed_window_warning(cap)
-        return [] if warning is None else [warning]
+        if cap is not None:
+            warning = engine_params.embed_window_warning(cap)
+            if warning is not None:
+                warnings.append(warning)
+        with self._lock:
+            swaps = list(self._swaps.values())
+        for swap in swaps:
+            warnings.extend(swap.health_warnings())
+        return warnings
 
     def chat_prefill_progress(self) -> tuple[int, int] | None:
         """``(processed, total)`` of a chat prefill in flight, or None when idle."""

--- a/src/lilbee/providers/fleet/readback.py
+++ b/src/lilbee/providers/fleet/readback.py
@@ -36,6 +36,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from lilbee.core.health_warnings import HealthWarning, WarningCode
 from lilbee.providers.fleet.devices import FleetDevice
 from lilbee.providers.fleet.vram import usable_vram_fraction
 from lilbee.providers.roles import WorkerRole
@@ -151,6 +152,34 @@ def device_label(device: FleetDevice) -> str:
     return f"{device.backend}{device.index}"
 
 
+def divergence_warning(
+    role: WorkerRole,
+    model: str,
+    estimated_bytes: int,
+    actual_bytes: int,
+    *,
+    tolerance: float,
+) -> HealthWarning | None:
+    """The placement warning when the engine's footprint diverges from the estimate."""
+    if estimated_bytes <= 0 or actual_bytes <= 0:
+        return None
+    ratio = actual_bytes / estimated_bytes
+    limit = min(tolerance, _absorbable_overrun()) if ratio > 1.0 else tolerance
+    if abs(ratio - 1.0) <= limit:
+        return None
+    return HealthWarning(
+        code=WarningCode.PLACEMENT_DIVERGED,
+        message=(
+            f"The {role.value} model {model} allocated {actual_bytes / 1024**3:.1f} GiB "
+            f"of GPU memory but was planned for {estimated_bytes / 1024**3:.1f} GiB "
+            f"({(ratio - 1.0) * 100:+.0f}%). Placement decisions for this model were "
+            f"made on the smaller figure; if it fails to load or runs slowly, that "
+            f"gap is why."
+        ),
+        remedy="Free up GPU memory or use a smaller model." if ratio > 1.0 else None,
+    )
+
+
 def report_divergence(
     role: WorkerRole,
     model: str,
@@ -158,34 +187,21 @@ def report_divergence(
     actual_bytes: int,
     *,
     tolerance: float,
-) -> bool:
+) -> HealthWarning | None:
     """Warn when the engine's real footprint diverges materially from the estimate.
 
-    Returns whether a warning was emitted, so a caller can record that this
-    instance has already been checked and not repeat it on every request.
+    Returns the warning when one was emitted, so a caller can surface it and not
+    repeat the check on every request.
 
     Both directions are worth saying. An under-estimate is how a plan that fit on
     paper OOMs, and it is the one that ends in a failed load. A large
     over-estimate is quieter but costs capacity: it is why a role gets fewer
     slots, a narrower context, or a split it did not need.
     """
-    if estimated_bytes <= 0 or actual_bytes <= 0:
-        return False
-    ratio = actual_bytes / estimated_bytes
-    limit = min(tolerance, _absorbable_overrun()) if ratio > 1.0 else tolerance
-    if abs(ratio - 1.0) <= limit:
-        return False
-    log.warning(
-        "The %s model %s allocated %.1f GiB of GPU memory but was planned for %.1f GiB "
-        "(%+.0f%%). Placement decisions for this model were made on the smaller figure; "
-        "if it fails to load or runs slowly, that gap is why.",
-        role.value,
-        model,
-        actual_bytes / 1024**3,
-        estimated_bytes / 1024**3,
-        (ratio - 1.0) * 100,
-    )
-    return True
+    warning = divergence_warning(role, model, estimated_bytes, actual_bytes, tolerance=tolerance)
+    if warning is not None:
+        log.warning("%s", warning.message)
+    return warning
 
 
 # The engine's own log, one per instance, beside the swap process's log. Named
@@ -233,7 +249,7 @@ def check_launch(
     estimated_bytes: int,
     est_by_device: dict[str, int] | None = None,
     unreported_bytes: int = 0,
-) -> bool:
+) -> HealthWarning | None:
     """Compare the engine's own report for *model_id* against the estimate.
 
     Checked per device when *est_by_device* says what each card was planned for,
@@ -261,9 +277,9 @@ def check_launch(
         # No log at all. Usually the engine simply has not written one yet, so
         # this is silent by default. It is also exactly what a wrong environment
         # variable name looks like, which is how an earlier spelling went
-        # unnoticed: the check returned False forever and read as "estimate fine".
+        # unnoticed: the check returned None forever and read as "estimate fine".
         # report_missing_log is how a caller that knows the engine is up says so.
-        return False
+        return None
     per_device = {
         label: size
         for label, size in parse_device_buffers(text).items()
@@ -286,7 +302,7 @@ def check_launch(
                 engine_build(text) or "unknown",
                 VERIFIED_ENGINE_BUILD,
             )
-        return False
+        return None
     return report_divergence(
         role, model, estimated_bytes - unreported_bytes, actual, tolerance=_TOLERANCE
     )
@@ -335,18 +351,13 @@ def _absorbable_overrun() -> float:
     return max(0.0, 1.0 / committed - 1.0) * _MARGIN_WARN_FRACTION
 
 
-def _report_per_device(
+def _per_device_warning(
     role: WorkerRole,
     model: str,
     estimated: dict[str, int],
     actual: dict[str, int],
-) -> bool:
-    """Warn about the card that diverged worst, naming both figures.
-
-    One warning rather than one per card: the operator needs to know the plan did
-    not hold and which card to look at, and a split that skews puts every card out
-    at once by construction.
-    """
+) -> HealthWarning | None:
+    """The placement warning for the card that diverged worst, naming both figures."""
     worst_label, worst_gap, worst_over = "", 0.0, False
     for label in set(estimated) | set(actual):
         planned, landed = estimated.get(label, 0), actual.get(label, 0)
@@ -359,18 +370,36 @@ def _report_per_device(
             worst_label, worst_gap, worst_over = label, gap, over
     limit = min(_TOLERANCE, _absorbable_overrun()) if worst_over else _TOLERANCE
     if not worst_label or (estimated.get(worst_label) and worst_gap <= limit):
-        return False
-    log.warning(
-        "The %s model %s did not land where it was planned: %s holds %.1f GiB but was "
-        "planned for %.1f GiB. Placement, the tensor split and the context were all "
-        "decided per card, so a total that looks right can still overrun one of them.",
-        role.value,
-        model,
-        worst_label,
-        actual.get(worst_label, 0) / 1024**3,
-        estimated.get(worst_label, 0) / 1024**3,
+        return None
+    return HealthWarning(
+        code=WarningCode.PLACEMENT_DIVERGED,
+        message=(
+            f"The {role.value} model {model} did not land where it was planned: "
+            f"{worst_label} holds {actual.get(worst_label, 0) / 1024**3:.1f} GiB but was "
+            f"planned for {estimated.get(worst_label, 0) / 1024**3:.1f} GiB. Placement, "
+            f"the tensor split and the context were all decided per card, so a total "
+            f"that looks right can still overrun one of them."
+        ),
+        remedy="Free up GPU memory or use a smaller model." if worst_over else None,
     )
-    return True
+
+
+def _report_per_device(
+    role: WorkerRole,
+    model: str,
+    estimated: dict[str, int],
+    actual: dict[str, int],
+) -> HealthWarning | None:
+    """Warn about the card that diverged worst, naming both figures.
+
+    One warning rather than one per card: the operator needs to know the plan did
+    not hold and which card to look at, and a split that skews puts every card out
+    at once by construction.
+    """
+    warning = _per_device_warning(role, model, estimated, actual)
+    if warning is not None:
+        log.warning("%s", warning.message)
+    return warning
 
 
 # llama-server flag (llama.cpp PR 26130) that both enables GET /memory and
@@ -449,7 +478,7 @@ def check_memory_report(
     estimated_bytes: int,
     est_by_device: dict[str, int] | None,
     payload: object,
-) -> bool:
+) -> HealthWarning | None:
     """Compare a ``GET /memory`` payload against the estimate; the API-mode twin
     of :func:`check_launch`.
 
@@ -474,7 +503,7 @@ def check_memory_report(
             "changed since the build lilbee's reader was written against.",
             role.value,
         )
-        return True
+        return None
     if est_by_device:
         return _report_per_device(role, model, est_by_device, per_device)
     return report_divergence(

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, BinaryIO
 import httpx
 import psutil
 
+from lilbee.core.health_warnings import HealthWarning
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.binary import engine_pin, resolve_llama_swap
 from lilbee.providers.fleet.child_guard import release_death_pipe, spawn_bound_child
@@ -209,6 +210,10 @@ class SwapManager:
         # so the check runs once per start rather than on every readiness poll.
         self._estimate_checked: set[str] = set()
         self._launch_by_model: dict[str, InstanceLaunch] = {}
+        # Placement divergences by model id, surfaced on health. Guarded because
+        # role_ready probes off the provider lock while health reads anytime.
+        self._placement_warnings: dict[str, HealthWarning] = {}
+        self._warnings_lock = threading.Lock()
         self._state_path = data_dir / _state_filename(os.getpid(), group.value)
         self._proc: subprocess.Popen[bytes] | None = None
         self._log_file: BinaryIO | None = None
@@ -265,6 +270,8 @@ class SwapManager:
         self._launches_payload = [launch.to_state() for launch in launches]
         self._launch_by_model = {launch.model_id: launch for launch in launches}
         self._estimate_checked.clear()
+        with self._warnings_lock:
+            self._placement_warnings.clear()
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
         self._log_path.parent.mkdir(parents=True, exist_ok=True)
         _atomic_write(
@@ -387,7 +394,7 @@ class SwapManager:
                 continue
             if launch.est_vram_bytes <= 0:
                 continue
-            check_launch(
+            warning = check_launch(
                 self._log_path.parent,
                 model_id,
                 launch.role,
@@ -396,6 +403,9 @@ class SwapManager:
                 launch.est_vram_by_device,
                 launch.est_unreported_bytes,
             )
+            if warning is not None:
+                with self._warnings_lock:
+                    self._placement_warnings[model_id] = warning
 
     def _check_memory_estimate(self, model_id: str, launch: InstanceLaunch) -> None:
         """Run the estimate check off the engine's own ``GET /memory``.
@@ -425,13 +435,21 @@ class SwapManager:
             return
         if launch.est_vram_bytes <= 0:
             return
-        check_memory_report(
+        warning = check_memory_report(
             launch.role,
             launch.model,
             launch.est_vram_bytes,
             launch.est_vram_by_device,
             payload,
         )
+        if warning is not None:
+            with self._warnings_lock:
+                self._placement_warnings[model_id] = warning
+
+    def health_warnings(self) -> list[HealthWarning]:
+        """Placement divergences recorded from ready engines in this group."""
+        with self._warnings_lock:
+            return list(self._placement_warnings.values())
 
     def is_live(self) -> bool:
         """Whether the swap process is up and its proxy answers ``/running``."""

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 from lilbee.app.services import get_services
 from lilbee.catalog.refs import is_bare_hf_repo
 from lilbee.core.config import cfg
-from lilbee.core.health_warnings import HealthWarning
+from lilbee.core.health_warnings import HealthWarning, WarningCode
 from lilbee.core.vectors import Vector
 from lilbee.providers.base import (
     ChatResult,
@@ -362,9 +362,17 @@ class RoutingProvider(LLMProvider):
         return None if local is None else local.embed_token_cap()
 
     def health_warnings(self) -> list[HealthWarning]:
-        """Serving degradations of the local engine; none for a remote or unset embedder."""
+        """Serving degradations of the local engine; the embed warning needs a local embedder."""
         local = self._local_embedder()
-        return [] if local is None else local.health_warnings()
+        if local is not None:
+            return local.health_warnings()
+        if self._local is None:
+            return []
+        return [
+            w
+            for w in self._local.health_warnings()
+            if w.code != WarningCode.EMBED_WINDOW_BELOW_CHUNK
+        ]
 
     def chat_prefill_progress(self) -> tuple[int, int] | None:
         """Chat prefill progress of the local engine, or None when none exists."""

--- a/tests/test_fleet_memory_readback.py
+++ b/tests/test_fleet_memory_readback.py
@@ -134,11 +134,12 @@ class TestCheckMemoryReport:
     def test_an_empty_report_is_said_not_swallowed(self, caplog) -> None:
         # The engine took the flag but reported nothing lilbee can use; silence
         # here would read as "estimate fine" forever, like the log-format drift.
+        # Said via the log, but no divergence to surface on health.
         with caplog.at_level(logging.WARNING):
             warned = check_memory_report(
                 WorkerRole.CHAT, "m", 4 * GIB, {"CUDA0": 4 * GIB}, {"data": []}
             )
-        assert warned
+        assert warned is None
         assert "unverified" in caplog.text
 
     def test_host_rows_never_charge_a_card(self, caplog) -> None:
@@ -295,7 +296,7 @@ class TestSwapManagerRouting:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         log_checks: list[str] = []
-        monkeypatch.setattr(sm, "check_launch", lambda *a, **k: log_checks.append("log") or False)
+        monkeypatch.setattr(sm, "check_launch", lambda *a, **k: log_checks.append("log"))
         monkeypatch.setattr(sm, "report_missing_log", lambda *a, **k: False)
         monkeypatch.setattr(
             sm, "_probe_client", lambda: pytest.fail("log mode must not touch HTTP")

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -87,6 +87,9 @@ class _FakeSwap:
     def role_ready(self, role: WorkerRole) -> bool:
         return role in self.ready
 
+    def health_warnings(self) -> list:
+        return []
+
     def reload(self, launches: list) -> None:
         self.reloads += 1
 
@@ -2761,20 +2764,25 @@ class TestRoutingProviderEmbedCap:
     @staticmethod
     def _routing_over_a_capped_engine(monkeypatch, embedding_model: str):
         """A RoutingProvider whose local engine would report a cap and a warning."""
+        from lilbee.core.health_warnings import HealthWarning, WarningCode
         from lilbee.providers.routing_provider import RoutingProvider
 
         monkeypatch.setattr(cfg, "embedding_model", embedding_model)
         routing = RoutingProvider()
         local = MagicMock()
         local.embed_token_cap.return_value = 504
-        local.health_warnings.return_value = ["warned"]
+        local.health_warnings.return_value = [
+            HealthWarning(code=WarningCode.EMBED_WINDOW_BELOW_CHUNK, message="chunks are cut")
+        ]
         routing._local = local
         return routing
 
     def test_delegates_to_the_local_engine_for_a_local_embedder(self, monkeypatch) -> None:
+        from lilbee.core.health_warnings import WarningCode
+
         routing = self._routing_over_a_capped_engine(monkeypatch, "org/repo/e.gguf")
         assert routing.embed_token_cap() == 504
-        assert routing.health_warnings() == ["warned"]
+        assert [w.code for w in routing.health_warnings()] == [WarningCode.EMBED_WINDOW_BELOW_CHUNK]
 
     def test_reports_nothing_for_a_remote_embedder(self, monkeypatch) -> None:
         """The local engine's cap is not the remote embedder's, so it is not reported."""
@@ -2786,6 +2794,21 @@ class TestRoutingProviderEmbedCap:
         routing = self._routing_over_a_capped_engine(monkeypatch, "")
         assert routing.embed_token_cap() is None
         assert routing.health_warnings() == []
+
+    def test_keeps_placement_warnings_for_a_remote_embedder(self, monkeypatch) -> None:
+        """Placement covers every local role, so it is not gated on the embedder."""
+        from lilbee.core.health_warnings import HealthWarning, WarningCode
+        from lilbee.providers.routing_provider import RoutingProvider
+
+        monkeypatch.setattr(cfg, "embedding_model", "openai/text-embedding-3-small")
+        routing = RoutingProvider()
+        local = MagicMock()
+        local.health_warnings.return_value = [
+            HealthWarning(code=WarningCode.EMBED_WINDOW_BELOW_CHUNK, message="chunks are cut"),
+            HealthWarning(code=WarningCode.PLACEMENT_DIVERGED, message="off plan"),
+        ]
+        routing._local = local
+        assert [w.code for w in routing.health_warnings()] == [WarningCode.PLACEMENT_DIVERGED]
 
 
 class _FakeReplica:

--- a/tests/test_fleet_readback.py
+++ b/tests/test_fleet_readback.py
@@ -74,22 +74,30 @@ class TestDeviceFootprint:
 
 class TestReportDivergence:
     def test_warns_when_the_engine_used_materially_more(self, caplog) -> None:
+        from lilbee.core.health_warnings import WarningCode
+
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
             warned = report_divergence(
                 WorkerRole.CHAT, "org/m.gguf", 4 * 1024**3, 6 * 1024**3, tolerance=0.15
             )
-        assert warned is True
+        assert warned is not None
+        assert warned.code is WarningCode.PLACEMENT_DIVERGED
+        assert warned.remedy is not None
         assert "allocated 6.0 GiB" in caplog.text
         assert "planned for 4.0 GiB" in caplog.text
         assert "+50%" in caplog.text
 
     def test_warns_when_the_estimate_was_far_too_large(self, caplog) -> None:
+        from lilbee.core.health_warnings import WarningCode
+
         # Quieter, but it is why a role gets fewer slots or a split it did not need.
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
             warned = report_divergence(
                 WorkerRole.RERANK, "org/r.gguf", 8 * 1024**3, 2 * 1024**3, tolerance=0.15
             )
-        assert warned is True
+        assert warned is not None
+        assert warned.code is WarningCode.PLACEMENT_DIVERGED
+        assert warned.remedy is None
         assert "-75%" in caplog.text
 
     def test_the_binding_fraction_is_the_one_that_leaves_least_room(self, monkeypatch) -> None:
@@ -133,7 +141,7 @@ class TestReportDivergence:
                 int(4.6 * 1024**3),  # +15%: quiet under the old constant
                 tolerance=readback._TOLERANCE,
             )
-        assert warned is True
+        assert warned is not None
         assert "+15%" in caplog.text
 
     def test_a_shortfall_keeps_the_wider_tolerance(self, monkeypatch, caplog) -> None:
@@ -151,7 +159,7 @@ class TestReportDivergence:
                 int(3.2 * 1024**3),  # -20%, inside the baseline tolerance
                 tolerance=readback._TOLERANCE,
             )
-        assert warned is False
+        assert warned is None
 
     @pytest.mark.parametrize("usable", [0.5, 0.75, 0.9, 0.95, 1.0])
     @pytest.mark.parametrize("serve", [0.5, 0.75, 0.9, 1.0])
@@ -171,15 +179,15 @@ class TestReportDivergence:
             warned = report_divergence(
                 WorkerRole.CHAT, "org/m.gguf", 4 * 1024**3, int(4.3 * 1024**3), tolerance=0.15
             )
-        assert warned is False
+        assert warned is None
         assert caplog.text == ""
 
     def test_an_unparsed_or_unestimated_instance_says_nothing(self, caplog) -> None:
         # No buffer report, or a model enrolled at its file size with no estimate:
         # there is no comparison to make, and a warning would be noise.
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
-            assert report_divergence(WorkerRole.CHAT, "m", 0, 6 * 1024**3, tolerance=0.15) is False
-            assert report_divergence(WorkerRole.CHAT, "m", 4 * 1024**3, 0, tolerance=0.15) is False
+            assert report_divergence(WorkerRole.CHAT, "m", 0, 6 * 1024**3, tolerance=0.15) is None
+            assert report_divergence(WorkerRole.CHAT, "m", 4 * 1024**3, 0, tolerance=0.15) is None
         assert caplog.text == ""
 
 
@@ -220,14 +228,14 @@ class TestTheCheckRunsOnARealLog:
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
             # The engine really allocated ~0.22 GiB; planning charged 4 GiB.
             warned = check_launch(tmp_path, "chat-0", WorkerRole.CHAT, "org/m.gguf", 4 * 1024**3)
-        assert warned is True
+        assert warned is not None
         assert "planned for 4.0 GiB" in caplog.text
 
     def test_a_missing_log_says_nothing(self, tmp_path, caplog) -> None:
         from lilbee.providers.fleet.readback import check_launch
 
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.readback"):
-            assert check_launch(tmp_path, "chat-0", WorkerRole.CHAT, "m", 4 * 1024**3) is False
+            assert check_launch(tmp_path, "chat-0", WorkerRole.CHAT, "m", 4 * 1024**3) is None
         assert caplog.text == ""
 
     def test_the_engine_is_told_where_to_write_and_how_loudly(self, tmp_path) -> None:

--- a/tests/test_placement_warnings.py
+++ b/tests/test_placement_warnings.py
@@ -1,0 +1,101 @@
+"""Placement divergence reaches /api/health warnings when the engine lands off plan."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from lilbee.core.config import cfg
+from lilbee.providers.fleet import planning as planning_mod
+from lilbee.providers.fleet.groups import SwapGroup
+from lilbee.providers.fleet.provider import FleetProvider
+from lilbee.providers.roles import WorkerRole
+
+
+class TestPlacementWarnings:
+    def test_health_carries_divergence_from_a_swap(self, monkeypatch, tmp_path: Path) -> None:
+        from lilbee.core.health_warnings import HealthWarning, WarningCode
+
+        monkeypatch.setattr(cfg, "chunk_size", 512)
+        monkeypatch.setattr(planning_mod, "planned_embed_token_cap", lambda _r: 2048)
+        placed = HealthWarning(
+            code=WarningCode.PLACEMENT_DIVERGED,
+            message="The chat model did not land where it was planned.",
+            remedy="Free up GPU memory or use a smaller model.",
+        )
+        swap = MagicMock()
+        swap.health_warnings.return_value = [placed]
+        provider = FleetProvider()
+        provider._swaps = {SwapGroup.CHAT: swap}
+        codes = [w.code for w in provider.health_warnings()]
+        assert codes == [WarningCode.PLACEMENT_DIVERGED]
+
+    def test_swap_records_divergence_from_the_engine_log(self, tmp_path: Path, monkeypatch) -> None:
+        from lilbee.core.health_warnings import WarningCode
+        from lilbee.providers.fleet import swap_manager as sm
+        from lilbee.providers.fleet.launch import InstanceLaunch
+        from lilbee.providers.fleet.readback import MIB, engine_log_path
+
+        engine_log_path(tmp_path / "logs", "chat-0").parent.mkdir(parents=True, exist_ok=True)
+        engine_log_path(tmp_path / "logs", "chat-0").write_text(
+            "load_tensors:        CUDA0 model buffer size =  6000.00 MiB\n"
+            "load_model: initializing slots\n",
+            encoding="utf-8",
+        )
+        manager = sm.SwapManager(tmp_path, SwapGroup.CHAT)
+        manager._log_path = tmp_path / "logs" / "llama-swap-chat.log"
+        launch = InstanceLaunch(
+            role=WorkerRole.CHAT,
+            argv=["/bin/llama-server"],
+            env_overrides={},
+            model="chat-model",
+            est_vram_bytes=4000 * MIB,
+        )
+        manager._launch_by_model = {"chat-0": launch}
+        manager._check_estimates({"chat-0"})
+        codes = [w.code for w in manager.health_warnings()]
+        assert codes == [WarningCode.PLACEMENT_DIVERGED]
+
+    def test_swap_records_divergence_from_the_memory_endpoint(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from lilbee.core.health_warnings import WarningCode
+        from lilbee.providers.fleet import swap_manager as sm
+        from lilbee.providers.fleet.launch import InstanceLaunch
+        from lilbee.providers.fleet.readback import MEMORY_FLAG
+
+        GIB = 1024**3
+
+        class _Resp:
+            status_code = 200
+
+            def json(self) -> dict:
+                return {"data": [{"name": "CUDA0", "model": 8 * GIB}]}
+
+        class _Client:
+            def get(self, url: str, timeout: float | None = None) -> _Resp:
+                return _Resp()
+
+        monkeypatch.setattr(sm, "_probe_client", lambda: _Client())
+        manager = sm.SwapManager(tmp_path, SwapGroup.CHAT)
+        launch = InstanceLaunch(
+            role=WorkerRole.CHAT,
+            argv=["/bin/llama-server", MEMORY_FLAG],
+            env_overrides={},
+            model="chat-model",
+            est_vram_bytes=4 * GIB,
+            est_vram_by_device={"CUDA0": 4 * GIB},
+        )
+        manager._launch_by_model = {launch.model_id: launch}
+        manager._member_port_by_model = {launch.model_id: 5901}
+        manager._check_estimates({launch.model_id})
+        codes = [w.code for w in manager.health_warnings()]
+        assert codes == [WarningCode.PLACEMENT_DIVERGED]
+
+    def test_routing_reports_nothing_with_no_local_engine(self, monkeypatch) -> None:
+        from lilbee.providers.routing_provider import RoutingProvider
+
+        monkeypatch.setattr(cfg, "embedding_model", "openai/text-embedding-3-small")
+        routing = RoutingProvider()
+        assert routing._local is None
+        assert routing.health_warnings() == []

--- a/tests/test_readback_per_device.py
+++ b/tests/test_readback_per_device.py
@@ -27,6 +27,8 @@ class TestASkewedSplitIsCaught:
     lands 80/20 passed silently, and card 0 is the one that OOMs."""
 
     def test_a_skewed_split_with_the_right_total_is_reported(self, tmp_path, caplog) -> None:
+        from lilbee.core.health_warnings import WarningCode
+
         engine_log_path(tmp_path, "chat-0").write_text(_split_log(8000.0, 2000.0))
         with caplog.at_level(logging.WARNING, logger=_LOGGER):
             warned = check_launch(
@@ -37,7 +39,8 @@ class TestASkewedSplitIsCaught:
                 5000 * MIB * 2,
                 est_by_device={"CUDA0": 5000 * MIB, "CUDA1": 5000 * MIB},
             )
-        assert warned is True
+        assert warned is not None
+        assert warned.code is WarningCode.PLACEMENT_DIVERGED
         assert "CUDA0" in caplog.text
 
     def test_a_split_that_landed_as_planned_stays_quiet(self, tmp_path, caplog) -> None:
@@ -51,7 +54,7 @@ class TestASkewedSplitIsCaught:
                 5000 * MIB * 2,
                 est_by_device={"CUDA0": 5000 * MIB, "CUDA1": 5000 * MIB},
             )
-        assert warned is False
+        assert warned is None
         assert caplog.text == ""
 
     def test_a_role_that_landed_on_an_unplanned_card_is_reported(self, tmp_path, caplog) -> None:
@@ -66,7 +69,7 @@ class TestASkewedSplitIsCaught:
                 10000 * MIB,
                 est_by_device={"CUDA0": 10000 * MIB},
             )
-        assert warned is True
+        assert warned is not None
         assert "CUDA1" in caplog.text
 
     def test_without_a_per_device_estimate_the_total_is_still_checked(
@@ -76,7 +79,7 @@ class TestASkewedSplitIsCaught:
         engine_log_path(tmp_path, "chat-0").write_text(_split_log(8000.0, 8000.0))
         with caplog.at_level(logging.WARNING, logger=_LOGGER):
             warned = check_launch(tmp_path, "chat-0", WorkerRole.CHAT, "m", 4000 * MIB)
-        assert warned is True
+        assert warned is not None
 
 
 class TestTheDeviceNameIsTheJoin:


### PR DESCRIPTION
## Problem

The planner logs when the engine lands off plan, but no client sees it. The allocation check runs, warns in the log, and discards the result.

## Solution

The check now returns the warning it logs. Each swap process keeps its engines' divergences, and the fleet exposes them on health with the existing embed warning. A remote embedder hides only the embed warning; placement warnings still surface.

The plugin consumes GET /api/health warnings with code placement_diverged.