### PR TITLE
Route do-you-have counts to the corpus total

### DIFF
--- a/src/lilbee/retrieval/language.py
+++ b/src/lilbee/retrieval/language.py
@@ -116,10 +116,12 @@ ENGLISH = QueryLanguage(
     how_many_pattern=re.compile(
         r"^\s*(?:roughly\s+|approximately\s+|about\s+)?how\s+many\b", re.IGNORECASE
     ),
-    # "how many documents/books/sources are there/indexed": corpus totals.
+    # "how many documents are there/indexed/do you have/have you got": totals.
     total_pattern=re.compile(
         r"how\s+many\s+" + _EN_OF_THESE + _EN_CORPUS_NOUNS + r"\s*"
-        r"(?:are\s+(?:there|indexed|in\s+the\s+index)|do(?:es)?\s+.*\b(?:index|corpus|vault)\b.*)?[?\s]*$",
+        r"(?:are\s+(?:there|indexed|in\s+the\s+index)"
+        r"|(?:do\s+(?:you|i|we)\s+have|have\s+(?:you|i|we)\s+got)"
+        r"|do(?:es)?\s+.*\b(?:index|corpus|vault)\b.*)?[?\s]*$",
         re.IGNORECASE,
     ),
     # "how many X is each Y associated with" / "how many X per Y": typed

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -226,6 +226,35 @@ class TestParseAggregate:
         assert agg is not None
         assert agg.kind is AggregateKind.TOTAL_SOURCES
 
+    @pytest.mark.parametrize(
+        "question",
+        [
+            "how many documents do you have?",
+            "how many files do you have?",
+            "how many documents do I have?",
+            "how many papers do we have?",
+            "how many documents have you got?",
+            "how many sources have I got?",
+        ],
+    )
+    def test_possessive_phrasings_route_to_total(self, question):
+        agg = parse_aggregate(question)
+        assert agg is not None
+        assert agg.kind is AggregateKind.TOTAL_SOURCES
+
+    @pytest.mark.parametrize(
+        "question",
+        [
+            "how many people do you have?",
+            "how many documents do researchers have?",
+            "how many documents do you have about birds?",
+        ],
+    )
+    def test_entity_and_filtered_counts_still_decline(self, question):
+        agg = parse_aggregate(question)
+        assert agg is not None
+        assert agg.kind is AggregateKind.UNSUPPORTED
+
     def test_association_question_parses_both_nouns(self):
         agg = parse_aggregate("how many shipments is each part number associated with?")
         assert agg is not None

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2687,6 +2687,13 @@ class TestAggregateRoute:
         assert "369" in result.answer
         assert "123456" in result.answer
 
+    def test_possessive_total_count_answers_without_llm(self, mock_svc):
+        mock_svc.store.count_sources.return_value = 8
+        mock_svc.store.count_chunks.return_value = 8
+        result = get_services().searcher.ask_raw("how many documents do you have?")
+        assert "8 documents" in result.answer
+        mock_svc.provider.chat.assert_not_called()
+
     def test_typed_count_declines_precisely(self, mock_svc, tmp_path):
         old_dir = cfg.data_dir
         cfg.data_dir = tmp_path / "no_schema_here"


### PR DESCRIPTION
## Problem

The most natural count question, "how many documents do you have?", falls through the deterministic parser to the structured-records decline. The near-identical "are indexed" form answers exactly. A user checking whether their documents landed gets a refusal about entity extraction and concludes the index is broken.

## Solution

The corpus-total pattern now matches possessive tails ("do you have", "have you got", with first-person and plural siblings) after a corpus noun. Counts over entity nouns and filtered counts still decline precisely. Regression tests pin both sides.
