### PR TITLE
Expose the next catalog offset to clients

### DIFF
--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -487,6 +487,7 @@ async def models_catalog(
         limit=limit,
         offset=offset,
         has_more=result.has_more,
+        next_offset=offset + limit if result.has_more else None,
         models=hosted[offset : offset + limit] + native_rows,
     )
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -405,13 +405,18 @@ class CatalogEntryResponse(BaseModel):
 
 
 class ModelsCatalogResponse(BaseModel):
-    """Response for GET /api/models/catalog."""
+    """Response for GET /api/models/catalog.
+
+    ``next_offset`` names the offset to request next, None on the last page, so
+    a short filtered page never strands the client.
+    """
 
     total: int | None
     limit: int
     offset: int
     models: list[CatalogEntryResponse]
     has_more: bool = False
+    next_offset: int | None
 
 
 class InstalledModelEntry(BaseModel):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -3085,6 +3085,31 @@ class TestModelsCatalog:
         assert result.has_more is True
 
     @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_next_offset_advances_past_an_empty_page(self, mock_get_catalog, mock_svc):
+        """An empty page with rows behind it still names the next offset."""
+        from lilbee.catalog import CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=None, limit=20, offset=0, models=[], has_more=True
+        )
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog(task="chat", limit=20, offset=0)
+        assert result.models == []
+        assert result.next_offset == 20
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_next_offset_is_none_on_the_last_page(self, mock_get_catalog, mock_svc):
+        """The last page reports no next offset."""
+        from lilbee.catalog import CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=None, limit=20, offset=20, models=[], has_more=False
+        )
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog(task="chat", limit=20, offset=20)
+        assert result.next_offset is None
+
+    @patch("lilbee.server.handlers.models.get_catalog")
     async def test_installed_reflects_registry_not_routing_provider(
         self, mock_get_catalog, mock_svc
     ):


### PR DESCRIPTION
## Problem
A filtered catalog page can be empty while more rows wait behind it. A client that advances by rows received re-requests the same offset and stalls.

## Solution
The browse response now carries the next offset, computed by the server. Clients follow it instead of doing arithmetic. The route is GET /api/models/catalog and the response field is next_offset: the offset to request next, null on the last page. The plugin change that reads it ships separately.