### PR TITLE
Move live-Ollama tests off the per-PR job

### DIFF
--- a/.github/actions/ollama-up/action.yml
+++ b/.github/actions/ollama-up/action.yml
@@ -5,6 +5,10 @@ inputs:
   model:
     description: "Ollama model ref to pull (e.g. qwen3:0.6b)."
     required: true
+  version:
+    description: "Ollama version to install (e.g. 0.33.3)."
+    required: false
+    default: "0.33.3"
 
 runs:
   using: composite
@@ -13,7 +17,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        curl -fsSL https://ollama.com/install.sh | sh
+        curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION="${{ inputs.version }}" sh
         # Stop the systemd service install.sh starts: it holds port 11434 as the
         # 'ollama' user, so the daemon below would lose the bind and die.
         sudo systemctl disable --now ollama

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,9 +245,6 @@ jobs:
     # hit the unauthenticated rate limit (429) on the featured-model sweep.
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      # Never below 0.32.2: earlier builds segfault in the Sapphire Rapids CPU
-      # backend on the first inference (ollama#17205).
-      OLLAMA_PIN: "0.33.3"
     strategy:
       fail-fast: false
       matrix:
@@ -324,10 +321,7 @@ jobs:
           # PATH only, deliberately no loader variable: llama-server and every
           # library it pulls in carry RUNPATH $ORIGIN on Linux and LC_RPATH
           # @loader_path on macOS, so the engine resolves its own libraries. A
-          # GITHUB_ENV export would apply to every later step in the job, and
-          # ollama's bundled runner links the same libggml/libllama SONAMEs this
-          # tarball ships, so it would load these instead of its own and
-          # segfault on the model warm-up.
+          # GITHUB_ENV export would apply to every later step in the job.
           if command -v cygpath >/dev/null 2>&1; then
             cygpath -w "${bindir}" >> "${GITHUB_PATH}"
           else
@@ -381,11 +375,6 @@ jobs:
             echo "${helperdir}" >> "${GITHUB_PATH}"
           fi
 
-      # No cache for C:\ollama: the extracted tree (ollama plus its CUDA/ROCm
-      # runner DLLs) was 1.4 GB, the largest entry in the repo, to save a ~1 min
-      # download. Against a hard 10 GB cap it was evicting engine caches worth
-      # ~50 min apiece to a release build.
-
       - name: Install dependencies
         run: uv sync --locked --all-extras
 
@@ -436,200 +425,6 @@ jobs:
       # nothing ever wrote ~/.cache/huggingface/hub. The cache block that used to
       # sit here only churned a key off pyproject.toml and consumed the cap.
 
-      # Linux only, deliberately. The entry is ~750 MB per OS, and the repo cache
-      # sits against a hard 10 GB cap where every GB evicts an engine cache worth
-      # ~50 min to a release build. Windows/macOS re-pull.
-      #
-      # This is the runner's model store, which only works because the step below
-      # stops the daemon that install.sh runs as the 'ollama' user. The v1 entry
-      # was written against that other store and never fed a pull, so start a
-      # fresh key here.
-      - name: Cache Ollama models
-        if: runner.os == 'Linux'
-        uses: actions/cache@v6
-        with:
-          path: ~/.ollama/models
-          key: ollama-models-${{ runner.os }}-qwen3-nomic-v2
-
-      # install.sh also registers a systemd service that runs the daemon as the
-      # 'ollama' user, whose model store is /usr/share/ollama/.ollama/models.
-      # That daemon takes port 11434 first, so the 'ollama serve' below loses the
-      # bind and dies, every pull writes to a store no cache covers, and
-      # OLLAMA_KEEP_ALIVE never reaches the daemon that serves the tests. Stop it
-      # and serve the models ourselves.
-      - name: Install Ollama (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION="${OLLAMA_PIN}" sh
-          sudo systemctl disable --now ollama
-
-      - name: Install Ollama (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          curl -fsSL "https://github.com/ollama/ollama/releases/download/v${OLLAMA_PIN}/Ollama-darwin.zip" -o /tmp/ollama.zip
-          unzip -q /tmp/ollama.zip -d /tmp/ollama
-          sudo mv /tmp/ollama/Ollama.app /Applications/
-          sudo ln -sf /Applications/Ollama.app/Contents/Resources/ollama /usr/local/bin/ollama
-
-      - name: Install Ollama (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://github.com/ollama/ollama/releases/download/v$env:OLLAMA_PIN/ollama-windows-amd64.zip" -OutFile "$env:TEMP\ollama.zip"
-          Expand-Archive "$env:TEMP\ollama.zip" -DestinationPath "C:\ollama" -Force
-
-      # KEEP_ALIVE=-1 pins loaded models in memory: the litellm tests run well
-      # past ollama's 5-minute default unload, and a cold reload plus first
-      # generation on a loaded runner overruns the request timeout ("Couldn't
-      # reach the provider ... or it timed out"). The warm-up calls pay the
-      # load cost here, where nothing is timing the request.
-      # ollama runs its llama-server subprocess at --log-verbosity 4 and wires its
-      # output to the daemon's stderr, so this file carries the "load_backend:
-      # loaded CPU backend from libggml-cpu-<variant>.so" line. OLLAMA_DEBUG=1 adds
-      # the launched binary path and the LD_LIBRARY_PATH ollama built for it.
-      - name: Start Ollama (Linux/macOS)
-        if: runner.os != 'Windows'
-        run: |
-          OLLAMA_DEBUG=1 OLLAMA_KEEP_ALIVE=-1 nohup ollama serve > "${RUNNER_TEMP}/ollama-serve.log" 2>&1 &
-          for _ in $(seq 1 30); do
-            curl -fsS localhost:11434/api/version >/dev/null 2>&1 && break
-            sleep 1
-          done
-
-      - name: Pull Ollama models (Linux/macOS)
-        if: runner.os != 'Windows'
-        uses: ./.github/actions/ollama-pull
-        with:
-          models: |
-            qwen3:0.6b
-            nomic-embed-text
-
-      # Guards the cache against a silent return to a daemon with its own store:
-      # if the pull did not land here, there is nothing to save and the next run
-      # re-downloads ~800 MB.
-      - name: Check the models landed in the cached store (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          if [ ! -d ~/.ollama/models/blobs ]; then
-            echo "::error::The pull did not write to ~/.ollama/models. Another daemon owns port 11434."
-            exit 1
-          fi
-          du -sh ~/.ollama/models
-
-      # Ollama's model runner segfaults here often enough to kill whole runs
-      # ("llama runner process has terminated: signal: segmentation fault"),
-      # and the pull steps around it already retry. Warming a model is setup,
-      # not a subject under test, so a transient crash must not fail the job
-      # before a single test runs. Three failures still fail it.
-      - name: Warm up Ollama models (Linux/macOS)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          warm_up() {
-            ollama run qwen3:0.6b "warm up" >/dev/null &&
-              curl -fsS localhost:11434/api/embed \
-                -d '{"model":"nomic-embed-text","input":"warm up"}' >/dev/null
-          }
-
-          delay=5
-          for attempt in 1 2 3; do
-            if warm_up; then
-              exit 0
-            fi
-            if [ "${attempt}" -lt 3 ]; then
-              echo "Ollama warm-up failed (attempt ${attempt}/3). Retry in ${delay}s."
-              sleep "${delay}"
-              delay=$((delay * 2))
-            fi
-          done
-          echo "::error::Ollama warm-up failed after 3 attempts."
-          exit 1
-
-      # On step failure, not job failure, so a later green rerun cannot discard
-      # the evidence.
-      - name: Collect diagnostics for the Ollama crash
-        if: failure() && runner.os != 'Windows'
-        shell: bash
-        run: |
-          set +e
-          out="${RUNNER_TEMP}/ollama-diagnostics"
-          mkdir -p "${out}"
-          cp "${RUNNER_TEMP}/ollama-serve.log" "${out}/" 2>/dev/null
-          ollama -v > "${out}/ollama-version.txt" 2>&1
-          # Spelled out per OS: only uname, uptime and df exist on both.
-          {
-            uname -a
-            uptime
-            df -h
-          } > "${out}/host.txt" 2>&1
-          if [ "${RUNNER_OS}" = "Linux" ]; then
-            { nproc; free -g; } >> "${out}/host.txt" 2>&1
-            lscpu > "${out}/lscpu.txt" 2>&1
-            sudo dmesg | tail -50 > "${out}/dmesg.txt" 2>&1
-          else
-            { sysctl -n hw.model hw.ncpu hw.memsize; vm_stat; } >> "${out}/host.txt" 2>&1
-          fi
-          echo "--- kernel segfault lines, if any ---"
-          grep -i "segfault\|general protection" "${out}/dmesg.txt" 2>/dev/null || echo "none in dmesg"
-          echo "--- backend variant loaded by ollama ---"
-          grep -i "load_backend\|loaded CPU backend" "${out}/ollama-serve.log" 2>/dev/null || echo "no backend line captured"
-
-      - name: Upload the Ollama crash diagnostics
-        if: failure() && runner.os != 'Windows'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ollama-diagnostics-${{ runner.os }}-${{ matrix.python-version }}
-          path: ${{ runner.temp }}/ollama-diagnostics
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Start Ollama (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:OLLAMA_KEEP_ALIVE = "-1"
-          Start-Process -FilePath "C:\ollama\ollama.exe" -ArgumentList "serve" -WindowStyle Hidden
-          foreach ($i in 1..30) {
-            try { Invoke-RestMethod "http://localhost:11434/api/version" | Out-Null; break }
-            catch { Start-Sleep -Seconds 1 }
-          }
-
-      - name: Pull Ollama models (Windows)
-        if: runner.os == 'Windows'
-        uses: ./.github/actions/ollama-pull
-        with:
-          ollama: C:/ollama/ollama.exe
-          models: |
-            qwen3:0.6b
-            nomic-embed-text
-
-      # Same retry as the Linux/macOS warm-up: one runner crash must not end
-      # the job. ollama.exe reports failure through the exit code, not an
-      # exception, so check it rather than relying on try/catch alone.
-      - name: Warm up Ollama models (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          for ($attempt = 1; $attempt -le 3; $attempt++) {
-            & C:\ollama\ollama.exe run qwen3:0.6b "warm up" | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-              try {
-                Invoke-RestMethod -Method Post -Uri "http://localhost:11434/api/embed" `
-                  -Body '{"model":"nomic-embed-text","input":"warm up"}' | Out-Null
-                exit 0
-              } catch { }
-            }
-            if ($attempt -lt 3) {
-              Write-Host "Ollama warm-up failed (attempt $attempt/3). Retry in 5s."
-              Start-Sleep -Seconds 5
-            }
-          }
-          Write-Host "::error::Ollama warm-up failed after 3 attempts."
-          exit 1
-
       - name: Restore GGUF models from release mirror
         id: ci-models
         uses: ./.github/actions/restore-ci-models
@@ -653,6 +448,5 @@ jobs:
         env:
           LILBEE_DATA: ${{ runner.temp }}/lilbee
           LILBEE_LLM_PROVIDER: auto
-          OLLAMA_HOST: http://127.0.0.1:11434
           PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/qa-matrix.yml
+++ b/.github/workflows/qa-matrix.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'tools/qa/**'
       - '.github/workflows/qa-matrix.yml'
+  # Weekly drift check: litellm upgrades and Ollama API changes arrive on a
+  # calendar, not on a diff. Only ollama-pypi runs on this trigger.
+  schedule:
+    - cron: '0 8 * * 1'
   workflow_dispatch:
     inputs:
       lilbee_version:
@@ -49,6 +53,9 @@ permissions:
 env:
   # Ollama-registry analogue of conftest's _DEFAULT_CHAT_MODEL; keep param count aligned.
   OLLAMA_TINY_MODEL: qwen3:0.6b
+  # Same floor as ci.yml's OLLAMA_PIN: earlier builds segfault in the
+  # Sapphire Rapids CPU backend on the first inference (ollama#17205).
+  OLLAMA_PIN: "0.33.3"
 
 concurrency:
   group: qa-matrix-${{ github.ref }}
@@ -57,6 +64,7 @@ concurrency:
 jobs:
   native:
     name: native (${{ matrix.label }}, ${{ matrix.lane }})
+    if: github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -158,6 +166,7 @@ jobs:
         uses: ./.github/actions/ollama-up
         with:
           model: ${{ env.OLLAMA_TINY_MODEL }}
+          version: ${{ env.OLLAMA_PIN }}
 
       - name: Run QA matrix
         env:
@@ -194,6 +203,7 @@ jobs:
   # Same lanes against Arch/Fedora containers (where most Linux install bugs surface).
   linux-distros:
     name: linux-distros (${{ matrix.label }}, ${{ matrix.lane }})
+    if: github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -289,6 +299,7 @@ jobs:
         uses: ./.github/actions/ollama-up
         with:
           model: ${{ env.OLLAMA_TINY_MODEL }}
+          version: ${{ env.OLLAMA_PIN }}
 
       - name: Run QA matrix
         env:
@@ -371,11 +382,13 @@ jobs:
         uses: ./.github/actions/ollama-up
         with:
           model: ${{ env.OLLAMA_TINY_MODEL }}
+          version: ${{ env.OLLAMA_PIN }}
 
       - name: Run ollama tests only
         env:
           LILBEE_QA_LANE: l1-pypi
           LILBEE_QA_MODELS_DIR: ${{ github.workspace }}/.lilbee-qa-models
+          LILBEE_QA_OLLAMA_REQUIRED: "1"
           PYTHONUNBUFFERED: "1"
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -402,6 +415,7 @@ jobs:
   # Dedicated [crawler] lane on a single ubuntu cell; isolation rationale matches ollama-pypi.
   crawler-pypi:
     name: crawler-pypi (ubuntu-latest)
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/tests/integration/_ollama_stub.py
+++ b/tests/integration/_ollama_stub.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Minimal stand-in for an Ollama daemon, used by the litellm integration tests.
+
+Parses ``--port`` from argv and serves the subset of the Ollama API the
+litellm SDK calls: ``GET /api/tags``, ``POST /api/generate`` (plain and
+streaming NDJSON), ``POST /api/embed``, and ``POST /api/show``. Chat goes
+through ``/api/generate`` because litellm routes the ``ollama/`` prefix to
+its completion handler, not its chat handler.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+_STUB_CHAT_TEXT = "stub-chat"
+_STUB_EMBEDDING = [0.5, 0.5]
+_STUB_MODELS = ["qwen3:0.6b", "nomic-embed-text"]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args: object) -> None:
+        pass
+
+    def do_GET(self) -> None:
+        if self.path == "/api/tags":
+            self._send_json({"models": [{"name": name} for name in _STUB_MODELS]})
+        elif self.path == "/api/version":
+            self._send_json({"version": "stub"})
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        if self.path == "/api/generate":
+            model = body.get("model", "qwen3:0.6b")
+            if body.get("stream"):
+                self._send_ndjson(
+                    [
+                        {"model": model, "response": "stub-", "done": False},
+                        {"model": model, "response": "chat", "done": False},
+                        {"model": model, "response": "", "done": True},
+                    ]
+                )
+            else:
+                self._send_json(
+                    {
+                        "model": model,
+                        "response": _STUB_CHAT_TEXT,
+                        "done": True,
+                        "done_reason": "stop",
+                    }
+                )
+        elif self.path == "/api/embed":
+            inputs = body.get("input", [])
+            count = len(inputs) if isinstance(inputs, list) else 1
+            # prompt_eval_count is required: without it litellm calls a
+            # logging method its own Logging object does not have.
+            self._send_json(
+                {"embeddings": [_STUB_EMBEDDING for _ in range(count)], "prompt_eval_count": 8}
+            )
+        elif self.path == "/api/show":
+            self._send_json({"parameters": "stub-params", "capabilities": ["completion"]})
+        else:
+            self.send_error(404)
+
+    def _send_json(self, payload: dict[str, object]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_ndjson(self, chunks: list[dict[str, object]]) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-ndjson")
+        self.end_headers()
+        for chunk in chunks:
+            self.wfile.write((json.dumps(chunk) + "\n").encode())
+
+
+def _port_from_argv(argv: list[str]) -> int:
+    for index, arg in enumerate(argv):
+        if arg == "--port" and index + 1 < len(argv):
+            return int(argv[index + 1])
+    raise SystemExit("--port is required")
+
+
+if __name__ == "__main__":
+    HTTPServer(("127.0.0.1", _port_from_argv(sys.argv)), _Handler).serve_forever()

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -1,19 +1,27 @@
-"""SDK-backed provider integration tests: real Ollama server, no mocks.
+"""SDK-backed provider integration tests against an Ollama-shaped stub.
 
-Requires litellm installed and Ollama running at OLLAMA_HOST (default
-localhost:11434) with the qwen3:0.6b and nomic-embed-text models pulled.
+Spawns ``_ollama_stub.py`` over real HTTP: no daemon, no model pulls,
+deterministic. Drift against a real Ollama daemon is covered by the
+scheduled ollama-pypi lane in qa-matrix.yml.
 """
 
 from __future__ import annotations
 
-import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
 
+import httpx
 import numpy as np
 import pytest
 
 litellm = pytest.importorskip("litellm")
 
 from lilbee.core.config import cfg  # noqa: E402
+from lilbee.providers import litellm_sdk as _litellm_sdk_mod  # noqa: E402
 from lilbee.providers.base import (  # noqa: E402
     ChatResult,
     StreamFinish,
@@ -21,47 +29,75 @@ from lilbee.providers.base import (  # noqa: E402
     ToolCallDelta,
 )
 from lilbee.providers.litellm_sdk import LitellmSdkBackend  # noqa: E402
+from lilbee.providers.local_servers import OLLAMA  # noqa: E402
+from lilbee.providers.local_servers.spec import LocalServerSpec  # noqa: E402
 from lilbee.providers.sdk_llm_provider import SdkLLMProvider  # noqa: E402
 
-OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434")
+_STUB = Path(__file__).parent / "_ollama_stub.py"
 # Ollama keeps its own ``name:tag`` shape; lilbee's config layer requires
 # the ``ollama/`` prefix so its routing knows where to send the request.
 OLLAMA_MODEL = "ollama/qwen3:0.6b"
 OLLAMA_EMBED_MODEL = "ollama/nomic-embed-text"
 
 
-def _ollama_reachable() -> bool:
-    try:
-        import httpx
-
-        resp = httpx.get(f"{OLLAMA_HOST}/api/tags", timeout=5)
-        return resp.status_code == 200
-    except Exception:
-        return False
-
-
 pytestmark = [pytest.mark.slow]
 
-# Per class, not per module: TestSdkFactory asserts config-boundary behaviour
-# and opens no socket, so it must run whether or not a daemon is reachable.
-requires_ollama = pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not running")
+
+def _pick_free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def ollama_stub_base() -> Iterator[str]:
+    """Base URL of a freshly spawned Ollama stub server."""
+    port = _pick_free_port()
+    proc = subprocess.Popen([sys.executable, str(_STUB), "--port", str(port)])
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            try:
+                if httpx.get(f"{base}/api/tags", timeout=1.0).status_code == 200:
+                    break
+            except httpx.HTTPError:
+                time.sleep(0.05)
+        else:
+            raise RuntimeError("ollama stub did not become ready")
+        yield base
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10.0)
 
 
 @pytest.fixture(autouse=True)
-def _isolate_cfg():
+def _isolate_cfg(ollama_stub_base: str):
     snapshot = {name: getattr(cfg, name) for name in type(cfg).model_fields}
     # ollama/ refs resolve their api_base from this field, so point it at the
-    # real server for the duration of each test.
-    cfg.ollama_base_url = OLLAMA_HOST
+    # stub for the duration of each test.
+    cfg.ollama_base_url = ollama_stub_base
     yield
     for name, val in snapshot.items():
         setattr(cfg, name, val)
 
 
-@requires_ollama
+@pytest.fixture(autouse=True)
+def _stub_detects_as_ollama(monkeypatch: pytest.MonkeyPatch, ollama_stub_base: str):
+    """Map the stub URL to the Ollama spec; its random port matches no URL pattern."""
+    real_detect = _litellm_sdk_mod.detect_local_server
+
+    def _detect(base_url: str) -> LocalServerSpec | None:
+        if base_url.rstrip("/") == ollama_stub_base:
+            return OLLAMA
+        return real_detect(base_url)
+
+    monkeypatch.setattr(_litellm_sdk_mod, "detect_local_server", _detect)
+
+
 class TestSdkEmbed:
     def test_embed_returns_vectors(self) -> None:
-        """Real embedding via Ollama returns float vectors."""
+        """Embedding via the stub returns float vectors."""
         cfg.embedding_model = OLLAMA_EMBED_MODEL
         provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.embed(["hello world"])
@@ -81,10 +117,9 @@ class TestSdkEmbed:
         assert all(len(v) > 0 for v in result)
 
 
-@requires_ollama
 class TestSdkChat:
     def test_chat_returns_response(self) -> None:
-        """Real chat completion via Ollama returns non-empty text."""
+        """Chat completion via the stub returns non-empty text."""
         cfg.chat_model = OLLAMA_MODEL
         provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.chat(
@@ -126,10 +161,9 @@ class TestSdkChat:
         assert len(result.text) > 0
 
 
-@requires_ollama
 class TestSdkModelManagement:
     def test_list_models(self) -> None:
-        """list_models returns models from Ollama."""
+        """list_models returns the stub's models."""
         provider = SdkLLMProvider(LitellmSdkBackend())
         models = provider.list_models()
 
@@ -152,7 +186,6 @@ class TestSdkFactory:
         from lilbee.providers.factory import create_provider
 
         cfg.llm_provider = "remote"
-        cfg.ollama_base_url = OLLAMA_HOST
         provider = create_provider(cfg)
 
         assert isinstance(provider, SdkLLMProvider)

--- a/tools/qa/test_e2e_litellm_ollama.py
+++ b/tools/qa/test_e2e_litellm_ollama.py
@@ -8,7 +8,9 @@ asserting `returncode >= 0` distinguishes a clean failure from a crash.
 
 Skips cleanly when no ollama daemon is reachable on the default port. The
 matrix runs cells without ollama too, and the absence of the daemon is a
-test-environment fact, not a regression.
+test-environment fact, not a regression. The dedicated ollama-pypi lane
+sets LILBEE_QA_OLLAMA_REQUIRED=1, which turns those skips into failures
+so the drift coverage cannot disappear silently.
 """
 
 from __future__ import annotations
@@ -38,6 +40,7 @@ from conftest import (
 _OLLAMA_DEFAULT_HOST = "127.0.0.1"
 _OLLAMA_DEFAULT_PORT = 11434
 _OLLAMA_HEALTHCHECK_TIMEOUT = 2.0
+_OLLAMA_REQUIRED_ENV_VAR = "LILBEE_QA_OLLAMA_REQUIRED"
 # Remote ollama responses run cold-start each test, ~40s slower than the
 # in-process llama.cpp ASK_TIMEOUT covers; bump above the local-model budget.
 _OLLAMA_ASK_TIMEOUT = 360.0
@@ -60,14 +63,22 @@ def _ollama_reachable() -> bool:
         return False
 
 
+def _ollama_required() -> bool:
+    """Whether this lane must fail instead of skip when ollama is absent."""
+    return os.environ.get(_OLLAMA_REQUIRED_ENV_VAR) == "1"
+
+
 @pytest.fixture(scope="session")
 def ollama_url() -> str:
     """Resolve the ollama daemon URL or skip the suite."""
     if not _ollama_reachable():
-        pytest.skip(
+        message = (
             "ollama daemon not reachable on 127.0.0.1:11434; "
             "set LILBEE_QA_OLLAMA_HOST/PORT or start `ollama serve`"
         )
+        if _ollama_required():
+            pytest.fail(f"{message} (required in this lane)")
+        pytest.skip(message)
     return _ollama_base_url()
 
 
@@ -86,10 +97,13 @@ def ollama_chat_model(ollama_url: str) -> str:
     payload = response.json()
     models = payload.get("models", [])
     if not models:
-        pytest.skip(
+        message = (
             f"no models installed in ollama; pull one (e.g. `ollama pull qwen3:0.6b`) "
             f"or set {OLLAMA_MODEL_ENV_VAR}"
         )
+        if _ollama_required():
+            pytest.fail(f"{message} (required in this lane)")
+        pytest.skip(message)
     return models[0]["name"]
 
 
@@ -133,6 +147,8 @@ def _skip_without_litellm(lane: Lane, lilbee_data: Path) -> None:
     import importlib.util
 
     if importlib.util.find_spec("litellm") is None:
+        if _ollama_required():
+            pytest.fail("litellm not importable in a lane that requires the ollama path")
         pytest.skip("litellm not importable; ollama provider path not available")
 
 


### PR DESCRIPTION
## Problem

Nine per-PR cells install Ollama and pull 800MB to serve one test file. The model warm-up segfaults inside third-party code often enough to block pull requests. That coverage detects dependency upgrades and API changes, which arrive on a calendar rather than on a diff.

## Solution

Per-PR, the provider integration tests now drive a small stub over real HTTP instead of a daemon. The suite runs in seconds with no model downloads.

Scheduled, the dedicated Ollama QA lane runs weekly against a real daemon with a pinned version. It fails instead of skipping when the daemon is unreachable, so the drift coverage cannot disappear silently.