### PR TITLE
Stop the server through its loop instead of a signal

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -392,6 +392,36 @@ def reset_store() -> None:
     old_store.close()
 
 
+class _ServerExit:
+    """Holds the running server's graceful-exit callback while it serves."""
+
+    def __init__(self) -> None:
+        self._hook: Callable[[], None] | None = None
+
+    def set(self, hook: Callable[[], None] | None) -> None:
+        self._hook = hook
+
+    def request(self) -> bool:
+        """Run the hook; False when no server registered one."""
+        if self._hook is None:
+            return False
+        self._hook()
+        return True
+
+
+_server_exit = _ServerExit()
+
+
+def set_server_exit_hook(hook: Callable[[], None] | None) -> None:
+    """Register the running server's graceful-exit callback (None clears it)."""
+    _server_exit.set(hook)
+
+
+def request_server_exit() -> bool:
+    """Ask the running server to exit; False when none registered."""
+    return _server_exit.request()
+
+
 class _EngineLifecycle:
     """Owns the hard-exit hooks that stop the engine fleet."""
 
@@ -423,15 +453,18 @@ class _EngineLifecycle:
     def _on_hard_exit(self, signum: int, frame: object) -> None:
         """Stop the fleet on its own thread, then exit with the signal status.
 
-        Signal handlers all run on the main thread, and a second signal can
-        interrupt this one mid-teardown: the kernel pairs SIGCONT with SIGHUP
-        for an orphaned process group, and Textual's SIGCONT handler raises
-        once the event loop is gone, which aborted the reap half-done and
-        orphaned a loaded fleet. A dedicated non-daemon thread cannot be
-        interrupted by signals, and the interpreter waits for it even as the
-        SystemExit unwinds the main thread.
+        The serving loop is asked to stop first: a SystemExit raised while the
+        main thread runs a request dies inside that request's ASGI wrapper, so
+        the flag stops the loop when the raise cannot reach it. Signal handlers
+        all run on the main thread, and a second signal can interrupt this one
+        mid-teardown: the kernel pairs SIGCONT with SIGHUP for an orphaned
+        process group, and Textual's SIGCONT handler raises once the event loop
+        is gone, which aborted the reap half-done and orphaned a loaded fleet.
+        A dedicated non-daemon thread cannot be interrupted by signals, and the
+        interpreter waits for it even as the SystemExit unwinds the main thread.
         """
         del frame
+        request_server_exit()
         threading.Thread(
             target=_teardown_for_signal, args=(signum,), name=_HARD_EXIT_THREAD_NAME
         ).start()

--- a/src/lilbee/cli/commands/servers.py
+++ b/src/lilbee/cli/commands/servers.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 import typer
 
-from lilbee.app.services import wait_for_hard_exit_teardown
+from lilbee.app.services import set_server_exit_hook, wait_for_hard_exit_teardown
 from lilbee.cli.app import (
     apply_overrides,
     console,
@@ -70,6 +70,9 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
     def _cleanup_port_file() -> None:
         port_path.unlink(missing_ok=True)
 
+    def _request_exit() -> None:
+        server.should_exit = True
+
     if not config.loaded:
         config.load()
     server.lifespan = config.lifespan_class(config)
@@ -80,6 +83,7 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
     started = False
     parent_watcher: asyncio.Task[None] | None = None
     try:
+        set_server_exit_hook(_request_exit)
         await server.startup()
         started = True
 
@@ -100,6 +104,7 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
             console.print(f"Listening on http://{host}:{actual_port}")
         await server.main_loop()
     finally:
+        set_server_exit_hook(None)
         if parent_watcher is not None and not parent_watcher.done():
             parent_watcher.cancel()
         port_path.unlink(missing_ok=True)

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -146,12 +146,12 @@ async def health() -> HealthResponse:
 
 
 async def shutdown() -> ShutdownResponse:
-    """Accept an API-requested stop; the route's background task sends SIGTERM.
+    """Accept an API-requested stop; the route's background task stops the server.
 
     Litestar runs that task only after the response has been handed to the
-    transport, so the signal cannot beat the 202 out and no wall-clock delay
-    has to be guessed. Routing through SIGTERM keeps the fleet teardown and
-    shutdown logging identical however the stop arrives.
+    transport, so the stop cannot beat the 202 out and no wall-clock delay
+    has to be guessed. Stopping through the serving loop keeps teardown
+    ordered; without a loop the task falls back to SIGTERM.
     """
     log.info("Shutdown requested via the API")
     return ShutdownResponse(status="shutting_down")

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -19,6 +19,7 @@ from litestar.response import Stream
 from litestar.status_codes import HTTP_202_ACCEPTED, HTTP_503_SERVICE_UNAVAILABLE
 from pydantic import ValidationError
 
+from lilbee.app.services import request_server_exit
 from lilbee.app.settings import config_write_failure_message
 from lilbee.server import handlers
 from lilbee.server.handlers.sse import SSE_MEDIA_TYPE
@@ -50,18 +51,24 @@ async def status_route() -> StatusResponse:
     return await handlers.status()
 
 
+async def _stop_server() -> None:
+    """Stop the serving loop when one runs; otherwise raise SIGTERM."""
+    if not request_server_exit():
+        signal.raise_signal(signal.SIGTERM)
+
+
 @post("/api/shutdown", status_code=HTTP_202_ACCEPTED)
 async def shutdown_route() -> Response[ShutdownResponse]:
-    """Gracefully stop the server, exactly as an external SIGTERM would.
+    """Gracefully stop the server through its serving loop.
 
-    The signal rides a background task so it is raised after the response has
+    The stop rides a background task so it runs after the response has
     been handed to the transport, rather than after a guessed delay that a
     slow flush could lose.
     """
     return Response(
         await handlers.shutdown(),
         status_code=HTTP_202_ACCEPTED,
-        background=BackgroundTask(signal.raise_signal, signal.SIGTERM),
+        background=BackgroundTask(_stop_server),
     )
 
 

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -242,6 +242,30 @@ class TestRunServer:
 
         assert not (cfg.data_dir / "server.port").exists()
 
+    def test_registers_exit_hook_while_serving(self):
+        """The shutdown route stops this loop; the hook clears on the way out."""
+        from lilbee.app.services import request_server_exit
+        from lilbee.cli.commands.servers import _run_server
+
+        fake_server_obj = mock.MagicMock()
+        fake_server_obj.servers = []
+        fake_server_obj.startup = mock.AsyncMock()
+        fake_server_obj.shutdown = mock.AsyncMock()
+
+        seen: list[bool] = []
+
+        async def capture_hook() -> None:
+            seen.append(request_server_exit())
+
+        fake_server_obj.main_loop = capture_hook
+        fake_config = mock.MagicMock()
+
+        asyncio.run(_run_server(fake_server_obj, fake_config, "127.0.0.1"))
+
+        assert seen == [True]
+        assert fake_server_obj.should_exit is True
+        assert request_server_exit() is False
+
     def test_loads_config_when_not_loaded(self):
         from lilbee.cli.commands.servers import _run_server
 

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -2254,6 +2254,30 @@ class TestShutdownRoute:
             # which a slow flush could lose the race to a wall-clock timer.
             raise_signal.assert_called_once_with(signal_mod.SIGTERM)
 
+    def test_registered_exit_hook_replaces_the_signal(self, client):
+        """A serving loop stops through its own exit flag, not a self-signal.
+
+        Regression: the route raised SIGTERM at its own process, and the
+        handler's SystemExit landed back inside the request's ASGI stack,
+        where uvicorn's BaseException wrapper swallowed it; the server kept
+        serving after the 202.
+        """
+        import signal as signal_mod
+
+        from lilbee.app.services import set_server_exit_hook
+
+        calls: list[None] = []
+        set_server_exit_hook(lambda: calls.append(None))
+        try:
+            with mock.patch.object(signal_mod, "raise_signal") as raise_signal:
+                response = client.post("/api/shutdown")
+                assert response.status_code == 202
+                assert response.json() == {"status": "shutting_down"}
+                assert calls == [None]
+                raise_signal.assert_not_called()
+        finally:
+            set_server_exit_hook(None)
+
 
 class TestPaginationAndTopKLowerBounds:
     """Upper bounds without lower bounds let 0 and negatives through.

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -16,6 +16,7 @@ from lilbee.app.services import (
     peek_services,
     reset_services,
     reset_services_on_exit,
+    set_server_exit_hook,
     set_services,
     wait_for_hard_exit_teardown,
 )
@@ -125,6 +126,20 @@ def test_signal_without_services_still_exits():
     install_engine_lifecycle_hooks()
     with pytest.raises(SystemExit):
         signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+
+
+def test_hard_exit_invokes_the_registered_exit_hook():
+    """A SystemExit swallowed mid-request must still stop the serving loop."""
+    calls: list[None] = []
+    set_server_exit_hook(lambda: calls.append(None))
+    try:
+        install_engine_lifecycle_hooks()
+        with pytest.raises(SystemExit):
+            signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+        _join_teardown()
+    finally:
+        set_server_exit_hook(None)
+    assert calls == [None]
 
 
 def test_cli_entry_point_installs_the_hooks():


### PR DESCRIPTION
## Problem
A shutdown request answered 202 and the server kept serving. The route raised SIGTERM at its own process, and the handler's exit landed back inside the request's own network stack, where the framework's error wrapper caught it and closed only that connection. A pull abort widens the window with teardown churn, but an idle server hangs the same way.

## Solution
The serving loop now exits through its own flag, registered while it serves. Without a loop the route keeps the old signal fallback. The signal handler also trips the flag, so an external stop cannot be swallowed the same way.