### PR TITLE
Score single-character terms in retrieval

### DIFF
--- a/src/lilbee/retrieval/query/tokenize.py
+++ b/src/lilbee/retrieval/query/tokenize.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import math
 import re
 
-_MIN_TOKEN_LEN = 2
+_MIN_TOKEN_LEN = 1
 _TOKEN_SPLIT_RE = re.compile(r"\W+")
+
+# A single-character match counts at most this much: enough to prefer the
+# chunk naming the subject (C, R, W-2), too little for a stray contraction
+# splinter to outrank a distinctive longer term.
+_SINGLE_CHAR_MAX_WEIGHT = 1.0
 
 
 def _tokenize(text: str) -> list[str]:
@@ -24,10 +29,18 @@ def _idf_weights(
     of Term Specificity and Its Application in Retrieval", Journal of
     Documentation 28:11-21. Terms that appear in every chunk collapse to
     zero weight, so corpus-specific stopwords are filtered automatically.
+    Single-character terms are capped, since a rare one-letter fragment
+    would otherwise outrank a distinctive longer term.
     """
     n = len(chunk_tokens)
     df: dict[str, int] = {}
     for tokens in chunk_tokens:
         for term in tokens & question_terms:
             df[term] = df.get(term, 0) + 1
-    return {t: max(0.0, math.log(n / (1 + df.get(t, 0)))) for t in question_terms}
+    weights: dict[str, float] = {}
+    for term in question_terms:
+        weight = max(0.0, math.log(n / (1 + df.get(term, 0))))
+        if len(term) <= _MIN_TOKEN_LEN:
+            weight = min(weight, _SINGLE_CHAR_MAX_WEIGHT)
+        weights[term] = weight
+    return weights

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -746,6 +746,14 @@ class TestExpandQuery:
         assert len(variants) == 2
         mock_svc.provider.chat.assert_called_once()
 
+    def test_counts_single_character_terms_for_short_query(self, mock_svc):
+        # "R" is query content, so a 3-token query with a single-character
+        # subject runs LLM expansion instead of skipping as short.
+        mock_svc.provider.chat.return_value = _text_result("v one\nv two")
+        variants = get_services().searcher._expand_query("R intro guide", self._QUESTION_VEC)
+        assert len(variants) == 2
+        mock_svc.provider.chat.assert_called_once()
+
     def test_short_threshold_zero_disables_skip(self, mock_svc):
         old = cfg.expansion_short_query_tokens
         cfg.expansion_short_query_tokens = 0
@@ -1649,6 +1657,45 @@ class TestSelectContext:
         )
         assert len(result) == 1
         assert result[0].source == "a.md"
+
+    def test_single_character_subject_selects_naming_chunk(self, mock_svc):
+        chunks = [
+            _make_result(chunk="Python programming tutorial", source="a.md"),
+            _make_result(chunk="R programming guide", source="b.md"),
+            _make_result(chunk="unrelated filler words here", source="c.md"),
+        ]
+        result = get_services().searcher.select_context(
+            chunks, "What about R programming?", max_sources=1
+        )
+        assert [r.source for r in result] == ["b.md"]
+
+    def test_hyphenated_identifier_selects_naming_chunk(self, mock_svc):
+        chunks = [
+            _make_result(chunk="the reimbursement was issued yesterday", source="a.md"),
+            _make_result(chunk="the W-2 was issued in January", source="b.md"),
+            _make_result(chunk="unrelated filler words here", source="c.md"),
+        ]
+        result = get_services().searcher.select_context(
+            chunks, "When was the W-2 issued?", max_sources=1
+        )
+        assert [r.source for r in result] == ["b.md"]
+
+    def test_capped_fragment_loses_to_distinctive_term(self, mock_svc):
+        # The contraction splinter "s" is exactly as rare as "deploy", so its
+        # raw IDF ties; only the single-character cap breaks the tie. The
+        # noise chunk ranks first so a tie would select it.
+        chunks = [
+            _make_result(chunk="model's readme guide", source="noise.md"),
+            _make_result(chunk="deploy checklist notes", source="deploy.md"),
+            _make_result(chunk="alpha beta gamma delta", source="f1.md"),
+            _make_result(chunk="kappa lambda mu nu", source="f2.md"),
+            _make_result(chunk="oak pine birch cedar", source="f3.md"),
+            _make_result(chunk="ember quartz flint shale", source="f4.md"),
+        ]
+        result = get_services().searcher.select_context(
+            chunks, "What's the deploy status", max_sources=1
+        )
+        assert [r.source for r in result] == ["deploy.md"]
 
 
 class TestShouldSkipExpansion:

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,0 +1,30 @@
+"""Tests for the RAG query tokenizer and IDF weights."""
+
+import math
+
+import pytest
+
+from lilbee.retrieval.query.tokenize import _idf_weights, _tokenize
+
+
+class TestTokenize:
+    def test_keeps_single_character_terms(self) -> None:
+        assert "c" in _tokenize("How do I use C for this?")
+
+    def test_keeps_hyphen_split_letters_and_digits(self) -> None:
+        assert _tokenize("W-2") == ["w", "2"]
+
+    def test_drops_empty_fragments(self) -> None:
+        assert _tokenize("") == []
+        assert _tokenize("...") == []
+
+
+class TestIdfWeights:
+    def test_caps_single_character_weight(self) -> None:
+        weights = _idf_weights({"s", "deploy"}, [{"deploy"}, set(), set(), set(), set(), set()])
+        assert weights["s"] == pytest.approx(1.0)
+        assert weights["deploy"] == pytest.approx(math.log(6 / 2))
+
+    def test_leaves_small_single_character_weight_uncapped(self) -> None:
+        weights = _idf_weights({"r"}, [{"r"}, {"other"}, {"filler"}])
+        assert weights["r"] == pytest.approx(math.log(3 / 2))


### PR DESCRIPTION
## Problem

The query tokenizer drops every one-letter token before scoring, so a question about the C language, R, or a W-2 ranks on its generic words alone. The chunk naming the subject has no term to match on.

## Solution

One-letter tokens now reach term weighting with a capped weight. The cap sits below a distinctive longer term, so the naming chunk wins ties while a stray contraction splinter cannot dominate. Short-query expansion counts the kept tokens.

On a three-question fixture (W-2, C, R), context selection moved from the wrong chunk to the naming chunk in all three cases.

## Notes

The tradeoff: a query whose longer terms are all ubiquitous can still tilt on a capped fragment. The cap keeps that tilt small.
