### PR TITLE
Report sources shed by the context fit

### DIFF
--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -330,6 +330,7 @@ def ask(
                     "sources": [clean_result(s) for s in result.sources],
                     "cited_sources": [clean_result(s) for s in result.cited_sources],
                     "retrieval_query": result.retrieval_query,
+                    "dropped_sources": [clean_result(s) for s in result.dropped_sources],
                 }
             )
             return

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -218,12 +218,15 @@ class AskResult(BaseModel):
     consumer can tell whether the answer was grounded without re-parsing the text.
     ``retrieval_query`` carries the follow-up rewrite retrieval ran on, or ``None``
     when the question as typed was searched.
+    ``dropped_sources`` names the chunks the budget fit shed, so a caller can say
+    what went in and what was trimmed.
     """
 
     answer: str
     sources: list[SearchChunk]
     cited_sources: list[SearchChunk] = Field(default_factory=list)
     retrieval_query: str | None = None
+    dropped_sources: list[SearchChunk] = Field(default_factory=list)
 
 
 class StructuredQuery(NamedTuple):
@@ -242,12 +245,16 @@ class RagContext(NamedTuple):
 
     ``retrieval_query`` is the standalone rewrite retrieval ran on, set only when
     it replaced the question as typed.
+
+    ``dropped`` names the chunks the budget fit shed, so a caller can say what
+    went in and what was trimmed. ``None`` when no fit ran.
     """
 
     results: list[SearchChunk]
     messages: list[ChatMessage]
     base_results: list[SearchChunk] | None = None
     retrieval_query: str | None = None
+    dropped: list[SearchChunk] | None = None
 
 
 class Searcher:
@@ -1004,7 +1011,7 @@ class Searcher:
         system = self._system_with_memory(self._config.rag_system_prompt, question)
         base_results = list(results)
         budget = self._context_budget(system, question, history, scale)
-        results, used = self._fit_to_budget(results, budget)
+        results, used, dropped = self._fit_to_budget(results, budget)
         results = self._widen_with_neighbors(results, max(0, budget - used))
         context = build_context(results)
         prompt = CONTEXT_TEMPLATE.format(context=context, question=question)
@@ -1012,7 +1019,7 @@ class Searcher:
         if history:
             messages.extend(history)
         messages.append({"role": "user", "content": prompt})
-        return RagContext(results, messages, base_results, retrieval_query)
+        return RagContext(results, messages, base_results, retrieval_query, dropped)
 
     def _context_budget(
         self,
@@ -1045,32 +1052,36 @@ class Searcher:
 
     def _fit_to_budget(
         self, results: list[SearchChunk], budget: int
-    ) -> tuple[list[SearchChunk], int]:
-        """Fit *results* into *budget*: the kept sources and the tokens they cost.
+    ) -> tuple[list[SearchChunk], int, list[SearchChunk]]:
+        """Fit *results* into *budget*: kept sources, tokens spent, dropped sources.
 
         ``max_context_sources`` caps by count; this caps by tokens so a
         retrieval-heavy query degrades gracefully instead of erroring with
-        CONTEXT_OVERFLOW. The top-ranked source is always kept.
+        CONTEXT_OVERFLOW. The top-ranked source is always kept. A chunk that
+        does not fit is skipped rather than terminal, so later smaller chunks
+        still fill the remaining budget in rank order.
 
         Returning the spent total lets the caller derive the leftover for
         neighbor expansion instead of re-deriving the same per-chunk cost, so
         the two stages cannot drift apart on the accounting.
         """
         kept: list[SearchChunk] = []
+        dropped: list[SearchChunk] = []
         used = 0
         for r in results:
             cost = estimate_budget_tokens(r.chunk) + _PER_SOURCE_TOKENS
             if kept and used + cost > budget:
-                break
+                dropped.append(r)
+                continue
             kept.append(r)
             used += cost
-        if len(kept) < len(results):
+        if dropped:
             log.info(
                 "Kept %d of %d sources to fit the model context window.",
                 len(kept),
                 len(results),
             )
-        return kept, used
+        return kept, used, dropped
 
     def _widen_with_neighbors(self, results: list[SearchChunk], leftover: int) -> list[SearchChunk]:
         """Widen each fitted passage with adjacent same-source chunks.
@@ -1373,6 +1384,7 @@ class Searcher:
         if rag is None:
             return AskResult(answer=GROUNDED_REFUSAL, sources=[])
         results, messages = rag.results, rag.messages
+        dropped = rag.dropped or []
         opts = options if options is not None else self._config.generation_options()
         try:
             result = self._provider.chat(
@@ -1393,6 +1405,7 @@ class Searcher:
                 scale=_OVERFLOW_RETRY_SCALE,
             )
             results, messages = retry.results, retry.messages
+            dropped = retry.dropped or []
             result = self._provider.chat(
                 self._messages_for_provider(messages), options=opts or None
             )
@@ -1405,6 +1418,7 @@ class Searcher:
             sources=results,
             cited_sources=cited_subset(strip_llm_citations(clean), results),
             retrieval_query=rag.retrieval_query,
+            dropped_sources=dropped,
         )
 
     def ask(

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -164,6 +164,7 @@ async def ask(
         sources=[CleanedChunk(**clean_result(s)) for s in result.sources],
         cited_sources=[CleanedChunk(**clean_result(s)) for s in result.cited_sources],
         retrieval_query=result.retrieval_query,
+        dropped_sources=[CleanedChunk(**clean_result(s)) for s in result.dropped_sources],
     )
 
 
@@ -507,6 +508,7 @@ async def chat(
     history, compaction = await asyncio.to_thread(_manage_history, history, summary)
     _persist_summary(session_id, compaction)
     retrieval_query: str | None = None
+    dropped: list[SearchChunk] = []
     if _retrieval_off(searcher, top_k):
         # Chat-only mode or an explicit top_k:0 pure-LLM call.
         sources: list[SearchChunk] = []
@@ -530,6 +532,7 @@ async def chat(
             )
         sources, messages = rag.results, rag.messages
         retrieval_query = rag.retrieval_query
+        dropped = rag.dropped or []
     req = _build_canonical_request(messages, options)
     response = await asyncio.to_thread(dispatch_chat, req)
     text = _join_text_blocks(response.content)
@@ -552,6 +555,7 @@ async def chat(
         ],
         compaction=compaction,
         retrieval_query=retrieval_query,
+        dropped_sources=[CleanedChunk(**clean_result(s)) for s in dropped],
     )
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -296,6 +296,8 @@ class AskResponse(BaseModel):
     """Set when a /api/chat turn compacted its history before answering."""
     retrieval_query: str | None = None
     """The standalone rewrite retrieval ran on, when a follow-up was rewritten."""
+    dropped_sources: list[CleanedChunk] = Field(default_factory=list)
+    """Chunks the budget fit shed, so a client can say what was trimmed."""
 
 
 class SetModelResponse(BaseModel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2420,6 +2420,31 @@ class TestAskJson:
         assert data["retrieval_query"] == "when was the journal written"
 
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_json_carries_dropped_sources(self, mock_sync, mock_svc):
+        from lilbee.data.store import SearchChunk
+        from lilbee.retrieval.query import AskResult
+
+        shed = SearchChunk(
+            source="shed.pdf",
+            content_type="pdf",
+            chunk="trimmed",
+            page_start=1,
+            page_end=1,
+            line_start=0,
+            line_end=0,
+            chunk_index=3,
+            vector=[0.1],
+        )
+        mock_svc.searcher.ask_raw.return_value = AskResult(
+            answer="42 [1]", sources=[], dropped_sources=[shed]
+        )
+        result = runner.invoke(app, ["--json", "ask", "what?"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert [s["source"] for s in data["dropped_sources"]] == ["shed.pdf"]
+        assert "vector" not in data["dropped_sources"][0]
+
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_json_no_results(self, mock_sync, mock_svc):
         from lilbee.retrieval.query import AskResult
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1028,6 +1028,35 @@ class TestContextBudget:
             _fit(results)
         assert "to fit the model context window" in caplog.text
 
+    def test_fit_skips_an_over_budget_chunk_for_a_later_fittable_one(self, mock_svc):
+        """A small chunk ranked below a large one still fills the budget; the
+        skipped chunk is reported as dropped, not silently lost."""
+        searcher = get_services().searcher
+        small, huge = "x" * 100, "x" * 9000
+        results = [
+            _make_result(source="a.pdf", chunk=small),
+            _make_result(source="b.pdf", chunk=huge),
+            _make_result(source="c.pdf", chunk=small),
+        ]
+        one = estimate_budget_tokens(small) + _PER_SOURCE_TOKENS
+        kept, used, dropped = searcher._fit_to_budget(results, one * 2)
+        assert [r.source for r in kept] == ["a.pdf", "c.pdf"]
+        assert [r.source for r in dropped] == ["b.pdf"]
+        assert used == one * 2
+
+    def test_finalize_reports_dropped_sources_on_the_context(self, mock_svc):
+        """The shed chunks land on the context with their identities, so a
+        caller can say what went in and what was trimmed."""
+        cfg.num_ctx = 1400
+        searcher = get_services().searcher
+        results = [_make_result(source=f"{i}.pdf", chunk="x" * 300) for i in range(5)]
+        rag = searcher._finalize_context(results, "q", None)
+        kept = {r.source for r in rag.results}
+        dropped = {r.source for r in rag.dropped or []}
+        assert dropped, "a tight budget must shed sources and say so"
+        assert kept.isdisjoint(dropped)
+        assert kept | dropped == {f"{i}.pdf" for i in range(5)}
+
 
 class TestNeighborExpansion:
     """Selected chunks widen with adjacent same-source chunks at answer time."""
@@ -1142,7 +1171,7 @@ class TestNeighborExpansion:
 
         searcher = get_services().searcher
         budget = searcher._context_budget(system, question, None, 1.0)
-        fitted, used = searcher._fit_to_budget(base, budget)
+        fitted, used, _ = searcher._fit_to_budget(base, budget)
         widened = searcher._widen_with_neighbors(fitted, max(0, budget - used))
 
         # Non-vacuous: at least one neighbor was actually merged in.
@@ -1166,6 +1195,22 @@ class TestAskRaw:
         assert result.answer == "5 quarts."
         assert len(result.sources) == 1
         assert result.sources[0].source == "test.pdf"
+
+    def test_ask_raw_reports_dropped_sources(self, mock_svc):
+        """A tight budget sheds sources; the answer names what it dropped."""
+        cfg.num_ctx = 1400
+        # Distinct text per source: identical chunks collapse in near-identical
+        # dedup before the budget fit ever sees them.
+        mock_svc.store.search.return_value = [
+            _make_result(source=f"{i}.pdf", chunk=chr(ord("a") + i) * 300) for i in range(5)
+        ]
+        mock_svc.provider.chat.return_value = _text_result("answer")
+        result = get_services().searcher.ask_raw("q")
+        kept = {r.source for r in result.sources}
+        dropped = {r.source for r in result.dropped_sources}
+        assert dropped, "a tight budget must shed sources and say so"
+        assert kept.isdisjoint(dropped)
+        assert kept | dropped == {f"{i}.pdf" for i in range(5)}
 
     def test_a_source_only_named_in_the_models_own_block_is_not_cited(self, mock_svc):
         """cited_sources is the grounding signal JSON callers read, so it must
@@ -2531,6 +2576,28 @@ class TestKnownItemRoute:
         first = mock_svc.provider.chat.call_args_list[0][0][0][-1]["content"]
         second = mock_svc.provider.chat.call_args_list[1][0][0][-1]["content"]
         assert len(second) < len(first)
+
+    def test_overflow_retry_reports_the_tighter_fits_drops(self, mock_svc):
+        """After an overflow refit, kept and dropped partition the retrieved
+        set: every chunk is either in the answer's context or named as shed."""
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        mock_svc.store.get_sources.return_value = [self._source("survey_report.pdf")]
+        mock_svc.store.get_chunks_by_source.return_value = [
+            _make_result(source="survey_report.pdf", chunk="word " * 400, chunk_index=i)
+            for i in range(40)
+        ]
+        mock_svc.provider.served_chat_ctx.return_value = 8192
+        mock_svc.provider.chat.side_effect = [
+            ProviderError("overflow", kind=ProviderErrorKind.CONTEXT_OVERFLOW),
+            _text_result("fits now [1]"),
+        ]
+        result = get_services().searcher.ask_raw("summarize survey_report.pdf")
+        kept = {r.chunk_index for r in result.sources}
+        dropped = {r.chunk_index for r in result.dropped_sources}
+        assert dropped, "the tighter refit must shed chunks and say so"
+        assert kept.isdisjoint(dropped)
+        assert kept | dropped == set(range(40))
 
     def test_budget_falls_back_to_config_when_served_ctx_unknown(self, mock_svc):
         mock_svc.store.get_sources.return_value = [self._source("survey_report.pdf")]

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -565,6 +565,19 @@ class TestAsk:
         result = await handlers.ask("what?")
         assert result.retrieval_query is None
 
+    async def test_dropped_sources_reach_the_response(self, mock_svc):
+        """A budget-trimmed turn reports what it shed, vectors stripped like
+        every other chunk crossing the wire."""
+        from lilbee.retrieval.query import AskResult
+
+        shed = _SAMPLE_CHUNK.model_copy(update={"source": "shed.pdf"})
+        mock_svc.searcher.ask_raw.return_value = AskResult(
+            answer="42 [1]", sources=[_SAMPLE_CHUNK], dropped_sources=[shed]
+        )
+        result = await handlers.ask("what?")
+        assert [s.source for s in result.dropped_sources] == ["shed.pdf"]
+        assert "vector" not in result.dropped_sources[0].model_dump()
+
     async def test_empty_question_raises(self):
         with pytest.raises(ValueError, match="question must not be empty"):
             await handlers.ask("")
@@ -1059,6 +1072,31 @@ class TestChat:
         )
         result = await handlers.chat("and what did he record?", [])
         assert result.retrieval_query == "what did the lighthouse keeper record"
+
+    async def test_grounded_turn_reports_dropped_sources(self, mock_svc, monkeypatch):
+        """A budget-trimmed chat turn reports what the fit shed."""
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalResponse,
+            CanonicalUsage,
+            StopReason,
+            TextBlock,
+        )
+
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat",
+            lambda req: CanonicalResponse(
+                id="msg_test",
+                model=req.model,
+                content=[TextBlock(text="ok")],
+                stop_reason=StopReason.END_TURN,
+                usage=CanonicalUsage(input_tokens=0, output_tokens=0),
+            ),
+        )
+        shed = _SAMPLE_CHUNK.model_copy(update={"source": "shed.pdf"})
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()._replace(dropped=[shed])
+        result = await handlers.chat("what?", [])
+        assert [s.source for s in result.dropped_sources] == ["shed.pdf"]
 
     async def test_ungrounded_turn_carries_no_retrieval_query(self, mock_svc, monkeypatch):
         """A pure-LLM turn runs no retrieval, so there is no query to report."""


### PR DESCRIPTION
## Problem
Over-budget sources vanish behind a log line. A caller cannot tell what went into the answer and what was trimmed, so a document grounding one turn can disappear the next with no signal. A small chunk below a large one never gets considered at all.

## Solution
The context fit now reports what it sheds. One-shot answers, the HTTP ask and chat routes, and JSON ask output carry the trimmed chunks as `dropped_sources` next to the kept ones. The fit also skips past an over-budget chunk instead of stopping, so later smaller chunks still fill the remaining budget in rank order.

## Notes
Stream renderers do not announce the trimmed set yet. That presentation follow-up stays out of scope here.
