### PR TITLE
Fuse typed and rewritten queries with RRF

### DIFF
--- a/src/lilbee/data/store/fusion.py
+++ b/src/lilbee/data/store/fusion.py
@@ -29,6 +29,13 @@ other. Arm depth matters as much as the formula: rows both arms rank
 mid-pool accumulate two contributions, so deep candidate pools crowd out
 single-arm certainty; the hybrid path therefore feeds fusion arms of
 exactly ``top_k`` rows.
+
+Per-query fusion serves the history-rewrite path: the condensed rewrite's
+ranking fuses with the typed question's own retrieval at equal weight, so
+a rewrite that absorbed conversation context cannot crowd out the
+question's evidence. Shares normalize over the live lists, so one silent
+query does not demote the other, and a row found by both keeps the
+closest distance and any lexical support.
 """
 
 from __future__ import annotations
@@ -164,4 +171,48 @@ def fuse_arms(
         _merge_arm(merged, fts_rows, lexical_weight / weight_total)
     if title_rows and title_weight > 0:
         _merge_arm(merged, title_rows, title_weight / weight_total)
+    return sorted(merged.values(), key=lambda r: r.score or 0.0, reverse=True)
+
+
+def _merge_query_arm(
+    merged: dict[tuple[str, int], SearchChunk],
+    rows: list[SearchChunk],
+    share: float,
+) -> None:
+    """Fold one query's ranked rows into *merged*, each contributing *share* of its rank weight.
+
+    A row found by several queries keeps the closest distance and any
+    lexical support, so each query's winner survives the downstream
+    distance filter on its own evidence.
+    """
+    for rank, row in enumerate(rows, start=1):
+        key = _key(row)
+        contribution = _rank_weight(rank) * share
+        seen = merged.get(key)
+        if seen is None:
+            merged[key] = row.model_copy(update={"score": contribution})
+        else:
+            update: dict[str, object] = {"score": (seen.score or 0.0) + contribution}
+            if row.distance is not None and (seen.distance is None or row.distance < seen.distance):
+                update["distance"] = row.distance
+            if seen.bm25_score is None and row.bm25_score is not None:
+                update["bm25_score"] = row.bm25_score
+            merged[key] = seen.model_copy(update=update)
+
+
+def fuse_ranked_lists(query_lists: list[list[SearchChunk]]) -> list[SearchChunk]:
+    """Fuse equally-weighted per-query rankings by reciprocal rank.
+
+    Each live list contributes its rank weights scaled by its share of the
+    lists in the call, so one silent query does not demote the other. The
+    result is sorted by score descending and deduplicated on
+    (source, chunk_index).
+    """
+    lists = [rows for rows in query_lists if rows]
+    if not lists:
+        return []
+    share = 1.0 / len(lists)
+    merged: dict[tuple[str, int], SearchChunk] = {}
+    for rows in lists:
+        _merge_query_arm(merged, rows, share)
     return sorted(merged.values(), key=lambda r: r.score or 0.0, reverse=True)

--- a/src/lilbee/data/store/fusion.py
+++ b/src/lilbee/data/store/fusion.py
@@ -120,12 +120,13 @@ def _merge_arm(
     merged: dict[tuple[str, int], SearchChunk],
     rows: list[SearchChunk],
     share: float,
+    *,
+    keep_closest_distance: bool = False,
 ) -> None:
     """Fold one arm's ranked rows into *merged*, each contributing *share* of its rank weight.
 
-    A lexical row (title or chunk FTS) carries ``bm25_score``; when the row was
-    already seen, that provenance is kept from whichever lexical arm set it
-    first, so the lexical-support exemption applies either way.
+    A row seen before keeps the first lexical support; with
+    *keep_closest_distance* it also keeps the closest distance.
     """
     for rank, row in enumerate(rows, start=1):
         key = _key(row)
@@ -135,6 +136,12 @@ def _merge_arm(
             merged[key] = row.model_copy(update={"score": contribution})
         else:
             update: dict[str, object] = {"score": (seen.score or 0.0) + contribution}
+            if (
+                keep_closest_distance
+                and row.distance is not None
+                and (seen.distance is None or row.distance < seen.distance)
+            ):
+                update["distance"] = row.distance
             if seen.bm25_score is None and row.bm25_score is not None:
                 update["bm25_score"] = row.bm25_score
             merged[key] = seen.model_copy(update=update)
@@ -174,38 +181,13 @@ def fuse_arms(
     return sorted(merged.values(), key=lambda r: r.score or 0.0, reverse=True)
 
 
-def _merge_query_arm(
-    merged: dict[tuple[str, int], SearchChunk],
-    rows: list[SearchChunk],
-    share: float,
-) -> None:
-    """Fold one query's ranked rows into *merged*, each contributing *share* of its rank weight.
-
-    A row found by several queries keeps the closest distance and any
-    lexical support, so each query's winner survives the downstream
-    distance filter on its own evidence.
-    """
-    for rank, row in enumerate(rows, start=1):
-        key = _key(row)
-        contribution = _rank_weight(rank) * share
-        seen = merged.get(key)
-        if seen is None:
-            merged[key] = row.model_copy(update={"score": contribution})
-        else:
-            update: dict[str, object] = {"score": (seen.score or 0.0) + contribution}
-            if row.distance is not None and (seen.distance is None or row.distance < seen.distance):
-                update["distance"] = row.distance
-            if seen.bm25_score is None and row.bm25_score is not None:
-                update["bm25_score"] = row.bm25_score
-            merged[key] = seen.model_copy(update=update)
-
-
 def fuse_ranked_lists(query_lists: list[list[SearchChunk]]) -> list[SearchChunk]:
     """Fuse equally-weighted per-query rankings by reciprocal rank.
 
     Each live list contributes its rank weights scaled by its share of the
-    lists in the call, so one silent query does not demote the other. The
-    result is sorted by score descending and deduplicated on
+    lists in the call, so one silent query does not demote the other. A row
+    found by several queries keeps the closest distance and any lexical
+    support. The result is sorted by score descending and deduplicated on
     (source, chunk_index).
     """
     lists = [rows for rows in query_lists if rows]
@@ -214,5 +196,5 @@ def fuse_ranked_lists(query_lists: list[list[SearchChunk]]) -> list[SearchChunk]
     share = 1.0 / len(lists)
     merged: dict[tuple[str, int], SearchChunk] = {}
     for rows in lists:
-        _merge_query_arm(merged, rows, share)
+        _merge_arm(merged, rows, share, keep_closest_distance=True)
     return sorted(merged.values(), key=lambda r: r.score or 0.0, reverse=True)

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -299,6 +299,16 @@ class Searcher:
                 filtered.append(r)
         return filtered if filtered else results
 
+    def _drop_structural(self, results: list[SearchChunk]) -> list[SearchChunk]:
+        """Drop structural chunks the lexical arms did not support."""
+        if not self._config.filter_structural_chunks:
+            return results
+        return [
+            r
+            for i, r in enumerate(results)
+            if r.bm25_score is not None or i == 0 or not is_structural_chunk(r.chunk)
+        ]
+
     def _apply_guardrails(
         self,
         variants: list[tuple[str, Vector]],
@@ -659,20 +669,9 @@ class Searcher:
         # HTTP, and MCP copies of a bare distance cutoff dropped both-arm
         # rows the fusion layer deliberately keeps past max_distance.
         results = filter_results(results, self._config.max_distance)
-        # Drop tables-of-contents and cover pages that only the vector arm
-        # surfaced: they dilute context precision without answering a question.
-        # Filtered from the top_k*2 candidate buffer so enough real passages
-        # remain for the downstream trim. Runs before the concept boost so a
-        # boost cannot promote a structural chunk into the rank-0 exemption.
-        if self._config.filter_structural_chunks:
-            # A lexical (BM25 or title) hit or the top-ranked row is content the
-            # answer may need, whatever its shape, so it is never dropped; only
-            # structural chunks the lexical arms did not support are removed.
-            results = [
-                r
-                for i, r in enumerate(results)
-                if r.bm25_score is not None or i == 0 or not is_structural_chunk(r.chunk)
-            ]
+        # Runs before the concept boost so a boost cannot promote a
+        # structural chunk into the rank-0 exemption.
+        results = self._drop_structural(results)
         results = self._apply_concept_boost(results, question)
         results = order_by_fusion(results)
         # Rerank when a cross-encoder is loaded so every search surface (HTTP,
@@ -927,7 +926,11 @@ class Searcher:
     def _search_typed_arm(
         self, question: str, top_k: int, chunk_type: ChunkType | None
     ) -> list[SearchChunk]:
-        """Direct retrieval for the typed question: no expansion or rerank."""
+        """Direct retrieval for the typed question.
+
+        Applies the temporal and structural filters; skips expansion,
+        intent routing, concept boost, and rerank.
+        """
         mode, clean_query = self._parse_structured_query(question)
         if mode is not None:
             typed = self._search_structured(mode, clean_query, top_k, chunk_type=chunk_type)
@@ -940,7 +943,7 @@ class Searcher:
             query_text=question,
             chunk_type=self._retrieval_scope(chunk_type),
         )
-        return self._apply_temporal_filter(typed, question)
+        return self._drop_structural(self._apply_temporal_filter(typed, question))
 
     def build_rag_context(
         self,

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -25,6 +25,7 @@ from lilbee.data.store import (
     cosine_sim,
     human_recall_predicate,
 )
+from lilbee.data.store.fusion import fuse_ranked_lists
 from lilbee.providers.base import (
     LLMProvider,
     ProviderError,
@@ -923,6 +924,24 @@ class Searcher:
             return top_source
         return None
 
+    def _search_typed_arm(
+        self, question: str, top_k: int, chunk_type: ChunkType | None
+    ) -> list[SearchChunk]:
+        """Direct retrieval for the typed question: no expansion or rerank."""
+        mode, clean_query = self._parse_structured_query(question)
+        if mode is not None:
+            typed = self._search_structured(mode, clean_query, top_k, chunk_type=chunk_type)
+            return self._apply_temporal_filter(typed, clean_query)
+        if self._refuse_wiki_scope(chunk_type):
+            return []
+        typed = self._store.search(
+            self._embedder.embed_query(question),
+            top_k=top_k,
+            query_text=question,
+            chunk_type=self._retrieval_scope(chunk_type),
+        )
+        return self._apply_temporal_filter(typed, question)
+
     def build_rag_context(
         self,
         question: str,
@@ -968,6 +987,9 @@ class Searcher:
             if self._config.reranker_model:
                 retrieve_k = max(retrieve_k, self._config.rerank_candidates)
             results = self.search(retrieval_query, top_k=retrieve_k, chunk_type=chunk_type)
+            if rewrite is not None:
+                typed_results = self._search_typed_arm(question, retrieve_k, chunk_type)
+                results = fuse_ranked_lists([results, typed_results])
             results = filter_results(
                 results, self._config.max_distance, self._config.min_relevance_score
             )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3156,6 +3156,49 @@ class TestTypedRewriteFusion:
         probed = [c[0][0] for c in mock_svc.store.bm25_probe.call_args_list]
         assert "it" in probed
 
+    def test_typed_arm_drops_structural_chunk(self, mock_svc):
+        """With the structural filter on, a TOC the typed arm surfaced is
+        dropped like the rewrite arm's."""
+        cfg.filter_structural_chunks = True
+        toc = "A. Summary ......... 1\nB. Intro ......... 3\nC. Trends ......... 9\n"
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            "when was the Split Rock lighthouse journal written",
+            [_make_result(source="rewrite.md", chunk="rewrite evidence")],
+            [
+                _make_result(source="typed.md", chunk="typed evidence"),
+                _make_result(source="toc.md", chunk=toc),
+            ],
+        )
+        assert rag is not None
+        assert "toc.md" not in {r.source for r in rag.results}
+        assert "typed.md" in {r.source for r in rag.results}
+
+    def test_high_relevance_threshold_drops_single_query_rows(self, mock_svc):
+        """Fused single-query rows score at most their query share (0.5 for
+        two queries), so a threshold above that drops each query's winner
+        and only a row both queries found survives."""
+        cfg.min_relevance_score = 0.6
+        rewritten = "when was the Split Rock lighthouse journal written"
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            rewritten,
+            [_make_result(source="rewrite.md", chunk="rewrite evidence")],
+            [_make_result(source="typed.md", chunk="typed evidence")],
+        )
+        assert rag is None
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            rewritten,
+            [_make_result(source="both.md", chunk="shared evidence")],
+            [_make_result(source="both.md", chunk="shared evidence")],
+        )
+        assert rag is not None
+        assert [r.source for r in rag.results] == ["both.md"]
+
     def test_wiki_scope_refuses_the_typed_arm(self, mock_svc):
         """A disabled wiki serves nothing on either arm: the typed arm honors
         the same scope guard as the main search."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2855,7 +2855,8 @@ class TestHistoryCondensation:
             cfg.query_expansion_count = 3
         assert rag is not None
         messages = rag.messages
-        assert mock_svc.store.search.call_args[1]["query_text"] == rewritten
+        texts = [c[1]["query_text"] for c in mock_svc.store.search.call_args_list]
+        assert texts == [rewritten, "and when was it written?"]
         assert "and when was it written?" in messages[-1]["content"]
         assert rewritten not in messages[-1]["content"]
 
@@ -2907,7 +2908,8 @@ class TestHistoryCondensation:
         finally:
             cfg.query_expansion_count = 3
         expected = "when was the Split Rock journal written"
-        assert mock_svc.store.search.call_args[1]["query_text"] == expected
+        texts = [c[1]["query_text"] for c in mock_svc.store.search.call_args_list]
+        assert texts == [expected, "and when was it written?"]
 
     def test_context_carries_the_rewrite(self, mock_svc):
         """The query retrieval actually ran is on the context, so a client can
@@ -3037,6 +3039,136 @@ class TestHistoryCondensation:
         )
         assert rewritten == "standalone question"
         assert mock_svc.provider.chat.call_args.kwargs["options"]["think"] is False
+
+
+class TestTypedRewriteFusion:
+    """A rewrite that absorbed conversation context must not crowd out the
+    typed question's own retrieval: the turn searches both and fuses."""
+
+    _HISTORY: ClassVar[list[dict[str, str]]] = [
+        {"role": "user", "content": "who kept the lighthouse journal at Split Rock"},
+        {"role": "assistant", "content": "It was kept by E. Larsen [1]."},
+    ]
+
+    @pytest.fixture(autouse=True)
+    def _rewrite_on(self, monkeypatch):
+        monkeypatch.setattr(cfg, "history_rewrite", True)
+        monkeypatch.setattr(cfg, "query_expansion_count", 0)
+
+    def _build(self, mock_svc, question, rewritten, rewrite_rows, typed_rows, **kwargs):
+        mock_svc.provider.chat.return_value = _text_result(rewritten)
+        mock_svc.store.search.side_effect = [rewrite_rows, typed_rows]
+        return get_services().searcher.build_rag_context(
+            question, history=list(self._HISTORY), **kwargs
+        )
+
+    def test_both_rankings_reach_the_context(self, mock_svc):
+        rewritten = "when was the Split Rock lighthouse journal written"
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            rewritten,
+            [_make_result(source="rewrite.md", chunk="rewrite evidence")],
+            [_make_result(source="typed.md", chunk="typed evidence")],
+        )
+        assert rag is not None
+        assert {r.source for r in rag.results} == {"rewrite.md", "typed.md"}
+        assert rag.retrieval_query == rewritten
+
+    def test_typed_winner_survives_on_its_own_evidence(self, mock_svc):
+        """The same chunk far from the rewrite but close to the typed
+        question keeps the close distance through the fuse, so the relevance
+        filter judges it on the evidence that found it."""
+        rewritten = "when was the Split Rock lighthouse journal written"
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            rewritten,
+            [_make_result(source="drift.md", chunk="drifted passage", distance=0.7)],
+            [_make_result(source="drift.md", chunk="drifted passage", distance=0.2)],
+        )
+        assert rag is not None
+        assert [r.source for r in rag.results] == ["drift.md"]
+        assert rag.results[0].distance == pytest.approx(0.2)
+
+    def test_typed_arm_makes_no_llm_call(self, mock_svc):
+        self._build(
+            mock_svc,
+            "and when was it written?",
+            "when was the Split Rock lighthouse journal written",
+            [_make_result()],
+            [_make_result(source="typed.md", chunk="typed evidence")],
+        )
+        assert mock_svc.provider.chat.call_count == 1
+
+    def test_silent_rewrite_arm_keeps_typed_results(self, mock_svc):
+        """A rewrite that retrieves nothing no longer refuses the turn when
+        the typed question matches."""
+        rewritten = "when was the Split Rock lighthouse journal written"
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            rewritten,
+            [],
+            [_make_result(source="typed.md", chunk="typed evidence")],
+        )
+        assert rag is not None
+        assert [r.source for r in rag.results] == ["typed.md"]
+        assert rag.retrieval_query == rewritten
+
+    def test_silent_typed_arm_keeps_rewrite_results(self, mock_svc):
+        rewritten = "when was the Split Rock lighthouse journal written"
+        rag = self._build(
+            mock_svc,
+            "and when was it written?",
+            rewritten,
+            [_make_result(source="rewrite.md", chunk="rewrite evidence")],
+            [],
+        )
+        assert rag is not None
+        assert [r.source for r in rag.results] == ["rewrite.md"]
+
+    def test_no_rewrite_searches_once(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result()]
+        rag = get_services().searcher.build_rag_context(
+            "who designed the Split Rock lighthouse?", history=list(self._HISTORY)
+        )
+        assert rag is not None
+        assert mock_svc.store.search.call_count == 1
+        assert mock_svc.store.search.call_args[1]["query_text"] == (
+            "who designed the Split Rock lighthouse?"
+        )
+
+    def test_structured_prefix_routes_the_typed_arm(self, mock_svc):
+        """A mode prefix on the typed question reaches the typed arm's own
+        search rather than polluting it as literal text."""
+        term_row = _make_result(source="term.md", chunk="term evidence", bm25_score=9.0)
+        mock_svc.store.bm25_probe.return_value = [term_row]
+        rag = self._build(
+            mock_svc,
+            "term:it",
+            "who kept the lighthouse journal",
+            [_make_result(source="rewrite.md", chunk="rewrite evidence")],
+            [],
+        )
+        assert rag is not None
+        assert {r.source for r in rag.results} == {"rewrite.md", "term.md"}
+        probed = [c[0][0] for c in mock_svc.store.bm25_probe.call_args_list]
+        assert "it" in probed
+
+    def test_wiki_scope_refuses_the_typed_arm(self, mock_svc):
+        """A disabled wiki serves nothing on either arm: the typed arm honors
+        the same scope guard as the main search."""
+        mock_svc.provider.chat.return_value = _text_result(
+            "when was the Split Rock lighthouse journal written"
+        )
+        rag = get_services().searcher.build_rag_context(
+            "and when was it written?",
+            history=list(self._HISTORY),
+            chunk_type=ChunkType.WIKI,
+        )
+        assert rag is None
+        assert mock_svc.store.search.call_count == 0
 
 
 class TestAskRawWithReranker:

--- a/tests/test_store_fusion.py
+++ b/tests/test_store_fusion.py
@@ -6,6 +6,7 @@ from lilbee.data.store import SearchChunk
 from lilbee.data.store.fusion import (
     adaptive_weight_scale,
     fuse_arms,
+    fuse_ranked_lists,
     normalized_bm25,
     vector_similarity,
 )
@@ -374,3 +375,80 @@ class TestTitleArmFusion:
         high = fuse_arms([], [], [_chunk("t.md", 0, bm25=3.0)], title_weight=1.0)
         assert low[0].score < high[0].score
         assert high[0].score == pytest.approx(1.0 / 3.0)
+
+
+class TestFuseRankedLists:
+    """RRF over per-query rankings: the typed question's own retrieval fused
+    with the condensed rewrite's, so drift cannot crowd out the question."""
+
+    def test_no_lists_fuses_to_nothing(self):
+        assert fuse_ranked_lists([]) == []
+        assert fuse_ranked_lists([[], []]) == []
+
+    def test_top_of_both_queries_scores_one(self):
+        fused = fuse_ranked_lists(
+            [[_chunk("a.md", 0, distance=0.3)], [_chunk("a.md", 0, distance=0.2)]]
+        )
+        assert len(fused) == 1
+        assert fused[0].score == pytest.approx(1.0)
+
+    def test_single_live_list_is_not_demoted(self):
+        live = [_chunk("a.md", 0, distance=0.2), _chunk("b.md", 0, distance=0.4)]
+        fused = fuse_ranked_lists([live, []])
+        assert [r.source for r in fused] == ["a.md", "b.md"]
+        assert fused[0].score == pytest.approx(1.0)
+
+    def test_consensus_beats_single_query_support(self):
+        both = _chunk("both.md", 0, distance=0.4)
+        single = _chunk("single.md", 0, distance=0.2)
+        fused = fuse_ranked_lists([[single, both], [both]])
+        scores = {r.source: r.score for r in fused}
+        assert scores["both.md"] > scores["single.md"]
+
+    def test_single_query_head_outranks_deep_other_query_tail(self):
+        """Each query's winner stays visible: a rank-1 row from one query
+        outranks rows the other query buried."""
+        head = _chunk("head.md", 0, distance=0.2)
+        tail = [_chunk("tail.md", i, distance=0.5) for i in range(10)]
+        fused = fuse_ranked_lists([[head], tail])
+        assert fused[0].source == "head.md"
+
+    def test_closest_distance_wins(self):
+        fused = fuse_ranked_lists(
+            [
+                [_chunk("a.md", 0, distance=0.8, bm25=5.0)],
+                [_chunk("a.md", 0, distance=0.2)],
+            ]
+        )
+        assert fused[0].distance == pytest.approx(0.2)
+        assert fused[0].bm25_score == pytest.approx(5.0)
+
+    def test_farther_duplicate_keeps_the_seen_distance(self):
+        fused = fuse_ranked_lists(
+            [[_chunk("a.md", 0, distance=0.2)], [_chunk("a.md", 0, distance=0.8)]]
+        )
+        assert fused[0].distance == pytest.approx(0.2)
+
+    def test_missing_distance_keeps_the_other(self):
+        fused = fuse_ranked_lists([[_chunk("a.md", 0, distance=0.3)], [_chunk("a.md", 0)]])
+        assert fused[0].distance == pytest.approx(0.3)
+
+    def test_distance_fills_in_when_first_copy_lacks_it(self):
+        fused = fuse_ranked_lists([[_chunk("a.md", 0)], [_chunk("a.md", 0, distance=0.4)]])
+        assert fused[0].distance == pytest.approx(0.4)
+
+    def test_lexical_support_unions(self):
+        fused = fuse_ranked_lists(
+            [[_chunk("a.md", 0, distance=0.3)], [_chunk("a.md", 0, bm25=9.0)]]
+        )
+        assert fused[0].bm25_score == pytest.approx(9.0)
+        assert fused[0].distance == pytest.approx(0.3)
+
+    def test_rank_order_ignores_score_magnitude(self):
+        """Each list's incoming scores never enter the fusion: ranks alone decide."""
+        first = _chunk("first.md", 0, distance=0.9)
+        first.score = 0.01
+        second = _chunk("second.md", 0, distance=0.1)
+        second.score = 0.99
+        fused = fuse_ranked_lists([[first, second], []])
+        assert [r.source for r in fused] == ["first.md", "second.md"]

--- a/tests/test_store_fusion.py
+++ b/tests/test_store_fusion.py
@@ -405,13 +405,14 @@ class TestFuseRankedLists:
         scores = {r.source: r.score for r in fused}
         assert scores["both.md"] > scores["single.md"]
 
-    def test_single_query_head_outranks_deep_other_query_tail(self):
-        """Each query's winner stays visible: a rank-1 row from one query
-        outranks rows the other query buried."""
+    def test_single_query_head_outscores_deep_other_query_tail(self):
+        """A rank-1 row outscores rows the other query buried deep."""
         head = _chunk("head.md", 0, distance=0.2)
         tail = [_chunk("tail.md", i, distance=0.5) for i in range(10)]
         fused = fuse_ranked_lists([[head], tail])
-        assert fused[0].source == "head.md"
+        scores = {(r.source, r.chunk_index): r.score or 0.0 for r in fused}
+        assert scores[("head.md", 0)] == pytest.approx(0.5)
+        assert scores[("head.md", 0)] > scores[("tail.md", 9)]
 
     def test_closest_distance_wins(self):
         fused = fuse_ranked_lists(


### PR DESCRIPTION
## Problem

A follow-up rewrite that absorbed conversation context was the only query retrieval ran. The typed question's own evidence never entered the pool, so the turn answered from the drift.

## Solution

A rewritten turn now searches both the rewrite and the typed question and fuses the two rankings by reciprocal rank. The typed search is one extra lookup with no extra LLM call. A passage found by both keeps its closest distance and any lexical match, so each query's winner survives distance filtering on its own evidence. Turns without a rewrite search once, exactly as before.