### PR TITLE
Rebuild FTS files pruned by the vector-path optimize

### DIFF
--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -881,6 +881,9 @@ class Store:
             if _has_vector_index(table):
                 table.optimize()
                 log.debug("Vector index optimized on '%s'", CHUNKS_TABLE)
+                if self._fts_index_dangling(table):
+                    # Re-register in the same step when the prune dropped the FTS files.
+                    self._rebuild_fts(table, "its files are missing after optimize()")
                 return True
             if not force and (threshold <= 0 or table.count_rows() < threshold):
                 return False

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1279,6 +1279,36 @@ class TestEnsureVectorIndex:
             assert store.ensure_vector_index() is True
         optimize_spy.assert_called_once()
 
+    def test_optimize_rebuilds_fts_when_vector_path_prunes_it(self, store, test_config):
+        """The vector path optimizes the same chunks table every sync, so a prune
+        that drops the FTS files there must re-register in the same step.
+
+        The prune is simulated; the producer of the dangling index is not confirmed."""
+        import shutil
+
+        from lilbee.core.config import CHUNKS_TABLE
+
+        test_config.ann_index_threshold = 50
+        store.add_chunks(_make_indexable_records(self._INDEXABLE, test_config.embedding_dim))
+        store.ensure_fts_index()
+        store.ensure_vector_index()
+        table = store.open_table("chunks")
+        assert table is not None
+
+        indices_dir = test_config.lancedb_dir / f"{CHUNKS_TABLE}.lance" / "_indices"
+
+        def _optimize_then_prune():
+            for d in indices_dir.iterdir():
+                shutil.rmtree(d)
+
+        with (
+            mock.patch.object(type(table), "optimize", side_effect=_optimize_then_prune),
+            mock.patch.object(type(store), "_rebuild_fts") as rebuild_spy,
+        ):
+            assert store.ensure_vector_index() is True
+
+        rebuild_spy.assert_called_once()
+
     def test_build_failure_warns_and_returns_false(self, store, test_config, caplog):
         """bb-con: a real ANN build failure at scale is surfaced as a warning with
         the flat-search impact, not swallowed at debug."""


### PR DESCRIPTION
## Problem

Each sync that indexes compacts the chunks table twice, once on the text path and once on the vector path. Only the text path checks whether the compaction deleted the text index files and rebuilds them in the same step. A deletion on the vector path leaves the text index registered without files until some later pass rebuilds it.

## Solution

The vector path now runs the same missing-files check after compaction and rebuilds in the same locked step. Both compaction sites on the chunks table pair a deletion with its re-registration.

## Notes

The producer stays unconfirmed. A forced prune against a current-format fixture writes a new index directory and moves the registration to it instead of stranding it, so that arm does not reproduce. A legacy-format fixture could not be verified through the public index metadata, so that arm stays open.